### PR TITLE
[tools] Second take to fix bloat check

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -41,7 +41,6 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000

--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -375,8 +375,10 @@ class V1Comment:
                     cols, rows = memdf.util.markdown.read_hierified(body)
                     break
         logging.debug('REC: read %d rows', len(rows))
+        attrs = df.attrs
         df = pd.concat([df, pd.DataFrame(data=rows, columns=cols).astype(df.dtypes)],
                        ignore_index=True)
+        df.attrs = attrs
         return df.sort_values(
             by=['platform', 'target', 'config', 'section']).drop_duplicates()
 


### PR DESCRIPTION
In the previous PR (#26479) I replaced the deprecated `DataFrame.append` with `pandas.concat`, but I didn't realize that our memory scripts add extra attributes to the data frame object, which are not copied during the concatenation.

This time, I verified the script locally using `--github-comment` and `--github-dryrun-comment` to test the code for preparing the PR comments.

Also, do not fetch submodules in the bloat check job as it takes most of the job's execution time.