### PR TITLE
Add esp32-devkitc-light-rpc target in smoke-test.yaml

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -29,6 +29,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle --target
+              esp32-devkitc-light-rpc --target
               esp32-m5stack-all-clusters-ipv6only --target
               esp32-m5stack-all-clusters-rpc --target
               esp32-m5stack-light --target


### PR DESCRIPTION
Adding esp32-devkitc-light-rpc to smoke-test.yaml so it's included in the continuous delivery cloud build pipeline.

