### PR TITLE
ESP32: avoid installing gdbgui when not needed

### DIFF
--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -9,4 +9,4 @@ ecdsa>=0.16.0
 kconfiglib==13.7.1
 construct==2.10.54
 python-socketio<5
-gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+gdbgui==0.13.2.0 ; python_version < "3.11" and platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
ESP-IDF v4.4.4 requires gdbgui only when Python before 3.11 is used (see https://github.com/espressif/esp-idf/commit/3974be7fec1ea6c529ecbee795c0152b42b61d55). Avoid installing it when not needed. This allows to boostrap the SDK on systems with Python 3.11.

Fixes: #25385