### PR TITLE
[tools] Try to fix bloat check when comment has empty cell

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -375,7 +375,8 @@ class V1Comment:
                     cols, rows = memdf.util.markdown.read_hierified(body)
                     break
         logging.debug('REC: read %d rows', len(rows))
-        df = df.append(pd.DataFrame(data=rows, columns=cols).astype(df.dtypes))
+        df = pd.concat([df, pd.DataFrame(data=rows, columns=cols).astype(df.dtypes)],
+                       ignore_index=True)
         return df.sort_values(
             by=['platform', 'target', 'config', 'section']).drop_duplicates()
 

--- a/scripts/tools/memory/memdf/util/markdown.py
+++ b/scripts/tools/memory/memdf/util/markdown.py
@@ -34,7 +34,7 @@ def read_hierified(f):
         for i in range(0, len(header)):
             column = columns[i + 1].strip()
             if not column:
-                column = rows[-1][i]
+                column = rows[-1][i] if rows else '(blank)'
             row.append(column)
         rows.append(tuple(row))
 


### PR DESCRIPTION
The bloat check has been failing for months now because gh_report.py script seems to assume that the first row in a comment to the analyzed PR has no empty cells, and for the cc32xx platform, which happens to finish the build as the first one, a row with a blank section name is added.

I don't know what is the reason of the blank section, but the script should not give up just because of one invalid entry as we miss important code size increase warnings.