### PR TITLE
Log session id in SecureSession::MoveToState.

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -87,8 +87,8 @@ void SecureSession::MoveToState(State targetState)
 {
     if (mState != targetState)
     {
-        ChipLogProgress(SecureChannel, "SecureSession[%p]: Moving from state '%s' --> '%s'", this, StateToString(mState),
-                        StateToString(targetState));
+        ChipLogProgress(SecureChannel, "SecureSession[%p, LSID:%d]: State change '%s' --> '%s'", this, mLocalSessionId,
+                        StateToString(mState), StateToString(targetState));
         mState = targetState;
     }
 }


### PR DESCRIPTION
This is the only progress-level log in SecureSession, so without this if detail logging is disabled it's hard to make sense of what's going on with sessions.

