### PR TITLE
[Docker] Add ARM64 support to chip-build image

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -35,8 +35,10 @@ VERSION=${DOCKER_BUILD_VERSION:-$(sed 's/ .*//' version)}
 
 if [[ $OSTYPE == 'darwin'* ]]; then
     DOCKER_VOLUME_PATH=~/Library/Containers/com.docker.docker/Data/vms/0/
+    TARGET_PLATFORM_TYPE="linux/arm64"
 else
     DOCKER_VOLUME_PATH=/var/lib/docker/
+    TARGET_PLATFORM_TYPE="linux/amd64"
 fi
 
 [[ ${*/--help//} != "${*}" ]] && {
@@ -82,7 +84,7 @@ if [[ ${*/--no-cache//} != "${*}" ]]; then
 fi
 
 [[ ${*/--skip-build//} != "${*}" ]] || {
-    docker build "${BUILD_ARGS[@]}" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$VERSION" .
+    docker build "${BUILD_ARGS[@]}" --build-arg TARGETPLATFORM="$TARGET_PLATFORM_TYPE" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$VERSION" .
     docker image prune --force
 }
 

--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -3,6 +3,29 @@ FROM ubuntu:focal
 
 VOLUME "/var/source"
 
+ARG TARGETPLATFORM
+
+# Ensure TARGETPLATFORM is set
+RUN case ${TARGETPLATFORM} in \
+        "linux/amd64") \
+            echo "Building for linux/amd64" \
+        ;; \
+        "linux/arm64") \
+            echo "Building for linux/arm64" \
+        ;; \
+        *) \
+        if [ -z "$TARGETPLATFORM" ] ;\
+        then \
+            echo "TARGETPLATFORM not defined! Please run from buildkit (buildx)." \
+            && return 1 ;\
+        else \
+            echo "Unsupported platform ${TARGETPLATFORM}." \
+            && return 1 ;\
+        fi \
+        ;; \
+    esac
+
+
 # base build and check tools and libraries layer
 RUN set -x \
     && apt-get update \
@@ -75,11 +98,21 @@ RUN set -x \
     && : # last line
 
 # Cmake v3.23.1
-RUN set -x \
+ENV CMAKE_PLATFORM_VERSION=
+RUN case ${TARGETPLATFORM} in \
+        "linux/amd64") CMAKE_PLATFORM_VERSION="x86_64";; \
+        "linux/arm64") CMAKE_PLATFORM_VERSION="aarch64";; \
+        *) \
+            test -n "$TARGETPLATFORM" \
+            echo "Unsupported platform ${TARGETPLATFORM}" \
+            && return 1 ;\
+            ;; \
+    esac \
+    && set -x \
     && (cd /tmp \
-    && wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-Linux-x86_64.sh \
-    && sh cmake-3.23.1-Linux-x86_64.sh --exclude-subdir --prefix=/usr/local \
-    && rm -rf cmake-3.23.1-Linux-x86_64.sh) \
+    && wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-Linux-$CMAKE_PLATFORM_VERSION.sh \
+    && sh cmake-3.23.1-Linux-$CMAKE_PLATFORM_VERSION.sh --exclude-subdir --prefix=/usr/local \
+    && rm -rf cmake-3.23.1-Linux-$CMAKE_PLATFORM_VERSION.sh) \
     && exec bash \
     && : # last line
 
@@ -165,16 +198,26 @@ RUN set -x \
 # report false positives. This case is most prominent with glib-2.0, which has
 # a lot of threads-related APIs.
 ENV LD_LIBRARY_PATH_TSAN=/usr/lib/x86_64-linux-gnu-tsan
-RUN set -x \
-    && mkdir -p $LD_LIBRARY_PATH_TSAN \
-    && export CCACHE_DISABLE=1 PYTHONDONTWRITEBYTECODE=1 \
-    && GLIB_VERSION=$(pkg-config --modversion glib-2.0) \
-    && git clone --depth=1 --branch=$GLIB_VERSION https://github.com/GNOME/glib.git \
-    && CFLAGS="-O2 -g -fsanitize=thread" meson glib/build glib \
-    && DESTDIR=../build-image ninja -C glib/build install \
-    && mv glib/build-image/usr/local/lib/x86_64-linux-gnu/lib* $LD_LIBRARY_PATH_TSAN \
-    && rm -rf glib \
-    && : # last line
+RUN case ${TARGETPLATFORM} in \
+        "linux/amd64") \
+            set -x \
+            && mkdir -p $LD_LIBRARY_PATH_TSAN \
+            && export CCACHE_DISABLE=1 PYTHONDONTWRITEBYTECODE=1 \
+            && GLIB_VERSION=$(pkg-config --modversion glib-2.0) \
+            && git clone --depth=1 --branch=$GLIB_VERSION https://github.com/GNOME/glib.git \
+            && CFLAGS="-O2 -g -fsanitize=thread" meson glib/build glib \
+            && DESTDIR=../build-image ninja -C glib/build install \
+            && mv glib/build-image/usr/local/lib/x86_64-linux-gnu/lib* $LD_LIBRARY_PATH_TSAN \
+            && rm -rf glib \
+            ;; \
+        "linux/arm64") \
+            echo "ARM64 unsupported with TSAN" \
+            ;; \
+        *) \
+            echo "Unsupported platform ${TARGETPLATFORM}" \
+            && return 1 ;\
+            ;; \
+    esac
 
 # NodeJS: install a newer version than what apt-get would read
 # This installs the latest LTS version of nodejs
@@ -184,13 +227,23 @@ RUN set -x \
 #
 # This is not a CHIP dependency directly, but used by CI
 ENV CHIP_NODE_VERSION=v16.13.2
-RUN set -x \
+ENV NODE_PLATFORM_VERSION=
+RUN case ${TARGETPLATFORM} in \
+        "linux/amd64") NODE_PLATFORM_VERSION=x64;; \
+        "linux/arm64") NODE_PLATFORM_VERSION=arm64;; \
+        *) \
+            test -n "$TARGETPLATFORM" \
+            echo "Unsupported platform ${TARGETPLATFORM}" \
+            && return 1 ;\
+            ;; \
+    esac \
+    && set -x \
     && mkdir node_js \
     && cd node_js \
-    && wget https://nodejs.org/dist/$CHIP_NODE_VERSION/node-$CHIP_NODE_VERSION-linux-x64.tar.xz \
-    && tar xfvJ node-$CHIP_NODE_VERSION-linux-x64.tar.xz \
-    && mv node-$CHIP_NODE_VERSION-linux-x64 /opt/ \
-    && ln -s /opt/node-$CHIP_NODE_VERSION-linux-x64 /opt/node \
+    && wget https://nodejs.org/dist/$CHIP_NODE_VERSION/node-$CHIP_NODE_VERSION-linux-$NODE_PLATFORM_VERSION.tar.xz \
+    && tar xfvJ node-$CHIP_NODE_VERSION-linux-$NODE_PLATFORM_VERSION.tar.xz \
+    && mv node-$CHIP_NODE_VERSION-linux-$NODE_PLATFORM_VERSION /opt/ \
+    && ln -s /opt/node-$CHIP_NODE_VERSION-linux-$NODE_PLATFORM_VERSION /opt/node \
     && ln -s /opt/node/bin/* /usr/bin \
     && cd .. \
     && rm -rf node_js \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.16 Version bump reason: [nrfconnect] Update nRF Connect SDK version.
+0.7.17 Version bump reason: Enable ARM64 build

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -289,7 +289,7 @@ pyserial==3.5
     #   bflb-iot-tool
     #   mbed-os-tools
     #   mbed-tools
-pytest==6.2.5 ; platform_machine != "aarch64" and sys_platform == "linux"
+pytest==6.2.5 ; sys_platform == "linux"
     # via
     #   -r requirements.mbed.txt
     #   pytest-json-report

--- a/scripts/setup/requirements.mbed.txt
+++ b/scripts/setup/requirements.mbed.txt
@@ -1,5 +1,5 @@
 mbed-tools>=7.55.1.dev1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pytest==6.2.5 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+pytest==6.2.5 ; sys_platform == 'linux'
 mbed-ls==1.8.11 ; platform_machine != 'aarch64' and sys_platform == 'linux'
 pdoc3 ; platform_machine != 'aarch64' and sys_platform == 'linux'
 gitpython ; platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
- Adapt chip-build to build on ARM64.
- Allow pytest installation in the Pigweed environment on ARM64.
