### PR TITLE
Rename Nullable::HasValidValue so people won't try to use it.

### DIFF
--- a/examples/dynamic-bridge-app/linux/include/data-model/DataModel.h
+++ b/examples/dynamic-bridge-app/linux/include/data-model/DataModel.h
@@ -201,7 +201,7 @@ CHIP_ERROR Encode(const ConcreteReadAttributePath & aPath, AttributeValueEncoder
     // CONFIG_BUILD_FOR_HOST_UNIT_TEST is true, so we can test how the other side
     // responds.
 #if !CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    if (!x.HasValidValue())
+    if (!x.ExistingValueInEncodableRange())
     {
         return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }
@@ -313,7 +313,7 @@ CHIP_ERROR Decode(const ConcreteDataAttributePath & aPath, AttributeValueDecoder
 
     // We have a value; decode it.
     ReturnErrorOnFailure(Decode(aPath, aDecoder, x.SetNonNull()));
-    if (!x.HasValidValue())
+    if (!x.ExistingValueInEncodableRange())
     {
         return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }

--- a/src/app/data-model/Decode.h
+++ b/src/app/data-model/Decode.h
@@ -170,7 +170,7 @@ CHIP_ERROR Decode(TLV::TLVReader & reader, Nullable<X> & x)
 
     // We have a value; decode it.
     ReturnErrorOnFailure(Decode(reader, x.SetNonNull()));
-    if (!x.HasValidValue())
+    if (!x.ExistingValueInEncodableRange())
     {
         return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -188,7 +188,7 @@ CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const Nullable<X> & x)
     // CONFIG_BUILD_FOR_HOST_UNIT_TEST is true, so we can test how the other side
     // responds.
 #if !CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    if (!x.HasValidValue())
+    if (!x.ExistingValueInEncodableRange())
     {
         return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -65,7 +65,7 @@ struct Nullable : protected Optional<T>
     template <
         typename U = std::decay_t<T>,
         typename std::enable_if_t<(std::is_integral<U>::value && !std::is_same<U, bool>::value) || std::is_enum<U>::value, int> = 0>
-    constexpr bool HasValidValue() const
+    constexpr bool ExistingValueInEncodableRange() const
     {
         return NumericAttributeTraits<T>::CanRepresentValue(/* isNullable = */ true, Value());
     }
@@ -74,7 +74,7 @@ struct Nullable : protected Optional<T>
     template <typename U                     = std::decay_t<T>,
               typename std::enable_if_t<(!std::is_integral<U>::value || std::is_same<U, bool>::value) && !std::is_enum<U>::value,
                                         int> = 0>
-    constexpr bool HasValidValue() const
+    constexpr bool ExistingValueInEncodableRange() const
     {
         return true;
     }


### PR DESCRIPTION
This function is a pretty specific thing, and people are confusing it with IsNull().  Rename to something that will make it less likely.
