### PR TITLE
[matter_yamltests] Properly convert wait values from str to int if ne…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/delay_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/delay_commands.py
@@ -58,7 +58,7 @@ class DelayCommands(PseudoCluster):
                 duration_in_ms = argument['value']
 
         sys.stdout.flush()
-        time.sleep(duration_in_ms / 1000)
+        time.sleep(int(duration_in_ms) / 1000)
 
     async def WaitForMessage(self, request):
         AccessoryServerBridge.waitForMessage(request)


### PR DESCRIPTION
…cessary in the WaitFor command

#### Problem

When passed as an argument on the command line it is not converted properly.

fix #26461

