### PR TITLE
CI: Skip cache segment download after 3 minutes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,7 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -185,6 +186,7 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -347,6 +349,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -406,6 +409,7 @@ jobs:
                   mkdir -p ~/Library/Logs/DiagnosticReports || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -506,6 +510,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     build_linux_gcc_debug:
@@ -68,7 +70,6 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -186,7 +187,6 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -349,7 +349,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -409,7 +408,6 @@ jobs:
                   mkdir -p ~/Library/Logs/DiagnosticReports || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -510,7 +508,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -23,6 +23,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     chef_linux:
         name: Chef - Linux CI Examples
@@ -45,7 +50,6 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -82,7 +86,6 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -119,7 +122,6 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -45,6 +45,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -81,6 +82,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -117,6 +119,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -24,6 +24,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     cirque:
         name: Cirque
@@ -61,7 +66,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               if: ${{ !env.ACT }}

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -61,6 +61,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               if: ${{ !env.ACT }}

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -28,6 +28,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     test_suites_chip_tool_darwin:
@@ -67,7 +69,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -67,6 +67,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -24,6 +24,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     darwin:
         name: Build Darwin
@@ -47,7 +52,6 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -47,6 +47,7 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     ameba:
@@ -51,7 +53,6 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ameba
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -51,6 +51,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ameba
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 env:
   CHIP_NO_LOG_TIMESTAMPS: true
+  # XXX: Workaround for https://github.com/actions/cache/issues/1141
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
   bouffalolab:
@@ -58,7 +60,6 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
-        if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
         uses: actions/cache@v3
         timeout-minutes: 10
         with:

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -58,6 +58,7 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
+        if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
         uses: actions/cache@v3
         timeout-minutes: 10
         with:

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     cc26x2x7:
@@ -59,7 +61,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -59,6 +59,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -56,6 +56,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -23,6 +23,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     cc32xx:
         name: cc32xx
@@ -56,7 +61,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
   CHIP_NO_LOG_TIMESTAMPS: true
+  # XXX: Workaround for https://github.com/actions/cache/issues/1141
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
   efr32:
@@ -64,7 +66,6 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
-        if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
         uses: actions/cache@v3
         timeout-minutes: 10
         with:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -64,6 +64,7 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
+        if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
         uses: actions/cache@v3
         timeout-minutes: 10
         with:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     esp32:
@@ -58,7 +60,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -178,7 +179,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -58,6 +58,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -177,6 +178,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     infineon:
@@ -58,7 +60,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -58,6 +58,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     k32w:
@@ -60,7 +62,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -60,6 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     arm_crosscompile:
@@ -58,7 +60,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -58,6 +58,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -50,6 +50,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     imx:
@@ -50,7 +52,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     linux_standalone:
@@ -58,7 +60,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -58,6 +58,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     mbedos:
@@ -74,7 +76,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -74,6 +74,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     mw320:
@@ -60,7 +62,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -60,6 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     nrfconnect:
@@ -75,7 +77,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -75,6 +75,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -24,6 +24,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     openiotsdk:
         name: Open IoT SDK examples building
@@ -60,7 +65,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -60,6 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     qpg:
@@ -60,7 +62,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -60,6 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -59,6 +59,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     telink:
@@ -59,7 +61,6 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -53,6 +53,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     tizen:
@@ -53,7 +55,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -64,6 +64,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -24,6 +24,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     full_android:
@@ -64,7 +66,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -55,6 +55,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -115,6 +116,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -24,6 +24,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     build_linux_fuzzing:
@@ -55,7 +57,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -116,7 +117,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,10 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     code-lints:
         runs-on: ubuntu-latest
@@ -56,7 +60,6 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -210,4 +211,3 @@ jobs:
               if: always()
               run: |
                   git grep -n 'SuccessOrExit(CHIP_ERROR' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
-

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -56,6 +56,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -120,6 +121,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
 
@@ -56,7 +58,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -121,7 +122,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -44,6 +44,7 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -99,6 +100,7 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -21,6 +21,11 @@ on:
                 description: Release Tag
                 required: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     esp32:
         name: ESP32
@@ -44,7 +49,6 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -100,7 +104,6 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -25,6 +25,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     android:
@@ -55,7 +57,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -55,6 +55,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -24,6 +24,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     darwin:
         name: Smoke Run - Darwin
@@ -47,7 +52,6 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -47,6 +47,7 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,6 +81,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -337,6 +338,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -459,6 +461,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -546,6 +549,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -719,6 +723,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,8 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
 jobs:
     test_suites_linux:
@@ -81,7 +83,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -338,7 +339,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -461,7 +461,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -549,7 +548,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:
@@ -723,7 +721,6 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -21,6 +21,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     zap_regeneration:
         name: ZAP Regeneration
@@ -48,7 +53,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -48,6 +48,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -23,6 +23,11 @@ concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
+env:
+    CHIP_NO_LOG_TIMESTAMPS: true
+    # XXX: Workaround for https://github.com/actions/cache/issues/1141
+    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
 jobs:
     zap_templates:
         name: ZAP templates generation
@@ -49,7 +54,6 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -49,6 +49,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
+              if: false # XXX: Disabled until cache is fixed: https://github.com/actions/cache/issues/1141
               uses: actions/cache@v3
               timeout-minutes: 10
               with:


### PR DESCRIPTION
### Problem

GitHub cache action is not stable enough in our setup.... Probably because of cache blob size which is ~1.5GB and lots of jobs spawned at the same time.
One can subscribe to this issues https://github.com/actions/cache/issues/1141 for monitoring the status.

### Changes

Set non-fatal timeout for cache blob download to 3 minutes. After that time the cache action will be skipped and the rest of the workflow will continue to run.
https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout