### PR TITLE
[Tizen] Account for 0-terminator in WriteConfigValueStr

### DIFF
--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -101,7 +101,14 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint64_t & val)
 CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
+
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+
+    VerifyOrReturnError(outLen > 0, CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+    outLen--; // Account for null terminator
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
@@ -133,13 +140,20 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint64_t val)
 CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str)
 {
     VerifyOrReturnError(str != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return PersistedStorage::KeyValueStoreMgr().Put(key.Name, str, strlen(str));
+    return PersistedStorage::KeyValueStoreMgr().Put(key.Name, str, strlen(str) + 1);
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     VerifyOrReturnError(str != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return PersistedStorage::KeyValueStoreMgr().Put(key.Name, str, strLen);
+
+    auto * strCopy = strndup(str, strLen);
+    VerifyOrReturnError(strCopy != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    auto err = PersistedStorage::KeyValueStoreMgr().Put(key.Name, strCopy, strLen + 1);
+
+    free(strCopy);
+    return err;
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 
     // We are storing string values in the config store without
     // the null terminator, so we need to add it here.
-    VerifyOrReturnError(bufSize >= outLen + 1, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(bufSize >= outLen + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
     buf[outLen] = '\0';
 
     return CHIP_NO_ERROR;

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -449,7 +449,6 @@ static void TestConfigurationMgr_GetProductId(nlTestSuite * inSuite, void * inCo
  *   Test Suite. It lists all the test functions.
  */
 static const nlTest sTests[] = {
-
     NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
 #if !defined(NDEBUG)
     NL_TEST_DEF("Test PlatformMgr::RunUnitTest", TestPlatformMgr_RunUnitTest),
@@ -466,8 +465,8 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ConfigurationMgr::GetVendorId", TestConfigurationMgr_GetVendorId),
     NL_TEST_DEF("Test ConfigurationMgr::GetProductName", TestConfigurationMgr_GetProductName),
     NL_TEST_DEF("Test ConfigurationMgr::GetProductId", TestConfigurationMgr_GetProductId),
-    NL_TEST_SENTINEL()
-}; // namespace
+    NL_TEST_SENTINEL(),
+};
 
 /**
  *  Set up the test suite.


### PR DESCRIPTION
### Problem

On Tizen test `TestConfigurationMgr` fails on "Test ConfigurationMgr::SerialNumber" because during reading a serial number from the `GetDeviceInstanceInfoProvider()` the returned string is not 0-terminated.

### Changes

When handling string values in `ConfigurationManagerImpl` (which internally uses PosixConfig) account for 0-terminator.

### Testing

Tested locally (in the future all unit tests will be checked by the CI, but firstly we need to fix all failing tests):
```
root:~> /opt/usr/apps/TestConfigurationMgr 
'#0:','ConfigurationMgr tests'
'#2:','Setup                                      ','PASSED'
'#3:','Test PlatformMgr::Init                     ','PASSED'
'#3:','Test PlatformMgr::RunUnitTest              ','PASSED'
'#3:','Test ConfigurationMgr::SerialNumber        ','PASSED'
'#3:','Test ConfigurationMgr::UniqueId            ','PASSED'
'#3:','Test ConfigurationMgr::ManufacturingDate   ','PASSED'
'#3:','Test ConfigurationMgr::HardwareVersion     ','PASSED'
'#3:','Test ConfigurationMgr::FirmwareBuildTime   ','PASSED'
'#3:','Test ConfigurationMgr::CountryCode         ','PASSED'
'#3:','Test ConfigurationMgr::GetPrimaryMACAddress','PASSED'
'#3:','Test ConfigurationMgr::GetFailSafeArmed    ','PASSED'
'#3:','Test ConfigurationMgr::GetVendorName       ','PASSED'
'#3:','Test ConfigurationMgr::GetVendorId         ','PASSED'
'#3:','Test ConfigurationMgr::GetProductName      ','PASSED'
'#3:','Test ConfigurationMgr::GetProductId        ','PASSED'
'#4:','Teardown                                   ','PASSED'
'#6:','0','14'
'#7:','0','100053'
```