### PR TITLE
Fix use of certificate validity policy in CHIPDeviceController. (v1.1 cherry-pick of PR  26405)

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -249,12 +249,13 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.caseClientPool   = Platform::New<DeviceControllerSystemStateParams::CASEClientPool>();
 
     CASEClientInitParams sessionInitParams = {
-        .sessionManager           = stateParams.sessionMgr,
-        .sessionResumptionStorage = stateParams.sessionResumptionStorage.get(),
-        .exchangeMgr              = stateParams.exchangeMgr,
-        .fabricTable              = stateParams.fabricTable,
-        .groupDataProvider        = stateParams.groupDataProvider,
-        .mrpLocalConfig           = GetLocalMRPConfig(),
+        .sessionManager            = stateParams.sessionMgr,
+        .sessionResumptionStorage  = stateParams.sessionResumptionStorage.get(),
+        .certificateValidityPolicy = stateParams.certificateValidityPolicy,
+        .exchangeMgr               = stateParams.exchangeMgr,
+        .fabricTable               = stateParams.fabricTable,
+        .groupDataProvider         = stateParams.groupDataProvider,
+        .mrpLocalConfig            = GetLocalMRPConfig(),
     };
 
     CASESessionManagerConfig sessionManagerConfig = {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/project-chip/connectedhomeip/pull/26405 to the v1.1 branch.

In CHIPDeviceControllerFactory we were using the provided validity policy for our CASE server (i.e. when acting as a CASE responder), but not for our CASE client (i.e. not when acting as CASE initiator).

As a result, when acting as a CASE client we ended up using the default validity policy for the NOC provided by the other side, instead of using the one that was passed in via the FactoryInitParams.

