### PR TITLE
Split up cluster read mapping

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
@@ -46,7 +46,9 @@ public class ClusterReadMapping {
     }
 
 {%- endfor %}
+    @SuppressWarnings("serial")
     public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+
         return new HashMap<String, Map<String, InteractionInfo>>(){% raw %}{{{% endraw %}
     {%- for cluster in clientClusters | sort(attribute='code') %}
             put("{{cluster.name | lowfirst_except_acronym}}", read{{cluster.name}}InteractionInfo());

--- a/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
@@ -47,7 +47,7 @@ public class ClusterReadMapping {
 
 {%- endfor %}
     public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-        return new HashMap<>(){% raw %}{{{% endraw %}
+        return new HashMap<String, Map<String, InteractionInfo>>(){% raw %}{{{% endraw %}
     {%- for cluster in clientClusters | sort(attribute='code') %}
             put("{{cluster.name | lowfirst_except_acronym}}", read{{cluster.name}}InteractionInfo());
     {%- endfor -%}

--- a/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ClusterReadMapping.jinja
@@ -23,13 +23,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ClusterReadMapping {
-    public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-        Map<String, Map<String, InteractionInfo>> readAttributeMap = new HashMap<>();
 
-    {%- for cluster in clientClusters | sort(attribute='code') %}
-      {%-  set typeLookup = idl | createLookupContext(cluster) %}
-        Map<String, InteractionInfo> read{{cluster.name}}InteractionInfo = new LinkedHashMap<>();
-      {%- for attribute in cluster.attributes | sort(attribute='name') | attributesWithCallback(typeLookup) %}
+{% for cluster in clientClusters | sort(attribute='code') %}
+  {%-  set typeLookup = idl | createLookupContext(cluster) %}
+    private static Map<String, InteractionInfo> read{{cluster.name}}InteractionInfo() {
+       Map<String, InteractionInfo> result = new LinkedHashMap<>();
+     {%- for attribute in cluster.attributes | sort(attribute='name') | attributesWithCallback(typeLookup) %}
         {#- TODO: add support for struct-typed attributes -#}
         Map<String, CommandParameterInfo> read{{cluster.name}}{{attribute.definition.name | upfirst}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo read{{cluster.name}}{{attribute.definition.name | upfirst}}AttributeInteractionInfo = new InteractionInfo(
@@ -41,11 +40,18 @@ public class ClusterReadMapping {
           () -> new ClusterInfoMapping.{{ attribute | delegatedCallbackName(typeLookup)}}(),
           read{{cluster.name}}{{attribute.definition.name | upfirst}}CommandParams
         );
-        read{{cluster.name}}InteractionInfo.put("read{{attribute.definition.name | upfirst}}Attribute", read{{cluster.name}}{{attribute.definition.name | upfirst}}AttributeInteractionInfo);
-      {%- endfor %}
-        readAttributeMap.put("{{cluster.name | lowfirst_except_acronym}}", read{{cluster.name}}InteractionInfo);
+        result.put("read{{attribute.definition.name | upfirst}}Attribute", read{{cluster.name}}{{attribute.definition.name | upfirst}}AttributeInteractionInfo);
+     {% endfor %}
+       return result;
+    }
+
+{%- endfor %}
+    public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+        return new HashMap<>(){% raw %}{{{% endraw %}
+    {%- for cluster in clientClusters | sort(attribute='code') %}
+            put("{{cluster.name | lowfirst_except_acronym}}", read{{cluster.name}}InteractionInfo());
     {%- endfor -%}
-        return readAttributeMap;
+        }};
     }
 }
 

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
@@ -23,9 +23,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ClusterReadMapping {
-    public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-        Map<String, Map<String, InteractionInfo>> readAttributeMap = new HashMap<>();
-        Map<String, InteractionInfo> readFirstInteractionInfo = new LinkedHashMap<>();Map<String, CommandParameterInfo> readFirstSomeIntegerCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+
+
+    private static Map<String, InteractionInfo> readFirstInteractionInfo() {
+       Map<String, InteractionInfo> result = new LinkedHashMap<>();Map<String, CommandParameterInfo> readFirstSomeIntegerCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo readFirstSomeIntegerAttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {
             ((ChipClusters.FirstCluster) cluster).readSomeIntegerAttribute(
@@ -35,9 +36,12 @@ public class ClusterReadMapping {
           () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
           readFirstSomeIntegerCommandParams
         );
-        readFirstInteractionInfo.put("readSomeIntegerAttribute", readFirstSomeIntegerAttributeInteractionInfo);
-        readAttributeMap.put("first", readFirstInteractionInfo);
-        Map<String, InteractionInfo> readSecondInteractionInfo = new LinkedHashMap<>();Map<String, CommandParameterInfo> readSecondSomeBytesCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+        result.put("readSomeIntegerAttribute", readFirstSomeIntegerAttributeInteractionInfo);
+     
+       return result;
+    }
+    private static Map<String, InteractionInfo> readSecondInteractionInfo() {
+       Map<String, InteractionInfo> result = new LinkedHashMap<>();Map<String, CommandParameterInfo> readSecondSomeBytesCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo readSecondSomeBytesAttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {
             ((ChipClusters.SecondCluster) cluster).readSomeBytesAttribute(
@@ -47,9 +51,12 @@ public class ClusterReadMapping {
           () -> new ClusterInfoMapping.DelegatedOctetStringAttributeCallback(),
           readSecondSomeBytesCommandParams
         );
-        readSecondInteractionInfo.put("readSomeBytesAttribute", readSecondSomeBytesAttributeInteractionInfo);
-        readAttributeMap.put("second", readSecondInteractionInfo);
-        Map<String, InteractionInfo> readThirdInteractionInfo = new LinkedHashMap<>();Map<String, CommandParameterInfo> readThirdSomeEnumCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+        result.put("readSomeBytesAttribute", readSecondSomeBytesAttributeInteractionInfo);
+     
+       return result;
+    }
+    private static Map<String, InteractionInfo> readThirdInteractionInfo() {
+       Map<String, InteractionInfo> result = new LinkedHashMap<>();Map<String, CommandParameterInfo> readThirdSomeEnumCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo readThirdSomeEnumAttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {
             ((ChipClusters.ThirdCluster) cluster).readSomeEnumAttribute(
@@ -59,7 +66,8 @@ public class ClusterReadMapping {
           () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
           readThirdSomeEnumCommandParams
         );
-        readThirdInteractionInfo.put("readSomeEnumAttribute", readThirdSomeEnumAttributeInteractionInfo);Map<String, CommandParameterInfo> readThirdOptionsCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+        result.put("readSomeEnumAttribute", readThirdSomeEnumAttributeInteractionInfo);
+     Map<String, CommandParameterInfo> readThirdOptionsCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo readThirdOptionsAttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {
             ((ChipClusters.ThirdCluster) cluster).readOptionsAttribute(
@@ -69,8 +77,15 @@ public class ClusterReadMapping {
           () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
           readThirdOptionsCommandParams
         );
-        readThirdInteractionInfo.put("readOptionsAttribute", readThirdOptionsAttributeInteractionInfo);
-        readAttributeMap.put("third", readThirdInteractionInfo);return readAttributeMap;
+        result.put("readOptionsAttribute", readThirdOptionsAttributeInteractionInfo);
+     
+       return result;
+    }
+    public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+        return new HashMap<>(){{
+            put("first", readFirstInteractionInfo());
+            put("second", readSecondInteractionInfo());
+            put("third", readThirdInteractionInfo());}};
     }
 }
 

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
@@ -81,7 +81,9 @@ public class ClusterReadMapping {
      
        return result;
     }
+    @SuppressWarnings("serial")
     public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+
         return new HashMap<String, Map<String, InteractionInfo>>(){{
             put("first", readFirstInteractionInfo());
             put("second", readSecondInteractionInfo());

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ClusterReadMapping.java
@@ -82,7 +82,7 @@ public class ClusterReadMapping {
        return result;
     }
     public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-        return new HashMap<>(){{
+        return new HashMap<String, Map<String, InteractionInfo>>(){{
             put("first", readFirstInteractionInfo());
             put("second", readSecondInteractionInfo());
             put("third", readThirdInteractionInfo());}};

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
@@ -16416,7 +16416,7 @@ public class ClusterReadMapping {
   }
 
   public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-    return new HashMap<>() {
+    return new HashMap<String, Map<String, InteractionInfo>>() {
       {
         put("identify", readIdentifyInteractionInfo());
         put("groups", readGroupsInteractionInfo());

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
@@ -23,9 +23,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ClusterReadMapping {
-  public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
-    Map<String, Map<String, InteractionInfo>> readAttributeMap = new HashMap<>();
-    Map<String, InteractionInfo> readIdentifyInteractionInfo = new LinkedHashMap<>();
+
+  private static Map<String, InteractionInfo> readIdentifyInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readIdentifyIdentifyTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyIdentifyTimeAttributeInteractionInfo =
@@ -36,8 +36,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readIdentifyIdentifyTimeCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readIdentifyTimeAttribute", readIdentifyIdentifyTimeAttributeInteractionInfo);
+    result.put("readIdentifyTimeAttribute", readIdentifyIdentifyTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyIdentifyTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyIdentifyTypeAttributeInteractionInfo =
@@ -48,8 +47,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readIdentifyIdentifyTypeCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readIdentifyTypeAttribute", readIdentifyIdentifyTypeAttributeInteractionInfo);
+    result.put("readIdentifyTypeAttribute", readIdentifyIdentifyTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyGeneratedCommandListAttributeInteractionInfo =
@@ -64,7 +62,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIdentifyClusterGeneratedCommandListAttributeCallback(),
             readIdentifyGeneratedCommandListCommandParams);
-    readIdentifyInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readIdentifyGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyAcceptedCommandListCommandParams =
@@ -80,7 +78,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIdentifyClusterAcceptedCommandListAttributeCallback(),
             readIdentifyAcceptedCommandListCommandParams);
-    readIdentifyInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readIdentifyAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyEventListCommandParams =
@@ -94,8 +92,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIdentifyClusterEventListAttributeCallback(),
             readIdentifyEventListCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readEventListAttribute", readIdentifyEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readIdentifyEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyAttributeListAttributeInteractionInfo =
@@ -107,8 +104,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIdentifyClusterAttributeListAttributeCallback(),
             readIdentifyAttributeListCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readAttributeListAttribute", readIdentifyAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readIdentifyAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyFeatureMapAttributeInteractionInfo =
@@ -119,8 +115,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readIdentifyFeatureMapCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readFeatureMapAttribute", readIdentifyFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readIdentifyFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIdentifyClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIdentifyClusterRevisionAttributeInteractionInfo =
@@ -131,10 +126,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readIdentifyClusterRevisionCommandParams);
-    readIdentifyInteractionInfo.put(
-        "readClusterRevisionAttribute", readIdentifyClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("identify", readIdentifyInteractionInfo);
-    Map<String, InteractionInfo> readGroupsInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readIdentifyClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readGroupsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readGroupsNameSupportCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupsNameSupportAttributeInteractionInfo =
@@ -145,8 +143,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGroupsNameSupportCommandParams);
-    readGroupsInteractionInfo.put(
-        "readNameSupportAttribute", readGroupsNameSupportAttributeInteractionInfo);
+    result.put("readNameSupportAttribute", readGroupsNameSupportAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupsGeneratedCommandListAttributeInteractionInfo =
@@ -160,7 +157,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupsClusterGeneratedCommandListAttributeCallback(),
             readGroupsGeneratedCommandListCommandParams);
-    readGroupsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readGroupsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsAcceptedCommandListCommandParams =
@@ -175,7 +172,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedGroupsClusterAcceptedCommandListAttributeCallback(),
             readGroupsAcceptedCommandListCommandParams);
-    readGroupsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readGroupsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -188,8 +185,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedGroupsClusterEventListAttributeCallback(),
             readGroupsEventListCommandParams);
-    readGroupsInteractionInfo.put(
-        "readEventListAttribute", readGroupsEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readGroupsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupsAttributeListAttributeInteractionInfo =
@@ -201,8 +197,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedGroupsClusterAttributeListAttributeCallback(),
             readGroupsAttributeListCommandParams);
-    readGroupsInteractionInfo.put(
-        "readAttributeListAttribute", readGroupsAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readGroupsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupsFeatureMapAttributeInteractionInfo =
@@ -213,8 +208,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGroupsFeatureMapCommandParams);
-    readGroupsInteractionInfo.put(
-        "readFeatureMapAttribute", readGroupsFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readGroupsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupsClusterRevisionAttributeInteractionInfo =
@@ -225,10 +219,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGroupsClusterRevisionCommandParams);
-    readGroupsInteractionInfo.put(
-        "readClusterRevisionAttribute", readGroupsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("groups", readGroupsInteractionInfo);
-    Map<String, InteractionInfo> readScenesInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readGroupsClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readScenesInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readScenesSceneCountCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesSceneCountAttributeInteractionInfo =
@@ -239,8 +236,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readScenesSceneCountCommandParams);
-    readScenesInteractionInfo.put(
-        "readSceneCountAttribute", readScenesSceneCountAttributeInteractionInfo);
+    result.put("readSceneCountAttribute", readScenesSceneCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesCurrentSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesCurrentSceneAttributeInteractionInfo =
@@ -251,8 +247,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readScenesCurrentSceneCommandParams);
-    readScenesInteractionInfo.put(
-        "readCurrentSceneAttribute", readScenesCurrentSceneAttributeInteractionInfo);
+    result.put("readCurrentSceneAttribute", readScenesCurrentSceneAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesCurrentGroupCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesCurrentGroupAttributeInteractionInfo =
@@ -263,8 +258,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readScenesCurrentGroupCommandParams);
-    readScenesInteractionInfo.put(
-        "readCurrentGroupAttribute", readScenesCurrentGroupAttributeInteractionInfo);
+    result.put("readCurrentGroupAttribute", readScenesCurrentGroupAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesSceneValidCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesSceneValidAttributeInteractionInfo =
@@ -275,8 +269,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readScenesSceneValidCommandParams);
-    readScenesInteractionInfo.put(
-        "readSceneValidAttribute", readScenesSceneValidAttributeInteractionInfo);
+    result.put("readSceneValidAttribute", readScenesSceneValidAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesNameSupportCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesNameSupportAttributeInteractionInfo =
@@ -287,8 +280,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readScenesNameSupportCommandParams);
-    readScenesInteractionInfo.put(
-        "readNameSupportAttribute", readScenesNameSupportAttributeInteractionInfo);
+    result.put("readNameSupportAttribute", readScenesNameSupportAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesLastConfiguredByCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesLastConfiguredByAttributeInteractionInfo =
@@ -300,8 +292,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedScenesClusterLastConfiguredByAttributeCallback(),
             readScenesLastConfiguredByCommandParams);
-    readScenesInteractionInfo.put(
-        "readLastConfiguredByAttribute", readScenesLastConfiguredByAttributeInteractionInfo);
+    result.put("readLastConfiguredByAttribute", readScenesLastConfiguredByAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesGeneratedCommandListAttributeInteractionInfo =
@@ -315,7 +306,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedScenesClusterGeneratedCommandListAttributeCallback(),
             readScenesGeneratedCommandListCommandParams);
-    readScenesInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readScenesGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesAcceptedCommandListCommandParams =
@@ -330,7 +321,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedScenesClusterAcceptedCommandListAttributeCallback(),
             readScenesAcceptedCommandListCommandParams);
-    readScenesInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readScenesAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -343,8 +334,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedScenesClusterEventListAttributeCallback(),
             readScenesEventListCommandParams);
-    readScenesInteractionInfo.put(
-        "readEventListAttribute", readScenesEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readScenesEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesAttributeListAttributeInteractionInfo =
@@ -356,8 +346,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedScenesClusterAttributeListAttributeCallback(),
             readScenesAttributeListCommandParams);
-    readScenesInteractionInfo.put(
-        "readAttributeListAttribute", readScenesAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readScenesAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesFeatureMapAttributeInteractionInfo =
@@ -368,8 +357,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readScenesFeatureMapCommandParams);
-    readScenesInteractionInfo.put(
-        "readFeatureMapAttribute", readScenesFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readScenesFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readScenesClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readScenesClusterRevisionAttributeInteractionInfo =
@@ -380,10 +368,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readScenesClusterRevisionCommandParams);
-    readScenesInteractionInfo.put(
-        "readClusterRevisionAttribute", readScenesClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("scenes", readScenesInteractionInfo);
-    Map<String, InteractionInfo> readOnOffInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readScenesClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOnOffInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readOnOffOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffOnOffAttributeInteractionInfo =
@@ -394,7 +385,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readOnOffOnOffCommandParams);
-    readOnOffInteractionInfo.put("readOnOffAttribute", readOnOffOnOffAttributeInteractionInfo);
+    result.put("readOnOffAttribute", readOnOffOnOffAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffGlobalSceneControlCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffGlobalSceneControlAttributeInteractionInfo =
@@ -406,7 +397,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readOnOffGlobalSceneControlCommandParams);
-    readOnOffInteractionInfo.put(
+    result.put(
         "readGlobalSceneControlAttribute", readOnOffGlobalSceneControlAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffOnTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -418,7 +409,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffOnTimeCommandParams);
-    readOnOffInteractionInfo.put("readOnTimeAttribute", readOnOffOnTimeAttributeInteractionInfo);
+    result.put("readOnTimeAttribute", readOnOffOnTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffOffWaitTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffOffWaitTimeAttributeInteractionInfo =
@@ -429,8 +420,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffOffWaitTimeCommandParams);
-    readOnOffInteractionInfo.put(
-        "readOffWaitTimeAttribute", readOnOffOffWaitTimeAttributeInteractionInfo);
+    result.put("readOffWaitTimeAttribute", readOnOffOffWaitTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffStartUpOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffStartUpOnOffAttributeInteractionInfo =
@@ -442,8 +432,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedOnOffClusterStartUpOnOffAttributeCallback(),
             readOnOffStartUpOnOffCommandParams);
-    readOnOffInteractionInfo.put(
-        "readStartUpOnOffAttribute", readOnOffStartUpOnOffAttributeInteractionInfo);
+    result.put("readStartUpOnOffAttribute", readOnOffStartUpOnOffAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffGeneratedCommandListAttributeInteractionInfo =
@@ -456,7 +445,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedOnOffClusterGeneratedCommandListAttributeCallback(),
             readOnOffGeneratedCommandListCommandParams);
-    readOnOffInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute", readOnOffGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffAcceptedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -470,7 +459,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedOnOffClusterAcceptedCommandListAttributeCallback(),
             readOnOffAcceptedCommandListCommandParams);
-    readOnOffInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readOnOffAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -483,8 +472,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedOnOffClusterEventListAttributeCallback(),
             readOnOffEventListCommandParams);
-    readOnOffInteractionInfo.put(
-        "readEventListAttribute", readOnOffEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readOnOffEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffAttributeListAttributeInteractionInfo =
@@ -496,8 +484,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedOnOffClusterAttributeListAttributeCallback(),
             readOnOffAttributeListCommandParams);
-    readOnOffInteractionInfo.put(
-        "readAttributeListAttribute", readOnOffAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readOnOffAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffFeatureMapAttributeInteractionInfo =
@@ -508,8 +495,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOnOffFeatureMapCommandParams);
-    readOnOffInteractionInfo.put(
-        "readFeatureMapAttribute", readOnOffFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readOnOffFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffClusterRevisionAttributeInteractionInfo =
@@ -520,11 +506,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffClusterRevisionCommandParams);
-    readOnOffInteractionInfo.put(
-        "readClusterRevisionAttribute", readOnOffClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("onOff", readOnOffInteractionInfo);
-    Map<String, InteractionInfo> readOnOffSwitchConfigurationInteractionInfo =
-        new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readOnOffClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOnOffSwitchConfigurationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationSwitchTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOnOffSwitchConfigurationSwitchTypeAttributeInteractionInfo =
@@ -535,7 +523,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffSwitchConfigurationSwitchTypeCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readSwitchTypeAttribute", readOnOffSwitchConfigurationSwitchTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationSwitchActionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -547,7 +535,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffSwitchConfigurationSwitchActionsCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readSwitchActionsAttribute",
         readOnOffSwitchConfigurationSwitchActionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -566,7 +554,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOnOffSwitchConfigurationClusterGeneratedCommandListAttributeCallback(),
             readOnOffSwitchConfigurationGeneratedCommandListCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readOnOffSwitchConfigurationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationAcceptedCommandListCommandParams =
@@ -584,7 +572,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOnOffSwitchConfigurationClusterAcceptedCommandListAttributeCallback(),
             readOnOffSwitchConfigurationAcceptedCommandListCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readOnOffSwitchConfigurationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationEventListCommandParams =
@@ -601,7 +589,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOnOffSwitchConfigurationClusterEventListAttributeCallback(),
             readOnOffSwitchConfigurationEventListCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readOnOffSwitchConfigurationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -617,7 +605,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOnOffSwitchConfigurationClusterAttributeListAttributeCallback(),
             readOnOffSwitchConfigurationAttributeListCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readOnOffSwitchConfigurationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationFeatureMapCommandParams =
@@ -630,7 +618,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOnOffSwitchConfigurationFeatureMapCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readOnOffSwitchConfigurationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOnOffSwitchConfigurationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -642,11 +630,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOnOffSwitchConfigurationClusterRevisionCommandParams);
-    readOnOffSwitchConfigurationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readOnOffSwitchConfigurationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("onOffSwitchConfiguration", readOnOffSwitchConfigurationInteractionInfo);
-    Map<String, InteractionInfo> readLevelControlInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readLevelControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readLevelControlCurrentLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlCurrentLevelAttributeInteractionInfo =
@@ -659,8 +651,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedLevelControlClusterCurrentLevelAttributeCallback(),
             readLevelControlCurrentLevelCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readCurrentLevelAttribute", readLevelControlCurrentLevelAttributeInteractionInfo);
+    result.put("readCurrentLevelAttribute", readLevelControlCurrentLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlRemainingTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlRemainingTimeAttributeInteractionInfo =
@@ -671,8 +662,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlRemainingTimeCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readRemainingTimeAttribute", readLevelControlRemainingTimeAttributeInteractionInfo);
+    result.put("readRemainingTimeAttribute", readLevelControlRemainingTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlMinLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlMinLevelAttributeInteractionInfo =
@@ -683,8 +673,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlMinLevelCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readMinLevelAttribute", readLevelControlMinLevelAttributeInteractionInfo);
+    result.put("readMinLevelAttribute", readLevelControlMinLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlMaxLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlMaxLevelAttributeInteractionInfo =
@@ -695,8 +684,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlMaxLevelCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readMaxLevelAttribute", readLevelControlMaxLevelAttributeInteractionInfo);
+    result.put("readMaxLevelAttribute", readLevelControlMaxLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlCurrentFrequencyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlCurrentFrequencyAttributeInteractionInfo =
@@ -707,7 +695,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlCurrentFrequencyCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readCurrentFrequencyAttribute", readLevelControlCurrentFrequencyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlMinFrequencyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -719,8 +707,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlMinFrequencyCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readMinFrequencyAttribute", readLevelControlMinFrequencyAttributeInteractionInfo);
+    result.put("readMinFrequencyAttribute", readLevelControlMinFrequencyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlMaxFrequencyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlMaxFrequencyAttributeInteractionInfo =
@@ -731,8 +718,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlMaxFrequencyCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readMaxFrequencyAttribute", readLevelControlMaxFrequencyAttributeInteractionInfo);
+    result.put("readMaxFrequencyAttribute", readLevelControlMaxFrequencyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlOptionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlOptionsAttributeInteractionInfo =
@@ -743,8 +729,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlOptionsCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readOptionsAttribute", readLevelControlOptionsAttributeInteractionInfo);
+    result.put("readOptionsAttribute", readLevelControlOptionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlOnOffTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlOnOffTransitionTimeAttributeInteractionInfo =
@@ -756,7 +741,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlOnOffTransitionTimeCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readOnOffTransitionTimeAttribute",
         readLevelControlOnOffTransitionTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlOnLevelCommandParams =
@@ -770,8 +755,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLevelControlClusterOnLevelAttributeCallback(),
             readLevelControlOnLevelCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readOnLevelAttribute", readLevelControlOnLevelAttributeInteractionInfo);
+    result.put("readOnLevelAttribute", readLevelControlOnLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlOnTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlOnTransitionTimeAttributeInteractionInfo =
@@ -786,7 +770,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterOnTransitionTimeAttributeCallback(),
             readLevelControlOnTransitionTimeCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readOnTransitionTimeAttribute", readLevelControlOnTransitionTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlOffTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -802,7 +786,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterOffTransitionTimeAttributeCallback(),
             readLevelControlOffTransitionTimeCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readOffTransitionTimeAttribute",
         readLevelControlOffTransitionTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlDefaultMoveRateCommandParams =
@@ -818,7 +802,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterDefaultMoveRateAttributeCallback(),
             readLevelControlDefaultMoveRateCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readDefaultMoveRateAttribute", readLevelControlDefaultMoveRateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlStartUpCurrentLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -834,7 +818,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterStartUpCurrentLevelAttributeCallback(),
             readLevelControlStartUpCurrentLevelCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readStartUpCurrentLevelAttribute",
         readLevelControlStartUpCurrentLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlGeneratedCommandListCommandParams =
@@ -851,7 +835,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterGeneratedCommandListAttributeCallback(),
             readLevelControlGeneratedCommandListCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readLevelControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlAcceptedCommandListCommandParams =
@@ -868,7 +852,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLevelControlClusterAcceptedCommandListAttributeCallback(),
             readLevelControlAcceptedCommandListCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readLevelControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlEventListCommandParams =
@@ -882,8 +866,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLevelControlClusterEventListAttributeCallback(),
             readLevelControlEventListCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readEventListAttribute", readLevelControlEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readLevelControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlAttributeListAttributeInteractionInfo =
@@ -896,8 +879,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedLevelControlClusterAttributeListAttributeCallback(),
             readLevelControlAttributeListCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readAttributeListAttribute", readLevelControlAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readLevelControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlFeatureMapAttributeInteractionInfo =
@@ -908,8 +890,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readLevelControlFeatureMapCommandParams);
-    readLevelControlInteractionInfo.put(
-        "readFeatureMapAttribute", readLevelControlFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readLevelControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLevelControlClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLevelControlClusterRevisionAttributeInteractionInfo =
@@ -920,10 +901,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLevelControlClusterRevisionCommandParams);
-    readLevelControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readLevelControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("levelControl", readLevelControlInteractionInfo);
-    Map<String, InteractionInfo> readBinaryInputBasicInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBinaryInputBasicInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBinaryInputBasicActiveTextCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicActiveTextAttributeInteractionInfo =
@@ -934,8 +919,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBinaryInputBasicActiveTextCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readActiveTextAttribute", readBinaryInputBasicActiveTextAttributeInteractionInfo);
+    result.put("readActiveTextAttribute", readBinaryInputBasicActiveTextAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicDescriptionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicDescriptionAttributeInteractionInfo =
@@ -946,8 +930,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBinaryInputBasicDescriptionCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readDescriptionAttribute", readBinaryInputBasicDescriptionAttributeInteractionInfo);
+    result.put("readDescriptionAttribute", readBinaryInputBasicDescriptionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicInactiveTextCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicInactiveTextAttributeInteractionInfo =
@@ -958,7 +941,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBinaryInputBasicInactiveTextCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readInactiveTextAttribute", readBinaryInputBasicInactiveTextAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicOutOfServiceCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -970,7 +953,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBinaryInputBasicOutOfServiceCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readOutOfServiceAttribute", readBinaryInputBasicOutOfServiceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicPolarityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -982,8 +965,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBinaryInputBasicPolarityCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readPolarityAttribute", readBinaryInputBasicPolarityAttributeInteractionInfo);
+    result.put("readPolarityAttribute", readBinaryInputBasicPolarityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicPresentValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicPresentValueAttributeInteractionInfo =
@@ -994,7 +976,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBinaryInputBasicPresentValueCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readPresentValueAttribute", readBinaryInputBasicPresentValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicReliabilityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1006,8 +988,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBinaryInputBasicReliabilityCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readReliabilityAttribute", readBinaryInputBasicReliabilityAttributeInteractionInfo);
+    result.put("readReliabilityAttribute", readBinaryInputBasicReliabilityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicStatusFlagsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicStatusFlagsAttributeInteractionInfo =
@@ -1018,8 +999,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBinaryInputBasicStatusFlagsCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readStatusFlagsAttribute", readBinaryInputBasicStatusFlagsAttributeInteractionInfo);
+    result.put("readStatusFlagsAttribute", readBinaryInputBasicStatusFlagsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicApplicationTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicApplicationTypeAttributeInteractionInfo =
@@ -1030,7 +1010,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBinaryInputBasicApplicationTypeCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readApplicationTypeAttribute",
         readBinaryInputBasicApplicationTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicGeneratedCommandListCommandParams =
@@ -1047,7 +1027,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBinaryInputBasicClusterGeneratedCommandListAttributeCallback(),
             readBinaryInputBasicGeneratedCommandListCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBinaryInputBasicGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicAcceptedCommandListCommandParams =
@@ -1064,7 +1044,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBinaryInputBasicClusterAcceptedCommandListAttributeCallback(),
             readBinaryInputBasicAcceptedCommandListCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBinaryInputBasicAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicEventListCommandParams =
@@ -1079,8 +1059,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedBinaryInputBasicClusterEventListAttributeCallback(),
             readBinaryInputBasicEventListCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readEventListAttribute", readBinaryInputBasicEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBinaryInputBasicEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicAttributeListAttributeInteractionInfo =
@@ -1095,7 +1074,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBinaryInputBasicClusterAttributeListAttributeCallback(),
             readBinaryInputBasicAttributeListCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readBinaryInputBasicAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1107,8 +1086,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBinaryInputBasicFeatureMapCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
-        "readFeatureMapAttribute", readBinaryInputBasicFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readBinaryInputBasicFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBinaryInputBasicClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBinaryInputBasicClusterRevisionAttributeInteractionInfo =
@@ -1119,11 +1097,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBinaryInputBasicClusterRevisionCommandParams);
-    readBinaryInputBasicInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readBinaryInputBasicClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("binaryInputBasic", readBinaryInputBasicInteractionInfo);
-    Map<String, InteractionInfo> readDescriptorInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readDescriptorInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readDescriptorDeviceTypeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorDeviceTypeListAttributeInteractionInfo =
@@ -1136,8 +1118,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedDescriptorClusterDeviceTypeListAttributeCallback(),
             readDescriptorDeviceTypeListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readDeviceTypeListAttribute", readDescriptorDeviceTypeListAttributeInteractionInfo);
+    result.put("readDeviceTypeListAttribute", readDescriptorDeviceTypeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorServerListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorServerListAttributeInteractionInfo =
@@ -1149,8 +1130,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDescriptorClusterServerListAttributeCallback(),
             readDescriptorServerListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readServerListAttribute", readDescriptorServerListAttributeInteractionInfo);
+    result.put("readServerListAttribute", readDescriptorServerListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorClientListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorClientListAttributeInteractionInfo =
@@ -1162,8 +1142,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDescriptorClusterClientListAttributeCallback(),
             readDescriptorClientListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readClientListAttribute", readDescriptorClientListAttributeInteractionInfo);
+    result.put("readClientListAttribute", readDescriptorClientListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorPartsListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorPartsListAttributeInteractionInfo =
@@ -1175,8 +1154,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDescriptorClusterPartsListAttributeCallback(),
             readDescriptorPartsListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readPartsListAttribute", readDescriptorPartsListAttributeInteractionInfo);
+    result.put("readPartsListAttribute", readDescriptorPartsListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorGeneratedCommandListAttributeInteractionInfo =
@@ -1191,7 +1169,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDescriptorClusterGeneratedCommandListAttributeCallback(),
             readDescriptorGeneratedCommandListCommandParams);
-    readDescriptorInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readDescriptorGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorAcceptedCommandListCommandParams =
@@ -1208,7 +1186,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDescriptorClusterAcceptedCommandListAttributeCallback(),
             readDescriptorAcceptedCommandListCommandParams);
-    readDescriptorInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readDescriptorAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorEventListCommandParams =
@@ -1222,8 +1200,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDescriptorClusterEventListAttributeCallback(),
             readDescriptorEventListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readEventListAttribute", readDescriptorEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readDescriptorEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorAttributeListAttributeInteractionInfo =
@@ -1235,8 +1212,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDescriptorClusterAttributeListAttributeCallback(),
             readDescriptorAttributeListCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readAttributeListAttribute", readDescriptorAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readDescriptorAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorFeatureMapAttributeInteractionInfo =
@@ -1247,8 +1223,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDescriptorFeatureMapCommandParams);
-    readDescriptorInteractionInfo.put(
-        "readFeatureMapAttribute", readDescriptorFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readDescriptorFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDescriptorClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDescriptorClusterRevisionAttributeInteractionInfo =
@@ -1259,10 +1234,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDescriptorClusterRevisionCommandParams);
-    readDescriptorInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readDescriptorClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("descriptor", readDescriptorInteractionInfo);
-    Map<String, InteractionInfo> readBindingInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBindingInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBindingBindingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBindingBindingAttributeInteractionInfo =
@@ -1274,8 +1253,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBindingClusterBindingAttributeCallback(),
             readBindingBindingCommandParams);
-    readBindingInteractionInfo.put(
-        "readBindingAttribute", readBindingBindingAttributeInteractionInfo);
+    result.put("readBindingAttribute", readBindingBindingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBindingGeneratedCommandListAttributeInteractionInfo =
@@ -1289,7 +1267,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBindingClusterGeneratedCommandListAttributeCallback(),
             readBindingGeneratedCommandListCommandParams);
-    readBindingInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBindingGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingAcceptedCommandListCommandParams =
@@ -1305,7 +1283,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBindingClusterAcceptedCommandListAttributeCallback(),
             readBindingAcceptedCommandListCommandParams);
-    readBindingInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readBindingAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1318,8 +1296,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBindingClusterEventListAttributeCallback(),
             readBindingEventListCommandParams);
-    readBindingInteractionInfo.put(
-        "readEventListAttribute", readBindingEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBindingEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBindingAttributeListAttributeInteractionInfo =
@@ -1331,8 +1308,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBindingClusterAttributeListAttributeCallback(),
             readBindingAttributeListCommandParams);
-    readBindingInteractionInfo.put(
-        "readAttributeListAttribute", readBindingAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readBindingAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBindingFeatureMapAttributeInteractionInfo =
@@ -1343,8 +1319,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBindingFeatureMapCommandParams);
-    readBindingInteractionInfo.put(
-        "readFeatureMapAttribute", readBindingFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readBindingFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBindingClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBindingClusterRevisionAttributeInteractionInfo =
@@ -1355,10 +1330,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBindingClusterRevisionCommandParams);
-    readBindingInteractionInfo.put(
-        "readClusterRevisionAttribute", readBindingClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("binding", readBindingInteractionInfo);
-    Map<String, InteractionInfo> readAccessControlInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readBindingClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readAccessControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readAccessControlAclCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccessControlAclAttributeInteractionInfo =
@@ -1370,8 +1348,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAccessControlClusterAclAttributeCallback(),
             readAccessControlAclCommandParams);
-    readAccessControlInteractionInfo.put(
-        "readAclAttribute", readAccessControlAclAttributeInteractionInfo);
+    result.put("readAclAttribute", readAccessControlAclAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlExtensionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccessControlExtensionAttributeInteractionInfo =
@@ -1383,8 +1360,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAccessControlClusterExtensionAttributeCallback(),
             readAccessControlExtensionCommandParams);
-    readAccessControlInteractionInfo.put(
-        "readExtensionAttribute", readAccessControlExtensionAttributeInteractionInfo);
+    result.put("readExtensionAttribute", readAccessControlExtensionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlSubjectsPerAccessControlEntryCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccessControlSubjectsPerAccessControlEntryAttributeInteractionInfo =
@@ -1396,7 +1372,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAccessControlSubjectsPerAccessControlEntryCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readSubjectsPerAccessControlEntryAttribute",
         readAccessControlSubjectsPerAccessControlEntryAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlTargetsPerAccessControlEntryCommandParams =
@@ -1410,7 +1386,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAccessControlTargetsPerAccessControlEntryCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readTargetsPerAccessControlEntryAttribute",
         readAccessControlTargetsPerAccessControlEntryAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlAccessControlEntriesPerFabricCommandParams =
@@ -1424,7 +1400,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAccessControlAccessControlEntriesPerFabricCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readAccessControlEntriesPerFabricAttribute",
         readAccessControlAccessControlEntriesPerFabricAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlGeneratedCommandListCommandParams =
@@ -1441,7 +1417,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAccessControlClusterGeneratedCommandListAttributeCallback(),
             readAccessControlGeneratedCommandListCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readAccessControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlAcceptedCommandListCommandParams =
@@ -1458,7 +1434,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAccessControlClusterAcceptedCommandListAttributeCallback(),
             readAccessControlAcceptedCommandListCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readAccessControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlEventListCommandParams =
@@ -1472,8 +1448,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAccessControlClusterEventListAttributeCallback(),
             readAccessControlEventListCommandParams);
-    readAccessControlInteractionInfo.put(
-        "readEventListAttribute", readAccessControlEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readAccessControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccessControlAttributeListAttributeInteractionInfo =
@@ -1487,7 +1462,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAccessControlClusterAttributeListAttributeCallback(),
             readAccessControlAttributeListCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readAccessControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1499,8 +1474,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readAccessControlFeatureMapCommandParams);
-    readAccessControlInteractionInfo.put(
-        "readFeatureMapAttribute", readAccessControlFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readAccessControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccessControlClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccessControlClusterRevisionAttributeInteractionInfo =
@@ -1511,10 +1485,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAccessControlClusterRevisionCommandParams);
-    readAccessControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readAccessControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("accessControl", readAccessControlInteractionInfo);
-    Map<String, InteractionInfo> readActionsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readActionsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readActionsActionListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsActionListAttributeInteractionInfo =
@@ -1526,8 +1504,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedActionsClusterActionListAttributeCallback(),
             readActionsActionListCommandParams);
-    readActionsInteractionInfo.put(
-        "readActionListAttribute", readActionsActionListAttributeInteractionInfo);
+    result.put("readActionListAttribute", readActionsActionListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsEndpointListsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsEndpointListsAttributeInteractionInfo =
@@ -1539,8 +1516,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedActionsClusterEndpointListsAttributeCallback(),
             readActionsEndpointListsCommandParams);
-    readActionsInteractionInfo.put(
-        "readEndpointListsAttribute", readActionsEndpointListsAttributeInteractionInfo);
+    result.put("readEndpointListsAttribute", readActionsEndpointListsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsSetupURLCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsSetupURLAttributeInteractionInfo =
@@ -1551,8 +1527,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readActionsSetupURLCommandParams);
-    readActionsInteractionInfo.put(
-        "readSetupURLAttribute", readActionsSetupURLAttributeInteractionInfo);
+    result.put("readSetupURLAttribute", readActionsSetupURLAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsGeneratedCommandListAttributeInteractionInfo =
@@ -1566,7 +1541,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedActionsClusterGeneratedCommandListAttributeCallback(),
             readActionsGeneratedCommandListCommandParams);
-    readActionsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readActionsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsAcceptedCommandListCommandParams =
@@ -1582,7 +1557,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedActionsClusterAcceptedCommandListAttributeCallback(),
             readActionsAcceptedCommandListCommandParams);
-    readActionsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readActionsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1595,8 +1570,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedActionsClusterEventListAttributeCallback(),
             readActionsEventListCommandParams);
-    readActionsInteractionInfo.put(
-        "readEventListAttribute", readActionsEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readActionsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsAttributeListAttributeInteractionInfo =
@@ -1608,8 +1582,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedActionsClusterAttributeListAttributeCallback(),
             readActionsAttributeListCommandParams);
-    readActionsInteractionInfo.put(
-        "readAttributeListAttribute", readActionsAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readActionsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsFeatureMapAttributeInteractionInfo =
@@ -1620,8 +1593,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readActionsFeatureMapCommandParams);
-    readActionsInteractionInfo.put(
-        "readFeatureMapAttribute", readActionsFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readActionsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readActionsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readActionsClusterRevisionAttributeInteractionInfo =
@@ -1632,10 +1604,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readActionsClusterRevisionCommandParams);
-    readActionsInteractionInfo.put(
-        "readClusterRevisionAttribute", readActionsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("actions", readActionsInteractionInfo);
-    Map<String, InteractionInfo> readBasicInformationInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readActionsClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBasicInformationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBasicInformationDataModelRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationDataModelRevisionAttributeInteractionInfo =
@@ -1646,7 +1621,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBasicInformationDataModelRevisionCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readDataModelRevisionAttribute",
         readBasicInformationDataModelRevisionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationVendorNameCommandParams =
@@ -1659,8 +1634,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationVendorNameCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readVendorNameAttribute", readBasicInformationVendorNameAttributeInteractionInfo);
+    result.put("readVendorNameAttribute", readBasicInformationVendorNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationVendorIDCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationVendorIDAttributeInteractionInfo =
@@ -1671,8 +1645,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBasicInformationVendorIDCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readVendorIDAttribute", readBasicInformationVendorIDAttributeInteractionInfo);
+    result.put("readVendorIDAttribute", readBasicInformationVendorIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationProductNameCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationProductNameAttributeInteractionInfo =
@@ -1683,8 +1656,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationProductNameCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readProductNameAttribute", readBasicInformationProductNameAttributeInteractionInfo);
+    result.put("readProductNameAttribute", readBasicInformationProductNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationProductIDCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationProductIDAttributeInteractionInfo =
@@ -1695,8 +1667,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBasicInformationProductIDCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readProductIDAttribute", readBasicInformationProductIDAttributeInteractionInfo);
+    result.put("readProductIDAttribute", readBasicInformationProductIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationNodeLabelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationNodeLabelAttributeInteractionInfo =
@@ -1707,8 +1678,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationNodeLabelCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readNodeLabelAttribute", readBasicInformationNodeLabelAttributeInteractionInfo);
+    result.put("readNodeLabelAttribute", readBasicInformationNodeLabelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationLocationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationLocationAttributeInteractionInfo =
@@ -1719,8 +1689,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationLocationCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readLocationAttribute", readBasicInformationLocationAttributeInteractionInfo);
+    result.put("readLocationAttribute", readBasicInformationLocationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationHardwareVersionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationHardwareVersionAttributeInteractionInfo =
@@ -1731,7 +1700,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBasicInformationHardwareVersionCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readHardwareVersionAttribute",
         readBasicInformationHardwareVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationHardwareVersionStringCommandParams =
@@ -1745,7 +1714,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationHardwareVersionStringCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readHardwareVersionStringAttribute",
         readBasicInformationHardwareVersionStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationSoftwareVersionCommandParams =
@@ -1758,7 +1727,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBasicInformationSoftwareVersionCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readSoftwareVersionAttribute",
         readBasicInformationSoftwareVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationSoftwareVersionStringCommandParams =
@@ -1772,7 +1741,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationSoftwareVersionStringCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readSoftwareVersionStringAttribute",
         readBasicInformationSoftwareVersionStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationManufacturingDateCommandParams =
@@ -1786,7 +1755,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationManufacturingDateCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readManufacturingDateAttribute",
         readBasicInformationManufacturingDateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationPartNumberCommandParams =
@@ -1799,8 +1768,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationPartNumberCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readPartNumberAttribute", readBasicInformationPartNumberAttributeInteractionInfo);
+    result.put("readPartNumberAttribute", readBasicInformationPartNumberAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationProductURLCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationProductURLAttributeInteractionInfo =
@@ -1811,8 +1779,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationProductURLCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readProductURLAttribute", readBasicInformationProductURLAttributeInteractionInfo);
+    result.put("readProductURLAttribute", readBasicInformationProductURLAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationProductLabelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationProductLabelAttributeInteractionInfo =
@@ -1823,7 +1790,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationProductLabelCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readProductLabelAttribute", readBasicInformationProductLabelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationSerialNumberCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1835,7 +1802,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationSerialNumberCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readSerialNumberAttribute", readBasicInformationSerialNumberAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationLocalConfigDisabledCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1848,7 +1815,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBasicInformationLocalConfigDisabledCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readLocalConfigDisabledAttribute",
         readBasicInformationLocalConfigDisabledAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationReachableCommandParams =
@@ -1861,8 +1828,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBasicInformationReachableCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readReachableAttribute", readBasicInformationReachableAttributeInteractionInfo);
+    result.put("readReachableAttribute", readBasicInformationReachableAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationUniqueIDCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationUniqueIDAttributeInteractionInfo =
@@ -1873,8 +1839,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBasicInformationUniqueIDCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readUniqueIDAttribute", readBasicInformationUniqueIDAttributeInteractionInfo);
+    result.put("readUniqueIDAttribute", readBasicInformationUniqueIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationGeneratedCommandListAttributeInteractionInfo =
@@ -1889,7 +1854,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBasicInformationClusterGeneratedCommandListAttributeCallback(),
             readBasicInformationGeneratedCommandListCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBasicInformationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationAcceptedCommandListCommandParams =
@@ -1906,7 +1871,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBasicInformationClusterAcceptedCommandListAttributeCallback(),
             readBasicInformationAcceptedCommandListCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBasicInformationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationEventListCommandParams =
@@ -1921,8 +1886,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedBasicInformationClusterEventListAttributeCallback(),
             readBasicInformationEventListCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readEventListAttribute", readBasicInformationEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBasicInformationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationAttributeListAttributeInteractionInfo =
@@ -1937,7 +1901,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBasicInformationClusterAttributeListAttributeCallback(),
             readBasicInformationAttributeListCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readBasicInformationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -1949,8 +1913,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBasicInformationFeatureMapCommandParams);
-    readBasicInformationInteractionInfo.put(
-        "readFeatureMapAttribute", readBasicInformationFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readBasicInformationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBasicInformationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBasicInformationClusterRevisionAttributeInteractionInfo =
@@ -1961,12 +1924,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBasicInformationClusterRevisionCommandParams);
-    readBasicInformationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readBasicInformationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("basicInformation", readBasicInformationInteractionInfo);
-    Map<String, InteractionInfo> readOtaSoftwareUpdateProviderInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOtaSoftwareUpdateProviderInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo>
         readOtaSoftwareUpdateProviderGeneratedCommandListCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -1983,7 +1949,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateProviderClusterGeneratedCommandListAttributeCallback(),
             readOtaSoftwareUpdateProviderGeneratedCommandListCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readOtaSoftwareUpdateProviderGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2002,7 +1968,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateProviderClusterAcceptedCommandListAttributeCallback(),
             readOtaSoftwareUpdateProviderAcceptedCommandListCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readOtaSoftwareUpdateProviderAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateProviderEventListCommandParams =
@@ -2019,7 +1985,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateProviderClusterEventListAttributeCallback(),
             readOtaSoftwareUpdateProviderEventListCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readOtaSoftwareUpdateProviderEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateProviderAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2035,7 +2001,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateProviderClusterAttributeListAttributeCallback(),
             readOtaSoftwareUpdateProviderAttributeListCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readOtaSoftwareUpdateProviderAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateProviderFeatureMapCommandParams =
@@ -2048,7 +2014,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOtaSoftwareUpdateProviderFeatureMapCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readOtaSoftwareUpdateProviderFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateProviderClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2060,12 +2026,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOtaSoftwareUpdateProviderClusterRevisionCommandParams);
-    readOtaSoftwareUpdateProviderInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readOtaSoftwareUpdateProviderClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("otaSoftwareUpdateProvider", readOtaSoftwareUpdateProviderInteractionInfo);
-    Map<String, InteractionInfo> readOtaSoftwareUpdateRequestorInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOtaSoftwareUpdateRequestorInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo>
         readOtaSoftwareUpdateRequestorDefaultOTAProvidersCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -2082,7 +2051,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterDefaultOTAProvidersAttributeCallback(),
             readOtaSoftwareUpdateRequestorDefaultOTAProvidersCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readDefaultOTAProvidersAttribute",
         readOtaSoftwareUpdateRequestorDefaultOTAProvidersAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorUpdatePossibleCommandParams =
@@ -2095,7 +2064,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readOtaSoftwareUpdateRequestorUpdatePossibleCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readUpdatePossibleAttribute",
         readOtaSoftwareUpdateRequestorUpdatePossibleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorUpdateStateCommandParams =
@@ -2108,7 +2077,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOtaSoftwareUpdateRequestorUpdateStateCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readUpdateStateAttribute",
         readOtaSoftwareUpdateRequestorUpdateStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2127,7 +2096,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterUpdateStateProgressAttributeCallback(),
             readOtaSoftwareUpdateRequestorUpdateStateProgressCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readUpdateStateProgressAttribute",
         readOtaSoftwareUpdateRequestorUpdateStateProgressAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2146,7 +2115,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterGeneratedCommandListAttributeCallback(),
             readOtaSoftwareUpdateRequestorGeneratedCommandListCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readOtaSoftwareUpdateRequestorGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2165,7 +2134,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterAcceptedCommandListAttributeCallback(),
             readOtaSoftwareUpdateRequestorAcceptedCommandListCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readOtaSoftwareUpdateRequestorAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorEventListCommandParams =
@@ -2182,7 +2151,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterEventListAttributeCallback(),
             readOtaSoftwareUpdateRequestorEventListCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readOtaSoftwareUpdateRequestorEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2199,7 +2168,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOtaSoftwareUpdateRequestorClusterAttributeListAttributeCallback(),
             readOtaSoftwareUpdateRequestorAttributeListCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readOtaSoftwareUpdateRequestorAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorFeatureMapCommandParams =
@@ -2212,7 +2181,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOtaSoftwareUpdateRequestorFeatureMapCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readOtaSoftwareUpdateRequestorFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOtaSoftwareUpdateRequestorClusterRevisionCommandParams =
@@ -2225,13 +2194,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOtaSoftwareUpdateRequestorClusterRevisionCommandParams);
-    readOtaSoftwareUpdateRequestorInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readOtaSoftwareUpdateRequestorClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "otaSoftwareUpdateRequestor", readOtaSoftwareUpdateRequestorInteractionInfo);
-    Map<String, InteractionInfo> readLocalizationConfigurationInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readLocalizationConfigurationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readLocalizationConfigurationActiveLocaleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLocalizationConfigurationActiveLocaleAttributeInteractionInfo =
@@ -2242,7 +2213,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readLocalizationConfigurationActiveLocaleCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readActiveLocaleAttribute",
         readLocalizationConfigurationActiveLocaleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLocalizationConfigurationSupportedLocalesCommandParams =
@@ -2260,7 +2231,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLocalizationConfigurationClusterSupportedLocalesAttributeCallback(),
             readLocalizationConfigurationSupportedLocalesCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readSupportedLocalesAttribute",
         readLocalizationConfigurationSupportedLocalesAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2279,7 +2250,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLocalizationConfigurationClusterGeneratedCommandListAttributeCallback(),
             readLocalizationConfigurationGeneratedCommandListCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readLocalizationConfigurationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2298,7 +2269,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLocalizationConfigurationClusterAcceptedCommandListAttributeCallback(),
             readLocalizationConfigurationAcceptedCommandListCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readLocalizationConfigurationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLocalizationConfigurationEventListCommandParams =
@@ -2315,7 +2286,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLocalizationConfigurationClusterEventListAttributeCallback(),
             readLocalizationConfigurationEventListCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readLocalizationConfigurationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLocalizationConfigurationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2331,7 +2302,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLocalizationConfigurationClusterAttributeListAttributeCallback(),
             readLocalizationConfigurationAttributeListCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readLocalizationConfigurationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLocalizationConfigurationFeatureMapCommandParams =
@@ -2344,7 +2315,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readLocalizationConfigurationFeatureMapCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readLocalizationConfigurationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLocalizationConfigurationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2356,11 +2327,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLocalizationConfigurationClusterRevisionCommandParams);
-    readLocalizationConfigurationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readLocalizationConfigurationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("localizationConfiguration", readLocalizationConfigurationInteractionInfo);
-    Map<String, InteractionInfo> readTimeFormatLocalizationInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readTimeFormatLocalizationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readTimeFormatLocalizationHourFormatCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTimeFormatLocalizationHourFormatAttributeInteractionInfo =
@@ -2371,7 +2346,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTimeFormatLocalizationHourFormatCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readHourFormatAttribute", readTimeFormatLocalizationHourFormatAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationActiveCalendarTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2384,7 +2359,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTimeFormatLocalizationActiveCalendarTypeCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readActiveCalendarTypeAttribute",
         readTimeFormatLocalizationActiveCalendarTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -2403,7 +2378,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTimeFormatLocalizationClusterSupportedCalendarTypesAttributeCallback(),
             readTimeFormatLocalizationSupportedCalendarTypesCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readSupportedCalendarTypesAttribute",
         readTimeFormatLocalizationSupportedCalendarTypesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationGeneratedCommandListCommandParams =
@@ -2421,7 +2396,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTimeFormatLocalizationClusterGeneratedCommandListAttributeCallback(),
             readTimeFormatLocalizationGeneratedCommandListCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readTimeFormatLocalizationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationAcceptedCommandListCommandParams =
@@ -2439,7 +2414,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTimeFormatLocalizationClusterAcceptedCommandListAttributeCallback(),
             readTimeFormatLocalizationAcceptedCommandListCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readTimeFormatLocalizationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationEventListCommandParams =
@@ -2456,7 +2431,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTimeFormatLocalizationClusterEventListAttributeCallback(),
             readTimeFormatLocalizationEventListCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readTimeFormatLocalizationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2472,7 +2447,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTimeFormatLocalizationClusterAttributeListAttributeCallback(),
             readTimeFormatLocalizationAttributeListCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readTimeFormatLocalizationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationFeatureMapCommandParams =
@@ -2485,7 +2460,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readTimeFormatLocalizationFeatureMapCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readTimeFormatLocalizationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTimeFormatLocalizationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2497,11 +2472,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTimeFormatLocalizationClusterRevisionCommandParams);
-    readTimeFormatLocalizationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readTimeFormatLocalizationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("timeFormatLocalization", readTimeFormatLocalizationInteractionInfo);
-    Map<String, InteractionInfo> readUnitLocalizationInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readUnitLocalizationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readUnitLocalizationTemperatureUnitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitLocalizationTemperatureUnitAttributeInteractionInfo =
@@ -2512,7 +2491,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitLocalizationTemperatureUnitCommandParams);
-    readUnitLocalizationInteractionInfo.put(
+    result.put(
         "readTemperatureUnitAttribute",
         readUnitLocalizationTemperatureUnitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationGeneratedCommandListCommandParams =
@@ -2529,7 +2508,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitLocalizationClusterGeneratedCommandListAttributeCallback(),
             readUnitLocalizationGeneratedCommandListCommandParams);
-    readUnitLocalizationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readUnitLocalizationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationAcceptedCommandListCommandParams =
@@ -2546,7 +2525,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitLocalizationClusterAcceptedCommandListAttributeCallback(),
             readUnitLocalizationAcceptedCommandListCommandParams);
-    readUnitLocalizationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readUnitLocalizationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationEventListCommandParams =
@@ -2561,8 +2540,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitLocalizationClusterEventListAttributeCallback(),
             readUnitLocalizationEventListCommandParams);
-    readUnitLocalizationInteractionInfo.put(
-        "readEventListAttribute", readUnitLocalizationEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readUnitLocalizationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitLocalizationAttributeListAttributeInteractionInfo =
@@ -2577,7 +2555,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitLocalizationClusterAttributeListAttributeCallback(),
             readUnitLocalizationAttributeListCommandParams);
-    readUnitLocalizationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readUnitLocalizationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2589,8 +2567,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitLocalizationFeatureMapCommandParams);
-    readUnitLocalizationInteractionInfo.put(
-        "readFeatureMapAttribute", readUnitLocalizationFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readUnitLocalizationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitLocalizationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitLocalizationClusterRevisionAttributeInteractionInfo =
@@ -2601,12 +2578,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitLocalizationClusterRevisionCommandParams);
-    readUnitLocalizationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readUnitLocalizationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("unitLocalization", readUnitLocalizationInteractionInfo);
-    Map<String, InteractionInfo> readPowerSourceConfigurationInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readPowerSourceConfigurationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readPowerSourceConfigurationSourcesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceConfigurationSourcesAttributeInteractionInfo =
@@ -2621,8 +2601,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceConfigurationClusterSourcesAttributeCallback(),
             readPowerSourceConfigurationSourcesCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
-        "readSourcesAttribute", readPowerSourceConfigurationSourcesAttributeInteractionInfo);
+    result.put("readSourcesAttribute", readPowerSourceConfigurationSourcesAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readPowerSourceConfigurationGeneratedCommandListCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -2639,7 +2618,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceConfigurationClusterGeneratedCommandListAttributeCallback(),
             readPowerSourceConfigurationGeneratedCommandListCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readPowerSourceConfigurationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceConfigurationAcceptedCommandListCommandParams =
@@ -2657,7 +2636,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceConfigurationClusterAcceptedCommandListAttributeCallback(),
             readPowerSourceConfigurationAcceptedCommandListCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readPowerSourceConfigurationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceConfigurationEventListCommandParams =
@@ -2674,7 +2653,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceConfigurationClusterEventListAttributeCallback(),
             readPowerSourceConfigurationEventListCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readPowerSourceConfigurationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceConfigurationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2690,7 +2669,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceConfigurationClusterAttributeListAttributeCallback(),
             readPowerSourceConfigurationAttributeListCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readPowerSourceConfigurationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceConfigurationFeatureMapCommandParams =
@@ -2703,7 +2682,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPowerSourceConfigurationFeatureMapCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readPowerSourceConfigurationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceConfigurationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2715,11 +2694,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceConfigurationClusterRevisionCommandParams);
-    readPowerSourceConfigurationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readPowerSourceConfigurationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("powerSourceConfiguration", readPowerSourceConfigurationInteractionInfo);
-    Map<String, InteractionInfo> readPowerSourceInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readPowerSourceInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readPowerSourceStatusCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceStatusAttributeInteractionInfo =
@@ -2730,8 +2713,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceStatusCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readStatusAttribute", readPowerSourceStatusAttributeInteractionInfo);
+    result.put("readStatusAttribute", readPowerSourceStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceOrderCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceOrderAttributeInteractionInfo =
@@ -2742,8 +2724,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceOrderCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readOrderAttribute", readPowerSourceOrderAttributeInteractionInfo);
+    result.put("readOrderAttribute", readPowerSourceOrderAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceDescriptionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceDescriptionAttributeInteractionInfo =
@@ -2754,8 +2735,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readPowerSourceDescriptionCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readDescriptionAttribute", readPowerSourceDescriptionAttributeInteractionInfo);
+    result.put("readDescriptionAttribute", readPowerSourceDescriptionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredAssessedInputVoltageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceWiredAssessedInputVoltageAttributeInteractionInfo =
@@ -2770,7 +2750,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterWiredAssessedInputVoltageAttributeCallback(),
             readPowerSourceWiredAssessedInputVoltageCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredAssessedInputVoltageAttribute",
         readPowerSourceWiredAssessedInputVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredAssessedInputFrequencyCommandParams =
@@ -2787,7 +2767,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterWiredAssessedInputFrequencyAttributeCallback(),
             readPowerSourceWiredAssessedInputFrequencyCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredAssessedInputFrequencyAttribute",
         readPowerSourceWiredAssessedInputFrequencyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredCurrentTypeCommandParams =
@@ -2800,7 +2780,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceWiredCurrentTypeCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredCurrentTypeAttribute", readPowerSourceWiredCurrentTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredAssessedCurrentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2816,7 +2796,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterWiredAssessedCurrentAttributeCallback(),
             readPowerSourceWiredAssessedCurrentCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredAssessedCurrentAttribute",
         readPowerSourceWiredAssessedCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredNominalVoltageCommandParams =
@@ -2829,7 +2809,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPowerSourceWiredNominalVoltageCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredNominalVoltageAttribute",
         readPowerSourceWiredNominalVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredMaximumCurrentCommandParams =
@@ -2842,7 +2822,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPowerSourceWiredMaximumCurrentCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readWiredMaximumCurrentAttribute",
         readPowerSourceWiredMaximumCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceWiredPresentCommandParams =
@@ -2855,8 +2835,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readPowerSourceWiredPresentCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readWiredPresentAttribute", readPowerSourceWiredPresentAttributeInteractionInfo);
+    result.put("readWiredPresentAttribute", readPowerSourceWiredPresentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceActiveWiredFaultsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceActiveWiredFaultsAttributeInteractionInfo =
@@ -2871,7 +2850,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterActiveWiredFaultsAttributeCallback(),
             readPowerSourceActiveWiredFaultsCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readActiveWiredFaultsAttribute", readPowerSourceActiveWiredFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatVoltageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2884,8 +2863,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedPowerSourceClusterBatVoltageAttributeCallback(),
             readPowerSourceBatVoltageCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readBatVoltageAttribute", readPowerSourceBatVoltageAttributeInteractionInfo);
+    result.put("readBatVoltageAttribute", readPowerSourceBatVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatPercentRemainingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceBatPercentRemainingAttributeInteractionInfo =
@@ -2900,7 +2878,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterBatPercentRemainingAttributeCallback(),
             readPowerSourceBatPercentRemainingCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatPercentRemainingAttribute",
         readPowerSourceBatPercentRemainingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatTimeRemainingCommandParams =
@@ -2916,7 +2894,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterBatTimeRemainingAttributeCallback(),
             readPowerSourceBatTimeRemainingCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatTimeRemainingAttribute", readPowerSourceBatTimeRemainingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatChargeLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2928,7 +2906,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatChargeLevelCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatChargeLevelAttribute", readPowerSourceBatChargeLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatReplacementNeededCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2941,7 +2919,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readPowerSourceBatReplacementNeededCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatReplacementNeededAttribute",
         readPowerSourceBatReplacementNeededAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatReplaceabilityCommandParams =
@@ -2954,7 +2932,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatReplaceabilityCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatReplaceabilityAttribute", readPowerSourceBatReplaceabilityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatPresentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2966,8 +2944,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readPowerSourceBatPresentCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readBatPresentAttribute", readPowerSourceBatPresentAttributeInteractionInfo);
+    result.put("readBatPresentAttribute", readPowerSourceBatPresentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceActiveBatFaultsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceActiveBatFaultsAttributeInteractionInfo =
@@ -2981,7 +2958,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterActiveBatFaultsAttributeCallback(),
             readPowerSourceActiveBatFaultsCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readActiveBatFaultsAttribute", readPowerSourceActiveBatFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatReplacementDescriptionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -2994,7 +2971,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readPowerSourceBatReplacementDescriptionCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatReplacementDescriptionAttribute",
         readPowerSourceBatReplacementDescriptionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatCommonDesignationCommandParams =
@@ -3008,7 +2985,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatCommonDesignationCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatCommonDesignationAttribute",
         readPowerSourceBatCommonDesignationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatANSIDesignationCommandParams =
@@ -3022,7 +2999,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readPowerSourceBatANSIDesignationCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatANSIDesignationAttribute",
         readPowerSourceBatANSIDesignationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatIECDesignationCommandParams =
@@ -3036,7 +3013,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readPowerSourceBatIECDesignationCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatIECDesignationAttribute", readPowerSourceBatIECDesignationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatApprovedChemistryCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3049,7 +3026,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatApprovedChemistryCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatApprovedChemistryAttribute",
         readPowerSourceBatApprovedChemistryAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatCapacityCommandParams =
@@ -3062,8 +3039,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPowerSourceBatCapacityCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readBatCapacityAttribute", readPowerSourceBatCapacityAttributeInteractionInfo);
+    result.put("readBatCapacityAttribute", readPowerSourceBatCapacityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatQuantityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceBatQuantityAttributeInteractionInfo =
@@ -3074,8 +3050,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatQuantityCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readBatQuantityAttribute", readPowerSourceBatQuantityAttributeInteractionInfo);
+    result.put("readBatQuantityAttribute", readPowerSourceBatQuantityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatChargeStateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceBatChargeStateAttributeInteractionInfo =
@@ -3086,7 +3061,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceBatChargeStateCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatChargeStateAttribute", readPowerSourceBatChargeStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatTimeToFullChargeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3102,7 +3077,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterBatTimeToFullChargeAttributeCallback(),
             readPowerSourceBatTimeToFullChargeCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatTimeToFullChargeAttribute",
         readPowerSourceBatTimeToFullChargeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatFunctionalWhileChargingCommandParams =
@@ -3116,7 +3091,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readPowerSourceBatFunctionalWhileChargingCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatFunctionalWhileChargingAttribute",
         readPowerSourceBatFunctionalWhileChargingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceBatChargingCurrentCommandParams =
@@ -3133,7 +3108,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterBatChargingCurrentAttributeCallback(),
             readPowerSourceBatChargingCurrentCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readBatChargingCurrentAttribute",
         readPowerSourceBatChargingCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceActiveBatChargeFaultsCommandParams =
@@ -3150,7 +3125,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterActiveBatChargeFaultsAttributeCallback(),
             readPowerSourceActiveBatChargeFaultsCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readActiveBatChargeFaultsAttribute",
         readPowerSourceActiveBatChargeFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceGeneratedCommandListCommandParams =
@@ -3167,7 +3142,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterGeneratedCommandListAttributeCallback(),
             readPowerSourceGeneratedCommandListCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readPowerSourceGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceAcceptedCommandListCommandParams =
@@ -3184,7 +3159,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPowerSourceClusterAcceptedCommandListAttributeCallback(),
             readPowerSourceAcceptedCommandListCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readPowerSourceAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceEventListCommandParams =
@@ -3198,8 +3173,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedPowerSourceClusterEventListAttributeCallback(),
             readPowerSourceEventListCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readEventListAttribute", readPowerSourceEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readPowerSourceEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceAttributeListAttributeInteractionInfo =
@@ -3212,8 +3186,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedPowerSourceClusterAttributeListAttributeCallback(),
             readPowerSourceAttributeListCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readAttributeListAttribute", readPowerSourceAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readPowerSourceAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceFeatureMapAttributeInteractionInfo =
@@ -3224,8 +3197,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPowerSourceFeatureMapCommandParams);
-    readPowerSourceInteractionInfo.put(
-        "readFeatureMapAttribute", readPowerSourceFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readPowerSourceFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPowerSourceClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPowerSourceClusterRevisionAttributeInteractionInfo =
@@ -3236,10 +3208,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPowerSourceClusterRevisionCommandParams);
-    readPowerSourceInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readPowerSourceClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("powerSource", readPowerSourceInteractionInfo);
-    Map<String, InteractionInfo> readGeneralCommissioningInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readGeneralCommissioningInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readGeneralCommissioningBreadcrumbCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralCommissioningBreadcrumbAttributeInteractionInfo =
@@ -3250,7 +3226,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGeneralCommissioningBreadcrumbCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readBreadcrumbAttribute", readGeneralCommissioningBreadcrumbAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningRegulatoryConfigCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3262,7 +3238,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralCommissioningRegulatoryConfigCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readRegulatoryConfigAttribute",
         readGeneralCommissioningRegulatoryConfigAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningLocationCapabilityCommandParams =
@@ -3276,7 +3252,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralCommissioningLocationCapabilityCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readLocationCapabilityAttribute",
         readGeneralCommissioningLocationCapabilityAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -3291,7 +3267,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readGeneralCommissioningSupportsConcurrentConnectionCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readSupportsConcurrentConnectionAttribute",
         readGeneralCommissioningSupportsConcurrentConnectionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningGeneratedCommandListCommandParams =
@@ -3309,7 +3285,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralCommissioningClusterGeneratedCommandListAttributeCallback(),
             readGeneralCommissioningGeneratedCommandListCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readGeneralCommissioningGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningAcceptedCommandListCommandParams =
@@ -3327,7 +3303,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralCommissioningClusterAcceptedCommandListAttributeCallback(),
             readGeneralCommissioningAcceptedCommandListCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readGeneralCommissioningAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningEventListCommandParams =
@@ -3344,8 +3320,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralCommissioningClusterEventListAttributeCallback(),
             readGeneralCommissioningEventListCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
-        "readEventListAttribute", readGeneralCommissioningEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readGeneralCommissioningEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralCommissioningAttributeListAttributeInteractionInfo =
@@ -3360,7 +3335,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralCommissioningClusterAttributeListAttributeCallback(),
             readGeneralCommissioningAttributeListCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readGeneralCommissioningAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningFeatureMapCommandParams =
@@ -3373,7 +3348,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGeneralCommissioningFeatureMapCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readGeneralCommissioningFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralCommissioningClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3385,11 +3360,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralCommissioningClusterRevisionCommandParams);
-    readGeneralCommissioningInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readGeneralCommissioningClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("generalCommissioning", readGeneralCommissioningInteractionInfo);
-    Map<String, InteractionInfo> readNetworkCommissioningInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readNetworkCommissioningInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readNetworkCommissioningMaxNetworksCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readNetworkCommissioningMaxNetworksAttributeInteractionInfo =
@@ -3400,7 +3379,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readNetworkCommissioningMaxNetworksCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readMaxNetworksAttribute", readNetworkCommissioningMaxNetworksAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningNetworksCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3416,8 +3395,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterNetworksAttributeCallback(),
             readNetworkCommissioningNetworksCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
-        "readNetworksAttribute", readNetworkCommissioningNetworksAttributeInteractionInfo);
+    result.put("readNetworksAttribute", readNetworkCommissioningNetworksAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningScanMaxTimeSecondsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readNetworkCommissioningScanMaxTimeSecondsAttributeInteractionInfo =
@@ -3429,7 +3407,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readNetworkCommissioningScanMaxTimeSecondsCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readScanMaxTimeSecondsAttribute",
         readNetworkCommissioningScanMaxTimeSecondsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningConnectMaxTimeSecondsCommandParams =
@@ -3443,7 +3421,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readNetworkCommissioningConnectMaxTimeSecondsCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readConnectMaxTimeSecondsAttribute",
         readNetworkCommissioningConnectMaxTimeSecondsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningInterfaceEnabledCommandParams =
@@ -3456,7 +3434,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readNetworkCommissioningInterfaceEnabledCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readInterfaceEnabledAttribute",
         readNetworkCommissioningInterfaceEnabledAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningLastNetworkingStatusCommandParams =
@@ -3474,7 +3452,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterLastNetworkingStatusAttributeCallback(),
             readNetworkCommissioningLastNetworkingStatusCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readLastNetworkingStatusAttribute",
         readNetworkCommissioningLastNetworkingStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningLastNetworkIDCommandParams =
@@ -3491,7 +3469,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterLastNetworkIDAttributeCallback(),
             readNetworkCommissioningLastNetworkIDCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readLastNetworkIDAttribute",
         readNetworkCommissioningLastNetworkIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningLastConnectErrorValueCommandParams =
@@ -3509,7 +3487,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterLastConnectErrorValueAttributeCallback(),
             readNetworkCommissioningLastConnectErrorValueCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readLastConnectErrorValueAttribute",
         readNetworkCommissioningLastConnectErrorValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningGeneratedCommandListCommandParams =
@@ -3527,7 +3505,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterGeneratedCommandListAttributeCallback(),
             readNetworkCommissioningGeneratedCommandListCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readNetworkCommissioningGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningAcceptedCommandListCommandParams =
@@ -3545,7 +3523,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterAcceptedCommandListAttributeCallback(),
             readNetworkCommissioningAcceptedCommandListCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readNetworkCommissioningAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningEventListCommandParams =
@@ -3562,8 +3540,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterEventListAttributeCallback(),
             readNetworkCommissioningEventListCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
-        "readEventListAttribute", readNetworkCommissioningEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readNetworkCommissioningEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readNetworkCommissioningAttributeListAttributeInteractionInfo =
@@ -3578,7 +3555,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedNetworkCommissioningClusterAttributeListAttributeCallback(),
             readNetworkCommissioningAttributeListCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readNetworkCommissioningAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningFeatureMapCommandParams =
@@ -3591,7 +3568,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readNetworkCommissioningFeatureMapCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readNetworkCommissioningFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readNetworkCommissioningClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3603,11 +3580,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readNetworkCommissioningClusterRevisionCommandParams);
-    readNetworkCommissioningInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readNetworkCommissioningClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("networkCommissioning", readNetworkCommissioningInteractionInfo);
-    Map<String, InteractionInfo> readDiagnosticLogsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readDiagnosticLogsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readDiagnosticLogsGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDiagnosticLogsGeneratedCommandListAttributeInteractionInfo =
@@ -3622,7 +3603,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDiagnosticLogsClusterGeneratedCommandListAttributeCallback(),
             readDiagnosticLogsGeneratedCommandListCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readDiagnosticLogsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDiagnosticLogsAcceptedCommandListCommandParams =
@@ -3639,7 +3620,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDiagnosticLogsClusterAcceptedCommandListAttributeCallback(),
             readDiagnosticLogsAcceptedCommandListCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readDiagnosticLogsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDiagnosticLogsEventListCommandParams =
@@ -3653,8 +3634,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDiagnosticLogsClusterEventListAttributeCallback(),
             readDiagnosticLogsEventListCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
-        "readEventListAttribute", readDiagnosticLogsEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readDiagnosticLogsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDiagnosticLogsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDiagnosticLogsAttributeListAttributeInteractionInfo =
@@ -3668,7 +3648,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDiagnosticLogsClusterAttributeListAttributeCallback(),
             readDiagnosticLogsAttributeListCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readDiagnosticLogsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDiagnosticLogsFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3680,8 +3660,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDiagnosticLogsFeatureMapCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
-        "readFeatureMapAttribute", readDiagnosticLogsFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readDiagnosticLogsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDiagnosticLogsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDiagnosticLogsClusterRevisionAttributeInteractionInfo =
@@ -3692,10 +3671,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDiagnosticLogsClusterRevisionCommandParams);
-    readDiagnosticLogsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readDiagnosticLogsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("diagnosticLogs", readDiagnosticLogsInteractionInfo);
-    Map<String, InteractionInfo> readGeneralDiagnosticsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readGeneralDiagnosticsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readGeneralDiagnosticsNetworkInterfacesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralDiagnosticsNetworkInterfacesAttributeInteractionInfo =
@@ -3710,7 +3693,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterNetworkInterfacesAttributeCallback(),
             readGeneralDiagnosticsNetworkInterfacesCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readNetworkInterfacesAttribute",
         readGeneralDiagnosticsNetworkInterfacesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsRebootCountCommandParams =
@@ -3723,7 +3706,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralDiagnosticsRebootCountCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readRebootCountAttribute", readGeneralDiagnosticsRebootCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsUpTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3735,8 +3718,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGeneralDiagnosticsUpTimeCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
-        "readUpTimeAttribute", readGeneralDiagnosticsUpTimeAttributeInteractionInfo);
+    result.put("readUpTimeAttribute", readGeneralDiagnosticsUpTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsTotalOperationalHoursCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralDiagnosticsTotalOperationalHoursAttributeInteractionInfo =
@@ -3748,7 +3730,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGeneralDiagnosticsTotalOperationalHoursCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readTotalOperationalHoursAttribute",
         readGeneralDiagnosticsTotalOperationalHoursAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsBootReasonCommandParams =
@@ -3761,8 +3743,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralDiagnosticsBootReasonCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
-        "readBootReasonAttribute", readGeneralDiagnosticsBootReasonAttributeInteractionInfo);
+    result.put("readBootReasonAttribute", readGeneralDiagnosticsBootReasonAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsActiveHardwareFaultsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralDiagnosticsActiveHardwareFaultsAttributeInteractionInfo =
@@ -3777,7 +3758,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterActiveHardwareFaultsAttributeCallback(),
             readGeneralDiagnosticsActiveHardwareFaultsCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readActiveHardwareFaultsAttribute",
         readGeneralDiagnosticsActiveHardwareFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsActiveRadioFaultsCommandParams =
@@ -3794,7 +3775,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterActiveRadioFaultsAttributeCallback(),
             readGeneralDiagnosticsActiveRadioFaultsCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readActiveRadioFaultsAttribute",
         readGeneralDiagnosticsActiveRadioFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsActiveNetworkFaultsCommandParams =
@@ -3811,7 +3792,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterActiveNetworkFaultsAttributeCallback(),
             readGeneralDiagnosticsActiveNetworkFaultsCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readActiveNetworkFaultsAttribute",
         readGeneralDiagnosticsActiveNetworkFaultsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsTestEventTriggersEnabledCommandParams =
@@ -3825,7 +3806,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readGeneralDiagnosticsTestEventTriggersEnabledCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readTestEventTriggersEnabledAttribute",
         readGeneralDiagnosticsTestEventTriggersEnabledAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsGeneratedCommandListCommandParams =
@@ -3842,7 +3823,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterGeneratedCommandListAttributeCallback(),
             readGeneralDiagnosticsGeneratedCommandListCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readGeneralDiagnosticsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsAcceptedCommandListCommandParams =
@@ -3859,7 +3840,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterAcceptedCommandListAttributeCallback(),
             readGeneralDiagnosticsAcceptedCommandListCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readGeneralDiagnosticsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsEventListCommandParams =
@@ -3875,8 +3856,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterEventListAttributeCallback(),
             readGeneralDiagnosticsEventListCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
-        "readEventListAttribute", readGeneralDiagnosticsEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readGeneralDiagnosticsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralDiagnosticsAttributeListAttributeInteractionInfo =
@@ -3891,7 +3871,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGeneralDiagnosticsClusterAttributeListAttributeCallback(),
             readGeneralDiagnosticsAttributeListCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readGeneralDiagnosticsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3903,8 +3883,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGeneralDiagnosticsFeatureMapCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
-        "readFeatureMapAttribute", readGeneralDiagnosticsFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readGeneralDiagnosticsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGeneralDiagnosticsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGeneralDiagnosticsClusterRevisionAttributeInteractionInfo =
@@ -3915,11 +3894,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGeneralDiagnosticsClusterRevisionCommandParams);
-    readGeneralDiagnosticsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readGeneralDiagnosticsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("generalDiagnostics", readGeneralDiagnosticsInteractionInfo);
-    Map<String, InteractionInfo> readSoftwareDiagnosticsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readSoftwareDiagnosticsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsThreadMetricsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSoftwareDiagnosticsThreadMetricsAttributeInteractionInfo =
@@ -3934,7 +3917,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSoftwareDiagnosticsClusterThreadMetricsAttributeCallback(),
             readSoftwareDiagnosticsThreadMetricsCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readThreadMetricsAttribute", readSoftwareDiagnosticsThreadMetricsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsCurrentHeapFreeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -3946,7 +3929,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readSoftwareDiagnosticsCurrentHeapFreeCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readCurrentHeapFreeAttribute",
         readSoftwareDiagnosticsCurrentHeapFreeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsCurrentHeapUsedCommandParams =
@@ -3959,7 +3942,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readSoftwareDiagnosticsCurrentHeapUsedCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readCurrentHeapUsedAttribute",
         readSoftwareDiagnosticsCurrentHeapUsedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsCurrentHeapHighWatermarkCommandParams =
@@ -3973,7 +3956,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readSoftwareDiagnosticsCurrentHeapHighWatermarkCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readCurrentHeapHighWatermarkAttribute",
         readSoftwareDiagnosticsCurrentHeapHighWatermarkAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsGeneratedCommandListCommandParams =
@@ -3991,7 +3974,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSoftwareDiagnosticsClusterGeneratedCommandListAttributeCallback(),
             readSoftwareDiagnosticsGeneratedCommandListCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readSoftwareDiagnosticsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsAcceptedCommandListCommandParams =
@@ -4008,7 +3991,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSoftwareDiagnosticsClusterAcceptedCommandListAttributeCallback(),
             readSoftwareDiagnosticsAcceptedCommandListCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readSoftwareDiagnosticsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsEventListCommandParams =
@@ -4025,8 +4008,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSoftwareDiagnosticsClusterEventListAttributeCallback(),
             readSoftwareDiagnosticsEventListCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
-        "readEventListAttribute", readSoftwareDiagnosticsEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readSoftwareDiagnosticsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSoftwareDiagnosticsAttributeListAttributeInteractionInfo =
@@ -4041,7 +4023,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSoftwareDiagnosticsClusterAttributeListAttributeCallback(),
             readSoftwareDiagnosticsAttributeListCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readSoftwareDiagnosticsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -4053,7 +4035,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readSoftwareDiagnosticsFeatureMapCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readSoftwareDiagnosticsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSoftwareDiagnosticsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -4065,12 +4047,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readSoftwareDiagnosticsClusterRevisionCommandParams);
-    readSoftwareDiagnosticsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readSoftwareDiagnosticsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("softwareDiagnostics", readSoftwareDiagnosticsInteractionInfo);
-    Map<String, InteractionInfo> readThreadNetworkDiagnosticsInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readThreadNetworkDiagnosticsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsChannelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThreadNetworkDiagnosticsChannelAttributeInteractionInfo =
@@ -4085,8 +4070,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterChannelAttributeCallback(),
             readThreadNetworkDiagnosticsChannelCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
-        "readChannelAttribute", readThreadNetworkDiagnosticsChannelAttributeInteractionInfo);
+    result.put("readChannelAttribute", readThreadNetworkDiagnosticsChannelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRoutingRoleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThreadNetworkDiagnosticsRoutingRoleAttributeInteractionInfo =
@@ -4101,7 +4085,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterRoutingRoleAttributeCallback(),
             readThreadNetworkDiagnosticsRoutingRoleCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRoutingRoleAttribute",
         readThreadNetworkDiagnosticsRoutingRoleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsNetworkNameCommandParams =
@@ -4118,7 +4102,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterNetworkNameAttributeCallback(),
             readThreadNetworkDiagnosticsNetworkNameCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readNetworkNameAttribute",
         readThreadNetworkDiagnosticsNetworkNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsPanIdCommandParams =
@@ -4135,8 +4119,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterPanIdAttributeCallback(),
             readThreadNetworkDiagnosticsPanIdCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
-        "readPanIdAttribute", readThreadNetworkDiagnosticsPanIdAttributeInteractionInfo);
+    result.put("readPanIdAttribute", readThreadNetworkDiagnosticsPanIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsExtendedPanIdCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThreadNetworkDiagnosticsExtendedPanIdAttributeInteractionInfo =
@@ -4151,7 +4134,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterExtendedPanIdAttributeCallback(),
             readThreadNetworkDiagnosticsExtendedPanIdCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readExtendedPanIdAttribute",
         readThreadNetworkDiagnosticsExtendedPanIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsMeshLocalPrefixCommandParams =
@@ -4169,7 +4152,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterMeshLocalPrefixAttributeCallback(),
             readThreadNetworkDiagnosticsMeshLocalPrefixCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readMeshLocalPrefixAttribute",
         readThreadNetworkDiagnosticsMeshLocalPrefixAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsOverrunCountCommandParams =
@@ -4182,7 +4165,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsOverrunCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readOverrunCountAttribute",
         readThreadNetworkDiagnosticsOverrunCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsNeighborTableCommandParams =
@@ -4199,7 +4182,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterNeighborTableAttributeCallback(),
             readThreadNetworkDiagnosticsNeighborTableCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readNeighborTableAttribute",
         readThreadNetworkDiagnosticsNeighborTableAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRouteTableCommandParams =
@@ -4216,7 +4199,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterRouteTableAttributeCallback(),
             readThreadNetworkDiagnosticsRouteTableCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRouteTableAttribute", readThreadNetworkDiagnosticsRouteTableAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsPartitionIdCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -4232,7 +4215,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterPartitionIdAttributeCallback(),
             readThreadNetworkDiagnosticsPartitionIdCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPartitionIdAttribute",
         readThreadNetworkDiagnosticsPartitionIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsWeightingCommandParams =
@@ -4249,7 +4232,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterWeightingAttributeCallback(),
             readThreadNetworkDiagnosticsWeightingCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readWeightingAttribute", readThreadNetworkDiagnosticsWeightingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsDataVersionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -4265,7 +4248,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterDataVersionAttributeCallback(),
             readThreadNetworkDiagnosticsDataVersionCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readDataVersionAttribute",
         readThreadNetworkDiagnosticsDataVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsStableDataVersionCommandParams =
@@ -4283,7 +4266,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterStableDataVersionAttributeCallback(),
             readThreadNetworkDiagnosticsStableDataVersionCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readStableDataVersionAttribute",
         readThreadNetworkDiagnosticsStableDataVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsLeaderRouterIdCommandParams =
@@ -4300,7 +4283,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterLeaderRouterIdAttributeCallback(),
             readThreadNetworkDiagnosticsLeaderRouterIdCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readLeaderRouterIdAttribute",
         readThreadNetworkDiagnosticsLeaderRouterIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsDetachedRoleCountCommandParams =
@@ -4313,7 +4296,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsDetachedRoleCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readDetachedRoleCountAttribute",
         readThreadNetworkDiagnosticsDetachedRoleCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsChildRoleCountCommandParams =
@@ -4326,7 +4309,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsChildRoleCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readChildRoleCountAttribute",
         readThreadNetworkDiagnosticsChildRoleCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRouterRoleCountCommandParams =
@@ -4339,7 +4322,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsRouterRoleCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRouterRoleCountAttribute",
         readThreadNetworkDiagnosticsRouterRoleCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsLeaderRoleCountCommandParams =
@@ -4352,7 +4335,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsLeaderRoleCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readLeaderRoleCountAttribute",
         readThreadNetworkDiagnosticsLeaderRoleCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsAttachAttemptCountCommandParams =
@@ -4366,7 +4349,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsAttachAttemptCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttachAttemptCountAttribute",
         readThreadNetworkDiagnosticsAttachAttemptCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4381,7 +4364,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsPartitionIdChangeCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPartitionIdChangeCountAttribute",
         readThreadNetworkDiagnosticsPartitionIdChangeCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4397,7 +4380,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readBetterPartitionAttachAttemptCountAttribute",
         readThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsParentChangeCountCommandParams =
@@ -4410,7 +4393,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsParentChangeCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readParentChangeCountAttribute",
         readThreadNetworkDiagnosticsParentChangeCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxTotalCountCommandParams =
@@ -4423,7 +4406,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxTotalCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxTotalCountAttribute",
         readThreadNetworkDiagnosticsTxTotalCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxUnicastCountCommandParams =
@@ -4436,7 +4419,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxUnicastCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxUnicastCountAttribute",
         readThreadNetworkDiagnosticsTxUnicastCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxBroadcastCountCommandParams =
@@ -4449,7 +4432,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxBroadcastCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxBroadcastCountAttribute",
         readThreadNetworkDiagnosticsTxBroadcastCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxAckRequestedCountCommandParams =
@@ -4462,7 +4445,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxAckRequestedCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxAckRequestedCountAttribute",
         readThreadNetworkDiagnosticsTxAckRequestedCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxAckedCountCommandParams =
@@ -4475,7 +4458,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxAckedCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxAckedCountAttribute",
         readThreadNetworkDiagnosticsTxAckedCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4490,7 +4473,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxNoAckRequestedCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxNoAckRequestedCountAttribute",
         readThreadNetworkDiagnosticsTxNoAckRequestedCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxDataCountCommandParams =
@@ -4503,7 +4486,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxDataCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxDataCountAttribute",
         readThreadNetworkDiagnosticsTxDataCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxDataPollCountCommandParams =
@@ -4516,7 +4499,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxDataPollCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxDataPollCountAttribute",
         readThreadNetworkDiagnosticsTxDataPollCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxBeaconCountCommandParams =
@@ -4529,7 +4512,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxBeaconCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxBeaconCountAttribute",
         readThreadNetworkDiagnosticsTxBeaconCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4543,7 +4526,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxBeaconRequestCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxBeaconRequestCountAttribute",
         readThreadNetworkDiagnosticsTxBeaconRequestCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxOtherCountCommandParams =
@@ -4556,7 +4539,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxOtherCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxOtherCountAttribute",
         readThreadNetworkDiagnosticsTxOtherCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxRetryCountCommandParams =
@@ -4569,7 +4552,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxRetryCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxRetryCountAttribute",
         readThreadNetworkDiagnosticsTxRetryCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4585,7 +4568,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
                 readThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxDirectMaxRetryExpiryCountAttribute",
         readThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4601,7 +4584,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
                 readThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxIndirectMaxRetryExpiryCountAttribute",
         readThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxErrCcaCountCommandParams =
@@ -4614,7 +4597,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxErrCcaCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxErrCcaCountAttribute",
         readThreadNetworkDiagnosticsTxErrCcaCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsTxErrAbortCountCommandParams =
@@ -4627,7 +4610,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxErrAbortCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxErrAbortCountAttribute",
         readThreadNetworkDiagnosticsTxErrAbortCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4642,7 +4625,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsTxErrBusyChannelCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxErrBusyChannelCountAttribute",
         readThreadNetworkDiagnosticsTxErrBusyChannelCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxTotalCountCommandParams =
@@ -4655,7 +4638,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxTotalCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxTotalCountAttribute",
         readThreadNetworkDiagnosticsRxTotalCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxUnicastCountCommandParams =
@@ -4668,7 +4651,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxUnicastCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxUnicastCountAttribute",
         readThreadNetworkDiagnosticsRxUnicastCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxBroadcastCountCommandParams =
@@ -4681,7 +4664,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxBroadcastCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxBroadcastCountAttribute",
         readThreadNetworkDiagnosticsRxBroadcastCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxDataCountCommandParams =
@@ -4694,7 +4677,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxDataCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxDataCountAttribute",
         readThreadNetworkDiagnosticsRxDataCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxDataPollCountCommandParams =
@@ -4707,7 +4690,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxDataPollCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxDataPollCountAttribute",
         readThreadNetworkDiagnosticsRxDataPollCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxBeaconCountCommandParams =
@@ -4720,7 +4703,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxBeaconCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxBeaconCountAttribute",
         readThreadNetworkDiagnosticsRxBeaconCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4734,7 +4717,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxBeaconRequestCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxBeaconRequestCountAttribute",
         readThreadNetworkDiagnosticsRxBeaconRequestCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxOtherCountCommandParams =
@@ -4747,7 +4730,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxOtherCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxOtherCountAttribute",
         readThreadNetworkDiagnosticsRxOtherCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4762,7 +4745,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxAddressFilteredCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxAddressFilteredCountAttribute",
         readThreadNetworkDiagnosticsRxAddressFilteredCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4777,7 +4760,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxDestAddrFilteredCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxDestAddrFilteredCountAttribute",
         readThreadNetworkDiagnosticsRxDestAddrFilteredCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxDuplicatedCountCommandParams =
@@ -4790,7 +4773,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxDuplicatedCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxDuplicatedCountAttribute",
         readThreadNetworkDiagnosticsRxDuplicatedCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxErrNoFrameCountCommandParams =
@@ -4803,7 +4786,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrNoFrameCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrNoFrameCountAttribute",
         readThreadNetworkDiagnosticsRxErrNoFrameCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4818,7 +4801,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrUnknownNeighborCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrUnknownNeighborCountAttribute",
         readThreadNetworkDiagnosticsRxErrUnknownNeighborCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4833,7 +4816,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrInvalidSrcAddrCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrInvalidSrcAddrCountAttribute",
         readThreadNetworkDiagnosticsRxErrInvalidSrcAddrCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxErrSecCountCommandParams =
@@ -4846,7 +4829,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrSecCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrSecCountAttribute",
         readThreadNetworkDiagnosticsRxErrSecCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxErrFcsCountCommandParams =
@@ -4859,7 +4842,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrFcsCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrFcsCountAttribute",
         readThreadNetworkDiagnosticsRxErrFcsCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsRxErrOtherCountCommandParams =
@@ -4872,7 +4855,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsRxErrOtherCountCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readRxErrOtherCountAttribute",
         readThreadNetworkDiagnosticsRxErrOtherCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsActiveTimestampCommandParams =
@@ -4890,7 +4873,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterActiveTimestampAttributeCallback(),
             readThreadNetworkDiagnosticsActiveTimestampCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readActiveTimestampAttribute",
         readThreadNetworkDiagnosticsActiveTimestampAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsPendingTimestampCommandParams =
@@ -4908,7 +4891,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterPendingTimestampAttributeCallback(),
             readThreadNetworkDiagnosticsPendingTimestampCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPendingTimestampAttribute",
         readThreadNetworkDiagnosticsPendingTimestampAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsDelayCommandParams =
@@ -4925,8 +4908,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterDelayAttributeCallback(),
             readThreadNetworkDiagnosticsDelayCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
-        "readDelayAttribute", readThreadNetworkDiagnosticsDelayAttributeInteractionInfo);
+    result.put("readDelayAttribute", readThreadNetworkDiagnosticsDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsChannelPage0MaskCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThreadNetworkDiagnosticsChannelPage0MaskAttributeInteractionInfo =
@@ -4942,7 +4924,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterChannelPage0MaskAttributeCallback(),
             readThreadNetworkDiagnosticsChannelPage0MaskCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readChannelPage0MaskAttribute",
         readThreadNetworkDiagnosticsChannelPage0MaskAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4961,7 +4943,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterActiveNetworkFaultsListAttributeCallback(),
             readThreadNetworkDiagnosticsActiveNetworkFaultsListCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readActiveNetworkFaultsListAttribute",
         readThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -4980,7 +4962,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterGeneratedCommandListAttributeCallback(),
             readThreadNetworkDiagnosticsGeneratedCommandListCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readThreadNetworkDiagnosticsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsAcceptedCommandListCommandParams =
@@ -4998,7 +4980,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterAcceptedCommandListAttributeCallback(),
             readThreadNetworkDiagnosticsAcceptedCommandListCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readThreadNetworkDiagnosticsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsEventListCommandParams =
@@ -5015,7 +4997,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterEventListAttributeCallback(),
             readThreadNetworkDiagnosticsEventListCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readThreadNetworkDiagnosticsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5031,7 +5013,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThreadNetworkDiagnosticsClusterAttributeListAttributeCallback(),
             readThreadNetworkDiagnosticsAttributeListCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readThreadNetworkDiagnosticsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsFeatureMapCommandParams =
@@ -5044,7 +5026,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThreadNetworkDiagnosticsFeatureMapCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readThreadNetworkDiagnosticsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThreadNetworkDiagnosticsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5056,11 +5038,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThreadNetworkDiagnosticsClusterRevisionCommandParams);
-    readThreadNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readThreadNetworkDiagnosticsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("threadNetworkDiagnostics", readThreadNetworkDiagnosticsInteractionInfo);
-    Map<String, InteractionInfo> readWiFiNetworkDiagnosticsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readWiFiNetworkDiagnosticsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsBssidCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWiFiNetworkDiagnosticsBssidAttributeInteractionInfo =
@@ -5074,8 +5060,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterBssidAttributeCallback(),
             readWiFiNetworkDiagnosticsBssidCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
-        "readBssidAttribute", readWiFiNetworkDiagnosticsBssidAttributeInteractionInfo);
+    result.put("readBssidAttribute", readWiFiNetworkDiagnosticsBssidAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsSecurityTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWiFiNetworkDiagnosticsSecurityTypeAttributeInteractionInfo =
@@ -5090,7 +5075,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterSecurityTypeAttributeCallback(),
             readWiFiNetworkDiagnosticsSecurityTypeCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readSecurityTypeAttribute",
         readWiFiNetworkDiagnosticsSecurityTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsWiFiVersionCommandParams =
@@ -5107,7 +5092,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterWiFiVersionAttributeCallback(),
             readWiFiNetworkDiagnosticsWiFiVersionCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readWiFiVersionAttribute", readWiFiNetworkDiagnosticsWiFiVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsChannelNumberCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5123,7 +5108,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterChannelNumberAttributeCallback(),
             readWiFiNetworkDiagnosticsChannelNumberCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readChannelNumberAttribute",
         readWiFiNetworkDiagnosticsChannelNumberAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsRssiCommandParams =
@@ -5139,8 +5124,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterRssiAttributeCallback(),
             readWiFiNetworkDiagnosticsRssiCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
-        "readRssiAttribute", readWiFiNetworkDiagnosticsRssiAttributeInteractionInfo);
+    result.put("readRssiAttribute", readWiFiNetworkDiagnosticsRssiAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsBeaconLostCountCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWiFiNetworkDiagnosticsBeaconLostCountAttributeInteractionInfo =
@@ -5155,7 +5139,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterBeaconLostCountAttributeCallback(),
             readWiFiNetworkDiagnosticsBeaconLostCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readBeaconLostCountAttribute",
         readWiFiNetworkDiagnosticsBeaconLostCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsBeaconRxCountCommandParams =
@@ -5172,7 +5156,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterBeaconRxCountAttributeCallback(),
             readWiFiNetworkDiagnosticsBeaconRxCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readBeaconRxCountAttribute",
         readWiFiNetworkDiagnosticsBeaconRxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5191,7 +5175,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterPacketMulticastRxCountAttributeCallback(),
             readWiFiNetworkDiagnosticsPacketMulticastRxCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketMulticastRxCountAttribute",
         readWiFiNetworkDiagnosticsPacketMulticastRxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5210,7 +5194,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterPacketMulticastTxCountAttributeCallback(),
             readWiFiNetworkDiagnosticsPacketMulticastTxCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketMulticastTxCountAttribute",
         readWiFiNetworkDiagnosticsPacketMulticastTxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsPacketUnicastRxCountCommandParams =
@@ -5228,7 +5212,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterPacketUnicastRxCountAttributeCallback(),
             readWiFiNetworkDiagnosticsPacketUnicastRxCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketUnicastRxCountAttribute",
         readWiFiNetworkDiagnosticsPacketUnicastRxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsPacketUnicastTxCountCommandParams =
@@ -5246,7 +5230,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterPacketUnicastTxCountAttributeCallback(),
             readWiFiNetworkDiagnosticsPacketUnicastTxCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketUnicastTxCountAttribute",
         readWiFiNetworkDiagnosticsPacketUnicastTxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsCurrentMaxRateCommandParams =
@@ -5263,7 +5247,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterCurrentMaxRateAttributeCallback(),
             readWiFiNetworkDiagnosticsCurrentMaxRateCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readCurrentMaxRateAttribute",
         readWiFiNetworkDiagnosticsCurrentMaxRateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsOverrunCountCommandParams =
@@ -5280,7 +5264,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterOverrunCountAttributeCallback(),
             readWiFiNetworkDiagnosticsOverrunCountCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readOverrunCountAttribute",
         readWiFiNetworkDiagnosticsOverrunCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsGeneratedCommandListCommandParams =
@@ -5298,7 +5282,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterGeneratedCommandListAttributeCallback(),
             readWiFiNetworkDiagnosticsGeneratedCommandListCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readWiFiNetworkDiagnosticsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsAcceptedCommandListCommandParams =
@@ -5316,7 +5300,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterAcceptedCommandListAttributeCallback(),
             readWiFiNetworkDiagnosticsAcceptedCommandListCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readWiFiNetworkDiagnosticsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsEventListCommandParams =
@@ -5333,7 +5317,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterEventListAttributeCallback(),
             readWiFiNetworkDiagnosticsEventListCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readWiFiNetworkDiagnosticsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5349,7 +5333,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWiFiNetworkDiagnosticsClusterAttributeListAttributeCallback(),
             readWiFiNetworkDiagnosticsAttributeListCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readWiFiNetworkDiagnosticsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsFeatureMapCommandParams =
@@ -5362,7 +5346,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readWiFiNetworkDiagnosticsFeatureMapCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readWiFiNetworkDiagnosticsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWiFiNetworkDiagnosticsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5374,12 +5358,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWiFiNetworkDiagnosticsClusterRevisionCommandParams);
-    readWiFiNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readWiFiNetworkDiagnosticsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("wiFiNetworkDiagnostics", readWiFiNetworkDiagnosticsInteractionInfo);
-    Map<String, InteractionInfo> readEthernetNetworkDiagnosticsInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readEthernetNetworkDiagnosticsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsPHYRateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readEthernetNetworkDiagnosticsPHYRateAttributeInteractionInfo =
@@ -5394,7 +5381,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterPHYRateAttributeCallback(),
             readEthernetNetworkDiagnosticsPHYRateCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPHYRateAttribute", readEthernetNetworkDiagnosticsPHYRateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsFullDuplexCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5410,7 +5397,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterFullDuplexAttributeCallback(),
             readEthernetNetworkDiagnosticsFullDuplexCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readFullDuplexAttribute",
         readEthernetNetworkDiagnosticsFullDuplexAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsPacketRxCountCommandParams =
@@ -5423,7 +5410,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsPacketRxCountCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketRxCountAttribute",
         readEthernetNetworkDiagnosticsPacketRxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsPacketTxCountCommandParams =
@@ -5436,7 +5423,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsPacketTxCountCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readPacketTxCountAttribute",
         readEthernetNetworkDiagnosticsPacketTxCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsTxErrCountCommandParams =
@@ -5449,7 +5436,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsTxErrCountCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTxErrCountAttribute",
         readEthernetNetworkDiagnosticsTxErrCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsCollisionCountCommandParams =
@@ -5462,7 +5449,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsCollisionCountCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readCollisionCountAttribute",
         readEthernetNetworkDiagnosticsCollisionCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsOverrunCountCommandParams =
@@ -5475,7 +5462,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsOverrunCountCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readOverrunCountAttribute",
         readEthernetNetworkDiagnosticsOverrunCountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsCarrierDetectCommandParams =
@@ -5493,7 +5480,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterCarrierDetectAttributeCallback(),
             readEthernetNetworkDiagnosticsCarrierDetectCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readCarrierDetectAttribute",
         readEthernetNetworkDiagnosticsCarrierDetectAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsTimeSinceResetCommandParams =
@@ -5506,7 +5493,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsTimeSinceResetCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readTimeSinceResetAttribute",
         readEthernetNetworkDiagnosticsTimeSinceResetAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5525,7 +5512,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterGeneratedCommandListAttributeCallback(),
             readEthernetNetworkDiagnosticsGeneratedCommandListCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readEthernetNetworkDiagnosticsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5544,7 +5531,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterAcceptedCommandListAttributeCallback(),
             readEthernetNetworkDiagnosticsAcceptedCommandListCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readEthernetNetworkDiagnosticsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsEventListCommandParams =
@@ -5561,7 +5548,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterEventListAttributeCallback(),
             readEthernetNetworkDiagnosticsEventListCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readEthernetNetworkDiagnosticsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5578,7 +5565,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedEthernetNetworkDiagnosticsClusterAttributeListAttributeCallback(),
             readEthernetNetworkDiagnosticsAttributeListCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readEthernetNetworkDiagnosticsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsFeatureMapCommandParams =
@@ -5591,7 +5578,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readEthernetNetworkDiagnosticsFeatureMapCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readEthernetNetworkDiagnosticsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readEthernetNetworkDiagnosticsClusterRevisionCommandParams =
@@ -5604,13 +5591,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readEthernetNetworkDiagnosticsClusterRevisionCommandParams);
-    readEthernetNetworkDiagnosticsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readEthernetNetworkDiagnosticsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "ethernetNetworkDiagnostics", readEthernetNetworkDiagnosticsInteractionInfo);
-    Map<String, InteractionInfo> readBridgedDeviceBasicInformationInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBridgedDeviceBasicInformationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationVendorNameCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBridgedDeviceBasicInformationVendorNameAttributeInteractionInfo =
@@ -5621,7 +5610,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationVendorNameCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readVendorNameAttribute",
         readBridgedDeviceBasicInformationVendorNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationVendorIDCommandParams =
@@ -5634,7 +5623,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBridgedDeviceBasicInformationVendorIDCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readVendorIDAttribute", readBridgedDeviceBasicInformationVendorIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationProductNameCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5646,7 +5635,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationProductNameCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readProductNameAttribute",
         readBridgedDeviceBasicInformationProductNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationNodeLabelCommandParams =
@@ -5659,7 +5648,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationNodeLabelCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readNodeLabelAttribute",
         readBridgedDeviceBasicInformationNodeLabelAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5673,7 +5662,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBridgedDeviceBasicInformationHardwareVersionCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readHardwareVersionAttribute",
         readBridgedDeviceBasicInformationHardwareVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5688,7 +5677,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationHardwareVersionStringCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readHardwareVersionStringAttribute",
         readBridgedDeviceBasicInformationHardwareVersionStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5702,7 +5691,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBridgedDeviceBasicInformationSoftwareVersionCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readSoftwareVersionAttribute",
         readBridgedDeviceBasicInformationSoftwareVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5717,7 +5706,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationSoftwareVersionStringCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readSoftwareVersionStringAttribute",
         readBridgedDeviceBasicInformationSoftwareVersionStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5732,7 +5721,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationManufacturingDateCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readManufacturingDateAttribute",
         readBridgedDeviceBasicInformationManufacturingDateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationPartNumberCommandParams =
@@ -5745,7 +5734,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationPartNumberCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readPartNumberAttribute",
         readBridgedDeviceBasicInformationPartNumberAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationProductURLCommandParams =
@@ -5758,7 +5747,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationProductURLCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readProductURLAttribute",
         readBridgedDeviceBasicInformationProductURLAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationProductLabelCommandParams =
@@ -5771,7 +5760,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationProductLabelCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readProductLabelAttribute",
         readBridgedDeviceBasicInformationProductLabelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationSerialNumberCommandParams =
@@ -5784,7 +5773,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationSerialNumberCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readSerialNumberAttribute",
         readBridgedDeviceBasicInformationSerialNumberAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationReachableCommandParams =
@@ -5797,7 +5786,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBridgedDeviceBasicInformationReachableCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readReachableAttribute",
         readBridgedDeviceBasicInformationReachableAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationUniqueIDCommandParams =
@@ -5810,7 +5799,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBridgedDeviceBasicInformationUniqueIDCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readUniqueIDAttribute", readBridgedDeviceBasicInformationUniqueIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readBridgedDeviceBasicInformationGeneratedCommandListCommandParams =
@@ -5828,7 +5817,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBridgedDeviceBasicInformationClusterGeneratedCommandListAttributeCallback(),
             readBridgedDeviceBasicInformationGeneratedCommandListCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBridgedDeviceBasicInformationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5847,7 +5836,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBridgedDeviceBasicInformationClusterAcceptedCommandListAttributeCallback(),
             readBridgedDeviceBasicInformationAcceptedCommandListCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBridgedDeviceBasicInformationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationEventListCommandParams =
@@ -5864,7 +5853,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBridgedDeviceBasicInformationClusterEventListAttributeCallback(),
             readBridgedDeviceBasicInformationEventListCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readEventListAttribute",
         readBridgedDeviceBasicInformationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationAttributeListCommandParams =
@@ -5882,7 +5871,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBridgedDeviceBasicInformationClusterAttributeListAttributeCallback(),
             readBridgedDeviceBasicInformationAttributeListCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readBridgedDeviceBasicInformationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBridgedDeviceBasicInformationFeatureMapCommandParams =
@@ -5895,7 +5884,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBridgedDeviceBasicInformationFeatureMapCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readBridgedDeviceBasicInformationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -5909,12 +5898,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBridgedDeviceBasicInformationClusterRevisionCommandParams);
-    readBridgedDeviceBasicInformationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readBridgedDeviceBasicInformationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "bridgedDeviceBasicInformation", readBridgedDeviceBasicInformationInteractionInfo);
-    Map<String, InteractionInfo> readSwitchInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readSwitchInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readSwitchNumberOfPositionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchNumberOfPositionsAttributeInteractionInfo =
@@ -5925,7 +5917,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readSwitchNumberOfPositionsCommandParams);
-    readSwitchInteractionInfo.put(
+    result.put(
         "readNumberOfPositionsAttribute", readSwitchNumberOfPositionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchCurrentPositionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5937,8 +5929,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readSwitchCurrentPositionCommandParams);
-    readSwitchInteractionInfo.put(
-        "readCurrentPositionAttribute", readSwitchCurrentPositionAttributeInteractionInfo);
+    result.put("readCurrentPositionAttribute", readSwitchCurrentPositionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchMultiPressMaxCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchMultiPressMaxAttributeInteractionInfo =
@@ -5949,8 +5940,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readSwitchMultiPressMaxCommandParams);
-    readSwitchInteractionInfo.put(
-        "readMultiPressMaxAttribute", readSwitchMultiPressMaxAttributeInteractionInfo);
+    result.put("readMultiPressMaxAttribute", readSwitchMultiPressMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchGeneratedCommandListAttributeInteractionInfo =
@@ -5964,7 +5954,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedSwitchClusterGeneratedCommandListAttributeCallback(),
             readSwitchGeneratedCommandListCommandParams);
-    readSwitchInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readSwitchGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchAcceptedCommandListCommandParams =
@@ -5979,7 +5969,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedSwitchClusterAcceptedCommandListAttributeCallback(),
             readSwitchAcceptedCommandListCommandParams);
-    readSwitchInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readSwitchAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -5992,8 +5982,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedSwitchClusterEventListAttributeCallback(),
             readSwitchEventListCommandParams);
-    readSwitchInteractionInfo.put(
-        "readEventListAttribute", readSwitchEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readSwitchEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchAttributeListAttributeInteractionInfo =
@@ -6005,8 +5994,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedSwitchClusterAttributeListAttributeCallback(),
             readSwitchAttributeListCommandParams);
-    readSwitchInteractionInfo.put(
-        "readAttributeListAttribute", readSwitchAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readSwitchAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchFeatureMapAttributeInteractionInfo =
@@ -6017,8 +6005,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readSwitchFeatureMapCommandParams);
-    readSwitchInteractionInfo.put(
-        "readFeatureMapAttribute", readSwitchFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readSwitchFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readSwitchClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readSwitchClusterRevisionAttributeInteractionInfo =
@@ -6029,11 +6016,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readSwitchClusterRevisionCommandParams);
-    readSwitchInteractionInfo.put(
-        "readClusterRevisionAttribute", readSwitchClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("switch", readSwitchInteractionInfo);
-    Map<String, InteractionInfo> readAdministratorCommissioningInteractionInfo =
-        new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readSwitchClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readAdministratorCommissioningInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readAdministratorCommissioningWindowStatusCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAdministratorCommissioningWindowStatusAttributeInteractionInfo =
@@ -6044,7 +6033,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAdministratorCommissioningWindowStatusCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readWindowStatusAttribute",
         readAdministratorCommissioningWindowStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningAdminFabricIndexCommandParams =
@@ -6062,7 +6051,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterAdminFabricIndexAttributeCallback(),
             readAdministratorCommissioningAdminFabricIndexCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readAdminFabricIndexAttribute",
         readAdministratorCommissioningAdminFabricIndexAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningAdminVendorIdCommandParams =
@@ -6080,7 +6069,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterAdminVendorIdAttributeCallback(),
             readAdministratorCommissioningAdminVendorIdCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readAdminVendorIdAttribute",
         readAdministratorCommissioningAdminVendorIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -6099,7 +6088,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterGeneratedCommandListAttributeCallback(),
             readAdministratorCommissioningGeneratedCommandListCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readAdministratorCommissioningGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -6118,7 +6107,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterAcceptedCommandListAttributeCallback(),
             readAdministratorCommissioningAcceptedCommandListCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readAdministratorCommissioningAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningEventListCommandParams =
@@ -6135,7 +6124,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterEventListAttributeCallback(),
             readAdministratorCommissioningEventListCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readAdministratorCommissioningEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6152,7 +6141,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAdministratorCommissioningClusterAttributeListAttributeCallback(),
             readAdministratorCommissioningAttributeListCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readAdministratorCommissioningAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningFeatureMapCommandParams =
@@ -6165,7 +6154,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readAdministratorCommissioningFeatureMapCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readAdministratorCommissioningFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAdministratorCommissioningClusterRevisionCommandParams =
@@ -6178,12 +6167,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAdministratorCommissioningClusterRevisionCommandParams);
-    readAdministratorCommissioningInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readAdministratorCommissioningClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "administratorCommissioning", readAdministratorCommissioningInteractionInfo);
-    Map<String, InteractionInfo> readOperationalCredentialsInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOperationalCredentialsInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readOperationalCredentialsNOCsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOperationalCredentialsNOCsAttributeInteractionInfo =
@@ -6197,8 +6189,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterNOCsAttributeCallback(),
             readOperationalCredentialsNOCsCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
-        "readNOCsAttribute", readOperationalCredentialsNOCsAttributeInteractionInfo);
+    result.put("readNOCsAttribute", readOperationalCredentialsNOCsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsFabricsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOperationalCredentialsFabricsAttributeInteractionInfo =
@@ -6213,8 +6204,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterFabricsAttributeCallback(),
             readOperationalCredentialsFabricsCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
-        "readFabricsAttribute", readOperationalCredentialsFabricsAttributeInteractionInfo);
+    result.put("readFabricsAttribute", readOperationalCredentialsFabricsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsSupportedFabricsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOperationalCredentialsSupportedFabricsAttributeInteractionInfo =
@@ -6225,7 +6215,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOperationalCredentialsSupportedFabricsCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readSupportedFabricsAttribute",
         readOperationalCredentialsSupportedFabricsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsCommissionedFabricsCommandParams =
@@ -6239,7 +6229,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOperationalCredentialsCommissionedFabricsCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readCommissionedFabricsAttribute",
         readOperationalCredentialsCommissionedFabricsAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -6258,7 +6248,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterTrustedRootCertificatesAttributeCallback(),
             readOperationalCredentialsTrustedRootCertificatesCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readTrustedRootCertificatesAttribute",
         readOperationalCredentialsTrustedRootCertificatesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsCurrentFabricIndexCommandParams =
@@ -6272,7 +6262,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOperationalCredentialsCurrentFabricIndexCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readCurrentFabricIndexAttribute",
         readOperationalCredentialsCurrentFabricIndexAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsGeneratedCommandListCommandParams =
@@ -6290,7 +6280,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterGeneratedCommandListAttributeCallback(),
             readOperationalCredentialsGeneratedCommandListCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readOperationalCredentialsGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsAcceptedCommandListCommandParams =
@@ -6308,7 +6298,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterAcceptedCommandListAttributeCallback(),
             readOperationalCredentialsAcceptedCommandListCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readOperationalCredentialsAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsEventListCommandParams =
@@ -6325,7 +6315,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterEventListAttributeCallback(),
             readOperationalCredentialsEventListCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readOperationalCredentialsEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6341,7 +6331,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOperationalCredentialsClusterAttributeListAttributeCallback(),
             readOperationalCredentialsAttributeListCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readOperationalCredentialsAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsFeatureMapCommandParams =
@@ -6354,7 +6344,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOperationalCredentialsFeatureMapCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readOperationalCredentialsFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOperationalCredentialsClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6366,11 +6356,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOperationalCredentialsClusterRevisionCommandParams);
-    readOperationalCredentialsInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readOperationalCredentialsClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("operationalCredentials", readOperationalCredentialsInteractionInfo);
-    Map<String, InteractionInfo> readGroupKeyManagementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readGroupKeyManagementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readGroupKeyManagementGroupKeyMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupKeyManagementGroupKeyMapAttributeInteractionInfo =
@@ -6385,7 +6379,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterGroupKeyMapAttributeCallback(),
             readGroupKeyManagementGroupKeyMapCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readGroupKeyMapAttribute", readGroupKeyManagementGroupKeyMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementGroupTableCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6401,8 +6395,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterGroupTableAttributeCallback(),
             readGroupKeyManagementGroupTableCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
-        "readGroupTableAttribute", readGroupKeyManagementGroupTableAttributeInteractionInfo);
+    result.put("readGroupTableAttribute", readGroupKeyManagementGroupTableAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementMaxGroupsPerFabricCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupKeyManagementMaxGroupsPerFabricAttributeInteractionInfo =
@@ -6414,7 +6407,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGroupKeyManagementMaxGroupsPerFabricCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readMaxGroupsPerFabricAttribute",
         readGroupKeyManagementMaxGroupsPerFabricAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementMaxGroupKeysPerFabricCommandParams =
@@ -6428,7 +6421,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGroupKeyManagementMaxGroupKeysPerFabricCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readMaxGroupKeysPerFabricAttribute",
         readGroupKeyManagementMaxGroupKeysPerFabricAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementGeneratedCommandListCommandParams =
@@ -6445,7 +6438,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterGeneratedCommandListAttributeCallback(),
             readGroupKeyManagementGeneratedCommandListCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readGroupKeyManagementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementAcceptedCommandListCommandParams =
@@ -6462,7 +6455,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterAcceptedCommandListAttributeCallback(),
             readGroupKeyManagementAcceptedCommandListCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readGroupKeyManagementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementEventListCommandParams =
@@ -6478,8 +6471,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterEventListAttributeCallback(),
             readGroupKeyManagementEventListCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
-        "readEventListAttribute", readGroupKeyManagementEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readGroupKeyManagementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupKeyManagementAttributeListAttributeInteractionInfo =
@@ -6494,7 +6486,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedGroupKeyManagementClusterAttributeListAttributeCallback(),
             readGroupKeyManagementAttributeListCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readGroupKeyManagementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6506,8 +6498,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readGroupKeyManagementFeatureMapCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
-        "readFeatureMapAttribute", readGroupKeyManagementFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readGroupKeyManagementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readGroupKeyManagementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readGroupKeyManagementClusterRevisionAttributeInteractionInfo =
@@ -6518,11 +6509,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readGroupKeyManagementClusterRevisionCommandParams);
-    readGroupKeyManagementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readGroupKeyManagementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("groupKeyManagement", readGroupKeyManagementInteractionInfo);
-    Map<String, InteractionInfo> readFixedLabelInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readFixedLabelInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readFixedLabelLabelListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFixedLabelLabelListAttributeInteractionInfo =
@@ -6534,8 +6529,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFixedLabelClusterLabelListAttributeCallback(),
             readFixedLabelLabelListCommandParams);
-    readFixedLabelInteractionInfo.put(
-        "readLabelListAttribute", readFixedLabelLabelListAttributeInteractionInfo);
+    result.put("readLabelListAttribute", readFixedLabelLabelListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFixedLabelGeneratedCommandListAttributeInteractionInfo =
@@ -6550,7 +6544,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFixedLabelClusterGeneratedCommandListAttributeCallback(),
             readFixedLabelGeneratedCommandListCommandParams);
-    readFixedLabelInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readFixedLabelGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelAcceptedCommandListCommandParams =
@@ -6567,7 +6561,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFixedLabelClusterAcceptedCommandListAttributeCallback(),
             readFixedLabelAcceptedCommandListCommandParams);
-    readFixedLabelInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readFixedLabelAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelEventListCommandParams =
@@ -6581,8 +6575,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFixedLabelClusterEventListAttributeCallback(),
             readFixedLabelEventListCommandParams);
-    readFixedLabelInteractionInfo.put(
-        "readEventListAttribute", readFixedLabelEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readFixedLabelEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFixedLabelAttributeListAttributeInteractionInfo =
@@ -6594,8 +6587,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFixedLabelClusterAttributeListAttributeCallback(),
             readFixedLabelAttributeListCommandParams);
-    readFixedLabelInteractionInfo.put(
-        "readAttributeListAttribute", readFixedLabelAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readFixedLabelAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFixedLabelFeatureMapAttributeInteractionInfo =
@@ -6606,8 +6598,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readFixedLabelFeatureMapCommandParams);
-    readFixedLabelInteractionInfo.put(
-        "readFeatureMapAttribute", readFixedLabelFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readFixedLabelFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFixedLabelClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFixedLabelClusterRevisionAttributeInteractionInfo =
@@ -6618,10 +6609,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFixedLabelClusterRevisionCommandParams);
-    readFixedLabelInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readFixedLabelClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("fixedLabel", readFixedLabelInteractionInfo);
-    Map<String, InteractionInfo> readUserLabelInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readUserLabelInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readUserLabelLabelListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUserLabelLabelListAttributeInteractionInfo =
@@ -6633,8 +6628,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedUserLabelClusterLabelListAttributeCallback(),
             readUserLabelLabelListCommandParams);
-    readUserLabelInteractionInfo.put(
-        "readLabelListAttribute", readUserLabelLabelListAttributeInteractionInfo);
+    result.put("readLabelListAttribute", readUserLabelLabelListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUserLabelGeneratedCommandListAttributeInteractionInfo =
@@ -6649,7 +6643,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUserLabelClusterGeneratedCommandListAttributeCallback(),
             readUserLabelGeneratedCommandListCommandParams);
-    readUserLabelInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readUserLabelGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelAcceptedCommandListCommandParams =
@@ -6666,7 +6660,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUserLabelClusterAcceptedCommandListAttributeCallback(),
             readUserLabelAcceptedCommandListCommandParams);
-    readUserLabelInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readUserLabelAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelEventListCommandParams =
@@ -6680,8 +6674,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedUserLabelClusterEventListAttributeCallback(),
             readUserLabelEventListCommandParams);
-    readUserLabelInteractionInfo.put(
-        "readEventListAttribute", readUserLabelEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readUserLabelEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUserLabelAttributeListAttributeInteractionInfo =
@@ -6693,8 +6686,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedUserLabelClusterAttributeListAttributeCallback(),
             readUserLabelAttributeListCommandParams);
-    readUserLabelInteractionInfo.put(
-        "readAttributeListAttribute", readUserLabelAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readUserLabelAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUserLabelFeatureMapAttributeInteractionInfo =
@@ -6705,8 +6697,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUserLabelFeatureMapCommandParams);
-    readUserLabelInteractionInfo.put(
-        "readFeatureMapAttribute", readUserLabelFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readUserLabelFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUserLabelClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUserLabelClusterRevisionAttributeInteractionInfo =
@@ -6717,10 +6708,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUserLabelClusterRevisionCommandParams);
-    readUserLabelInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readUserLabelClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("userLabel", readUserLabelInteractionInfo);
-    Map<String, InteractionInfo> readBooleanStateInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBooleanStateInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBooleanStateStateValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBooleanStateStateValueAttributeInteractionInfo =
@@ -6731,8 +6726,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readBooleanStateStateValueCommandParams);
-    readBooleanStateInteractionInfo.put(
-        "readStateValueAttribute", readBooleanStateStateValueAttributeInteractionInfo);
+    result.put("readStateValueAttribute", readBooleanStateStateValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBooleanStateGeneratedCommandListAttributeInteractionInfo =
@@ -6747,7 +6741,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBooleanStateClusterGeneratedCommandListAttributeCallback(),
             readBooleanStateGeneratedCommandListCommandParams);
-    readBooleanStateInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBooleanStateGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateAcceptedCommandListCommandParams =
@@ -6764,7 +6758,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBooleanStateClusterAcceptedCommandListAttributeCallback(),
             readBooleanStateAcceptedCommandListCommandParams);
-    readBooleanStateInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBooleanStateAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateEventListCommandParams =
@@ -6778,8 +6772,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanStateClusterEventListAttributeCallback(),
             readBooleanStateEventListCommandParams);
-    readBooleanStateInteractionInfo.put(
-        "readEventListAttribute", readBooleanStateEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBooleanStateEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBooleanStateAttributeListAttributeInteractionInfo =
@@ -6792,8 +6785,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedBooleanStateClusterAttributeListAttributeCallback(),
             readBooleanStateAttributeListCommandParams);
-    readBooleanStateInteractionInfo.put(
-        "readAttributeListAttribute", readBooleanStateAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readBooleanStateAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBooleanStateFeatureMapAttributeInteractionInfo =
@@ -6804,8 +6796,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBooleanStateFeatureMapCommandParams);
-    readBooleanStateInteractionInfo.put(
-        "readFeatureMapAttribute", readBooleanStateFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readBooleanStateFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBooleanStateClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBooleanStateClusterRevisionAttributeInteractionInfo =
@@ -6816,10 +6807,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBooleanStateClusterRevisionCommandParams);
-    readBooleanStateInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readBooleanStateClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("booleanState", readBooleanStateInteractionInfo);
-    Map<String, InteractionInfo> readModeSelectInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readModeSelectInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readModeSelectDescriptionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectDescriptionAttributeInteractionInfo =
@@ -6830,8 +6825,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readModeSelectDescriptionCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readDescriptionAttribute", readModeSelectDescriptionAttributeInteractionInfo);
+    result.put("readDescriptionAttribute", readModeSelectDescriptionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectStandardNamespaceCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectStandardNamespaceAttributeInteractionInfo =
@@ -6845,7 +6839,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedModeSelectClusterStandardNamespaceAttributeCallback(),
             readModeSelectStandardNamespaceCommandParams);
-    readModeSelectInteractionInfo.put(
+    result.put(
         "readStandardNamespaceAttribute", readModeSelectStandardNamespaceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectSupportedModesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -6859,8 +6853,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedModeSelectClusterSupportedModesAttributeCallback(),
             readModeSelectSupportedModesCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readSupportedModesAttribute", readModeSelectSupportedModesAttributeInteractionInfo);
+    result.put("readSupportedModesAttribute", readModeSelectSupportedModesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectCurrentModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectCurrentModeAttributeInteractionInfo =
@@ -6871,8 +6864,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readModeSelectCurrentModeCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readCurrentModeAttribute", readModeSelectCurrentModeAttributeInteractionInfo);
+    result.put("readCurrentModeAttribute", readModeSelectCurrentModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectStartUpModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectStartUpModeAttributeInteractionInfo =
@@ -6884,8 +6876,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedModeSelectClusterStartUpModeAttributeCallback(),
             readModeSelectStartUpModeCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readStartUpModeAttribute", readModeSelectStartUpModeAttributeInteractionInfo);
+    result.put("readStartUpModeAttribute", readModeSelectStartUpModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectOnModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectOnModeAttributeInteractionInfo =
@@ -6897,8 +6888,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedModeSelectClusterOnModeAttributeCallback(),
             readModeSelectOnModeCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readOnModeAttribute", readModeSelectOnModeAttributeInteractionInfo);
+    result.put("readOnModeAttribute", readModeSelectOnModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectGeneratedCommandListAttributeInteractionInfo =
@@ -6913,7 +6903,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedModeSelectClusterGeneratedCommandListAttributeCallback(),
             readModeSelectGeneratedCommandListCommandParams);
-    readModeSelectInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readModeSelectGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectAcceptedCommandListCommandParams =
@@ -6930,7 +6920,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedModeSelectClusterAcceptedCommandListAttributeCallback(),
             readModeSelectAcceptedCommandListCommandParams);
-    readModeSelectInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readModeSelectAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectEventListCommandParams =
@@ -6944,8 +6934,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedModeSelectClusterEventListAttributeCallback(),
             readModeSelectEventListCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readEventListAttribute", readModeSelectEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readModeSelectEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectAttributeListAttributeInteractionInfo =
@@ -6957,8 +6946,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedModeSelectClusterAttributeListAttributeCallback(),
             readModeSelectAttributeListCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readAttributeListAttribute", readModeSelectAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readModeSelectAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectFeatureMapAttributeInteractionInfo =
@@ -6969,8 +6957,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readModeSelectFeatureMapCommandParams);
-    readModeSelectInteractionInfo.put(
-        "readFeatureMapAttribute", readModeSelectFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readModeSelectFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readModeSelectClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readModeSelectClusterRevisionAttributeInteractionInfo =
@@ -6981,10 +6968,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readModeSelectClusterRevisionCommandParams);
-    readModeSelectInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readModeSelectClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("modeSelect", readModeSelectInteractionInfo);
-    Map<String, InteractionInfo> readDoorLockInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readDoorLockInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readDoorLockLockStateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockLockStateAttributeInteractionInfo =
@@ -6996,8 +6987,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDoorLockClusterLockStateAttributeCallback(),
             readDoorLockLockStateCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readLockStateAttribute", readDoorLockLockStateAttributeInteractionInfo);
+    result.put("readLockStateAttribute", readDoorLockLockStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockLockTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockLockTypeAttributeInteractionInfo =
@@ -7008,8 +6998,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockLockTypeCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readLockTypeAttribute", readDoorLockLockTypeAttributeInteractionInfo);
+    result.put("readLockTypeAttribute", readDoorLockLockTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockActuatorEnabledCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockActuatorEnabledAttributeInteractionInfo =
@@ -7020,8 +7009,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockActuatorEnabledCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readActuatorEnabledAttribute", readDoorLockActuatorEnabledAttributeInteractionInfo);
+    result.put("readActuatorEnabledAttribute", readDoorLockActuatorEnabledAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockDoorStateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockDoorStateAttributeInteractionInfo =
@@ -7033,8 +7021,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDoorLockClusterDoorStateAttributeCallback(),
             readDoorLockDoorStateCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readDoorStateAttribute", readDoorLockDoorStateAttributeInteractionInfo);
+    result.put("readDoorStateAttribute", readDoorLockDoorStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockDoorOpenEventsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockDoorOpenEventsAttributeInteractionInfo =
@@ -7045,8 +7032,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDoorLockDoorOpenEventsCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readDoorOpenEventsAttribute", readDoorLockDoorOpenEventsAttributeInteractionInfo);
+    result.put("readDoorOpenEventsAttribute", readDoorLockDoorOpenEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockDoorClosedEventsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockDoorClosedEventsAttributeInteractionInfo =
@@ -7057,7 +7043,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDoorLockDoorClosedEventsCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readDoorClosedEventsAttribute", readDoorLockDoorClosedEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockOpenPeriodCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7069,8 +7055,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockOpenPeriodCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readOpenPeriodAttribute", readDoorLockOpenPeriodAttributeInteractionInfo);
+    result.put("readOpenPeriodAttribute", readDoorLockOpenPeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockNumberOfTotalUsersSupportedCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockNumberOfTotalUsersSupportedAttributeInteractionInfo =
@@ -7082,7 +7067,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfTotalUsersSupportedCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfTotalUsersSupportedAttribute",
         readDoorLockNumberOfTotalUsersSupportedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockNumberOfPINUsersSupportedCommandParams =
@@ -7096,7 +7081,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfPINUsersSupportedCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfPINUsersSupportedAttribute",
         readDoorLockNumberOfPINUsersSupportedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockNumberOfRFIDUsersSupportedCommandParams =
@@ -7110,7 +7095,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfRFIDUsersSupportedCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfRFIDUsersSupportedAttribute",
         readDoorLockNumberOfRFIDUsersSupportedAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -7125,7 +7110,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfWeekDaySchedulesSupportedPerUserCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfWeekDaySchedulesSupportedPerUserAttribute",
         readDoorLockNumberOfWeekDaySchedulesSupportedPerUserAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -7140,7 +7125,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfYearDaySchedulesSupportedPerUserCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfYearDaySchedulesSupportedPerUserAttribute",
         readDoorLockNumberOfYearDaySchedulesSupportedPerUserAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockNumberOfHolidaySchedulesSupportedCommandParams =
@@ -7154,7 +7139,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfHolidaySchedulesSupportedCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfHolidaySchedulesSupportedAttribute",
         readDoorLockNumberOfHolidaySchedulesSupportedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockMaxPINCodeLengthCommandParams =
@@ -7167,7 +7152,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockMaxPINCodeLengthCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readMaxPINCodeLengthAttribute", readDoorLockMaxPINCodeLengthAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockMinPINCodeLengthCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7179,7 +7164,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockMinPINCodeLengthCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readMinPINCodeLengthAttribute", readDoorLockMinPINCodeLengthAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockMaxRFIDCodeLengthCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7191,7 +7176,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockMaxRFIDCodeLengthCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readMaxRFIDCodeLengthAttribute", readDoorLockMaxRFIDCodeLengthAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockMinRFIDCodeLengthCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7203,7 +7188,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockMinRFIDCodeLengthCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readMinRFIDCodeLengthAttribute", readDoorLockMinRFIDCodeLengthAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockCredentialRulesSupportCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7216,7 +7201,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockCredentialRulesSupportCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readCredentialRulesSupportAttribute",
         readDoorLockCredentialRulesSupportAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockNumberOfCredentialsSupportedPerUserCommandParams =
@@ -7230,7 +7215,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockNumberOfCredentialsSupportedPerUserCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readNumberOfCredentialsSupportedPerUserAttribute",
         readDoorLockNumberOfCredentialsSupportedPerUserAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockLanguageCommandParams =
@@ -7243,8 +7228,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readDoorLockLanguageCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readLanguageAttribute", readDoorLockLanguageAttributeInteractionInfo);
+    result.put("readLanguageAttribute", readDoorLockLanguageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockLEDSettingsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockLEDSettingsAttributeInteractionInfo =
@@ -7255,8 +7239,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockLEDSettingsCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readLEDSettingsAttribute", readDoorLockLEDSettingsAttributeInteractionInfo);
+    result.put("readLEDSettingsAttribute", readDoorLockLEDSettingsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockAutoRelockTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockAutoRelockTimeAttributeInteractionInfo =
@@ -7267,8 +7250,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDoorLockAutoRelockTimeCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readAutoRelockTimeAttribute", readDoorLockAutoRelockTimeAttributeInteractionInfo);
+    result.put("readAutoRelockTimeAttribute", readDoorLockAutoRelockTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockSoundVolumeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockSoundVolumeAttributeInteractionInfo =
@@ -7279,8 +7261,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockSoundVolumeCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readSoundVolumeAttribute", readDoorLockSoundVolumeAttributeInteractionInfo);
+    result.put("readSoundVolumeAttribute", readDoorLockSoundVolumeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockOperatingModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockOperatingModeAttributeInteractionInfo =
@@ -7291,8 +7272,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockOperatingModeCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readOperatingModeAttribute", readDoorLockOperatingModeAttributeInteractionInfo);
+    result.put("readOperatingModeAttribute", readDoorLockOperatingModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockSupportedOperatingModesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockSupportedOperatingModesAttributeInteractionInfo =
@@ -7304,7 +7284,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockSupportedOperatingModesCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readSupportedOperatingModesAttribute",
         readDoorLockSupportedOperatingModesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockDefaultConfigurationRegisterCommandParams =
@@ -7318,7 +7298,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockDefaultConfigurationRegisterCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readDefaultConfigurationRegisterAttribute",
         readDoorLockDefaultConfigurationRegisterAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockEnableLocalProgrammingCommandParams =
@@ -7332,7 +7312,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockEnableLocalProgrammingCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readEnableLocalProgrammingAttribute",
         readDoorLockEnableLocalProgrammingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockEnableOneTouchLockingCommandParams =
@@ -7346,7 +7326,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockEnableOneTouchLockingCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readEnableOneTouchLockingAttribute",
         readDoorLockEnableOneTouchLockingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockEnableInsideStatusLEDCommandParams =
@@ -7360,7 +7340,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockEnableInsideStatusLEDCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readEnableInsideStatusLEDAttribute",
         readDoorLockEnableInsideStatusLEDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockEnablePrivacyModeButtonCommandParams =
@@ -7374,7 +7354,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockEnablePrivacyModeButtonCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readEnablePrivacyModeButtonAttribute",
         readDoorLockEnablePrivacyModeButtonAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockLocalProgrammingFeaturesCommandParams =
@@ -7388,7 +7368,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockLocalProgrammingFeaturesCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readLocalProgrammingFeaturesAttribute",
         readDoorLockLocalProgrammingFeaturesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockWrongCodeEntryLimitCommandParams =
@@ -7402,7 +7382,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockWrongCodeEntryLimitCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readWrongCodeEntryLimitAttribute",
         readDoorLockWrongCodeEntryLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockUserCodeTemporaryDisableTimeCommandParams =
@@ -7416,7 +7396,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockUserCodeTemporaryDisableTimeCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readUserCodeTemporaryDisableTimeAttribute",
         readDoorLockUserCodeTemporaryDisableTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockSendPINOverTheAirCommandParams =
@@ -7429,7 +7409,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockSendPINOverTheAirCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readSendPINOverTheAirAttribute", readDoorLockSendPINOverTheAirAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockRequirePINforRemoteOperationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7442,7 +7422,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readDoorLockRequirePINforRemoteOperationCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readRequirePINforRemoteOperationAttribute",
         readDoorLockRequirePINforRemoteOperationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockExpiringUserTimeoutCommandParams =
@@ -7456,7 +7436,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockExpiringUserTimeoutCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readExpiringUserTimeoutAttribute",
         readDoorLockExpiringUserTimeoutAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockGeneratedCommandListCommandParams =
@@ -7473,7 +7453,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDoorLockClusterGeneratedCommandListAttributeCallback(),
             readDoorLockGeneratedCommandListCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readDoorLockGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockAcceptedCommandListCommandParams =
@@ -7489,7 +7469,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedDoorLockClusterAcceptedCommandListAttributeCallback(),
             readDoorLockAcceptedCommandListCommandParams);
-    readDoorLockInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readDoorLockAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockEventListCommandParams =
@@ -7503,8 +7483,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDoorLockClusterEventListAttributeCallback(),
             readDoorLockEventListCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readEventListAttribute", readDoorLockEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readDoorLockEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockAttributeListAttributeInteractionInfo =
@@ -7516,8 +7495,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDoorLockClusterAttributeListAttributeCallback(),
             readDoorLockAttributeListCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readAttributeListAttribute", readDoorLockAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readDoorLockAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockFeatureMapAttributeInteractionInfo =
@@ -7528,8 +7506,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readDoorLockFeatureMapCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readFeatureMapAttribute", readDoorLockFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readDoorLockFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readDoorLockClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readDoorLockClusterRevisionAttributeInteractionInfo =
@@ -7540,10 +7517,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readDoorLockClusterRevisionCommandParams);
-    readDoorLockInteractionInfo.put(
-        "readClusterRevisionAttribute", readDoorLockClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("doorLock", readDoorLockInteractionInfo);
-    Map<String, InteractionInfo> readWindowCoveringInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readDoorLockClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readWindowCoveringInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readWindowCoveringTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringTypeAttributeInteractionInfo =
@@ -7554,8 +7534,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringTypeCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readTypeAttribute", readWindowCoveringTypeAttributeInteractionInfo);
+    result.put("readTypeAttribute", readWindowCoveringTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringPhysicalClosedLimitLiftCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringPhysicalClosedLimitLiftAttributeInteractionInfo =
@@ -7567,7 +7546,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringPhysicalClosedLimitLiftCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readPhysicalClosedLimitLiftAttribute",
         readWindowCoveringPhysicalClosedLimitLiftAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringPhysicalClosedLimitTiltCommandParams =
@@ -7581,7 +7560,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringPhysicalClosedLimitTiltCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readPhysicalClosedLimitTiltAttribute",
         readWindowCoveringPhysicalClosedLimitTiltAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringCurrentPositionLiftCommandParams =
@@ -7598,7 +7577,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionLiftAttributeCallback(),
             readWindowCoveringCurrentPositionLiftCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionLiftAttribute",
         readWindowCoveringCurrentPositionLiftAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringCurrentPositionTiltCommandParams =
@@ -7615,7 +7594,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionTiltAttributeCallback(),
             readWindowCoveringCurrentPositionTiltCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionTiltAttribute",
         readWindowCoveringCurrentPositionTiltAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringNumberOfActuationsLiftCommandParams =
@@ -7629,7 +7608,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringNumberOfActuationsLiftCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readNumberOfActuationsLiftAttribute",
         readWindowCoveringNumberOfActuationsLiftAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringNumberOfActuationsTiltCommandParams =
@@ -7643,7 +7622,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringNumberOfActuationsTiltCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readNumberOfActuationsTiltAttribute",
         readWindowCoveringNumberOfActuationsTiltAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringConfigStatusCommandParams =
@@ -7656,8 +7635,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringConfigStatusCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readConfigStatusAttribute", readWindowCoveringConfigStatusAttributeInteractionInfo);
+    result.put("readConfigStatusAttribute", readWindowCoveringConfigStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringCurrentPositionLiftPercentageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringCurrentPositionLiftPercentageAttributeInteractionInfo =
@@ -7673,7 +7651,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionLiftPercentageAttributeCallback(),
             readWindowCoveringCurrentPositionLiftPercentageCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionLiftPercentageAttribute",
         readWindowCoveringCurrentPositionLiftPercentageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringCurrentPositionTiltPercentageCommandParams =
@@ -7691,7 +7669,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionTiltPercentageAttributeCallback(),
             readWindowCoveringCurrentPositionTiltPercentageCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionTiltPercentageAttribute",
         readWindowCoveringCurrentPositionTiltPercentageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringOperationalStatusCommandParams =
@@ -7704,7 +7682,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringOperationalStatusCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readOperationalStatusAttribute",
         readWindowCoveringOperationalStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -7723,7 +7701,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterTargetPositionLiftPercent100thsAttributeCallback(),
             readWindowCoveringTargetPositionLiftPercent100thsCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readTargetPositionLiftPercent100thsAttribute",
         readWindowCoveringTargetPositionLiftPercent100thsAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -7742,7 +7720,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterTargetPositionTiltPercent100thsAttributeCallback(),
             readWindowCoveringTargetPositionTiltPercent100thsCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readTargetPositionTiltPercent100thsAttribute",
         readWindowCoveringTargetPositionTiltPercent100thsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringEndProductTypeCommandParams =
@@ -7755,7 +7733,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringEndProductTypeCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readEndProductTypeAttribute", readWindowCoveringEndProductTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readWindowCoveringCurrentPositionLiftPercent100thsCommandParams =
@@ -7773,7 +7751,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionLiftPercent100thsAttributeCallback(),
             readWindowCoveringCurrentPositionLiftPercent100thsCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionLiftPercent100thsAttribute",
         readWindowCoveringCurrentPositionLiftPercent100thsAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -7792,7 +7770,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterCurrentPositionTiltPercent100thsAttributeCallback(),
             readWindowCoveringCurrentPositionTiltPercent100thsCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readCurrentPositionTiltPercent100thsAttribute",
         readWindowCoveringCurrentPositionTiltPercent100thsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringInstalledOpenLimitLiftCommandParams =
@@ -7806,7 +7784,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringInstalledOpenLimitLiftCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readInstalledOpenLimitLiftAttribute",
         readWindowCoveringInstalledOpenLimitLiftAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringInstalledClosedLimitLiftCommandParams =
@@ -7820,7 +7798,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringInstalledClosedLimitLiftCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readInstalledClosedLimitLiftAttribute",
         readWindowCoveringInstalledClosedLimitLiftAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringInstalledOpenLimitTiltCommandParams =
@@ -7834,7 +7812,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringInstalledOpenLimitTiltCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readInstalledOpenLimitTiltAttribute",
         readWindowCoveringInstalledOpenLimitTiltAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringInstalledClosedLimitTiltCommandParams =
@@ -7848,7 +7826,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringInstalledClosedLimitTiltCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readInstalledClosedLimitTiltAttribute",
         readWindowCoveringInstalledClosedLimitTiltAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringModeCommandParams =
@@ -7861,8 +7839,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringModeCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readModeAttribute", readWindowCoveringModeAttributeInteractionInfo);
+    result.put("readModeAttribute", readWindowCoveringModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringSafetyStatusCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringSafetyStatusAttributeInteractionInfo =
@@ -7873,8 +7850,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringSafetyStatusCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readSafetyStatusAttribute", readWindowCoveringSafetyStatusAttributeInteractionInfo);
+    result.put("readSafetyStatusAttribute", readWindowCoveringSafetyStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringGeneratedCommandListAttributeInteractionInfo =
@@ -7889,7 +7865,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterGeneratedCommandListAttributeCallback(),
             readWindowCoveringGeneratedCommandListCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readWindowCoveringGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringAcceptedCommandListCommandParams =
@@ -7906,7 +7882,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterAcceptedCommandListAttributeCallback(),
             readWindowCoveringAcceptedCommandListCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readWindowCoveringAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringEventListCommandParams =
@@ -7920,8 +7896,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedWindowCoveringClusterEventListAttributeCallback(),
             readWindowCoveringEventListCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readEventListAttribute", readWindowCoveringEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readWindowCoveringEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringAttributeListAttributeInteractionInfo =
@@ -7935,7 +7910,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWindowCoveringClusterAttributeListAttributeCallback(),
             readWindowCoveringAttributeListCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readWindowCoveringAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -7947,8 +7922,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readWindowCoveringFeatureMapCommandParams);
-    readWindowCoveringInteractionInfo.put(
-        "readFeatureMapAttribute", readWindowCoveringFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readWindowCoveringFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWindowCoveringClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWindowCoveringClusterRevisionAttributeInteractionInfo =
@@ -7959,10 +7933,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWindowCoveringClusterRevisionCommandParams);
-    readWindowCoveringInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readWindowCoveringClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("windowCovering", readWindowCoveringInteractionInfo);
-    Map<String, InteractionInfo> readBarrierControlInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBarrierControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBarrierControlBarrierMovingStateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBarrierControlBarrierMovingStateAttributeInteractionInfo =
@@ -7974,7 +7952,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierMovingStateCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierMovingStateAttribute",
         readBarrierControlBarrierMovingStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierSafetyStatusCommandParams =
@@ -7988,7 +7966,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierSafetyStatusCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierSafetyStatusAttribute",
         readBarrierControlBarrierSafetyStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierCapabilitiesCommandParams =
@@ -8002,7 +7980,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierCapabilitiesCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierCapabilitiesAttribute",
         readBarrierControlBarrierCapabilitiesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierOpenEventsCommandParams =
@@ -8015,7 +7993,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierOpenEventsCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierOpenEventsAttribute",
         readBarrierControlBarrierOpenEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierCloseEventsCommandParams =
@@ -8029,7 +8007,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierCloseEventsCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierCloseEventsAttribute",
         readBarrierControlBarrierCloseEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierCommandOpenEventsCommandParams =
@@ -8043,7 +8021,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierCommandOpenEventsCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierCommandOpenEventsAttribute",
         readBarrierControlBarrierCommandOpenEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierCommandCloseEventsCommandParams =
@@ -8057,7 +8035,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierCommandCloseEventsCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierCommandCloseEventsAttribute",
         readBarrierControlBarrierCommandCloseEventsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierOpenPeriodCommandParams =
@@ -8070,7 +8048,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierOpenPeriodCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierOpenPeriodAttribute",
         readBarrierControlBarrierOpenPeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierClosePeriodCommandParams =
@@ -8084,7 +8062,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierClosePeriodCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierClosePeriodAttribute",
         readBarrierControlBarrierClosePeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlBarrierPositionCommandParams =
@@ -8097,7 +8075,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlBarrierPositionCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readBarrierPositionAttribute", readBarrierControlBarrierPositionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8113,7 +8091,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBarrierControlClusterGeneratedCommandListAttributeCallback(),
             readBarrierControlGeneratedCommandListCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBarrierControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlAcceptedCommandListCommandParams =
@@ -8130,7 +8108,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBarrierControlClusterAcceptedCommandListAttributeCallback(),
             readBarrierControlAcceptedCommandListCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBarrierControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlEventListCommandParams =
@@ -8144,8 +8122,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBarrierControlClusterEventListAttributeCallback(),
             readBarrierControlEventListCommandParams);
-    readBarrierControlInteractionInfo.put(
-        "readEventListAttribute", readBarrierControlEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBarrierControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBarrierControlAttributeListAttributeInteractionInfo =
@@ -8159,7 +8136,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBarrierControlClusterAttributeListAttributeCallback(),
             readBarrierControlAttributeListCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readBarrierControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8171,8 +8148,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBarrierControlFeatureMapCommandParams);
-    readBarrierControlInteractionInfo.put(
-        "readFeatureMapAttribute", readBarrierControlFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readBarrierControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBarrierControlClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBarrierControlClusterRevisionAttributeInteractionInfo =
@@ -8183,11 +8159,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBarrierControlClusterRevisionCommandParams);
-    readBarrierControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readBarrierControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("barrierControl", readBarrierControlInteractionInfo);
-    Map<String, InteractionInfo> readPumpConfigurationAndControlInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readPumpConfigurationAndControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxPressureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPumpConfigurationAndControlMaxPressureAttributeInteractionInfo =
@@ -8202,7 +8181,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxPressureAttributeCallback(),
             readPumpConfigurationAndControlMaxPressureCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxPressureAttribute",
         readPumpConfigurationAndControlMaxPressureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxSpeedCommandParams =
@@ -8219,7 +8198,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxSpeedAttributeCallback(),
             readPumpConfigurationAndControlMaxSpeedCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxSpeedAttribute", readPumpConfigurationAndControlMaxSpeedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxFlowCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8235,7 +8214,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxFlowAttributeCallback(),
             readPumpConfigurationAndControlMaxFlowCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxFlowAttribute", readPumpConfigurationAndControlMaxFlowAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMinConstPressureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8252,7 +8231,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMinConstPressureAttributeCallback(),
             readPumpConfigurationAndControlMinConstPressureCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMinConstPressureAttribute",
         readPumpConfigurationAndControlMinConstPressureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxConstPressureCommandParams =
@@ -8270,7 +8249,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxConstPressureAttributeCallback(),
             readPumpConfigurationAndControlMaxConstPressureCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxConstPressureAttribute",
         readPumpConfigurationAndControlMaxConstPressureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMinCompPressureCommandParams =
@@ -8288,7 +8267,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMinCompPressureAttributeCallback(),
             readPumpConfigurationAndControlMinCompPressureCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMinCompPressureAttribute",
         readPumpConfigurationAndControlMinCompPressureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxCompPressureCommandParams =
@@ -8306,7 +8285,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxCompPressureAttributeCallback(),
             readPumpConfigurationAndControlMaxCompPressureCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxCompPressureAttribute",
         readPumpConfigurationAndControlMaxCompPressureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMinConstSpeedCommandParams =
@@ -8324,7 +8303,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMinConstSpeedAttributeCallback(),
             readPumpConfigurationAndControlMinConstSpeedCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMinConstSpeedAttribute",
         readPumpConfigurationAndControlMinConstSpeedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxConstSpeedCommandParams =
@@ -8342,7 +8321,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxConstSpeedAttributeCallback(),
             readPumpConfigurationAndControlMaxConstSpeedCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxConstSpeedAttribute",
         readPumpConfigurationAndControlMaxConstSpeedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMinConstFlowCommandParams =
@@ -8360,7 +8339,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMinConstFlowAttributeCallback(),
             readPumpConfigurationAndControlMinConstFlowCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMinConstFlowAttribute",
         readPumpConfigurationAndControlMinConstFlowAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxConstFlowCommandParams =
@@ -8378,7 +8357,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxConstFlowAttributeCallback(),
             readPumpConfigurationAndControlMaxConstFlowCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxConstFlowAttribute",
         readPumpConfigurationAndControlMaxConstFlowAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMinConstTempCommandParams =
@@ -8396,7 +8375,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMinConstTempAttributeCallback(),
             readPumpConfigurationAndControlMinConstTempCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMinConstTempAttribute",
         readPumpConfigurationAndControlMinConstTempAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlMaxConstTempCommandParams =
@@ -8414,7 +8393,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterMaxConstTempAttributeCallback(),
             readPumpConfigurationAndControlMaxConstTempCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readMaxConstTempAttribute",
         readPumpConfigurationAndControlMaxConstTempAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlPumpStatusCommandParams =
@@ -8427,7 +8406,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlPumpStatusCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readPumpStatusAttribute",
         readPumpConfigurationAndControlPumpStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -8442,7 +8421,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlEffectiveOperationModeCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readEffectiveOperationModeAttribute",
         readPumpConfigurationAndControlEffectiveOperationModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -8457,7 +8436,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlEffectiveControlModeCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readEffectiveControlModeAttribute",
         readPumpConfigurationAndControlEffectiveControlModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlCapacityCommandParams =
@@ -8474,7 +8453,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterCapacityAttributeCallback(),
             readPumpConfigurationAndControlCapacityCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readCapacityAttribute", readPumpConfigurationAndControlCapacityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlSpeedCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8490,8 +8469,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterSpeedAttributeCallback(),
             readPumpConfigurationAndControlSpeedCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
-        "readSpeedAttribute", readPumpConfigurationAndControlSpeedAttributeInteractionInfo);
+    result.put("readSpeedAttribute", readPumpConfigurationAndControlSpeedAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readPumpConfigurationAndControlLifetimeRunningHoursCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -8508,7 +8486,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterLifetimeRunningHoursAttributeCallback(),
             readPumpConfigurationAndControlLifetimeRunningHoursCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readLifetimeRunningHoursAttribute",
         readPumpConfigurationAndControlLifetimeRunningHoursAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlPowerCommandParams =
@@ -8525,8 +8503,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterPowerAttributeCallback(),
             readPumpConfigurationAndControlPowerCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
-        "readPowerAttribute", readPumpConfigurationAndControlPowerAttributeInteractionInfo);
+    result.put("readPowerAttribute", readPumpConfigurationAndControlPowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readPumpConfigurationAndControlLifetimeEnergyConsumedCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -8543,7 +8520,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterLifetimeEnergyConsumedAttributeCallback(),
             readPumpConfigurationAndControlLifetimeEnergyConsumedCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readLifetimeEnergyConsumedAttribute",
         readPumpConfigurationAndControlLifetimeEnergyConsumedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlOperationModeCommandParams =
@@ -8556,7 +8533,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlOperationModeCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readOperationModeAttribute",
         readPumpConfigurationAndControlOperationModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlControlModeCommandParams =
@@ -8569,7 +8546,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlControlModeCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readControlModeAttribute",
         readPumpConfigurationAndControlControlModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -8588,7 +8565,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterGeneratedCommandListAttributeCallback(),
             readPumpConfigurationAndControlGeneratedCommandListCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readPumpConfigurationAndControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -8607,7 +8584,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterAcceptedCommandListAttributeCallback(),
             readPumpConfigurationAndControlAcceptedCommandListCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readPumpConfigurationAndControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlEventListCommandParams =
@@ -8624,7 +8601,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterEventListAttributeCallback(),
             readPumpConfigurationAndControlEventListCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readPumpConfigurationAndControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8641,7 +8618,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPumpConfigurationAndControlClusterAttributeListAttributeCallback(),
             readPumpConfigurationAndControlAttributeListCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readPumpConfigurationAndControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlFeatureMapCommandParams =
@@ -8654,7 +8631,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPumpConfigurationAndControlFeatureMapCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readPumpConfigurationAndControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPumpConfigurationAndControlClusterRevisionCommandParams =
@@ -8667,12 +8644,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPumpConfigurationAndControlClusterRevisionCommandParams);
-    readPumpConfigurationAndControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readPumpConfigurationAndControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "pumpConfigurationAndControl", readPumpConfigurationAndControlInteractionInfo);
-    Map<String, InteractionInfo> readThermostatInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readThermostatInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readThermostatLocalTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatLocalTemperatureAttributeInteractionInfo =
@@ -8686,7 +8666,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterLocalTemperatureAttributeCallback(),
             readThermostatLocalTemperatureCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readLocalTemperatureAttribute", readThermostatLocalTemperatureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOutdoorTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8702,7 +8682,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterOutdoorTemperatureAttributeCallback(),
             readThermostatOutdoorTemperatureCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOutdoorTemperatureAttribute",
         readThermostatOutdoorTemperatureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupancyCommandParams =
@@ -8715,8 +8695,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatOccupancyCommandParams);
-    readThermostatInteractionInfo.put(
-        "readOccupancyAttribute", readThermostatOccupancyAttributeInteractionInfo);
+    result.put("readOccupancyAttribute", readThermostatOccupancyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAbsMinHeatSetpointLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatAbsMinHeatSetpointLimitAttributeInteractionInfo =
@@ -8728,7 +8707,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatAbsMinHeatSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readAbsMinHeatSetpointLimitAttribute",
         readThermostatAbsMinHeatSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAbsMaxHeatSetpointLimitCommandParams =
@@ -8742,7 +8721,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatAbsMaxHeatSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readAbsMaxHeatSetpointLimitAttribute",
         readThermostatAbsMaxHeatSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAbsMinCoolSetpointLimitCommandParams =
@@ -8756,7 +8735,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatAbsMinCoolSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readAbsMinCoolSetpointLimitAttribute",
         readThermostatAbsMinCoolSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAbsMaxCoolSetpointLimitCommandParams =
@@ -8770,7 +8749,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatAbsMaxCoolSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readAbsMaxCoolSetpointLimitAttribute",
         readThermostatAbsMaxCoolSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatPICoolingDemandCommandParams =
@@ -8783,7 +8762,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatPICoolingDemandCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readPICoolingDemandAttribute", readThermostatPICoolingDemandAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatPIHeatingDemandCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8795,7 +8774,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatPIHeatingDemandCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readPIHeatingDemandAttribute", readThermostatPIHeatingDemandAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatHVACSystemTypeConfigurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -8808,7 +8787,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatHVACSystemTypeConfigurationCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readHVACSystemTypeConfigurationAttribute",
         readThermostatHVACSystemTypeConfigurationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatLocalTemperatureCalibrationCommandParams =
@@ -8822,7 +8801,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatLocalTemperatureCalibrationCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readLocalTemperatureCalibrationAttribute",
         readThermostatLocalTemperatureCalibrationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupiedCoolingSetpointCommandParams =
@@ -8836,7 +8815,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatOccupiedCoolingSetpointCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOccupiedCoolingSetpointAttribute",
         readThermostatOccupiedCoolingSetpointAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupiedHeatingSetpointCommandParams =
@@ -8850,7 +8829,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatOccupiedHeatingSetpointCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOccupiedHeatingSetpointAttribute",
         readThermostatOccupiedHeatingSetpointAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatUnoccupiedCoolingSetpointCommandParams =
@@ -8864,7 +8843,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatUnoccupiedCoolingSetpointCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readUnoccupiedCoolingSetpointAttribute",
         readThermostatUnoccupiedCoolingSetpointAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatUnoccupiedHeatingSetpointCommandParams =
@@ -8878,7 +8857,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatUnoccupiedHeatingSetpointCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readUnoccupiedHeatingSetpointAttribute",
         readThermostatUnoccupiedHeatingSetpointAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatMinHeatSetpointLimitCommandParams =
@@ -8892,7 +8871,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatMinHeatSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readMinHeatSetpointLimitAttribute",
         readThermostatMinHeatSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatMaxHeatSetpointLimitCommandParams =
@@ -8906,7 +8885,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatMaxHeatSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readMaxHeatSetpointLimitAttribute",
         readThermostatMaxHeatSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatMinCoolSetpointLimitCommandParams =
@@ -8920,7 +8899,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatMinCoolSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readMinCoolSetpointLimitAttribute",
         readThermostatMinCoolSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatMaxCoolSetpointLimitCommandParams =
@@ -8934,7 +8913,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatMaxCoolSetpointLimitCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readMaxCoolSetpointLimitAttribute",
         readThermostatMaxCoolSetpointLimitAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatMinSetpointDeadBandCommandParams =
@@ -8948,7 +8927,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatMinSetpointDeadBandCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readMinSetpointDeadBandAttribute",
         readThermostatMinSetpointDeadBandAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatRemoteSensingCommandParams =
@@ -8961,8 +8940,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatRemoteSensingCommandParams);
-    readThermostatInteractionInfo.put(
-        "readRemoteSensingAttribute", readThermostatRemoteSensingAttributeInteractionInfo);
+    result.put("readRemoteSensingAttribute", readThermostatRemoteSensingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatControlSequenceOfOperationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatControlSequenceOfOperationAttributeInteractionInfo =
@@ -8974,7 +8952,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatControlSequenceOfOperationCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readControlSequenceOfOperationAttribute",
         readThermostatControlSequenceOfOperationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatSystemModeCommandParams =
@@ -8987,8 +8965,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatSystemModeCommandParams);
-    readThermostatInteractionInfo.put(
-        "readSystemModeAttribute", readThermostatSystemModeAttributeInteractionInfo);
+    result.put("readSystemModeAttribute", readThermostatSystemModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatThermostatRunningModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatThermostatRunningModeAttributeInteractionInfo =
@@ -9000,7 +8977,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatThermostatRunningModeCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readThermostatRunningModeAttribute",
         readThermostatThermostatRunningModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatStartOfWeekCommandParams =
@@ -9013,8 +8990,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatStartOfWeekCommandParams);
-    readThermostatInteractionInfo.put(
-        "readStartOfWeekAttribute", readThermostatStartOfWeekAttributeInteractionInfo);
+    result.put("readStartOfWeekAttribute", readThermostatStartOfWeekAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatNumberOfWeeklyTransitionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatNumberOfWeeklyTransitionsAttributeInteractionInfo =
@@ -9026,7 +9002,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatNumberOfWeeklyTransitionsCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readNumberOfWeeklyTransitionsAttribute",
         readThermostatNumberOfWeeklyTransitionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatNumberOfDailyTransitionsCommandParams =
@@ -9040,7 +9016,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatNumberOfDailyTransitionsCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readNumberOfDailyTransitionsAttribute",
         readThermostatNumberOfDailyTransitionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatTemperatureSetpointHoldCommandParams =
@@ -9054,7 +9030,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatTemperatureSetpointHoldCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readTemperatureSetpointHoldAttribute",
         readThermostatTemperatureSetpointHoldAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatTemperatureSetpointHoldDurationCommandParams =
@@ -9072,7 +9048,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterTemperatureSetpointHoldDurationAttributeCallback(),
             readThermostatTemperatureSetpointHoldDurationCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readTemperatureSetpointHoldDurationAttribute",
         readThermostatTemperatureSetpointHoldDurationAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9087,7 +9063,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatThermostatProgrammingOperationModeCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readThermostatProgrammingOperationModeAttribute",
         readThermostatThermostatProgrammingOperationModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatThermostatRunningStateCommandParams =
@@ -9101,7 +9077,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatThermostatRunningStateCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readThermostatRunningStateAttribute",
         readThermostatThermostatRunningStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatSetpointChangeSourceCommandParams =
@@ -9115,7 +9091,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatSetpointChangeSourceCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readSetpointChangeSourceAttribute",
         readThermostatSetpointChangeSourceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatSetpointChangeAmountCommandParams =
@@ -9132,7 +9108,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterSetpointChangeAmountAttributeCallback(),
             readThermostatSetpointChangeAmountCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readSetpointChangeAmountAttribute",
         readThermostatSetpointChangeAmountAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatSetpointChangeSourceTimestampCommandParams =
@@ -9146,7 +9122,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThermostatSetpointChangeSourceTimestampCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readSetpointChangeSourceTimestampAttribute",
         readThermostatSetpointChangeSourceTimestampAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupiedSetbackCommandParams =
@@ -9161,7 +9137,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedThermostatClusterOccupiedSetbackAttributeCallback(),
             readThermostatOccupiedSetbackCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOccupiedSetbackAttribute", readThermostatOccupiedSetbackAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupiedSetbackMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9177,7 +9153,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterOccupiedSetbackMinAttributeCallback(),
             readThermostatOccupiedSetbackMinCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOccupiedSetbackMinAttribute",
         readThermostatOccupiedSetbackMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatOccupiedSetbackMaxCommandParams =
@@ -9194,7 +9170,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterOccupiedSetbackMaxAttributeCallback(),
             readThermostatOccupiedSetbackMaxCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readOccupiedSetbackMaxAttribute",
         readThermostatOccupiedSetbackMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatUnoccupiedSetbackCommandParams =
@@ -9210,7 +9186,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterUnoccupiedSetbackAttributeCallback(),
             readThermostatUnoccupiedSetbackCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readUnoccupiedSetbackAttribute", readThermostatUnoccupiedSetbackAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatUnoccupiedSetbackMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9226,7 +9202,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterUnoccupiedSetbackMinAttributeCallback(),
             readThermostatUnoccupiedSetbackMinCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readUnoccupiedSetbackMinAttribute",
         readThermostatUnoccupiedSetbackMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatUnoccupiedSetbackMaxCommandParams =
@@ -9243,7 +9219,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterUnoccupiedSetbackMaxAttributeCallback(),
             readThermostatUnoccupiedSetbackMaxCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readUnoccupiedSetbackMaxAttribute",
         readThermostatUnoccupiedSetbackMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatEmergencyHeatDeltaCommandParams =
@@ -9257,7 +9233,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatEmergencyHeatDeltaCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readEmergencyHeatDeltaAttribute",
         readThermostatEmergencyHeatDeltaAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACTypeCommandParams =
@@ -9270,8 +9246,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACTypeCommandParams);
-    readThermostatInteractionInfo.put(
-        "readACTypeAttribute", readThermostatACTypeAttributeInteractionInfo);
+    result.put("readACTypeAttribute", readThermostatACTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACCapacityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatACCapacityAttributeInteractionInfo =
@@ -9282,8 +9257,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACCapacityCommandParams);
-    readThermostatInteractionInfo.put(
-        "readACCapacityAttribute", readThermostatACCapacityAttributeInteractionInfo);
+    result.put("readACCapacityAttribute", readThermostatACCapacityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACRefrigerantTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatACRefrigerantTypeAttributeInteractionInfo =
@@ -9294,7 +9268,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACRefrigerantTypeCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readACRefrigerantTypeAttribute", readThermostatACRefrigerantTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACCompressorTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9306,7 +9280,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACCompressorTypeCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readACCompressorTypeAttribute", readThermostatACCompressorTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACErrorCodeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9318,8 +9292,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThermostatACErrorCodeCommandParams);
-    readThermostatInteractionInfo.put(
-        "readACErrorCodeAttribute", readThermostatACErrorCodeAttributeInteractionInfo);
+    result.put("readACErrorCodeAttribute", readThermostatACErrorCodeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACLouverPositionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatACLouverPositionAttributeInteractionInfo =
@@ -9330,7 +9303,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACLouverPositionCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readACLouverPositionAttribute", readThermostatACLouverPositionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACCoilTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9345,7 +9318,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterACCoilTemperatureAttributeCallback(),
             readThermostatACCoilTemperatureCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readACCoilTemperatureAttribute", readThermostatACCoilTemperatureAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatACCapacityformatCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9357,7 +9330,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatACCapacityformatCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readACCapacityformatAttribute", readThermostatACCapacityformatAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9373,7 +9346,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterGeneratedCommandListAttributeCallback(),
             readThermostatGeneratedCommandListCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readThermostatGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAcceptedCommandListCommandParams =
@@ -9390,7 +9363,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatClusterAcceptedCommandListAttributeCallback(),
             readThermostatAcceptedCommandListCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readThermostatAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatEventListCommandParams =
@@ -9404,8 +9377,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedThermostatClusterEventListAttributeCallback(),
             readThermostatEventListCommandParams);
-    readThermostatInteractionInfo.put(
-        "readEventListAttribute", readThermostatEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readThermostatEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatAttributeListAttributeInteractionInfo =
@@ -9417,8 +9389,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedThermostatClusterAttributeListAttributeCallback(),
             readThermostatAttributeListCommandParams);
-    readThermostatInteractionInfo.put(
-        "readAttributeListAttribute", readThermostatAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readThermostatAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatFeatureMapAttributeInteractionInfo =
@@ -9429,8 +9400,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThermostatFeatureMapCommandParams);
-    readThermostatInteractionInfo.put(
-        "readFeatureMapAttribute", readThermostatFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readThermostatFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readThermostatClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readThermostatClusterRevisionAttributeInteractionInfo =
@@ -9441,10 +9411,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatClusterRevisionCommandParams);
-    readThermostatInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readThermostatClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("thermostat", readThermostatInteractionInfo);
-    Map<String, InteractionInfo> readFanControlInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readFanControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readFanControlFanModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlFanModeAttributeInteractionInfo =
@@ -9455,8 +9429,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlFanModeCommandParams);
-    readFanControlInteractionInfo.put(
-        "readFanModeAttribute", readFanControlFanModeAttributeInteractionInfo);
+    result.put("readFanModeAttribute", readFanControlFanModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlFanModeSequenceCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlFanModeSequenceAttributeInteractionInfo =
@@ -9467,7 +9440,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlFanModeSequenceCommandParams);
-    readFanControlInteractionInfo.put(
+    result.put(
         "readFanModeSequenceAttribute", readFanControlFanModeSequenceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlPercentSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9481,8 +9454,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedFanControlClusterPercentSettingAttributeCallback(),
             readFanControlPercentSettingCommandParams);
-    readFanControlInteractionInfo.put(
-        "readPercentSettingAttribute", readFanControlPercentSettingAttributeInteractionInfo);
+    result.put("readPercentSettingAttribute", readFanControlPercentSettingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlPercentCurrentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlPercentCurrentAttributeInteractionInfo =
@@ -9493,8 +9465,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlPercentCurrentCommandParams);
-    readFanControlInteractionInfo.put(
-        "readPercentCurrentAttribute", readFanControlPercentCurrentAttributeInteractionInfo);
+    result.put("readPercentCurrentAttribute", readFanControlPercentCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlSpeedMaxCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlSpeedMaxAttributeInteractionInfo =
@@ -9505,8 +9476,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlSpeedMaxCommandParams);
-    readFanControlInteractionInfo.put(
-        "readSpeedMaxAttribute", readFanControlSpeedMaxAttributeInteractionInfo);
+    result.put("readSpeedMaxAttribute", readFanControlSpeedMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlSpeedSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlSpeedSettingAttributeInteractionInfo =
@@ -9518,8 +9488,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFanControlClusterSpeedSettingAttributeCallback(),
             readFanControlSpeedSettingCommandParams);
-    readFanControlInteractionInfo.put(
-        "readSpeedSettingAttribute", readFanControlSpeedSettingAttributeInteractionInfo);
+    result.put("readSpeedSettingAttribute", readFanControlSpeedSettingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlSpeedCurrentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlSpeedCurrentAttributeInteractionInfo =
@@ -9530,8 +9499,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlSpeedCurrentCommandParams);
-    readFanControlInteractionInfo.put(
-        "readSpeedCurrentAttribute", readFanControlSpeedCurrentAttributeInteractionInfo);
+    result.put("readSpeedCurrentAttribute", readFanControlSpeedCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlRockSupportCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlRockSupportAttributeInteractionInfo =
@@ -9542,8 +9510,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlRockSupportCommandParams);
-    readFanControlInteractionInfo.put(
-        "readRockSupportAttribute", readFanControlRockSupportAttributeInteractionInfo);
+    result.put("readRockSupportAttribute", readFanControlRockSupportAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlRockSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlRockSettingAttributeInteractionInfo =
@@ -9554,8 +9521,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlRockSettingCommandParams);
-    readFanControlInteractionInfo.put(
-        "readRockSettingAttribute", readFanControlRockSettingAttributeInteractionInfo);
+    result.put("readRockSettingAttribute", readFanControlRockSettingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlWindSupportCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlWindSupportAttributeInteractionInfo =
@@ -9566,8 +9532,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlWindSupportCommandParams);
-    readFanControlInteractionInfo.put(
-        "readWindSupportAttribute", readFanControlWindSupportAttributeInteractionInfo);
+    result.put("readWindSupportAttribute", readFanControlWindSupportAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlWindSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlWindSettingAttributeInteractionInfo =
@@ -9578,8 +9543,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlWindSettingCommandParams);
-    readFanControlInteractionInfo.put(
-        "readWindSettingAttribute", readFanControlWindSettingAttributeInteractionInfo);
+    result.put("readWindSettingAttribute", readFanControlWindSettingAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlGeneratedCommandListAttributeInteractionInfo =
@@ -9594,7 +9558,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFanControlClusterGeneratedCommandListAttributeCallback(),
             readFanControlGeneratedCommandListCommandParams);
-    readFanControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readFanControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlAcceptedCommandListCommandParams =
@@ -9611,7 +9575,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFanControlClusterAcceptedCommandListAttributeCallback(),
             readFanControlAcceptedCommandListCommandParams);
-    readFanControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readFanControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlEventListCommandParams =
@@ -9625,8 +9589,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFanControlClusterEventListAttributeCallback(),
             readFanControlEventListCommandParams);
-    readFanControlInteractionInfo.put(
-        "readEventListAttribute", readFanControlEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readFanControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlAttributeListAttributeInteractionInfo =
@@ -9638,8 +9601,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFanControlClusterAttributeListAttributeCallback(),
             readFanControlAttributeListCommandParams);
-    readFanControlInteractionInfo.put(
-        "readAttributeListAttribute", readFanControlAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readFanControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlFeatureMapAttributeInteractionInfo =
@@ -9650,8 +9612,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readFanControlFeatureMapCommandParams);
-    readFanControlInteractionInfo.put(
-        "readFeatureMapAttribute", readFanControlFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readFanControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFanControlClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFanControlClusterRevisionAttributeInteractionInfo =
@@ -9662,11 +9623,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFanControlClusterRevisionCommandParams);
-    readFanControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readFanControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("fanControl", readFanControlInteractionInfo);
-    Map<String, InteractionInfo> readThermostatUserInterfaceConfigurationInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo>
+      readThermostatUserInterfaceConfigurationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo>
         readThermostatUserInterfaceConfigurationTemperatureDisplayModeCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
@@ -9680,7 +9645,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readThermostatUserInterfaceConfigurationTemperatureDisplayModeCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readTemperatureDisplayModeAttribute",
         readThermostatUserInterfaceConfigurationTemperatureDisplayModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9694,7 +9659,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readThermostatUserInterfaceConfigurationKeypadLockoutCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readKeypadLockoutAttribute",
         readThermostatUserInterfaceConfigurationKeypadLockoutAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9710,7 +9675,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readScheduleProgrammingVisibilityAttribute",
         readThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9730,7 +9695,7 @@ public class ClusterReadMapping {
                     new ClusterInfoMapping
                         .DelegatedThermostatUserInterfaceConfigurationClusterGeneratedCommandListAttributeCallback(),
                 readThermostatUserInterfaceConfigurationGeneratedCommandListCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readThermostatUserInterfaceConfigurationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9750,7 +9715,7 @@ public class ClusterReadMapping {
                     new ClusterInfoMapping
                         .DelegatedThermostatUserInterfaceConfigurationClusterAcceptedCommandListAttributeCallback(),
                 readThermostatUserInterfaceConfigurationAcceptedCommandListCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readThermostatUserInterfaceConfigurationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9769,7 +9734,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatUserInterfaceConfigurationClusterEventListAttributeCallback(),
             readThermostatUserInterfaceConfigurationEventListCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readEventListAttribute",
         readThermostatUserInterfaceConfigurationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9788,7 +9753,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedThermostatUserInterfaceConfigurationClusterAttributeListAttributeCallback(),
             readThermostatUserInterfaceConfigurationAttributeListCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readThermostatUserInterfaceConfigurationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9802,7 +9767,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readThermostatUserInterfaceConfigurationFeatureMapCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readThermostatUserInterfaceConfigurationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -9818,13 +9783,15 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readThermostatUserInterfaceConfigurationClusterRevisionCommandParams);
-    readThermostatUserInterfaceConfigurationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readThermostatUserInterfaceConfigurationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "thermostatUserInterfaceConfiguration",
-        readThermostatUserInterfaceConfigurationInteractionInfo);
-    Map<String, InteractionInfo> readColorControlInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readColorControlInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readColorControlCurrentHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlCurrentHueAttributeInteractionInfo =
@@ -9835,8 +9802,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlCurrentHueCommandParams);
-    readColorControlInteractionInfo.put(
-        "readCurrentHueAttribute", readColorControlCurrentHueAttributeInteractionInfo);
+    result.put("readCurrentHueAttribute", readColorControlCurrentHueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlCurrentSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlCurrentSaturationAttributeInteractionInfo =
@@ -9847,7 +9813,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlCurrentSaturationCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readCurrentSaturationAttribute",
         readColorControlCurrentSaturationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlRemainingTimeCommandParams =
@@ -9860,8 +9826,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlRemainingTimeCommandParams);
-    readColorControlInteractionInfo.put(
-        "readRemainingTimeAttribute", readColorControlRemainingTimeAttributeInteractionInfo);
+    result.put("readRemainingTimeAttribute", readColorControlRemainingTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlCurrentXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlCurrentXAttributeInteractionInfo =
@@ -9872,8 +9837,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlCurrentXCommandParams);
-    readColorControlInteractionInfo.put(
-        "readCurrentXAttribute", readColorControlCurrentXAttributeInteractionInfo);
+    result.put("readCurrentXAttribute", readColorControlCurrentXAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlCurrentYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlCurrentYAttributeInteractionInfo =
@@ -9884,8 +9848,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlCurrentYCommandParams);
-    readColorControlInteractionInfo.put(
-        "readCurrentYAttribute", readColorControlCurrentYAttributeInteractionInfo);
+    result.put("readCurrentYAttribute", readColorControlCurrentYAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlDriftCompensationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlDriftCompensationAttributeInteractionInfo =
@@ -9896,7 +9859,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlDriftCompensationCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readDriftCompensationAttribute",
         readColorControlDriftCompensationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlCompensationTextCommandParams =
@@ -9910,7 +9873,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readColorControlCompensationTextCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readCompensationTextAttribute", readColorControlCompensationTextAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorTemperatureMiredsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -9923,7 +9886,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorTemperatureMiredsCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorTemperatureMiredsAttribute",
         readColorControlColorTemperatureMiredsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorModeCommandParams =
@@ -9936,8 +9899,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorModeCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorModeAttribute", readColorControlColorModeAttributeInteractionInfo);
+    result.put("readColorModeAttribute", readColorControlColorModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlOptionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlOptionsAttributeInteractionInfo =
@@ -9948,8 +9910,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlOptionsCommandParams);
-    readColorControlInteractionInfo.put(
-        "readOptionsAttribute", readColorControlOptionsAttributeInteractionInfo);
+    result.put("readOptionsAttribute", readColorControlOptionsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlNumberOfPrimariesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlNumberOfPrimariesAttributeInteractionInfo =
@@ -9964,7 +9925,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterNumberOfPrimariesAttributeCallback(),
             readColorControlNumberOfPrimariesCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readNumberOfPrimariesAttribute",
         readColorControlNumberOfPrimariesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary1XCommandParams =
@@ -9977,8 +9938,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary1XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary1XAttribute", readColorControlPrimary1XAttributeInteractionInfo);
+    result.put("readPrimary1XAttribute", readColorControlPrimary1XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary1YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary1YAttributeInteractionInfo =
@@ -9989,8 +9949,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary1YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary1YAttribute", readColorControlPrimary1YAttributeInteractionInfo);
+    result.put("readPrimary1YAttribute", readColorControlPrimary1YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary1IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary1IntensityAttributeInteractionInfo =
@@ -10005,7 +9964,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary1IntensityAttributeCallback(),
             readColorControlPrimary1IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary1IntensityAttribute",
         readColorControlPrimary1IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary2XCommandParams =
@@ -10018,8 +9977,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary2XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary2XAttribute", readColorControlPrimary2XAttributeInteractionInfo);
+    result.put("readPrimary2XAttribute", readColorControlPrimary2XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary2YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary2YAttributeInteractionInfo =
@@ -10030,8 +9988,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary2YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary2YAttribute", readColorControlPrimary2YAttributeInteractionInfo);
+    result.put("readPrimary2YAttribute", readColorControlPrimary2YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary2IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary2IntensityAttributeInteractionInfo =
@@ -10046,7 +10003,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary2IntensityAttributeCallback(),
             readColorControlPrimary2IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary2IntensityAttribute",
         readColorControlPrimary2IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary3XCommandParams =
@@ -10059,8 +10016,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary3XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary3XAttribute", readColorControlPrimary3XAttributeInteractionInfo);
+    result.put("readPrimary3XAttribute", readColorControlPrimary3XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary3YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary3YAttributeInteractionInfo =
@@ -10071,8 +10027,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary3YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary3YAttribute", readColorControlPrimary3YAttributeInteractionInfo);
+    result.put("readPrimary3YAttribute", readColorControlPrimary3YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary3IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary3IntensityAttributeInteractionInfo =
@@ -10087,7 +10042,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary3IntensityAttributeCallback(),
             readColorControlPrimary3IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary3IntensityAttribute",
         readColorControlPrimary3IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary4XCommandParams =
@@ -10100,8 +10055,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary4XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary4XAttribute", readColorControlPrimary4XAttributeInteractionInfo);
+    result.put("readPrimary4XAttribute", readColorControlPrimary4XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary4YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary4YAttributeInteractionInfo =
@@ -10112,8 +10066,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary4YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary4YAttribute", readColorControlPrimary4YAttributeInteractionInfo);
+    result.put("readPrimary4YAttribute", readColorControlPrimary4YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary4IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary4IntensityAttributeInteractionInfo =
@@ -10128,7 +10081,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary4IntensityAttributeCallback(),
             readColorControlPrimary4IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary4IntensityAttribute",
         readColorControlPrimary4IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary5XCommandParams =
@@ -10141,8 +10094,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary5XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary5XAttribute", readColorControlPrimary5XAttributeInteractionInfo);
+    result.put("readPrimary5XAttribute", readColorControlPrimary5XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary5YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary5YAttributeInteractionInfo =
@@ -10153,8 +10105,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary5YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary5YAttribute", readColorControlPrimary5YAttributeInteractionInfo);
+    result.put("readPrimary5YAttribute", readColorControlPrimary5YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary5IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary5IntensityAttributeInteractionInfo =
@@ -10169,7 +10120,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary5IntensityAttributeCallback(),
             readColorControlPrimary5IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary5IntensityAttribute",
         readColorControlPrimary5IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary6XCommandParams =
@@ -10182,8 +10133,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary6XCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary6XAttribute", readColorControlPrimary6XAttributeInteractionInfo);
+    result.put("readPrimary6XAttribute", readColorControlPrimary6XAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary6YCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary6YAttributeInteractionInfo =
@@ -10194,8 +10144,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlPrimary6YCommandParams);
-    readColorControlInteractionInfo.put(
-        "readPrimary6YAttribute", readColorControlPrimary6YAttributeInteractionInfo);
+    result.put("readPrimary6YAttribute", readColorControlPrimary6YAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlPrimary6IntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlPrimary6IntensityAttributeInteractionInfo =
@@ -10210,7 +10159,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterPrimary6IntensityAttributeCallback(),
             readColorControlPrimary6IntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readPrimary6IntensityAttribute",
         readColorControlPrimary6IntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlWhitePointXCommandParams =
@@ -10223,8 +10172,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlWhitePointXCommandParams);
-    readColorControlInteractionInfo.put(
-        "readWhitePointXAttribute", readColorControlWhitePointXAttributeInteractionInfo);
+    result.put("readWhitePointXAttribute", readColorControlWhitePointXAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlWhitePointYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlWhitePointYAttributeInteractionInfo =
@@ -10235,8 +10183,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlWhitePointYCommandParams);
-    readColorControlInteractionInfo.put(
-        "readWhitePointYAttribute", readColorControlWhitePointYAttributeInteractionInfo);
+    result.put("readWhitePointYAttribute", readColorControlWhitePointYAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointRXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointRXAttributeInteractionInfo =
@@ -10247,8 +10194,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointRXCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointRXAttribute", readColorControlColorPointRXAttributeInteractionInfo);
+    result.put("readColorPointRXAttribute", readColorControlColorPointRXAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointRYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointRYAttributeInteractionInfo =
@@ -10259,8 +10205,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointRYCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointRYAttribute", readColorControlColorPointRYAttributeInteractionInfo);
+    result.put("readColorPointRYAttribute", readColorControlColorPointRYAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointRIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointRIntensityAttributeInteractionInfo =
@@ -10275,7 +10220,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterColorPointRIntensityAttributeCallback(),
             readColorControlColorPointRIntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorPointRIntensityAttribute",
         readColorControlColorPointRIntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointGXCommandParams =
@@ -10288,8 +10233,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointGXCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointGXAttribute", readColorControlColorPointGXAttributeInteractionInfo);
+    result.put("readColorPointGXAttribute", readColorControlColorPointGXAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointGYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointGYAttributeInteractionInfo =
@@ -10300,8 +10244,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointGYCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointGYAttribute", readColorControlColorPointGYAttributeInteractionInfo);
+    result.put("readColorPointGYAttribute", readColorControlColorPointGYAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointGIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointGIntensityAttributeInteractionInfo =
@@ -10316,7 +10259,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterColorPointGIntensityAttributeCallback(),
             readColorControlColorPointGIntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorPointGIntensityAttribute",
         readColorControlColorPointGIntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointBXCommandParams =
@@ -10329,8 +10272,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointBXCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointBXAttribute", readColorControlColorPointBXAttributeInteractionInfo);
+    result.put("readColorPointBXAttribute", readColorControlColorPointBXAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointBYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointBYAttributeInteractionInfo =
@@ -10341,8 +10283,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorPointBYCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorPointBYAttribute", readColorControlColorPointBYAttributeInteractionInfo);
+    result.put("readColorPointBYAttribute", readColorControlColorPointBYAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorPointBIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorPointBIntensityAttributeInteractionInfo =
@@ -10357,7 +10298,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterColorPointBIntensityAttributeCallback(),
             readColorControlColorPointBIntensityCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorPointBIntensityAttribute",
         readColorControlColorPointBIntensityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlEnhancedCurrentHueCommandParams =
@@ -10371,7 +10312,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlEnhancedCurrentHueCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readEnhancedCurrentHueAttribute",
         readColorControlEnhancedCurrentHueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlEnhancedColorModeCommandParams =
@@ -10384,7 +10325,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlEnhancedColorModeCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readEnhancedColorModeAttribute",
         readColorControlEnhancedColorModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorLoopActiveCommandParams =
@@ -10397,7 +10338,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorLoopActiveCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorLoopActiveAttribute", readColorControlColorLoopActiveAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorLoopDirectionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -10410,7 +10351,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorLoopDirectionCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorLoopDirectionAttribute",
         readColorControlColorLoopDirectionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorLoopTimeCommandParams =
@@ -10423,8 +10364,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorLoopTimeCommandParams);
-    readColorControlInteractionInfo.put(
-        "readColorLoopTimeAttribute", readColorControlColorLoopTimeAttributeInteractionInfo);
+    result.put("readColorLoopTimeAttribute", readColorControlColorLoopTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorLoopStartEnhancedHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlColorLoopStartEnhancedHueAttributeInteractionInfo =
@@ -10436,7 +10376,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorLoopStartEnhancedHueCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorLoopStartEnhancedHueAttribute",
         readColorControlColorLoopStartEnhancedHueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorLoopStoredEnhancedHueCommandParams =
@@ -10450,7 +10390,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorLoopStoredEnhancedHueCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorLoopStoredEnhancedHueAttribute",
         readColorControlColorLoopStoredEnhancedHueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorCapabilitiesCommandParams =
@@ -10463,7 +10403,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorCapabilitiesCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorCapabilitiesAttribute",
         readColorControlColorCapabilitiesAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorTempPhysicalMinMiredsCommandParams =
@@ -10477,7 +10417,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorTempPhysicalMinMiredsCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorTempPhysicalMinMiredsAttribute",
         readColorControlColorTempPhysicalMinMiredsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlColorTempPhysicalMaxMiredsCommandParams =
@@ -10491,7 +10431,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlColorTempPhysicalMaxMiredsCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readColorTempPhysicalMaxMiredsAttribute",
         readColorControlColorTempPhysicalMaxMiredsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlCoupleColorTempToLevelMinMiredsCommandParams =
@@ -10505,7 +10445,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlCoupleColorTempToLevelMinMiredsCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readCoupleColorTempToLevelMinMiredsAttribute",
         readColorControlCoupleColorTempToLevelMinMiredsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlStartUpColorTemperatureMiredsCommandParams =
@@ -10523,7 +10463,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterStartUpColorTemperatureMiredsAttributeCallback(),
             readColorControlStartUpColorTemperatureMiredsCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readStartUpColorTemperatureMiredsAttribute",
         readColorControlStartUpColorTemperatureMiredsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlGeneratedCommandListCommandParams =
@@ -10540,7 +10480,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterGeneratedCommandListAttributeCallback(),
             readColorControlGeneratedCommandListCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readColorControlGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlAcceptedCommandListCommandParams =
@@ -10557,7 +10497,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedColorControlClusterAcceptedCommandListAttributeCallback(),
             readColorControlAcceptedCommandListCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readColorControlAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlEventListCommandParams =
@@ -10571,8 +10511,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedColorControlClusterEventListAttributeCallback(),
             readColorControlEventListCommandParams);
-    readColorControlInteractionInfo.put(
-        "readEventListAttribute", readColorControlEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readColorControlEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlAttributeListAttributeInteractionInfo =
@@ -10585,8 +10524,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedColorControlClusterAttributeListAttributeCallback(),
             readColorControlAttributeListCommandParams);
-    readColorControlInteractionInfo.put(
-        "readAttributeListAttribute", readColorControlAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readColorControlAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlFeatureMapAttributeInteractionInfo =
@@ -10597,8 +10535,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readColorControlFeatureMapCommandParams);
-    readColorControlInteractionInfo.put(
-        "readFeatureMapAttribute", readColorControlFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readColorControlFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readColorControlClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readColorControlClusterRevisionAttributeInteractionInfo =
@@ -10609,10 +10546,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readColorControlClusterRevisionCommandParams);
-    readColorControlInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readColorControlClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("colorControl", readColorControlInteractionInfo);
-    Map<String, InteractionInfo> readBallastConfigurationInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readBallastConfigurationInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readBallastConfigurationPhysicalMinLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBallastConfigurationPhysicalMinLevelAttributeInteractionInfo =
@@ -10623,7 +10564,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationPhysicalMinLevelCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readPhysicalMinLevelAttribute",
         readBallastConfigurationPhysicalMinLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationPhysicalMaxLevelCommandParams =
@@ -10636,7 +10577,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationPhysicalMaxLevelCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readPhysicalMaxLevelAttribute",
         readBallastConfigurationPhysicalMaxLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationBallastStatusCommandParams =
@@ -10649,7 +10590,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationBallastStatusCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readBallastStatusAttribute",
         readBallastConfigurationBallastStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationMinLevelCommandParams =
@@ -10662,8 +10603,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationMinLevelCommandParams);
-    readBallastConfigurationInteractionInfo.put(
-        "readMinLevelAttribute", readBallastConfigurationMinLevelAttributeInteractionInfo);
+    result.put("readMinLevelAttribute", readBallastConfigurationMinLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationMaxLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBallastConfigurationMaxLevelAttributeInteractionInfo =
@@ -10674,8 +10614,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationMaxLevelCommandParams);
-    readBallastConfigurationInteractionInfo.put(
-        "readMaxLevelAttribute", readBallastConfigurationMaxLevelAttributeInteractionInfo);
+    result.put("readMaxLevelAttribute", readBallastConfigurationMaxLevelAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationIntrinsicBallastFactorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBallastConfigurationIntrinsicBallastFactorAttributeInteractionInfo =
@@ -10691,7 +10630,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterIntrinsicBallastFactorAttributeCallback(),
             readBallastConfigurationIntrinsicBallastFactorCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readIntrinsicBallastFactorAttribute",
         readBallastConfigurationIntrinsicBallastFactorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationBallastFactorAdjustmentCommandParams =
@@ -10709,7 +10648,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterBallastFactorAdjustmentAttributeCallback(),
             readBallastConfigurationBallastFactorAdjustmentCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readBallastFactorAdjustmentAttribute",
         readBallastConfigurationBallastFactorAdjustmentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampQuantityCommandParams =
@@ -10722,7 +10661,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationLampQuantityCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampQuantityAttribute", readBallastConfigurationLampQuantityAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -10734,8 +10673,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBallastConfigurationLampTypeCommandParams);
-    readBallastConfigurationInteractionInfo.put(
-        "readLampTypeAttribute", readBallastConfigurationLampTypeAttributeInteractionInfo);
+    result.put("readLampTypeAttribute", readBallastConfigurationLampTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampManufacturerCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBallastConfigurationLampManufacturerAttributeInteractionInfo =
@@ -10747,7 +10685,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readBallastConfigurationLampManufacturerCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampManufacturerAttribute",
         readBallastConfigurationLampManufacturerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampRatedHoursCommandParams =
@@ -10764,7 +10702,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterLampRatedHoursAttributeCallback(),
             readBallastConfigurationLampRatedHoursCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampRatedHoursAttribute",
         readBallastConfigurationLampRatedHoursAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampBurnHoursCommandParams =
@@ -10781,7 +10719,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterLampBurnHoursAttributeCallback(),
             readBallastConfigurationLampBurnHoursCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampBurnHoursAttribute",
         readBallastConfigurationLampBurnHoursAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampAlarmModeCommandParams =
@@ -10794,7 +10732,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationLampAlarmModeCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampAlarmModeAttribute",
         readBallastConfigurationLampAlarmModeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationLampBurnHoursTripPointCommandParams =
@@ -10812,7 +10750,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterLampBurnHoursTripPointAttributeCallback(),
             readBallastConfigurationLampBurnHoursTripPointCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readLampBurnHoursTripPointAttribute",
         readBallastConfigurationLampBurnHoursTripPointAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationGeneratedCommandListCommandParams =
@@ -10830,7 +10768,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterGeneratedCommandListAttributeCallback(),
             readBallastConfigurationGeneratedCommandListCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readBallastConfigurationGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationAcceptedCommandListCommandParams =
@@ -10848,7 +10786,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterAcceptedCommandListAttributeCallback(),
             readBallastConfigurationAcceptedCommandListCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readBallastConfigurationAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationEventListCommandParams =
@@ -10865,8 +10803,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterEventListAttributeCallback(),
             readBallastConfigurationEventListCommandParams);
-    readBallastConfigurationInteractionInfo.put(
-        "readEventListAttribute", readBallastConfigurationEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readBallastConfigurationEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readBallastConfigurationAttributeListAttributeInteractionInfo =
@@ -10881,7 +10818,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedBallastConfigurationClusterAttributeListAttributeCallback(),
             readBallastConfigurationAttributeListCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readBallastConfigurationAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationFeatureMapCommandParams =
@@ -10894,7 +10831,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readBallastConfigurationFeatureMapCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readBallastConfigurationFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readBallastConfigurationClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -10906,11 +10843,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readBallastConfigurationClusterRevisionCommandParams);
-    readBallastConfigurationInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readBallastConfigurationClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("ballastConfiguration", readBallastConfigurationInteractionInfo);
-    Map<String, InteractionInfo> readIlluminanceMeasurementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readIlluminanceMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readIlluminanceMeasurementMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readIlluminanceMeasurementMeasuredValueAttributeInteractionInfo =
@@ -10925,7 +10866,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterMeasuredValueAttributeCallback(),
             readIlluminanceMeasurementMeasuredValueCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredValueAttribute",
         readIlluminanceMeasurementMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementMinMeasuredValueCommandParams =
@@ -10942,7 +10883,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterMinMeasuredValueAttributeCallback(),
             readIlluminanceMeasurementMinMeasuredValueCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readMinMeasuredValueAttribute",
         readIlluminanceMeasurementMinMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementMaxMeasuredValueCommandParams =
@@ -10959,7 +10900,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterMaxMeasuredValueAttributeCallback(),
             readIlluminanceMeasurementMaxMeasuredValueCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readMaxMeasuredValueAttribute",
         readIlluminanceMeasurementMaxMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementToleranceCommandParams =
@@ -10972,7 +10913,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readIlluminanceMeasurementToleranceCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readToleranceAttribute", readIlluminanceMeasurementToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementLightSensorTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -10988,7 +10929,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterLightSensorTypeAttributeCallback(),
             readIlluminanceMeasurementLightSensorTypeCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readLightSensorTypeAttribute",
         readIlluminanceMeasurementLightSensorTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementGeneratedCommandListCommandParams =
@@ -11006,7 +10947,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterGeneratedCommandListAttributeCallback(),
             readIlluminanceMeasurementGeneratedCommandListCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readIlluminanceMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementAcceptedCommandListCommandParams =
@@ -11024,7 +10965,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterAcceptedCommandListAttributeCallback(),
             readIlluminanceMeasurementAcceptedCommandListCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readIlluminanceMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementEventListCommandParams =
@@ -11041,7 +10982,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterEventListAttributeCallback(),
             readIlluminanceMeasurementEventListCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readIlluminanceMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11057,7 +10998,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedIlluminanceMeasurementClusterAttributeListAttributeCallback(),
             readIlluminanceMeasurementAttributeListCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readIlluminanceMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementFeatureMapCommandParams =
@@ -11070,7 +11011,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readIlluminanceMeasurementFeatureMapCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readIlluminanceMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readIlluminanceMeasurementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11082,11 +11023,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readIlluminanceMeasurementClusterRevisionCommandParams);
-    readIlluminanceMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readIlluminanceMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("illuminanceMeasurement", readIlluminanceMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readTemperatureMeasurementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readTemperatureMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readTemperatureMeasurementMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTemperatureMeasurementMeasuredValueAttributeInteractionInfo =
@@ -11101,7 +11046,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterMeasuredValueAttributeCallback(),
             readTemperatureMeasurementMeasuredValueCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredValueAttribute",
         readTemperatureMeasurementMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementMinMeasuredValueCommandParams =
@@ -11118,7 +11063,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterMinMeasuredValueAttributeCallback(),
             readTemperatureMeasurementMinMeasuredValueCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readMinMeasuredValueAttribute",
         readTemperatureMeasurementMinMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementMaxMeasuredValueCommandParams =
@@ -11135,7 +11080,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterMaxMeasuredValueAttributeCallback(),
             readTemperatureMeasurementMaxMeasuredValueCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readMaxMeasuredValueAttribute",
         readTemperatureMeasurementMaxMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementToleranceCommandParams =
@@ -11148,7 +11093,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTemperatureMeasurementToleranceCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readToleranceAttribute", readTemperatureMeasurementToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11165,7 +11110,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterGeneratedCommandListAttributeCallback(),
             readTemperatureMeasurementGeneratedCommandListCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readTemperatureMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementAcceptedCommandListCommandParams =
@@ -11183,7 +11128,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterAcceptedCommandListAttributeCallback(),
             readTemperatureMeasurementAcceptedCommandListCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readTemperatureMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementEventListCommandParams =
@@ -11200,7 +11145,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterEventListAttributeCallback(),
             readTemperatureMeasurementEventListCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readTemperatureMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11216,7 +11161,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTemperatureMeasurementClusterAttributeListAttributeCallback(),
             readTemperatureMeasurementAttributeListCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readTemperatureMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementFeatureMapCommandParams =
@@ -11229,7 +11174,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readTemperatureMeasurementFeatureMapCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readTemperatureMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTemperatureMeasurementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11241,11 +11186,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTemperatureMeasurementClusterRevisionCommandParams);
-    readTemperatureMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readTemperatureMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("temperatureMeasurement", readTemperatureMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readPressureMeasurementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readPressureMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readPressureMeasurementMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPressureMeasurementMeasuredValueAttributeInteractionInfo =
@@ -11260,7 +11209,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterMeasuredValueAttributeCallback(),
             readPressureMeasurementMeasuredValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredValueAttribute", readPressureMeasurementMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementMinMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11276,7 +11225,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterMinMeasuredValueAttributeCallback(),
             readPressureMeasurementMinMeasuredValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readMinMeasuredValueAttribute",
         readPressureMeasurementMinMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementMaxMeasuredValueCommandParams =
@@ -11293,7 +11242,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterMaxMeasuredValueAttributeCallback(),
             readPressureMeasurementMaxMeasuredValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readMaxMeasuredValueAttribute",
         readPressureMeasurementMaxMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementToleranceCommandParams =
@@ -11306,8 +11255,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPressureMeasurementToleranceCommandParams);
-    readPressureMeasurementInteractionInfo.put(
-        "readToleranceAttribute", readPressureMeasurementToleranceAttributeInteractionInfo);
+    result.put("readToleranceAttribute", readPressureMeasurementToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementScaledValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPressureMeasurementScaledValueAttributeInteractionInfo =
@@ -11322,7 +11270,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterScaledValueAttributeCallback(),
             readPressureMeasurementScaledValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readScaledValueAttribute", readPressureMeasurementScaledValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementMinScaledValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11338,7 +11286,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterMinScaledValueAttributeCallback(),
             readPressureMeasurementMinScaledValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readMinScaledValueAttribute",
         readPressureMeasurementMinScaledValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementMaxScaledValueCommandParams =
@@ -11355,7 +11303,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterMaxScaledValueAttributeCallback(),
             readPressureMeasurementMaxScaledValueCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readMaxScaledValueAttribute",
         readPressureMeasurementMaxScaledValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementScaledToleranceCommandParams =
@@ -11368,7 +11316,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPressureMeasurementScaledToleranceCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readScaledToleranceAttribute",
         readPressureMeasurementScaledToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementScaleCommandParams =
@@ -11381,8 +11329,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPressureMeasurementScaleCommandParams);
-    readPressureMeasurementInteractionInfo.put(
-        "readScaleAttribute", readPressureMeasurementScaleAttributeInteractionInfo);
+    result.put("readScaleAttribute", readPressureMeasurementScaleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPressureMeasurementGeneratedCommandListAttributeInteractionInfo =
@@ -11398,7 +11345,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterGeneratedCommandListAttributeCallback(),
             readPressureMeasurementGeneratedCommandListCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readPressureMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementAcceptedCommandListCommandParams =
@@ -11415,7 +11362,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterAcceptedCommandListAttributeCallback(),
             readPressureMeasurementAcceptedCommandListCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readPressureMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementEventListCommandParams =
@@ -11432,8 +11379,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterEventListAttributeCallback(),
             readPressureMeasurementEventListCommandParams);
-    readPressureMeasurementInteractionInfo.put(
-        "readEventListAttribute", readPressureMeasurementEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readPressureMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readPressureMeasurementAttributeListAttributeInteractionInfo =
@@ -11448,7 +11394,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedPressureMeasurementClusterAttributeListAttributeCallback(),
             readPressureMeasurementAttributeListCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readPressureMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11460,7 +11406,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readPressureMeasurementFeatureMapCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readPressureMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readPressureMeasurementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11472,11 +11418,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readPressureMeasurementClusterRevisionCommandParams);
-    readPressureMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readPressureMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("pressureMeasurement", readPressureMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readFlowMeasurementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readFlowMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readFlowMeasurementMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFlowMeasurementMeasuredValueAttributeInteractionInfo =
@@ -11491,7 +11441,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterMeasuredValueAttributeCallback(),
             readFlowMeasurementMeasuredValueCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredValueAttribute", readFlowMeasurementMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementMinMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11507,7 +11457,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterMinMeasuredValueAttributeCallback(),
             readFlowMeasurementMinMeasuredValueCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readMinMeasuredValueAttribute",
         readFlowMeasurementMinMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementMaxMeasuredValueCommandParams =
@@ -11524,7 +11474,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterMaxMeasuredValueAttributeCallback(),
             readFlowMeasurementMaxMeasuredValueCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readMaxMeasuredValueAttribute",
         readFlowMeasurementMaxMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementToleranceCommandParams =
@@ -11537,8 +11487,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFlowMeasurementToleranceCommandParams);
-    readFlowMeasurementInteractionInfo.put(
-        "readToleranceAttribute", readFlowMeasurementToleranceAttributeInteractionInfo);
+    result.put("readToleranceAttribute", readFlowMeasurementToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFlowMeasurementGeneratedCommandListAttributeInteractionInfo =
@@ -11553,7 +11502,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterGeneratedCommandListAttributeCallback(),
             readFlowMeasurementGeneratedCommandListCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readFlowMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementAcceptedCommandListCommandParams =
@@ -11570,7 +11519,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterAcceptedCommandListAttributeCallback(),
             readFlowMeasurementAcceptedCommandListCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readFlowMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementEventListCommandParams =
@@ -11585,8 +11534,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedFlowMeasurementClusterEventListAttributeCallback(),
             readFlowMeasurementEventListCommandParams);
-    readFlowMeasurementInteractionInfo.put(
-        "readEventListAttribute", readFlowMeasurementEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readFlowMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFlowMeasurementAttributeListAttributeInteractionInfo =
@@ -11601,7 +11549,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedFlowMeasurementClusterAttributeListAttributeCallback(),
             readFlowMeasurementAttributeListCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readFlowMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11613,8 +11561,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readFlowMeasurementFeatureMapCommandParams);
-    readFlowMeasurementInteractionInfo.put(
-        "readFeatureMapAttribute", readFlowMeasurementFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readFlowMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readFlowMeasurementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readFlowMeasurementClusterRevisionAttributeInteractionInfo =
@@ -11625,11 +11572,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readFlowMeasurementClusterRevisionCommandParams);
-    readFlowMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readFlowMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("flowMeasurement", readFlowMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readRelativeHumidityMeasurementInteractionInfo =
-        new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readRelativeHumidityMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementMeasuredValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readRelativeHumidityMeasurementMeasuredValueAttributeInteractionInfo =
@@ -11645,7 +11595,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterMeasuredValueAttributeCallback(),
             readRelativeHumidityMeasurementMeasuredValueCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredValueAttribute",
         readRelativeHumidityMeasurementMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementMinMeasuredValueCommandParams =
@@ -11663,7 +11613,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterMinMeasuredValueAttributeCallback(),
             readRelativeHumidityMeasurementMinMeasuredValueCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readMinMeasuredValueAttribute",
         readRelativeHumidityMeasurementMinMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementMaxMeasuredValueCommandParams =
@@ -11681,7 +11631,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterMaxMeasuredValueAttributeCallback(),
             readRelativeHumidityMeasurementMaxMeasuredValueCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readMaxMeasuredValueAttribute",
         readRelativeHumidityMeasurementMaxMeasuredValueAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementToleranceCommandParams =
@@ -11694,7 +11644,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readRelativeHumidityMeasurementToleranceCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readToleranceAttribute", readRelativeHumidityMeasurementToleranceAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readRelativeHumidityMeasurementGeneratedCommandListCommandParams =
@@ -11712,7 +11662,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterGeneratedCommandListAttributeCallback(),
             readRelativeHumidityMeasurementGeneratedCommandListCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readRelativeHumidityMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11731,7 +11681,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterAcceptedCommandListAttributeCallback(),
             readRelativeHumidityMeasurementAcceptedCommandListCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readRelativeHumidityMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementEventListCommandParams =
@@ -11748,7 +11698,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterEventListAttributeCallback(),
             readRelativeHumidityMeasurementEventListCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readRelativeHumidityMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -11765,7 +11715,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedRelativeHumidityMeasurementClusterAttributeListAttributeCallback(),
             readRelativeHumidityMeasurementAttributeListCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readRelativeHumidityMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementFeatureMapCommandParams =
@@ -11778,7 +11728,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readRelativeHumidityMeasurementFeatureMapCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute",
         readRelativeHumidityMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readRelativeHumidityMeasurementClusterRevisionCommandParams =
@@ -11791,12 +11741,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readRelativeHumidityMeasurementClusterRevisionCommandParams);
-    readRelativeHumidityMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readRelativeHumidityMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put(
-        "relativeHumidityMeasurement", readRelativeHumidityMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readOccupancySensingInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readOccupancySensingInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readOccupancySensingOccupancyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOccupancySensingOccupancyAttributeInteractionInfo =
@@ -11807,8 +11760,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingOccupancyCommandParams);
-    readOccupancySensingInteractionInfo.put(
-        "readOccupancyAttribute", readOccupancySensingOccupancyAttributeInteractionInfo);
+    result.put("readOccupancyAttribute", readOccupancySensingOccupancyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingOccupancySensorTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOccupancySensingOccupancySensorTypeAttributeInteractionInfo =
@@ -11820,7 +11772,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingOccupancySensorTypeCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readOccupancySensorTypeAttribute",
         readOccupancySensingOccupancySensorTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingOccupancySensorTypeBitmapCommandParams =
@@ -11834,7 +11786,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingOccupancySensorTypeBitmapCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readOccupancySensorTypeBitmapAttribute",
         readOccupancySensingOccupancySensorTypeBitmapAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11849,7 +11801,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingPIROccupiedToUnoccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPIROccupiedToUnoccupiedDelayAttribute",
         readOccupancySensingPIROccupiedToUnoccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11864,7 +11816,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingPIRUnoccupiedToOccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPIRUnoccupiedToOccupiedDelayAttribute",
         readOccupancySensingPIRUnoccupiedToOccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11879,7 +11831,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingPIRUnoccupiedToOccupiedThresholdCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPIRUnoccupiedToOccupiedThresholdAttribute",
         readOccupancySensingPIRUnoccupiedToOccupiedThresholdAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11895,7 +11847,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingUltrasonicOccupiedToUnoccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readUltrasonicOccupiedToUnoccupiedDelayAttribute",
         readOccupancySensingUltrasonicOccupiedToUnoccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11911,7 +11863,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingUltrasonicUnoccupiedToOccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readUltrasonicUnoccupiedToOccupiedDelayAttribute",
         readOccupancySensingUltrasonicUnoccupiedToOccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11927,7 +11879,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingUltrasonicUnoccupiedToOccupiedThresholdCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readUltrasonicUnoccupiedToOccupiedThresholdAttribute",
         readOccupancySensingUltrasonicUnoccupiedToOccupiedThresholdAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11943,7 +11895,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingPhysicalContactOccupiedToUnoccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPhysicalContactOccupiedToUnoccupiedDelayAttribute",
         readOccupancySensingPhysicalContactOccupiedToUnoccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11959,7 +11911,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingPhysicalContactUnoccupiedToOccupiedDelayCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPhysicalContactUnoccupiedToOccupiedDelayAttribute",
         readOccupancySensingPhysicalContactUnoccupiedToOccupiedDelayAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -11975,7 +11927,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readOccupancySensingPhysicalContactUnoccupiedToOccupiedThresholdCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readPhysicalContactUnoccupiedToOccupiedThresholdAttribute",
         readOccupancySensingPhysicalContactUnoccupiedToOccupiedThresholdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingGeneratedCommandListCommandParams =
@@ -11992,7 +11944,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOccupancySensingClusterGeneratedCommandListAttributeCallback(),
             readOccupancySensingGeneratedCommandListCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readOccupancySensingGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingAcceptedCommandListCommandParams =
@@ -12009,7 +11961,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOccupancySensingClusterAcceptedCommandListAttributeCallback(),
             readOccupancySensingAcceptedCommandListCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readOccupancySensingAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingEventListCommandParams =
@@ -12024,8 +11976,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedOccupancySensingClusterEventListAttributeCallback(),
             readOccupancySensingEventListCommandParams);
-    readOccupancySensingInteractionInfo.put(
-        "readEventListAttribute", readOccupancySensingEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readOccupancySensingEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOccupancySensingAttributeListAttributeInteractionInfo =
@@ -12040,7 +11991,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedOccupancySensingClusterAttributeListAttributeCallback(),
             readOccupancySensingAttributeListCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readOccupancySensingAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12052,8 +12003,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readOccupancySensingFeatureMapCommandParams);
-    readOccupancySensingInteractionInfo.put(
-        "readFeatureMapAttribute", readOccupancySensingFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readOccupancySensingFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readOccupancySensingClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readOccupancySensingClusterRevisionAttributeInteractionInfo =
@@ -12064,11 +12014,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readOccupancySensingClusterRevisionCommandParams);
-    readOccupancySensingInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readOccupancySensingClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("occupancySensing", readOccupancySensingInteractionInfo);
-    Map<String, InteractionInfo> readWakeOnLanInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readWakeOnLanInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readWakeOnLanMACAddressCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWakeOnLanMACAddressAttributeInteractionInfo =
@@ -12079,8 +12033,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readWakeOnLanMACAddressCommandParams);
-    readWakeOnLanInteractionInfo.put(
-        "readMACAddressAttribute", readWakeOnLanMACAddressAttributeInteractionInfo);
+    result.put("readMACAddressAttribute", readWakeOnLanMACAddressAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWakeOnLanGeneratedCommandListAttributeInteractionInfo =
@@ -12095,7 +12048,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWakeOnLanClusterGeneratedCommandListAttributeCallback(),
             readWakeOnLanGeneratedCommandListCommandParams);
-    readWakeOnLanInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readWakeOnLanGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanAcceptedCommandListCommandParams =
@@ -12112,7 +12065,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedWakeOnLanClusterAcceptedCommandListAttributeCallback(),
             readWakeOnLanAcceptedCommandListCommandParams);
-    readWakeOnLanInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readWakeOnLanAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanEventListCommandParams =
@@ -12126,8 +12079,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedWakeOnLanClusterEventListAttributeCallback(),
             readWakeOnLanEventListCommandParams);
-    readWakeOnLanInteractionInfo.put(
-        "readEventListAttribute", readWakeOnLanEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readWakeOnLanEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWakeOnLanAttributeListAttributeInteractionInfo =
@@ -12139,8 +12091,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedWakeOnLanClusterAttributeListAttributeCallback(),
             readWakeOnLanAttributeListCommandParams);
-    readWakeOnLanInteractionInfo.put(
-        "readAttributeListAttribute", readWakeOnLanAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readWakeOnLanAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWakeOnLanFeatureMapAttributeInteractionInfo =
@@ -12151,8 +12102,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readWakeOnLanFeatureMapCommandParams);
-    readWakeOnLanInteractionInfo.put(
-        "readFeatureMapAttribute", readWakeOnLanFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readWakeOnLanFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readWakeOnLanClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readWakeOnLanClusterRevisionAttributeInteractionInfo =
@@ -12163,10 +12113,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readWakeOnLanClusterRevisionCommandParams);
-    readWakeOnLanInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readWakeOnLanClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("wakeOnLan", readWakeOnLanInteractionInfo);
-    Map<String, InteractionInfo> readChannelInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readChannelInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readChannelChannelListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readChannelChannelListAttributeInteractionInfo =
@@ -12178,8 +12132,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedChannelClusterChannelListAttributeCallback(),
             readChannelChannelListCommandParams);
-    readChannelInteractionInfo.put(
-        "readChannelListAttribute", readChannelChannelListAttributeInteractionInfo);
+    result.put("readChannelListAttribute", readChannelChannelListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readChannelGeneratedCommandListAttributeInteractionInfo =
@@ -12193,7 +12146,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedChannelClusterGeneratedCommandListAttributeCallback(),
             readChannelGeneratedCommandListCommandParams);
-    readChannelInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readChannelGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelAcceptedCommandListCommandParams =
@@ -12209,7 +12162,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedChannelClusterAcceptedCommandListAttributeCallback(),
             readChannelAcceptedCommandListCommandParams);
-    readChannelInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute", readChannelAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelEventListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12222,8 +12175,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedChannelClusterEventListAttributeCallback(),
             readChannelEventListCommandParams);
-    readChannelInteractionInfo.put(
-        "readEventListAttribute", readChannelEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readChannelEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readChannelAttributeListAttributeInteractionInfo =
@@ -12235,8 +12187,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedChannelClusterAttributeListAttributeCallback(),
             readChannelAttributeListCommandParams);
-    readChannelInteractionInfo.put(
-        "readAttributeListAttribute", readChannelAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readChannelAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readChannelFeatureMapAttributeInteractionInfo =
@@ -12247,8 +12198,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readChannelFeatureMapCommandParams);
-    readChannelInteractionInfo.put(
-        "readFeatureMapAttribute", readChannelFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readChannelFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readChannelClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readChannelClusterRevisionAttributeInteractionInfo =
@@ -12259,10 +12209,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readChannelClusterRevisionCommandParams);
-    readChannelInteractionInfo.put(
-        "readClusterRevisionAttribute", readChannelClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("channel", readChannelInteractionInfo);
-    Map<String, InteractionInfo> readTargetNavigatorInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readChannelClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readTargetNavigatorInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readTargetNavigatorTargetListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTargetNavigatorTargetListAttributeInteractionInfo =
@@ -12275,8 +12228,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedTargetNavigatorClusterTargetListAttributeCallback(),
             readTargetNavigatorTargetListCommandParams);
-    readTargetNavigatorInteractionInfo.put(
-        "readTargetListAttribute", readTargetNavigatorTargetListAttributeInteractionInfo);
+    result.put("readTargetListAttribute", readTargetNavigatorTargetListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorCurrentTargetCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTargetNavigatorCurrentTargetAttributeInteractionInfo =
@@ -12287,7 +12239,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTargetNavigatorCurrentTargetCommandParams);
-    readTargetNavigatorInteractionInfo.put(
+    result.put(
         "readCurrentTargetAttribute", readTargetNavigatorCurrentTargetAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12303,7 +12255,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTargetNavigatorClusterGeneratedCommandListAttributeCallback(),
             readTargetNavigatorGeneratedCommandListCommandParams);
-    readTargetNavigatorInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readTargetNavigatorGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorAcceptedCommandListCommandParams =
@@ -12320,7 +12272,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTargetNavigatorClusterAcceptedCommandListAttributeCallback(),
             readTargetNavigatorAcceptedCommandListCommandParams);
-    readTargetNavigatorInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readTargetNavigatorAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorEventListCommandParams =
@@ -12335,8 +12287,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedTargetNavigatorClusterEventListAttributeCallback(),
             readTargetNavigatorEventListCommandParams);
-    readTargetNavigatorInteractionInfo.put(
-        "readEventListAttribute", readTargetNavigatorEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readTargetNavigatorEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTargetNavigatorAttributeListAttributeInteractionInfo =
@@ -12351,7 +12302,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedTargetNavigatorClusterAttributeListAttributeCallback(),
             readTargetNavigatorAttributeListCommandParams);
-    readTargetNavigatorInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readTargetNavigatorAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12363,8 +12314,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readTargetNavigatorFeatureMapCommandParams);
-    readTargetNavigatorInteractionInfo.put(
-        "readFeatureMapAttribute", readTargetNavigatorFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readTargetNavigatorFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readTargetNavigatorClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readTargetNavigatorClusterRevisionAttributeInteractionInfo =
@@ -12375,10 +12325,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readTargetNavigatorClusterRevisionCommandParams);
-    readTargetNavigatorInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readTargetNavigatorClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("targetNavigator", readTargetNavigatorInteractionInfo);
-    Map<String, InteractionInfo> readMediaPlaybackInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readMediaPlaybackInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readMediaPlaybackCurrentStateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackCurrentStateAttributeInteractionInfo =
@@ -12389,8 +12343,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readMediaPlaybackCurrentStateCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readCurrentStateAttribute", readMediaPlaybackCurrentStateAttributeInteractionInfo);
+    result.put("readCurrentStateAttribute", readMediaPlaybackCurrentStateAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackStartTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackStartTimeAttributeInteractionInfo =
@@ -12402,8 +12355,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaPlaybackClusterStartTimeAttributeCallback(),
             readMediaPlaybackStartTimeCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readStartTimeAttribute", readMediaPlaybackStartTimeAttributeInteractionInfo);
+    result.put("readStartTimeAttribute", readMediaPlaybackStartTimeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackDurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackDurationAttributeInteractionInfo =
@@ -12415,8 +12367,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaPlaybackClusterDurationAttributeCallback(),
             readMediaPlaybackDurationCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readDurationAttribute", readMediaPlaybackDurationAttributeInteractionInfo);
+    result.put("readDurationAttribute", readMediaPlaybackDurationAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackPlaybackSpeedCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackPlaybackSpeedAttributeInteractionInfo =
@@ -12427,7 +12378,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFloatAttributeCallback(),
             readMediaPlaybackPlaybackSpeedCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readPlaybackSpeedAttribute", readMediaPlaybackPlaybackSpeedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackSeekRangeEndCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12441,8 +12392,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedMediaPlaybackClusterSeekRangeEndAttributeCallback(),
             readMediaPlaybackSeekRangeEndCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readSeekRangeEndAttribute", readMediaPlaybackSeekRangeEndAttributeInteractionInfo);
+    result.put("readSeekRangeEndAttribute", readMediaPlaybackSeekRangeEndAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackSeekRangeStartCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackSeekRangeStartAttributeInteractionInfo =
@@ -12456,7 +12406,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaPlaybackClusterSeekRangeStartAttributeCallback(),
             readMediaPlaybackSeekRangeStartCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readSeekRangeStartAttribute", readMediaPlaybackSeekRangeStartAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12472,7 +12422,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaPlaybackClusterGeneratedCommandListAttributeCallback(),
             readMediaPlaybackGeneratedCommandListCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readMediaPlaybackGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackAcceptedCommandListCommandParams =
@@ -12489,7 +12439,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaPlaybackClusterAcceptedCommandListAttributeCallback(),
             readMediaPlaybackAcceptedCommandListCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readMediaPlaybackAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackEventListCommandParams =
@@ -12503,8 +12453,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaPlaybackClusterEventListAttributeCallback(),
             readMediaPlaybackEventListCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readEventListAttribute", readMediaPlaybackEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readMediaPlaybackEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackAttributeListAttributeInteractionInfo =
@@ -12518,7 +12467,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaPlaybackClusterAttributeListAttributeCallback(),
             readMediaPlaybackAttributeListCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readMediaPlaybackAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12530,8 +12479,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaPlaybackFeatureMapCommandParams);
-    readMediaPlaybackInteractionInfo.put(
-        "readFeatureMapAttribute", readMediaPlaybackFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readMediaPlaybackFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaPlaybackClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaPlaybackClusterRevisionAttributeInteractionInfo =
@@ -12542,10 +12490,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readMediaPlaybackClusterRevisionCommandParams);
-    readMediaPlaybackInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readMediaPlaybackClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("mediaPlayback", readMediaPlaybackInteractionInfo);
-    Map<String, InteractionInfo> readMediaInputInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readMediaInputInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readMediaInputInputListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputInputListAttributeInteractionInfo =
@@ -12557,8 +12509,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaInputClusterInputListAttributeCallback(),
             readMediaInputInputListCommandParams);
-    readMediaInputInteractionInfo.put(
-        "readInputListAttribute", readMediaInputInputListAttributeInteractionInfo);
+    result.put("readInputListAttribute", readMediaInputInputListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputCurrentInputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputCurrentInputAttributeInteractionInfo =
@@ -12569,8 +12520,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readMediaInputCurrentInputCommandParams);
-    readMediaInputInteractionInfo.put(
-        "readCurrentInputAttribute", readMediaInputCurrentInputAttributeInteractionInfo);
+    result.put("readCurrentInputAttribute", readMediaInputCurrentInputAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputGeneratedCommandListAttributeInteractionInfo =
@@ -12585,7 +12535,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaInputClusterGeneratedCommandListAttributeCallback(),
             readMediaInputGeneratedCommandListCommandParams);
-    readMediaInputInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readMediaInputGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputAcceptedCommandListCommandParams =
@@ -12602,7 +12552,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedMediaInputClusterAcceptedCommandListAttributeCallback(),
             readMediaInputAcceptedCommandListCommandParams);
-    readMediaInputInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readMediaInputAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputEventListCommandParams =
@@ -12616,8 +12566,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaInputClusterEventListAttributeCallback(),
             readMediaInputEventListCommandParams);
-    readMediaInputInteractionInfo.put(
-        "readEventListAttribute", readMediaInputEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readMediaInputEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputAttributeListAttributeInteractionInfo =
@@ -12629,8 +12578,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedMediaInputClusterAttributeListAttributeCallback(),
             readMediaInputAttributeListCommandParams);
-    readMediaInputInteractionInfo.put(
-        "readAttributeListAttribute", readMediaInputAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readMediaInputAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputFeatureMapAttributeInteractionInfo =
@@ -12641,8 +12589,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaInputFeatureMapCommandParams);
-    readMediaInputInteractionInfo.put(
-        "readFeatureMapAttribute", readMediaInputFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readMediaInputFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readMediaInputClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readMediaInputClusterRevisionAttributeInteractionInfo =
@@ -12653,10 +12600,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readMediaInputClusterRevisionCommandParams);
-    readMediaInputInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readMediaInputClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("mediaInput", readMediaInputInteractionInfo);
-    Map<String, InteractionInfo> readLowPowerInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readLowPowerInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readLowPowerGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLowPowerGeneratedCommandListAttributeInteractionInfo =
@@ -12671,7 +12622,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLowPowerClusterGeneratedCommandListAttributeCallback(),
             readLowPowerGeneratedCommandListCommandParams);
-    readLowPowerInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readLowPowerGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLowPowerAcceptedCommandListCommandParams =
@@ -12687,7 +12638,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedLowPowerClusterAcceptedCommandListAttributeCallback(),
             readLowPowerAcceptedCommandListCommandParams);
-    readLowPowerInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readLowPowerAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLowPowerEventListCommandParams =
@@ -12701,8 +12652,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLowPowerClusterEventListAttributeCallback(),
             readLowPowerEventListCommandParams);
-    readLowPowerInteractionInfo.put(
-        "readEventListAttribute", readLowPowerEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readLowPowerEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLowPowerAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLowPowerAttributeListAttributeInteractionInfo =
@@ -12714,8 +12664,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLowPowerClusterAttributeListAttributeCallback(),
             readLowPowerAttributeListCommandParams);
-    readLowPowerInteractionInfo.put(
-        "readAttributeListAttribute", readLowPowerAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readLowPowerAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLowPowerFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLowPowerFeatureMapAttributeInteractionInfo =
@@ -12726,8 +12675,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readLowPowerFeatureMapCommandParams);
-    readLowPowerInteractionInfo.put(
-        "readFeatureMapAttribute", readLowPowerFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readLowPowerFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readLowPowerClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readLowPowerClusterRevisionAttributeInteractionInfo =
@@ -12738,10 +12686,13 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readLowPowerClusterRevisionCommandParams);
-    readLowPowerInteractionInfo.put(
-        "readClusterRevisionAttribute", readLowPowerClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("lowPower", readLowPowerInteractionInfo);
-    Map<String, InteractionInfo> readKeypadInputInteractionInfo = new LinkedHashMap<>();
+    result.put("readClusterRevisionAttribute", readLowPowerClusterRevisionAttributeInteractionInfo);
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readKeypadInputInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readKeypadInputGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readKeypadInputGeneratedCommandListAttributeInteractionInfo =
@@ -12756,7 +12707,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedKeypadInputClusterGeneratedCommandListAttributeCallback(),
             readKeypadInputGeneratedCommandListCommandParams);
-    readKeypadInputInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readKeypadInputGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readKeypadInputAcceptedCommandListCommandParams =
@@ -12773,7 +12724,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedKeypadInputClusterAcceptedCommandListAttributeCallback(),
             readKeypadInputAcceptedCommandListCommandParams);
-    readKeypadInputInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readKeypadInputAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readKeypadInputEventListCommandParams =
@@ -12787,8 +12738,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedKeypadInputClusterEventListAttributeCallback(),
             readKeypadInputEventListCommandParams);
-    readKeypadInputInteractionInfo.put(
-        "readEventListAttribute", readKeypadInputEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readKeypadInputEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readKeypadInputAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readKeypadInputAttributeListAttributeInteractionInfo =
@@ -12801,8 +12751,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedKeypadInputClusterAttributeListAttributeCallback(),
             readKeypadInputAttributeListCommandParams);
-    readKeypadInputInteractionInfo.put(
-        "readAttributeListAttribute", readKeypadInputAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readKeypadInputAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readKeypadInputFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readKeypadInputFeatureMapAttributeInteractionInfo =
@@ -12813,8 +12762,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readKeypadInputFeatureMapCommandParams);
-    readKeypadInputInteractionInfo.put(
-        "readFeatureMapAttribute", readKeypadInputFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readKeypadInputFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readKeypadInputClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readKeypadInputClusterRevisionAttributeInteractionInfo =
@@ -12825,10 +12773,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readKeypadInputClusterRevisionCommandParams);
-    readKeypadInputInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readKeypadInputClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("keypadInput", readKeypadInputInteractionInfo);
-    Map<String, InteractionInfo> readContentLauncherInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readContentLauncherInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readContentLauncherAcceptHeaderCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readContentLauncherAcceptHeaderAttributeInteractionInfo =
@@ -12842,7 +12794,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedContentLauncherClusterAcceptHeaderAttributeCallback(),
             readContentLauncherAcceptHeaderCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readAcceptHeaderAttribute", readContentLauncherAcceptHeaderAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherSupportedStreamingProtocolsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12855,7 +12807,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readContentLauncherSupportedStreamingProtocolsCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readSupportedStreamingProtocolsAttribute",
         readContentLauncherSupportedStreamingProtocolsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherGeneratedCommandListCommandParams =
@@ -12872,7 +12824,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedContentLauncherClusterGeneratedCommandListAttributeCallback(),
             readContentLauncherGeneratedCommandListCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readContentLauncherGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherAcceptedCommandListCommandParams =
@@ -12889,7 +12841,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedContentLauncherClusterAcceptedCommandListAttributeCallback(),
             readContentLauncherAcceptedCommandListCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readContentLauncherAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherEventListCommandParams =
@@ -12904,8 +12856,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedContentLauncherClusterEventListAttributeCallback(),
             readContentLauncherEventListCommandParams);
-    readContentLauncherInteractionInfo.put(
-        "readEventListAttribute", readContentLauncherEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readContentLauncherEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readContentLauncherAttributeListAttributeInteractionInfo =
@@ -12920,7 +12871,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedContentLauncherClusterAttributeListAttributeCallback(),
             readContentLauncherAttributeListCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readContentLauncherAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -12932,8 +12883,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readContentLauncherFeatureMapCommandParams);
-    readContentLauncherInteractionInfo.put(
-        "readFeatureMapAttribute", readContentLauncherFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readContentLauncherFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readContentLauncherClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readContentLauncherClusterRevisionAttributeInteractionInfo =
@@ -12944,10 +12894,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readContentLauncherClusterRevisionCommandParams);
-    readContentLauncherInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readContentLauncherClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("contentLauncher", readContentLauncherInteractionInfo);
-    Map<String, InteractionInfo> readAudioOutputInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readAudioOutputInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readAudioOutputOutputListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputOutputListAttributeInteractionInfo =
@@ -12959,8 +12913,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAudioOutputClusterOutputListAttributeCallback(),
             readAudioOutputOutputListCommandParams);
-    readAudioOutputInteractionInfo.put(
-        "readOutputListAttribute", readAudioOutputOutputListAttributeInteractionInfo);
+    result.put("readOutputListAttribute", readAudioOutputOutputListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputCurrentOutputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputCurrentOutputAttributeInteractionInfo =
@@ -12971,8 +12924,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAudioOutputCurrentOutputCommandParams);
-    readAudioOutputInteractionInfo.put(
-        "readCurrentOutputAttribute", readAudioOutputCurrentOutputAttributeInteractionInfo);
+    result.put("readCurrentOutputAttribute", readAudioOutputCurrentOutputAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputGeneratedCommandListAttributeInteractionInfo =
@@ -12987,7 +12939,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAudioOutputClusterGeneratedCommandListAttributeCallback(),
             readAudioOutputGeneratedCommandListCommandParams);
-    readAudioOutputInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readAudioOutputGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputAcceptedCommandListCommandParams =
@@ -13004,7 +12956,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAudioOutputClusterAcceptedCommandListAttributeCallback(),
             readAudioOutputAcceptedCommandListCommandParams);
-    readAudioOutputInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readAudioOutputAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputEventListCommandParams =
@@ -13018,8 +12970,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAudioOutputClusterEventListAttributeCallback(),
             readAudioOutputEventListCommandParams);
-    readAudioOutputInteractionInfo.put(
-        "readEventListAttribute", readAudioOutputEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readAudioOutputEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputAttributeListAttributeInteractionInfo =
@@ -13032,8 +12983,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedAudioOutputClusterAttributeListAttributeCallback(),
             readAudioOutputAttributeListCommandParams);
-    readAudioOutputInteractionInfo.put(
-        "readAttributeListAttribute", readAudioOutputAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readAudioOutputAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputFeatureMapAttributeInteractionInfo =
@@ -13044,8 +12994,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readAudioOutputFeatureMapCommandParams);
-    readAudioOutputInteractionInfo.put(
-        "readFeatureMapAttribute", readAudioOutputFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readAudioOutputFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAudioOutputClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAudioOutputClusterRevisionAttributeInteractionInfo =
@@ -13056,10 +13005,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAudioOutputClusterRevisionCommandParams);
-    readAudioOutputInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readAudioOutputClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("audioOutput", readAudioOutputInteractionInfo);
-    Map<String, InteractionInfo> readApplicationLauncherInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readApplicationLauncherInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readApplicationLauncherCatalogListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationLauncherCatalogListAttributeInteractionInfo =
@@ -13074,7 +13027,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationLauncherClusterCatalogListAttributeCallback(),
             readApplicationLauncherCatalogListCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readCatalogListAttribute", readApplicationLauncherCatalogListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13091,7 +13044,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationLauncherClusterGeneratedCommandListAttributeCallback(),
             readApplicationLauncherGeneratedCommandListCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readApplicationLauncherGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherAcceptedCommandListCommandParams =
@@ -13108,7 +13061,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationLauncherClusterAcceptedCommandListAttributeCallback(),
             readApplicationLauncherAcceptedCommandListCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readApplicationLauncherAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherEventListCommandParams =
@@ -13125,8 +13078,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationLauncherClusterEventListAttributeCallback(),
             readApplicationLauncherEventListCommandParams);
-    readApplicationLauncherInteractionInfo.put(
-        "readEventListAttribute", readApplicationLauncherEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readApplicationLauncherEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationLauncherAttributeListAttributeInteractionInfo =
@@ -13141,7 +13093,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationLauncherClusterAttributeListAttributeCallback(),
             readApplicationLauncherAttributeListCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readApplicationLauncherAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13153,7 +13105,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readApplicationLauncherFeatureMapCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readApplicationLauncherFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationLauncherClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13165,11 +13117,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readApplicationLauncherClusterRevisionCommandParams);
-    readApplicationLauncherInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readApplicationLauncherClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("applicationLauncher", readApplicationLauncherInteractionInfo);
-    Map<String, InteractionInfo> readApplicationBasicInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readApplicationBasicInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readApplicationBasicVendorNameCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicVendorNameAttributeInteractionInfo =
@@ -13180,8 +13136,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readApplicationBasicVendorNameCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readVendorNameAttribute", readApplicationBasicVendorNameAttributeInteractionInfo);
+    result.put("readVendorNameAttribute", readApplicationBasicVendorNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicVendorIDCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicVendorIDAttributeInteractionInfo =
@@ -13192,8 +13147,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readApplicationBasicVendorIDCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readVendorIDAttribute", readApplicationBasicVendorIDAttributeInteractionInfo);
+    result.put("readVendorIDAttribute", readApplicationBasicVendorIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicApplicationNameCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicApplicationNameAttributeInteractionInfo =
@@ -13205,7 +13159,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readApplicationBasicApplicationNameCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readApplicationNameAttribute",
         readApplicationBasicApplicationNameAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicProductIDCommandParams =
@@ -13218,8 +13172,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readApplicationBasicProductIDCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readProductIDAttribute", readApplicationBasicProductIDAttributeInteractionInfo);
+    result.put("readProductIDAttribute", readApplicationBasicProductIDAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicStatusCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicStatusAttributeInteractionInfo =
@@ -13230,8 +13183,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readApplicationBasicStatusCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readStatusAttribute", readApplicationBasicStatusAttributeInteractionInfo);
+    result.put("readStatusAttribute", readApplicationBasicStatusAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicApplicationVersionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicApplicationVersionAttributeInteractionInfo =
@@ -13243,7 +13195,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readApplicationBasicApplicationVersionCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readApplicationVersionAttribute",
         readApplicationBasicApplicationVersionAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicAllowedVendorListCommandParams =
@@ -13260,7 +13212,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationBasicClusterAllowedVendorListAttributeCallback(),
             readApplicationBasicAllowedVendorListCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readAllowedVendorListAttribute",
         readApplicationBasicAllowedVendorListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicGeneratedCommandListCommandParams =
@@ -13277,7 +13229,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationBasicClusterGeneratedCommandListAttributeCallback(),
             readApplicationBasicGeneratedCommandListCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readApplicationBasicGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicAcceptedCommandListCommandParams =
@@ -13294,7 +13246,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationBasicClusterAcceptedCommandListAttributeCallback(),
             readApplicationBasicAcceptedCommandListCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readApplicationBasicAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicEventListCommandParams =
@@ -13309,8 +13261,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedApplicationBasicClusterEventListAttributeCallback(),
             readApplicationBasicEventListCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readEventListAttribute", readApplicationBasicEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readApplicationBasicEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicAttributeListAttributeInteractionInfo =
@@ -13325,7 +13276,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedApplicationBasicClusterAttributeListAttributeCallback(),
             readApplicationBasicAttributeListCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute", readApplicationBasicAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13337,8 +13288,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readApplicationBasicFeatureMapCommandParams);
-    readApplicationBasicInteractionInfo.put(
-        "readFeatureMapAttribute", readApplicationBasicFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readApplicationBasicFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readApplicationBasicClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readApplicationBasicClusterRevisionAttributeInteractionInfo =
@@ -13349,11 +13299,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readApplicationBasicClusterRevisionCommandParams);
-    readApplicationBasicInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readApplicationBasicClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("applicationBasic", readApplicationBasicInteractionInfo);
-    Map<String, InteractionInfo> readAccountLoginInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readAccountLoginInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readAccountLoginGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccountLoginGeneratedCommandListAttributeInteractionInfo =
@@ -13368,7 +13322,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAccountLoginClusterGeneratedCommandListAttributeCallback(),
             readAccountLoginGeneratedCommandListCommandParams);
-    readAccountLoginInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readAccountLoginGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccountLoginAcceptedCommandListCommandParams =
@@ -13385,7 +13339,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedAccountLoginClusterAcceptedCommandListAttributeCallback(),
             readAccountLoginAcceptedCommandListCommandParams);
-    readAccountLoginInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readAccountLoginAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccountLoginEventListCommandParams =
@@ -13399,8 +13353,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedAccountLoginClusterEventListAttributeCallback(),
             readAccountLoginEventListCommandParams);
-    readAccountLoginInteractionInfo.put(
-        "readEventListAttribute", readAccountLoginEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readAccountLoginEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccountLoginAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccountLoginAttributeListAttributeInteractionInfo =
@@ -13413,8 +13366,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedAccountLoginClusterAttributeListAttributeCallback(),
             readAccountLoginAttributeListCommandParams);
-    readAccountLoginInteractionInfo.put(
-        "readAttributeListAttribute", readAccountLoginAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readAccountLoginAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccountLoginFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccountLoginFeatureMapAttributeInteractionInfo =
@@ -13425,8 +13377,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readAccountLoginFeatureMapCommandParams);
-    readAccountLoginInteractionInfo.put(
-        "readFeatureMapAttribute", readAccountLoginFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readAccountLoginFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readAccountLoginClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readAccountLoginClusterRevisionAttributeInteractionInfo =
@@ -13437,10 +13388,14 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readAccountLoginClusterRevisionCommandParams);
-    readAccountLoginInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readAccountLoginClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("accountLogin", readAccountLoginInteractionInfo);
-    Map<String, InteractionInfo> readElectricalMeasurementInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readElectricalMeasurementInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readElectricalMeasurementMeasurementTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readElectricalMeasurementMeasurementTypeAttributeInteractionInfo =
@@ -13451,7 +13406,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementMeasurementTypeCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasurementTypeAttribute",
         readElectricalMeasurementMeasurementTypeAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcVoltageCommandParams =
@@ -13464,7 +13419,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcVoltageAttribute", readElectricalMeasurementDcVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcVoltageMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13476,7 +13431,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcVoltageMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcVoltageMinAttribute", readElectricalMeasurementDcVoltageMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcVoltageMaxCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13488,7 +13443,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcVoltageMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcVoltageMaxAttribute", readElectricalMeasurementDcVoltageMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcCurrentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13500,7 +13455,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcCurrentAttribute", readElectricalMeasurementDcCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcCurrentMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13512,7 +13467,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcCurrentMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcCurrentMinAttribute", readElectricalMeasurementDcCurrentMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcCurrentMaxCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13524,7 +13479,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcCurrentMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcCurrentMaxAttribute", readElectricalMeasurementDcCurrentMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcPowerCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13536,8 +13491,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcPowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
-        "readDcPowerAttribute", readElectricalMeasurementDcPowerAttributeInteractionInfo);
+    result.put("readDcPowerAttribute", readElectricalMeasurementDcPowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcPowerMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readElectricalMeasurementDcPowerMinAttributeInteractionInfo =
@@ -13548,7 +13502,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcPowerMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcPowerMinAttribute", readElectricalMeasurementDcPowerMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcPowerMaxCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13560,7 +13514,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcPowerMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcPowerMaxAttribute", readElectricalMeasurementDcPowerMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcVoltageMultiplierCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13573,7 +13527,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcVoltageMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcVoltageMultiplierAttribute",
         readElectricalMeasurementDcVoltageMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcVoltageDivisorCommandParams =
@@ -13586,7 +13540,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcVoltageDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcVoltageDivisorAttribute",
         readElectricalMeasurementDcVoltageDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcCurrentMultiplierCommandParams =
@@ -13600,7 +13554,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcCurrentMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcCurrentMultiplierAttribute",
         readElectricalMeasurementDcCurrentMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcCurrentDivisorCommandParams =
@@ -13613,7 +13567,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcCurrentDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcCurrentDivisorAttribute",
         readElectricalMeasurementDcCurrentDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcPowerMultiplierCommandParams =
@@ -13626,7 +13580,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcPowerMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcPowerMultiplierAttribute",
         readElectricalMeasurementDcPowerMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementDcPowerDivisorCommandParams =
@@ -13639,7 +13593,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementDcPowerDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readDcPowerDivisorAttribute",
         readElectricalMeasurementDcPowerDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcFrequencyCommandParams =
@@ -13652,7 +13606,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcFrequencyCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcFrequencyAttribute", readElectricalMeasurementAcFrequencyAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcFrequencyMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -13664,7 +13618,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcFrequencyMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcFrequencyMinAttribute",
         readElectricalMeasurementAcFrequencyMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcFrequencyMaxCommandParams =
@@ -13677,7 +13631,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcFrequencyMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcFrequencyMaxAttribute",
         readElectricalMeasurementAcFrequencyMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementNeutralCurrentCommandParams =
@@ -13690,7 +13644,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementNeutralCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readNeutralCurrentAttribute",
         readElectricalMeasurementNeutralCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementTotalActivePowerCommandParams =
@@ -13703,7 +13657,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementTotalActivePowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readTotalActivePowerAttribute",
         readElectricalMeasurementTotalActivePowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementTotalReactivePowerCommandParams =
@@ -13716,7 +13670,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementTotalReactivePowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readTotalReactivePowerAttribute",
         readElectricalMeasurementTotalReactivePowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementTotalApparentPowerCommandParams =
@@ -13729,7 +13683,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementTotalApparentPowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readTotalApparentPowerAttribute",
         readElectricalMeasurementTotalApparentPowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13744,7 +13698,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured1stHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured1stHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured1stHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13759,7 +13713,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured3rdHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured3rdHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured3rdHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13774,7 +13728,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured5thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured5thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured5thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13789,7 +13743,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured7thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured7thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured7thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13804,7 +13758,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured9thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured9thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured9thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13819,7 +13773,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementMeasured11thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasured11thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasured11thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13835,7 +13789,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase1stHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase1stHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase1stHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13851,7 +13805,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase3rdHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase3rdHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase3rdHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13867,7 +13821,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase5thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase5thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase5thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13883,7 +13837,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase7thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase7thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase7thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13899,7 +13853,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase9thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase9thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase9thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13915,7 +13869,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementMeasuredPhase11thHarmonicCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readMeasuredPhase11thHarmonicCurrentAttribute",
         readElectricalMeasurementMeasuredPhase11thHarmonicCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcFrequencyMultiplierCommandParams =
@@ -13929,7 +13883,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcFrequencyMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcFrequencyMultiplierAttribute",
         readElectricalMeasurementAcFrequencyMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcFrequencyDivisorCommandParams =
@@ -13943,7 +13897,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcFrequencyDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcFrequencyDivisorAttribute",
         readElectricalMeasurementAcFrequencyDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementPowerMultiplierCommandParams =
@@ -13956,7 +13910,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementPowerMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPowerMultiplierAttribute",
         readElectricalMeasurementPowerMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementPowerDivisorCommandParams =
@@ -13969,7 +13923,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementPowerDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPowerDivisorAttribute", readElectricalMeasurementPowerDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readElectricalMeasurementHarmonicCurrentMultiplierCommandParams =
@@ -13983,7 +13937,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementHarmonicCurrentMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readHarmonicCurrentMultiplierAttribute",
         readElectricalMeasurementHarmonicCurrentMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -13999,7 +13953,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementPhaseHarmonicCurrentMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPhaseHarmonicCurrentMultiplierAttribute",
         readElectricalMeasurementPhaseHarmonicCurrentMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementInstantaneousVoltageCommandParams =
@@ -14013,7 +13967,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementInstantaneousVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readInstantaneousVoltageAttribute",
         readElectricalMeasurementInstantaneousVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14028,7 +13982,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementInstantaneousLineCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readInstantaneousLineCurrentAttribute",
         readElectricalMeasurementInstantaneousLineCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14043,7 +13997,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementInstantaneousActiveCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readInstantaneousActiveCurrentAttribute",
         readElectricalMeasurementInstantaneousActiveCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14058,7 +14012,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementInstantaneousReactiveCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readInstantaneousReactiveCurrentAttribute",
         readElectricalMeasurementInstantaneousReactiveCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementInstantaneousPowerCommandParams =
@@ -14072,7 +14026,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementInstantaneousPowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readInstantaneousPowerAttribute",
         readElectricalMeasurementInstantaneousPowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageCommandParams =
@@ -14085,7 +14039,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageAttribute", readElectricalMeasurementRmsVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -14097,7 +14051,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMinAttribute",
         readElectricalMeasurementRmsVoltageMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMaxCommandParams =
@@ -14110,7 +14064,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMaxAttribute",
         readElectricalMeasurementRmsVoltageMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentCommandParams =
@@ -14123,7 +14077,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentAttribute", readElectricalMeasurementRmsCurrentAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -14135,7 +14089,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMinAttribute",
         readElectricalMeasurementRmsCurrentMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMaxCommandParams =
@@ -14148,7 +14102,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMaxAttribute",
         readElectricalMeasurementRmsCurrentMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerCommandParams =
@@ -14161,7 +14115,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerAttribute", readElectricalMeasurementActivePowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMinCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -14173,7 +14127,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMinCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMinAttribute",
         readElectricalMeasurementActivePowerMinAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMaxCommandParams =
@@ -14186,7 +14140,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMaxCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMaxAttribute",
         readElectricalMeasurementActivePowerMaxAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementReactivePowerCommandParams =
@@ -14199,7 +14153,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementReactivePowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readReactivePowerAttribute",
         readElectricalMeasurementReactivePowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementApparentPowerCommandParams =
@@ -14212,7 +14166,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementApparentPowerCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readApparentPowerAttribute",
         readElectricalMeasurementApparentPowerAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementPowerFactorCommandParams =
@@ -14225,7 +14179,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementPowerFactorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPowerFactorAttribute", readElectricalMeasurementPowerFactorAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
         readElectricalMeasurementAverageRmsVoltageMeasurementPeriodCommandParams =
@@ -14240,7 +14194,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsVoltageMeasurementPeriodCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsVoltageMeasurementPeriodAttribute",
         readElectricalMeasurementAverageRmsVoltageMeasurementPeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14255,7 +14209,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAverageRmsUnderVoltageCounterCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsUnderVoltageCounterAttribute",
         readElectricalMeasurementAverageRmsUnderVoltageCounterAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14270,7 +14224,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsExtremeOverVoltagePeriodCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeOverVoltagePeriodAttribute",
         readElectricalMeasurementRmsExtremeOverVoltagePeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14285,7 +14239,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsExtremeUnderVoltagePeriodCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeUnderVoltagePeriodAttribute",
         readElectricalMeasurementRmsExtremeUnderVoltagePeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageSagPeriodCommandParams =
@@ -14299,7 +14253,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSagPeriodCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSagPeriodAttribute",
         readElectricalMeasurementRmsVoltageSagPeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageSwellPeriodCommandParams =
@@ -14313,7 +14267,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSwellPeriodCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSwellPeriodAttribute",
         readElectricalMeasurementRmsVoltageSwellPeriodAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcVoltageMultiplierCommandParams =
@@ -14327,7 +14281,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcVoltageMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcVoltageMultiplierAttribute",
         readElectricalMeasurementAcVoltageMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcVoltageDivisorCommandParams =
@@ -14340,7 +14294,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcVoltageDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcVoltageDivisorAttribute",
         readElectricalMeasurementAcVoltageDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcCurrentMultiplierCommandParams =
@@ -14354,7 +14308,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcCurrentMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcCurrentMultiplierAttribute",
         readElectricalMeasurementAcCurrentMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcCurrentDivisorCommandParams =
@@ -14367,7 +14321,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcCurrentDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcCurrentDivisorAttribute",
         readElectricalMeasurementAcCurrentDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcPowerMultiplierCommandParams =
@@ -14380,7 +14334,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcPowerMultiplierCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcPowerMultiplierAttribute",
         readElectricalMeasurementAcPowerMultiplierAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcPowerDivisorCommandParams =
@@ -14393,7 +14347,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcPowerDivisorCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcPowerDivisorAttribute",
         readElectricalMeasurementAcPowerDivisorAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementOverloadAlarmsMaskCommandParams =
@@ -14407,7 +14361,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementOverloadAlarmsMaskCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readOverloadAlarmsMaskAttribute",
         readElectricalMeasurementOverloadAlarmsMaskAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementVoltageOverloadCommandParams =
@@ -14420,7 +14374,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementVoltageOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readVoltageOverloadAttribute",
         readElectricalMeasurementVoltageOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementCurrentOverloadCommandParams =
@@ -14433,7 +14387,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementCurrentOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readCurrentOverloadAttribute",
         readElectricalMeasurementCurrentOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcOverloadAlarmsMaskCommandParams =
@@ -14447,7 +14401,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcOverloadAlarmsMaskCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcOverloadAlarmsMaskAttribute",
         readElectricalMeasurementAcOverloadAlarmsMaskAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcVoltageOverloadCommandParams =
@@ -14460,7 +14414,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcVoltageOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcVoltageOverloadAttribute",
         readElectricalMeasurementAcVoltageOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcCurrentOverloadCommandParams =
@@ -14473,7 +14427,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcCurrentOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcCurrentOverloadAttribute",
         readElectricalMeasurementAcCurrentOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcActivePowerOverloadCommandParams =
@@ -14487,7 +14441,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcActivePowerOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcActivePowerOverloadAttribute",
         readElectricalMeasurementAcActivePowerOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14502,7 +14456,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAcReactivePowerOverloadCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcReactivePowerOverloadAttribute",
         readElectricalMeasurementAcReactivePowerOverloadAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAverageRmsOverVoltageCommandParams =
@@ -14516,7 +14470,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAverageRmsOverVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsOverVoltageAttribute",
         readElectricalMeasurementAverageRmsOverVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAverageRmsUnderVoltageCommandParams =
@@ -14530,7 +14484,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementAverageRmsUnderVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsUnderVoltageAttribute",
         readElectricalMeasurementAverageRmsUnderVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsExtremeOverVoltageCommandParams =
@@ -14544,7 +14498,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsExtremeOverVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeOverVoltageAttribute",
         readElectricalMeasurementRmsExtremeOverVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsExtremeUnderVoltageCommandParams =
@@ -14558,7 +14512,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsExtremeUnderVoltageCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeUnderVoltageAttribute",
         readElectricalMeasurementRmsExtremeUnderVoltageAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageSagCommandParams =
@@ -14571,7 +14525,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSagCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSagAttribute",
         readElectricalMeasurementRmsVoltageSagAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageSwellCommandParams =
@@ -14584,7 +14538,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSwellCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSwellAttribute",
         readElectricalMeasurementRmsVoltageSwellAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementLineCurrentPhaseBCommandParams =
@@ -14597,7 +14551,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementLineCurrentPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readLineCurrentPhaseBAttribute",
         readElectricalMeasurementLineCurrentPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActiveCurrentPhaseBCommandParams =
@@ -14611,7 +14565,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActiveCurrentPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActiveCurrentPhaseBAttribute",
         readElectricalMeasurementActiveCurrentPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementReactiveCurrentPhaseBCommandParams =
@@ -14625,7 +14579,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementReactiveCurrentPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readReactiveCurrentPhaseBAttribute",
         readElectricalMeasurementReactiveCurrentPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltagePhaseBCommandParams =
@@ -14638,7 +14592,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltagePhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltagePhaseBAttribute",
         readElectricalMeasurementRmsVoltagePhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMinPhaseBCommandParams =
@@ -14652,7 +14606,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMinPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMinPhaseBAttribute",
         readElectricalMeasurementRmsVoltageMinPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMaxPhaseBCommandParams =
@@ -14666,7 +14620,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMaxPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMaxPhaseBAttribute",
         readElectricalMeasurementRmsVoltageMaxPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentPhaseBCommandParams =
@@ -14679,7 +14633,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentPhaseBAttribute",
         readElectricalMeasurementRmsCurrentPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMinPhaseBCommandParams =
@@ -14693,7 +14647,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMinPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMinPhaseBAttribute",
         readElectricalMeasurementRmsCurrentMinPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMaxPhaseBCommandParams =
@@ -14707,7 +14661,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMaxPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMaxPhaseBAttribute",
         readElectricalMeasurementRmsCurrentMaxPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerPhaseBCommandParams =
@@ -14720,7 +14674,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerPhaseBAttribute",
         readElectricalMeasurementActivePowerPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMinPhaseBCommandParams =
@@ -14734,7 +14688,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMinPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMinPhaseBAttribute",
         readElectricalMeasurementActivePowerMinPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMaxPhaseBCommandParams =
@@ -14748,7 +14702,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMaxPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMaxPhaseBAttribute",
         readElectricalMeasurementActivePowerMaxPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementReactivePowerPhaseBCommandParams =
@@ -14762,7 +14716,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementReactivePowerPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readReactivePowerPhaseBAttribute",
         readElectricalMeasurementReactivePowerPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementApparentPowerPhaseBCommandParams =
@@ -14776,7 +14730,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementApparentPowerPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readApparentPowerPhaseBAttribute",
         readElectricalMeasurementApparentPowerPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementPowerFactorPhaseBCommandParams =
@@ -14789,7 +14743,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementPowerFactorPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPowerFactorPhaseBAttribute",
         readElectricalMeasurementPowerFactorPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14805,7 +14759,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsVoltageMeasurementPeriodPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsVoltageMeasurementPeriodPhaseBAttribute",
         readElectricalMeasurementAverageRmsVoltageMeasurementPeriodPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14821,7 +14775,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsOverVoltageCounterPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsOverVoltageCounterPhaseBAttribute",
         readElectricalMeasurementAverageRmsOverVoltageCounterPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14837,7 +14791,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsUnderVoltageCounterPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsUnderVoltageCounterPhaseBAttribute",
         readElectricalMeasurementAverageRmsUnderVoltageCounterPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14853,7 +14807,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementRmsExtremeOverVoltagePeriodPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeOverVoltagePeriodPhaseBAttribute",
         readElectricalMeasurementRmsExtremeOverVoltagePeriodPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14869,7 +14823,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementRmsExtremeUnderVoltagePeriodPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeUnderVoltagePeriodPhaseBAttribute",
         readElectricalMeasurementRmsExtremeUnderVoltagePeriodPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14884,7 +14838,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSagPeriodPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSagPeriodPhaseBAttribute",
         readElectricalMeasurementRmsVoltageSagPeriodPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -14899,7 +14853,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSwellPeriodPhaseBCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSwellPeriodPhaseBAttribute",
         readElectricalMeasurementRmsVoltageSwellPeriodPhaseBAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementLineCurrentPhaseCCommandParams =
@@ -14912,7 +14866,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementLineCurrentPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readLineCurrentPhaseCAttribute",
         readElectricalMeasurementLineCurrentPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActiveCurrentPhaseCCommandParams =
@@ -14926,7 +14880,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActiveCurrentPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActiveCurrentPhaseCAttribute",
         readElectricalMeasurementActiveCurrentPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementReactiveCurrentPhaseCCommandParams =
@@ -14940,7 +14894,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementReactiveCurrentPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readReactiveCurrentPhaseCAttribute",
         readElectricalMeasurementReactiveCurrentPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltagePhaseCCommandParams =
@@ -14953,7 +14907,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltagePhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltagePhaseCAttribute",
         readElectricalMeasurementRmsVoltagePhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMinPhaseCCommandParams =
@@ -14967,7 +14921,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMinPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMinPhaseCAttribute",
         readElectricalMeasurementRmsVoltageMinPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsVoltageMaxPhaseCCommandParams =
@@ -14981,7 +14935,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageMaxPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageMaxPhaseCAttribute",
         readElectricalMeasurementRmsVoltageMaxPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentPhaseCCommandParams =
@@ -14994,7 +14948,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentPhaseCAttribute",
         readElectricalMeasurementRmsCurrentPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMinPhaseCCommandParams =
@@ -15008,7 +14962,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMinPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMinPhaseCAttribute",
         readElectricalMeasurementRmsCurrentMinPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementRmsCurrentMaxPhaseCCommandParams =
@@ -15022,7 +14976,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsCurrentMaxPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsCurrentMaxPhaseCAttribute",
         readElectricalMeasurementRmsCurrentMaxPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerPhaseCCommandParams =
@@ -15035,7 +14989,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerPhaseCAttribute",
         readElectricalMeasurementActivePowerPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMinPhaseCCommandParams =
@@ -15049,7 +15003,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMinPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMinPhaseCAttribute",
         readElectricalMeasurementActivePowerMinPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementActivePowerMaxPhaseCCommandParams =
@@ -15063,7 +15017,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementActivePowerMaxPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readActivePowerMaxPhaseCAttribute",
         readElectricalMeasurementActivePowerMaxPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementReactivePowerPhaseCCommandParams =
@@ -15077,7 +15031,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementReactivePowerPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readReactivePowerPhaseCAttribute",
         readElectricalMeasurementReactivePowerPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementApparentPowerPhaseCCommandParams =
@@ -15091,7 +15045,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementApparentPowerPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readApparentPowerPhaseCAttribute",
         readElectricalMeasurementApparentPowerPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementPowerFactorPhaseCCommandParams =
@@ -15104,7 +15058,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementPowerFactorPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readPowerFactorPhaseCAttribute",
         readElectricalMeasurementPowerFactorPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15120,7 +15074,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsVoltageMeasurementPeriodPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsVoltageMeasurementPeriodPhaseCAttribute",
         readElectricalMeasurementAverageRmsVoltageMeasurementPeriodPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15136,7 +15090,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsOverVoltageCounterPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsOverVoltageCounterPhaseCAttribute",
         readElectricalMeasurementAverageRmsOverVoltageCounterPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15152,7 +15106,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementAverageRmsUnderVoltageCounterPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAverageRmsUnderVoltageCounterPhaseCAttribute",
         readElectricalMeasurementAverageRmsUnderVoltageCounterPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15168,7 +15122,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementRmsExtremeOverVoltagePeriodPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeOverVoltagePeriodPhaseCAttribute",
         readElectricalMeasurementRmsExtremeOverVoltagePeriodPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15184,7 +15138,7 @@ public class ClusterReadMapping {
                 },
                 () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
                 readElectricalMeasurementRmsExtremeUnderVoltagePeriodPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsExtremeUnderVoltagePeriodPhaseCAttribute",
         readElectricalMeasurementRmsExtremeUnderVoltagePeriodPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15199,7 +15153,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSagPeriodPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSagPeriodPhaseCAttribute",
         readElectricalMeasurementRmsVoltageSagPeriodPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo>
@@ -15214,7 +15168,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementRmsVoltageSwellPeriodPhaseCCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readRmsVoltageSwellPeriodPhaseCAttribute",
         readElectricalMeasurementRmsVoltageSwellPeriodPhaseCAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementGeneratedCommandListCommandParams =
@@ -15232,7 +15186,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedElectricalMeasurementClusterGeneratedCommandListAttributeCallback(),
             readElectricalMeasurementGeneratedCommandListCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readElectricalMeasurementGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAcceptedCommandListCommandParams =
@@ -15250,7 +15204,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedElectricalMeasurementClusterAcceptedCommandListAttributeCallback(),
             readElectricalMeasurementAcceptedCommandListCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readElectricalMeasurementAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementEventListCommandParams =
@@ -15267,7 +15221,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedElectricalMeasurementClusterEventListAttributeCallback(),
             readElectricalMeasurementEventListCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readEventListAttribute", readElectricalMeasurementEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15283,7 +15237,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedElectricalMeasurementClusterAttributeListAttributeCallback(),
             readElectricalMeasurementAttributeListCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readAttributeListAttribute",
         readElectricalMeasurementAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementFeatureMapCommandParams =
@@ -15296,7 +15250,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readElectricalMeasurementFeatureMapCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readFeatureMapAttribute", readElectricalMeasurementFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readElectricalMeasurementClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15308,11 +15262,15 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readElectricalMeasurementClusterRevisionCommandParams);
-    readElectricalMeasurementInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute",
         readElectricalMeasurementClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("electricalMeasurement", readElectricalMeasurementInteractionInfo);
-    Map<String, InteractionInfo> readUnitTestingInteractionInfo = new LinkedHashMap<>();
+
+    return result;
+  }
+
+  private static Map<String, InteractionInfo> readUnitTestingInteractionInfo() {
+    Map<String, InteractionInfo> result = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> readUnitTestingBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingBooleanAttributeInteractionInfo =
@@ -15323,8 +15281,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readUnitTestingBooleanCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readBooleanAttribute", readUnitTestingBooleanAttributeInteractionInfo);
+    result.put("readBooleanAttribute", readUnitTestingBooleanAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingBitmap8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingBitmap8AttributeInteractionInfo =
@@ -15335,8 +15292,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingBitmap8CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readBitmap8Attribute", readUnitTestingBitmap8AttributeInteractionInfo);
+    result.put("readBitmap8Attribute", readUnitTestingBitmap8AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingBitmap16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingBitmap16AttributeInteractionInfo =
@@ -15347,8 +15303,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingBitmap16CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readBitmap16Attribute", readUnitTestingBitmap16AttributeInteractionInfo);
+    result.put("readBitmap16Attribute", readUnitTestingBitmap16AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingBitmap32CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingBitmap32AttributeInteractionInfo =
@@ -15359,8 +15314,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingBitmap32CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readBitmap32Attribute", readUnitTestingBitmap32AttributeInteractionInfo);
+    result.put("readBitmap32Attribute", readUnitTestingBitmap32AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingBitmap64CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingBitmap64AttributeInteractionInfo =
@@ -15371,8 +15325,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingBitmap64CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readBitmap64Attribute", readUnitTestingBitmap64AttributeInteractionInfo);
+    result.put("readBitmap64Attribute", readUnitTestingBitmap64AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt8uAttributeInteractionInfo =
@@ -15383,8 +15336,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt8uAttribute", readUnitTestingInt8uAttributeInteractionInfo);
+    result.put("readInt8uAttribute", readUnitTestingInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt16uAttributeInteractionInfo =
@@ -15395,8 +15347,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingInt16uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt16uAttribute", readUnitTestingInt16uAttributeInteractionInfo);
+    result.put("readInt16uAttribute", readUnitTestingInt16uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt24uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt24uAttributeInteractionInfo =
@@ -15407,8 +15358,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt24uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt24uAttribute", readUnitTestingInt24uAttributeInteractionInfo);
+    result.put("readInt24uAttribute", readUnitTestingInt24uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt32uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt32uAttributeInteractionInfo =
@@ -15419,8 +15369,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt32uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt32uAttribute", readUnitTestingInt32uAttributeInteractionInfo);
+    result.put("readInt32uAttribute", readUnitTestingInt32uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt40uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt40uAttributeInteractionInfo =
@@ -15431,8 +15380,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt40uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt40uAttribute", readUnitTestingInt40uAttributeInteractionInfo);
+    result.put("readInt40uAttribute", readUnitTestingInt40uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt48uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt48uAttributeInteractionInfo =
@@ -15443,8 +15391,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt48uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt48uAttribute", readUnitTestingInt48uAttributeInteractionInfo);
+    result.put("readInt48uAttribute", readUnitTestingInt48uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt56uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt56uAttributeInteractionInfo =
@@ -15455,8 +15402,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt56uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt56uAttribute", readUnitTestingInt56uAttributeInteractionInfo);
+    result.put("readInt56uAttribute", readUnitTestingInt56uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt64uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt64uAttributeInteractionInfo =
@@ -15467,8 +15413,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt64uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt64uAttribute", readUnitTestingInt64uAttributeInteractionInfo);
+    result.put("readInt64uAttribute", readUnitTestingInt64uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt8sAttributeInteractionInfo =
@@ -15479,8 +15424,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingInt8sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt8sAttribute", readUnitTestingInt8sAttributeInteractionInfo);
+    result.put("readInt8sAttribute", readUnitTestingInt8sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt16sAttributeInteractionInfo =
@@ -15491,8 +15435,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingInt16sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt16sAttribute", readUnitTestingInt16sAttributeInteractionInfo);
+    result.put("readInt16sAttribute", readUnitTestingInt16sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt24sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt24sAttributeInteractionInfo =
@@ -15503,8 +15446,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt24sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt24sAttribute", readUnitTestingInt24sAttributeInteractionInfo);
+    result.put("readInt24sAttribute", readUnitTestingInt24sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt32sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt32sAttributeInteractionInfo =
@@ -15515,8 +15457,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt32sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt32sAttribute", readUnitTestingInt32sAttributeInteractionInfo);
+    result.put("readInt32sAttribute", readUnitTestingInt32sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt40sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt40sAttributeInteractionInfo =
@@ -15527,8 +15468,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt40sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt40sAttribute", readUnitTestingInt40sAttributeInteractionInfo);
+    result.put("readInt40sAttribute", readUnitTestingInt40sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt48sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt48sAttributeInteractionInfo =
@@ -15539,8 +15479,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt48sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt48sAttribute", readUnitTestingInt48sAttributeInteractionInfo);
+    result.put("readInt48sAttribute", readUnitTestingInt48sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt56sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt56sAttributeInteractionInfo =
@@ -15551,8 +15490,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt56sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt56sAttribute", readUnitTestingInt56sAttributeInteractionInfo);
+    result.put("readInt56sAttribute", readUnitTestingInt56sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingInt64sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingInt64sAttributeInteractionInfo =
@@ -15563,8 +15501,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingInt64sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readInt64sAttribute", readUnitTestingInt64sAttributeInteractionInfo);
+    result.put("readInt64sAttribute", readUnitTestingInt64sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEnum8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingEnum8AttributeInteractionInfo =
@@ -15575,8 +15512,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingEnum8CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEnum8Attribute", readUnitTestingEnum8AttributeInteractionInfo);
+    result.put("readEnum8Attribute", readUnitTestingEnum8AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEnum16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingEnum16AttributeInteractionInfo =
@@ -15587,8 +15523,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingEnum16CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEnum16Attribute", readUnitTestingEnum16AttributeInteractionInfo);
+    result.put("readEnum16Attribute", readUnitTestingEnum16AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingFloatSingleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingFloatSingleAttributeInteractionInfo =
@@ -15599,8 +15534,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedFloatAttributeCallback(),
             readUnitTestingFloatSingleCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readFloatSingleAttribute", readUnitTestingFloatSingleAttributeInteractionInfo);
+    result.put("readFloatSingleAttribute", readUnitTestingFloatSingleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingFloatDoubleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingFloatDoubleAttributeInteractionInfo =
@@ -15611,8 +15545,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedDoubleAttributeCallback(),
             readUnitTestingFloatDoubleCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readFloatDoubleAttribute", readUnitTestingFloatDoubleAttributeInteractionInfo);
+    result.put("readFloatDoubleAttribute", readUnitTestingFloatDoubleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingOctetStringAttributeInteractionInfo =
@@ -15623,8 +15556,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedOctetStringAttributeCallback(),
             readUnitTestingOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readOctetStringAttribute", readUnitTestingOctetStringAttributeInteractionInfo);
+    result.put("readOctetStringAttribute", readUnitTestingOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingListInt8uAttributeInteractionInfo =
@@ -15636,8 +15568,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedUnitTestingClusterListInt8uAttributeCallback(),
             readUnitTestingListInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readListInt8uAttribute", readUnitTestingListInt8uAttributeInteractionInfo);
+    result.put("readListInt8uAttribute", readUnitTestingListInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingListOctetStringAttributeInteractionInfo =
@@ -15651,7 +15582,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterListOctetStringAttributeCallback(),
             readUnitTestingListOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readListOctetStringAttribute", readUnitTestingListOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListStructOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15667,7 +15598,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterListStructOctetStringAttributeCallback(),
             readUnitTestingListStructOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readListStructOctetStringAttribute",
         readUnitTestingListStructOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingLongOctetStringCommandParams =
@@ -15681,7 +15612,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedOctetStringAttributeCallback(),
             readUnitTestingLongOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readLongOctetStringAttribute", readUnitTestingLongOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingCharStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15693,8 +15624,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readUnitTestingCharStringCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readCharStringAttribute", readUnitTestingCharStringAttributeInteractionInfo);
+    result.put("readCharStringAttribute", readUnitTestingCharStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingLongCharStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingLongCharStringAttributeInteractionInfo =
@@ -15705,7 +15635,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedCharStringAttributeCallback(),
             readUnitTestingLongCharStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readLongCharStringAttribute", readUnitTestingLongCharStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEpochUsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15717,8 +15647,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingEpochUsCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEpochUsAttribute", readUnitTestingEpochUsAttributeInteractionInfo);
+    result.put("readEpochUsAttribute", readUnitTestingEpochUsAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEpochSCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingEpochSAttributeInteractionInfo =
@@ -15729,8 +15658,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingEpochSCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEpochSAttribute", readUnitTestingEpochSAttributeInteractionInfo);
+    result.put("readEpochSAttribute", readUnitTestingEpochSAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingVendorIdCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingVendorIdAttributeInteractionInfo =
@@ -15741,8 +15669,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingVendorIdCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readVendorIdAttribute", readUnitTestingVendorIdAttributeInteractionInfo);
+    result.put("readVendorIdAttribute", readUnitTestingVendorIdAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListNullablesAndOptionalsStructCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingListNullablesAndOptionalsStructAttributeInteractionInfo =
@@ -15758,7 +15685,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterListNullablesAndOptionalsStructAttributeCallback(),
             readUnitTestingListNullablesAndOptionalsStructCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readListNullablesAndOptionalsStructAttribute",
         readUnitTestingListNullablesAndOptionalsStructAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEnumAttrCommandParams =
@@ -15771,8 +15698,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingEnumAttrCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEnumAttrAttribute", readUnitTestingEnumAttrAttributeInteractionInfo);
+    result.put("readEnumAttrAttribute", readUnitTestingEnumAttrAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingRangeRestrictedInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingRangeRestrictedInt8uAttributeInteractionInfo =
@@ -15784,7 +15710,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingRangeRestrictedInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readRangeRestrictedInt8uAttribute",
         readUnitTestingRangeRestrictedInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingRangeRestrictedInt8sCommandParams =
@@ -15798,7 +15724,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingRangeRestrictedInt8sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readRangeRestrictedInt8sAttribute",
         readUnitTestingRangeRestrictedInt8sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingRangeRestrictedInt16uCommandParams =
@@ -15812,7 +15738,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingRangeRestrictedInt16uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readRangeRestrictedInt16uAttribute",
         readUnitTestingRangeRestrictedInt16uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingRangeRestrictedInt16sCommandParams =
@@ -15826,7 +15752,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingRangeRestrictedInt16sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readRangeRestrictedInt16sAttribute",
         readUnitTestingRangeRestrictedInt16sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListLongOctetStringCommandParams =
@@ -15843,7 +15769,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterListLongOctetStringAttributeCallback(),
             readUnitTestingListLongOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readListLongOctetStringAttribute",
         readUnitTestingListLongOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingListFabricScopedCommandParams =
@@ -15859,7 +15785,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterListFabricScopedAttributeCallback(),
             readUnitTestingListFabricScopedCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readListFabricScopedAttribute", readUnitTestingListFabricScopedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingTimedWriteBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15871,7 +15797,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readUnitTestingTimedWriteBooleanCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readTimedWriteBooleanAttribute", readUnitTestingTimedWriteBooleanAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingGeneralErrorBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15884,7 +15810,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readUnitTestingGeneralErrorBooleanCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readGeneralErrorBooleanAttribute",
         readUnitTestingGeneralErrorBooleanAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingClusterErrorBooleanCommandParams =
@@ -15898,7 +15824,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readUnitTestingClusterErrorBooleanCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readClusterErrorBooleanAttribute",
         readUnitTestingClusterErrorBooleanAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingUnsupportedCommandParams =
@@ -15911,8 +15837,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedBooleanAttributeCallback(),
             readUnitTestingUnsupportedCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readUnsupportedAttribute", readUnitTestingUnsupportedAttributeInteractionInfo);
+    result.put("readUnsupportedAttribute", readUnitTestingUnsupportedAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingNullableBooleanAttributeInteractionInfo =
@@ -15926,7 +15851,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableBooleanAttributeCallback(),
             readUnitTestingNullableBooleanCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableBooleanAttribute", readUnitTestingNullableBooleanAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableBitmap8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15941,7 +15866,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableBitmap8AttributeCallback(),
             readUnitTestingNullableBitmap8CommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableBitmap8Attribute", readUnitTestingNullableBitmap8AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableBitmap16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15956,7 +15881,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableBitmap16AttributeCallback(),
             readUnitTestingNullableBitmap16CommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableBitmap16Attribute", readUnitTestingNullableBitmap16AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableBitmap32CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15971,7 +15896,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableBitmap32AttributeCallback(),
             readUnitTestingNullableBitmap32CommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableBitmap32Attribute", readUnitTestingNullableBitmap32AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableBitmap64CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -15986,7 +15911,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableBitmap64AttributeCallback(),
             readUnitTestingNullableBitmap64CommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableBitmap64Attribute", readUnitTestingNullableBitmap64AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16000,8 +15925,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt8uAttributeCallback(),
             readUnitTestingNullableInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readNullableInt8uAttribute", readUnitTestingNullableInt8uAttributeInteractionInfo);
+    result.put("readNullableInt8uAttribute", readUnitTestingNullableInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingNullableInt16uAttributeInteractionInfo =
@@ -16014,7 +15938,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt16uAttributeCallback(),
             readUnitTestingNullableInt16uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt16uAttribute", readUnitTestingNullableInt16uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt24uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16028,7 +15952,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt24uAttributeCallback(),
             readUnitTestingNullableInt24uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt24uAttribute", readUnitTestingNullableInt24uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt32uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16042,7 +15966,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt32uAttributeCallback(),
             readUnitTestingNullableInt32uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt32uAttribute", readUnitTestingNullableInt32uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt40uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16056,7 +15980,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt40uAttributeCallback(),
             readUnitTestingNullableInt40uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt40uAttribute", readUnitTestingNullableInt40uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt48uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16070,7 +15994,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt48uAttributeCallback(),
             readUnitTestingNullableInt48uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt48uAttribute", readUnitTestingNullableInt48uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt56uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16084,7 +16008,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt56uAttributeCallback(),
             readUnitTestingNullableInt56uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt56uAttribute", readUnitTestingNullableInt56uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt64uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16098,7 +16022,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt64uAttributeCallback(),
             readUnitTestingNullableInt64uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt64uAttribute", readUnitTestingNullableInt64uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16112,8 +16036,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt8sAttributeCallback(),
             readUnitTestingNullableInt8sCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readNullableInt8sAttribute", readUnitTestingNullableInt8sAttributeInteractionInfo);
+    result.put("readNullableInt8sAttribute", readUnitTestingNullableInt8sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingNullableInt16sAttributeInteractionInfo =
@@ -16126,7 +16049,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt16sAttributeCallback(),
             readUnitTestingNullableInt16sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt16sAttribute", readUnitTestingNullableInt16sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt24sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16140,7 +16063,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt24sAttributeCallback(),
             readUnitTestingNullableInt24sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt24sAttribute", readUnitTestingNullableInt24sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt32sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16154,7 +16077,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt32sAttributeCallback(),
             readUnitTestingNullableInt32sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt32sAttribute", readUnitTestingNullableInt32sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt40sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16168,7 +16091,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt40sAttributeCallback(),
             readUnitTestingNullableInt40sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt40sAttribute", readUnitTestingNullableInt40sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt48sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16182,7 +16105,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt48sAttributeCallback(),
             readUnitTestingNullableInt48sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt48sAttribute", readUnitTestingNullableInt48sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt56sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16196,7 +16119,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt56sAttributeCallback(),
             readUnitTestingNullableInt56sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt56sAttribute", readUnitTestingNullableInt56sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableInt64sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16210,7 +16133,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableInt64sAttributeCallback(),
             readUnitTestingNullableInt64sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableInt64sAttribute", readUnitTestingNullableInt64sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableEnum8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16224,8 +16147,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableEnum8AttributeCallback(),
             readUnitTestingNullableEnum8CommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readNullableEnum8Attribute", readUnitTestingNullableEnum8AttributeInteractionInfo);
+    result.put("readNullableEnum8Attribute", readUnitTestingNullableEnum8AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableEnum16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingNullableEnum16AttributeInteractionInfo =
@@ -16238,7 +16160,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterNullableEnum16AttributeCallback(),
             readUnitTestingNullableEnum16CommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableEnum16Attribute", readUnitTestingNullableEnum16AttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableFloatSingleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16254,7 +16176,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableFloatSingleAttributeCallback(),
             readUnitTestingNullableFloatSingleCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableFloatSingleAttribute",
         readUnitTestingNullableFloatSingleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableFloatDoubleCommandParams =
@@ -16271,7 +16193,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableFloatDoubleAttributeCallback(),
             readUnitTestingNullableFloatDoubleCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableFloatDoubleAttribute",
         readUnitTestingNullableFloatDoubleAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableOctetStringCommandParams =
@@ -16288,7 +16210,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableOctetStringAttributeCallback(),
             readUnitTestingNullableOctetStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableOctetStringAttribute",
         readUnitTestingNullableOctetStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableCharStringCommandParams =
@@ -16305,7 +16227,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableCharStringAttributeCallback(),
             readUnitTestingNullableCharStringCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableCharStringAttribute",
         readUnitTestingNullableCharStringAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableEnumAttrCommandParams =
@@ -16321,7 +16243,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableEnumAttrAttributeCallback(),
             readUnitTestingNullableEnumAttrCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableEnumAttrAttribute", readUnitTestingNullableEnumAttrAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableRangeRestrictedInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16338,7 +16260,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableRangeRestrictedInt8uAttributeCallback(),
             readUnitTestingNullableRangeRestrictedInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableRangeRestrictedInt8uAttribute",
         readUnitTestingNullableRangeRestrictedInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableRangeRestrictedInt8sCommandParams =
@@ -16356,7 +16278,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableRangeRestrictedInt8sAttributeCallback(),
             readUnitTestingNullableRangeRestrictedInt8sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableRangeRestrictedInt8sAttribute",
         readUnitTestingNullableRangeRestrictedInt8sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableRangeRestrictedInt16uCommandParams =
@@ -16374,7 +16296,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableRangeRestrictedInt16uAttributeCallback(),
             readUnitTestingNullableRangeRestrictedInt16uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableRangeRestrictedInt16uAttribute",
         readUnitTestingNullableRangeRestrictedInt16uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingNullableRangeRestrictedInt16sCommandParams =
@@ -16392,7 +16314,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterNullableRangeRestrictedInt16sAttributeCallback(),
             readUnitTestingNullableRangeRestrictedInt16sCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readNullableRangeRestrictedInt16sAttribute",
         readUnitTestingNullableRangeRestrictedInt16sAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingWriteOnlyInt8uCommandParams =
@@ -16405,7 +16327,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingWriteOnlyInt8uCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readWriteOnlyInt8uAttribute", readUnitTestingWriteOnlyInt8uAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingGeneratedCommandListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
@@ -16421,7 +16343,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterGeneratedCommandListAttributeCallback(),
             readUnitTestingGeneratedCommandListCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readGeneratedCommandListAttribute",
         readUnitTestingGeneratedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingAcceptedCommandListCommandParams =
@@ -16438,7 +16360,7 @@ public class ClusterReadMapping {
                 new ClusterInfoMapping
                     .DelegatedUnitTestingClusterAcceptedCommandListAttributeCallback(),
             readUnitTestingAcceptedCommandListCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readAcceptedCommandListAttribute",
         readUnitTestingAcceptedCommandListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingEventListCommandParams =
@@ -16452,8 +16374,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedUnitTestingClusterEventListAttributeCallback(),
             readUnitTestingEventListCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readEventListAttribute", readUnitTestingEventListAttributeInteractionInfo);
+    result.put("readEventListAttribute", readUnitTestingEventListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingAttributeListCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingAttributeListAttributeInteractionInfo =
@@ -16466,8 +16387,7 @@ public class ClusterReadMapping {
             () ->
                 new ClusterInfoMapping.DelegatedUnitTestingClusterAttributeListAttributeCallback(),
             readUnitTestingAttributeListCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readAttributeListAttribute", readUnitTestingAttributeListAttributeInteractionInfo);
+    result.put("readAttributeListAttribute", readUnitTestingAttributeListAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingFeatureMapCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingFeatureMapAttributeInteractionInfo =
@@ -16478,8 +16398,7 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readUnitTestingFeatureMapCommandParams);
-    readUnitTestingInteractionInfo.put(
-        "readFeatureMapAttribute", readUnitTestingFeatureMapAttributeInteractionInfo);
+    result.put("readFeatureMapAttribute", readUnitTestingFeatureMapAttributeInteractionInfo);
     Map<String, CommandParameterInfo> readUnitTestingClusterRevisionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     InteractionInfo readUnitTestingClusterRevisionAttributeInteractionInfo =
@@ -16490,9 +16409,83 @@ public class ClusterReadMapping {
             },
             () -> new ClusterInfoMapping.DelegatedIntegerAttributeCallback(),
             readUnitTestingClusterRevisionCommandParams);
-    readUnitTestingInteractionInfo.put(
+    result.put(
         "readClusterRevisionAttribute", readUnitTestingClusterRevisionAttributeInteractionInfo);
-    readAttributeMap.put("unitTesting", readUnitTestingInteractionInfo);
-    return readAttributeMap;
+
+    return result;
+  }
+
+  public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+    return new HashMap<>() {
+      {
+        put("identify", readIdentifyInteractionInfo());
+        put("groups", readGroupsInteractionInfo());
+        put("scenes", readScenesInteractionInfo());
+        put("onOff", readOnOffInteractionInfo());
+        put("onOffSwitchConfiguration", readOnOffSwitchConfigurationInteractionInfo());
+        put("levelControl", readLevelControlInteractionInfo());
+        put("binaryInputBasic", readBinaryInputBasicInteractionInfo());
+        put("descriptor", readDescriptorInteractionInfo());
+        put("binding", readBindingInteractionInfo());
+        put("accessControl", readAccessControlInteractionInfo());
+        put("actions", readActionsInteractionInfo());
+        put("basicInformation", readBasicInformationInteractionInfo());
+        put("otaSoftwareUpdateProvider", readOtaSoftwareUpdateProviderInteractionInfo());
+        put("otaSoftwareUpdateRequestor", readOtaSoftwareUpdateRequestorInteractionInfo());
+        put("localizationConfiguration", readLocalizationConfigurationInteractionInfo());
+        put("timeFormatLocalization", readTimeFormatLocalizationInteractionInfo());
+        put("unitLocalization", readUnitLocalizationInteractionInfo());
+        put("powerSourceConfiguration", readPowerSourceConfigurationInteractionInfo());
+        put("powerSource", readPowerSourceInteractionInfo());
+        put("generalCommissioning", readGeneralCommissioningInteractionInfo());
+        put("networkCommissioning", readNetworkCommissioningInteractionInfo());
+        put("diagnosticLogs", readDiagnosticLogsInteractionInfo());
+        put("generalDiagnostics", readGeneralDiagnosticsInteractionInfo());
+        put("softwareDiagnostics", readSoftwareDiagnosticsInteractionInfo());
+        put("threadNetworkDiagnostics", readThreadNetworkDiagnosticsInteractionInfo());
+        put("wiFiNetworkDiagnostics", readWiFiNetworkDiagnosticsInteractionInfo());
+        put("ethernetNetworkDiagnostics", readEthernetNetworkDiagnosticsInteractionInfo());
+        put("bridgedDeviceBasicInformation", readBridgedDeviceBasicInformationInteractionInfo());
+        put("switch", readSwitchInteractionInfo());
+        put("administratorCommissioning", readAdministratorCommissioningInteractionInfo());
+        put("operationalCredentials", readOperationalCredentialsInteractionInfo());
+        put("groupKeyManagement", readGroupKeyManagementInteractionInfo());
+        put("fixedLabel", readFixedLabelInteractionInfo());
+        put("userLabel", readUserLabelInteractionInfo());
+        put("booleanState", readBooleanStateInteractionInfo());
+        put("modeSelect", readModeSelectInteractionInfo());
+        put("doorLock", readDoorLockInteractionInfo());
+        put("windowCovering", readWindowCoveringInteractionInfo());
+        put("barrierControl", readBarrierControlInteractionInfo());
+        put("pumpConfigurationAndControl", readPumpConfigurationAndControlInteractionInfo());
+        put("thermostat", readThermostatInteractionInfo());
+        put("fanControl", readFanControlInteractionInfo());
+        put(
+            "thermostatUserInterfaceConfiguration",
+            readThermostatUserInterfaceConfigurationInteractionInfo());
+        put("colorControl", readColorControlInteractionInfo());
+        put("ballastConfiguration", readBallastConfigurationInteractionInfo());
+        put("illuminanceMeasurement", readIlluminanceMeasurementInteractionInfo());
+        put("temperatureMeasurement", readTemperatureMeasurementInteractionInfo());
+        put("pressureMeasurement", readPressureMeasurementInteractionInfo());
+        put("flowMeasurement", readFlowMeasurementInteractionInfo());
+        put("relativeHumidityMeasurement", readRelativeHumidityMeasurementInteractionInfo());
+        put("occupancySensing", readOccupancySensingInteractionInfo());
+        put("wakeOnLan", readWakeOnLanInteractionInfo());
+        put("channel", readChannelInteractionInfo());
+        put("targetNavigator", readTargetNavigatorInteractionInfo());
+        put("mediaPlayback", readMediaPlaybackInteractionInfo());
+        put("mediaInput", readMediaInputInteractionInfo());
+        put("lowPower", readLowPowerInteractionInfo());
+        put("keypadInput", readKeypadInputInteractionInfo());
+        put("contentLauncher", readContentLauncherInteractionInfo());
+        put("audioOutput", readAudioOutputInteractionInfo());
+        put("applicationLauncher", readApplicationLauncherInteractionInfo());
+        put("applicationBasic", readApplicationBasicInteractionInfo());
+        put("accountLogin", readAccountLoginInteractionInfo());
+        put("electricalMeasurement", readElectricalMeasurementInteractionInfo());
+        put("unitTesting", readUnitTestingInteractionInfo());
+      }
+    };
   }
 }

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
@@ -16415,7 +16415,9 @@ public class ClusterReadMapping {
     return result;
   }
 
+  @SuppressWarnings("serial")
   public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
+
     return new HashMap<String, Map<String, InteractionInfo>>() {
       {
         put("identify", readIdentifyInteractionInfo());


### PR DESCRIPTION
Generating one large method for all clusters seems to hit the 65K code limit in java as we add new clusters:

https://github.com/project-chip/connectedhomeip/actions/runs/4935083044/jobs/8820949404?pr=26431 says

```
INFO    python3 ../../build/chip/java/javac_runner.py --classdir obj/src/controller/java/classes --outfile gen/src/controller/java/java.classlist --build-config gen/src/controller/java/java.json -- -d obj/src/controller/java/classes @gen/src/controller/java/java.sources -Werror -Xlint:all -Xlint:deprecation -parameters -Xlint:-options -source 8 -target 8
1492
INFO    ../../src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java:26: error: code too large
1493
INFO      public Map<String, Map<String, InteractionInfo>> getReadAttributeMap() {
```

Split the attribute map read into individual methods to build up the entries. Hoping this reduces individual method code size significantly.