### PR TITLE
[OIS] Remove download of GCC for Docker image

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -432,7 +432,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:openiotsdkApp}/openiotsdk",
             "executable": "./build/chip-openiotsdk-${input:openiotsdkApp}-example.elf",
-            "armToolchainPath": "${env:ARM_GCC_TOOLCHAIN_PATH}/bin",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/",
             "servertype": "external",
             "gdbTarget": "${input:openiotsdkRemoteHost}:31627", //GDBserver port on FVP
             "overrideLaunchCommands": [
@@ -452,7 +452,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/openiotsdk/unit-tests",
             "executable": "./build/${input:openiotsdkUnittest}.elf",
-            "armToolchainPath": "${env:ARM_GCC_TOOLCHAIN_PATH}/bin",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/",
             "servertype": "external",
             "gdbTarget": ":31627", //GDBserver port on FVP
             "overrideLaunchCommands": ["-enable-pretty-printing"],

--- a/integrations/docker/images/chip-build-openiotsdk/Dockerfile
+++ b/integrations/docker/images/chip-build-openiotsdk/Dockerfile
@@ -12,14 +12,6 @@ RUN set -x \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # ------------------------------------------------------------------------------
-# Download ARM GCC toolchain 10.3-2021.10
-RUN set -x \
-    && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 \
-    && tar -xjf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C /opt \
-    && rm -r gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 \
-    && : # last line
-
-# ------------------------------------------------------------------------------
 # Install FVP Corstone 300
 RUN set -x \
     && wget -q https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/FVP_Corstone_SSE-300_11.16_26.tgz \
@@ -30,7 +22,6 @@ RUN set -x \
 
 FROM connectedhomeip/chip-build:${VERSION}
 
-COPY --from=build /opt/gcc-arm-none-eabi-10.3-2021.10/ /opt/gcc-arm-none-eabi-10.3-2021.10/
 COPY --from=build /opt/FVP_Corstone_SSE-300/ /opt/FVP_Corstone_SSE-300/
 
 # Required packages for building, running and testing
@@ -47,6 +38,5 @@ RUN set -x \
 # ------------------------------------------------------------------------------
 # Configure environment variables
 ENV FVP_CORSTONE_300_PATH=/opt/FVP_Corstone_SSE-300
-ENV ARM_GCC_TOOLCHAIN_PATH=/opt/gcc-arm-none-eabi-10.3-2021.10
 
-ENV PATH="${PATH}:${FVP_CORSTONE_300_PATH}/models/Linux64_GCC-6.4:${ARM_GCC_TOOLCHAIN_PATH}/bin"
+ENV PATH="${PATH}:${FVP_CORSTONE_300_PATH}/models/Linux64_GCC-6.4"

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -115,5 +115,4 @@ ENV TIZEN_SDK_TOOLCHAIN $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2
 ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
 
 ENV FVP_CORSTONE_300_PATH=/opt/FVP_Corstone_SSE-300
-ENV ARM_GCC_TOOLCHAIN_PATH=/opt/gcc-arm-none-eabi-10.3-2021.10
 ENV BOUFFALOLAB_SDK_ROOT=/opt/bouffalolab_sdk

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.4 Version bump reason: [K32W0] SDK 2.6.11 update
+0.7.5 Version bump reason: [OIS] Remove GCC toolchain


### PR DESCRIPTION
Remove downloading of GCC toolchain for Open IoT SDK Docker image.
Use the Pigweed environment version.
Update VSCode launch tasks.

