### PR TITLE
[Java] Add API pairDeviceWithCode to test pair with setup code

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -674,6 +674,30 @@ jobs:
                      --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
                   '
+            - name: Run Pairing SetupQRCode Test
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "code --nodeid 1 --setup-payload MT:-24J0AFN00KA0648G00 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
+                     --factoryreset \
+                  '
+            - name: Run Pairing ManualCode Test
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "code --nodeid 1 --setup-payload 34970112332 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
+                     --factoryreset \
+                  '                                
             - name: Uploading core files
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.kt
@@ -123,6 +123,19 @@ class Argument {
         isValidArgument = value == str
       }
 
+      ArgumentType.STRING -> {
+        val strBuf = this.value as StringBuffer
+        strBuf.setLength(0)
+        strBuf.append(value)
+        isValidArgument = true
+      }
+
+      ArgumentType.BOOL -> {
+        val booleanValue = this.value as AtomicBoolean
+        booleanValue.set(value.toBoolean())
+        isValidArgument = true
+      }      
+
       ArgumentType.NUMBER_INT16 -> {
         val numShort = this.value as AtomicInteger
         numShort.set(value.toInt())

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/common/Argument.kt
@@ -123,19 +123,6 @@ class Argument {
         isValidArgument = value == str
       }
 
-      ArgumentType.STRING -> {
-        val strBuf = this.value as StringBuffer
-        strBuf.setLength(0)
-        strBuf.append(value)
-        isValidArgument = true
-      }
-
-      ArgumentType.BOOL -> {
-        val booleanValue = this.value as AtomicBoolean
-        booleanValue.set(value.toBoolean())
-        isValidArgument = true
-      }      
-
       ArgumentType.NUMBER_INT16 -> {
         val numShort = this.value as AtomicInteger
         numShort.set(value.toInt())

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.kt
@@ -28,7 +28,7 @@ class PairCodeCommand(controller: ChipDeviceController, credsIssue: CredentialsI
         getNodeId(),
         getOnboardingPayload(),
         getDiscoverOnce(),
-        getUseOnlyOnNetworkDiscovery()        
+        getUseOnlyOnNetworkDiscovery(),
         null,
         getWifiNetworkCredentials(),
       )

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeCommand.kt
@@ -27,6 +27,8 @@ class PairCodeCommand(controller: ChipDeviceController, credsIssue: CredentialsI
       .pairDeviceWithCode(
         getNodeId(),
         getOnboardingPayload(),
+        getDiscoverOnce(),
+        getUseOnlyOnNetworkDiscovery()        
         null,
         getWifiNetworkCredentials(),
       )

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeThreadCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeThreadCommand.kt
@@ -27,6 +27,8 @@ class PairCodeThreadCommand(controller: ChipDeviceController, credsIssue: Creden
       .pairDeviceWithCode(
         getNodeId(),
         getOnboardingPayload(),
+        getDiscoverOnce(),
+        getUseOnlyOnNetworkDiscovery(),        
         null,
         getThreadNetworkCredentials(),
       )

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeWifiCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairCodeWifiCommand.kt
@@ -27,6 +27,8 @@ class PairCodeWifiCommand(controller: ChipDeviceController, credsIssue: Credenti
       .pairDeviceWithCode(
         getNodeId(),
         getOnboardingPayload(),
+        getDiscoverOnce(),
+        getUseOnlyOnNetworkDiscovery(),        
         null,
         getWifiNetworkCredentials(),
       )

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
@@ -70,8 +70,8 @@ abstract class PairingCommand(
       PairingModeType.NONE -> {}
       PairingModeType.CODE, PairingModeType.CODE_PASE_ONLY -> {
         addArgument("payload", onboardingPayload, null, false)
-        addArgument("discover-once", discoverOnce, null, false)
-        addArgument("use-only-onnetwork-discovery", useOnlyOnNetworkDiscovery, null, false)
+        addArgument("discover-once", discoverOnce, null, true)
+        addArgument("use-only-onnetwork-discovery", useOnlyOnNetworkDiscovery, null, true)
       }
 
       PairingModeType.ADDRESS_PASE_ONLY -> {
@@ -243,6 +243,14 @@ abstract class PairingCommand(
   private fun String.hexToByteArray(): ByteArray {
     return chunked(2).map { byteStr -> byteStr.toUByte(16).toByte() }.toByteArray()
   }
+
+  fun getDiscoverOnce(): Boolean {
+    return discoverOnce.get()
+  }
+
+  fun getUseOnlyOnNetworkDiscovery(): Boolean {
+    return useOnlyOnNetworkDiscovery.get()
+  }  
 
   companion object {
     private val logger = Logger.getLogger(PairingCommand::class.java.name)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -590,6 +590,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
                                           DiscoveryType discoveryType)
 {
     MATTER_TRACE_EVENT_SCOPE("PairDevice", "DeviceCommissioner");
+
     if (mDefaultCommissioner == nullptr)
     {
         ChipLogError(Controller, "No default commissioner is specified");

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -443,6 +443,7 @@ public:
      * @param[in] rendezvousParams      The Rendezvous connection parameters
      */
     CHIP_ERROR PairDevice(NodeId remoteDeviceId, RendezvousParameters & rendezvousParams);
+
     /**
      * @overload
      * @param[in] remoteDeviceId        The remote device Id.

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -610,44 +610,6 @@ JNI_METHOD(void, pairDevice)
     }
 }
 
-JNI_METHOD(void, pairDeviceWithCode)
-(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring setUpCode, jboolean discoverOnce,
- jboolean useOnlyOnNetworkDiscovery)
-{
-    chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err                           = CHIP_NO_ERROR;
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-
-    ChipLogProgress(Controller, "pairDeviceWithCode() called");
-
-    JniUtfString setUpCodeJniString(env, setUpCode);
-
-    CommissioningParameters commissioningParams = wrapper->GetCommissioningParameters();
-
-    auto discoveryType = DiscoveryType::kAll;
-    if (useOnlyOnNetworkDiscovery)
-    {
-        discoveryType = DiscoveryType::kDiscoveryNetworkOnly;
-    }
-
-    if (discoverOnce)
-    {
-        discoveryType = DiscoveryType::kDiscoveryNetworkOnlyWithoutPASEAutoRetry;
-    }
-
-    if (wrapper->GetDeviceAttestationDelegateBridge() != nullptr)
-    {
-        commissioningParams.SetDeviceAttestationDelegate(wrapper->GetDeviceAttestationDelegateBridge());
-    }
-    err = wrapper->Controller()->PairDevice(deviceId, setUpCodeJniString.c_str(), commissioningParams, discoveryType);
-
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Failed to pair the device.");
-        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
-    }
-}
-
 JNI_METHOD(void, pairDeviceWithAddress)
 (JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring address, jint port, jint discriminator, jlong pinCode,
  jbyteArray csrNonce)
@@ -692,7 +654,8 @@ JNI_METHOD(void, pairDeviceWithAddress)
 }
 
 JNI_METHOD(void, pairDeviceWithCode)
-(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring setUpCode, jbyteArray csrNonce, jobject networkCredentials)
+(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring setUpCode, jboolean discoverOnce,
+ jboolean useOnlyOnNetworkDiscovery, jbyteArray csrNonce, jobject networkCredentials)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -703,6 +666,18 @@ JNI_METHOD(void, pairDeviceWithCode)
     JniUtfString setUpCodeJniString(env, setUpCode);
 
     CommissioningParameters commissioningParams = wrapper->GetCommissioningParameters();
+
+    auto discoveryType = DiscoveryType::kAll;
+    if (useOnlyOnNetworkDiscovery)
+    {
+        discoveryType = DiscoveryType::kDiscoveryNetworkOnly;
+    }
+
+    if (discoverOnce)
+    {
+        discoveryType = DiscoveryType::kDiscoveryNetworkOnlyWithoutPASEAutoRetry;
+    }
+
     if (csrNonce != nullptr)
     {
         JniByteArray jniCsrNonce(env, csrNonce);
@@ -718,7 +693,7 @@ JNI_METHOD(void, pairDeviceWithCode)
     {
         commissioningParams.SetDeviceAttestationDelegate(wrapper->GetDeviceAttestationDelegateBridge());
     }
-    err = wrapper->Controller()->PairDevice(deviceId, setUpCodeJniString.c_str(), commissioningParams, DiscoveryType::kAll);
+    err = wrapper->Controller()->PairDevice(deviceId, setUpCodeJniString.c_str(), commissioningParams, discoveryType);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -164,6 +164,12 @@ public class ChipDeviceController {
     }
   }
 
+  public void pairDeviceWithCode(
+      long deviceId, String setUpCode, boolean discoverOnce, boolean useOnlyOnNetworkDiscovery) {
+    pairDeviceWithCode(
+        deviceControllerPtr, deviceId, setUpCode, discoverOnce, useOnlyOnNetworkDiscovery);
+  }
+
   public void pairDeviceWithAddress(
       long deviceId,
       String address,
@@ -1003,6 +1009,13 @@ public class ChipDeviceController {
       long pinCode,
       @Nullable byte[] csrNonce,
       NetworkCredentials networkCredentials);
+
+  private native void pairDeviceWithCode(
+      long deviceControllerPtr,
+      long deviceId,
+      String setUpCode,
+      boolean discoverOnce,
+      boolean useOnlyOnNetworkDiscovery);
 
   private native void pairDeviceWithAddress(
       long deviceControllerPtr,

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -164,12 +164,6 @@ public class ChipDeviceController {
     }
   }
 
-  public void pairDeviceWithCode(
-      long deviceId, String setUpCode, boolean discoverOnce, boolean useOnlyOnNetworkDiscovery) {
-    pairDeviceWithCode(
-        deviceControllerPtr, deviceId, setUpCode, discoverOnce, useOnlyOnNetworkDiscovery);
-  }
-
   public void pairDeviceWithAddress(
       long deviceId,
       String address,
@@ -186,6 +180,9 @@ public class ChipDeviceController {
    *
    * @param deviceId the node ID to assign to the device
    * @param setupCode the scanned QR code or manual entry code
+   * @param discoverOnce the flag to enable/disable PASE auto retry mechanism
+   * @param useOnlyOnNetworkDiscovery the flag to indicate the commissionable device is available on
+   *     the network
    * @param csrNonce the 32-byte CSR nonce to use, or null if we want to use an internally randomly
    *     generated CSR nonce.
    * @param networkCredentials the credentials (Wi-Fi or Thread) to be provisioned
@@ -193,9 +190,18 @@ public class ChipDeviceController {
   public void pairDeviceWithCode(
       long deviceId,
       String setupCode,
+      boolean discoverOnce,
+      boolean useOnlyOnNetworkDiscovery,
       @Nullable byte[] csrNonce,
       @Nullable NetworkCredentials networkCredentials) {
-    pairDeviceWithCode(deviceControllerPtr, deviceId, setupCode, csrNonce, networkCredentials);
+    pairDeviceWithCode(
+        deviceControllerPtr,
+        deviceId,
+        setupCode,
+        discoverOnce,
+        useOnlyOnNetworkDiscovery,
+        csrNonce,
+        networkCredentials);
   }
 
   public void establishPaseConnection(long deviceId, int connId, long setupPincode) {
@@ -1010,13 +1016,6 @@ public class ChipDeviceController {
       @Nullable byte[] csrNonce,
       NetworkCredentials networkCredentials);
 
-  private native void pairDeviceWithCode(
-      long deviceControllerPtr,
-      long deviceId,
-      String setUpCode,
-      boolean discoverOnce,
-      boolean useOnlyOnNetworkDiscovery);
-
   private native void pairDeviceWithAddress(
       long deviceControllerPtr,
       long deviceId,
@@ -1030,6 +1029,8 @@ public class ChipDeviceController {
       long deviceControllerPtr,
       long deviceId,
       String setupCode,
+      boolean discoverOnce,
+      boolean useOnlyOnNetworkDiscovery,
       @Nullable byte[] csrNonce,
       @Nullable NetworkCredentials networkCredentials);
 


### PR DESCRIPTION
Add Java API pairDeviceWithCode to test pair with setup code, and later for new kotlin SetupPayload library.

Following two test cases are added in CI to validate this API 
- name: Run Pairing SetupQRCode Test
- name: Run Pairing ManualCode Test

