### PR TITLE
[chiptool.py] Make sure to update the exit code properly if parsing f…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
@@ -66,7 +66,7 @@ class TestParserBuilder:
         self.__tests = copy.copy(config.tests)
         self.__config = config
         self.__duration = 0
-        self.__done = False
+        self.done = False
 
     def __iter__(self):
         self.__config.hooks.start(len(self.__tests))
@@ -76,9 +76,9 @@ class TestParserBuilder:
         if len(self.__tests):
             return self.__get_test_parser(self.__tests.pop(0))
 
-        if not self.__done:
+        if not self.done:
             self.__config.hooks.stop(round(self.__duration))
-        self.__done = True
+        self.done = True
 
         raise StopIteration
 

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -155,7 +155,7 @@ class TestRunner(TestRunnerBase):
             duration = round((time.time() - start) * 1000)
             runner_config.hooks.stop(duration)
 
-        return True
+        return parser_builder.done
 
     async def _run(self, parser: TestParser, config: TestRunnerConfig):
         status = True


### PR DESCRIPTION
…ails

#### Problem

Running tests with `chiptool.py` under CI may not show parsing errors. One occurence of such issue is https://github.com/project-chip/connectedhomeip/actions/runs/4948194818/jobs/8848585378?pr=26082 where the parsing fails properly with `chip-repl` but not with `chiptool.py`.
