### PR TITLE
Fix handling of certificate validity policy in CHIPDeviceControllerFactory. (v1.1 cherry-pick of PR 26526)

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -58,11 +58,12 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
 
     // Save our initialization state that we can't recover later from a
     // created-but-shut-down system state.
-    mListenPort               = params.listenPort;
-    mFabricIndependentStorage = params.fabricIndependentStorage;
-    mOperationalKeystore      = params.operationalKeystore;
-    mOpCertStore              = params.opCertStore;
-    mEnableServerInteractions = params.enableServerInteractions;
+    mListenPort                = params.listenPort;
+    mFabricIndependentStorage  = params.fabricIndependentStorage;
+    mOperationalKeystore       = params.operationalKeystore;
+    mOpCertStore               = params.opCertStore;
+    mCertificateValidityPolicy = params.certificateValidityPolicy;
+    mEnableServerInteractions  = params.enableServerInteractions;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -82,14 +83,15 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState()
 #if CONFIG_NETWORK_LAYER_BLE
         params.bleLayer = mSystemState->BleLayer();
 #endif
-        params.listenPort               = mListenPort;
-        params.fabricIndependentStorage = mFabricIndependentStorage;
-        params.enableServerInteractions = mEnableServerInteractions;
-        params.groupDataProvider        = mSystemState->GetGroupDataProvider();
-        params.sessionKeystore          = mSystemState->GetSessionKeystore();
-        params.fabricTable              = mSystemState->Fabrics();
-        params.operationalKeystore      = mOperationalKeystore;
-        params.opCertStore              = mOpCertStore;
+        params.listenPort                = mListenPort;
+        params.fabricIndependentStorage  = mFabricIndependentStorage;
+        params.enableServerInteractions  = mEnableServerInteractions;
+        params.groupDataProvider         = mSystemState->GetGroupDataProvider();
+        params.sessionKeystore           = mSystemState->GetSessionKeystore();
+        params.fabricTable               = mSystemState->Fabrics();
+        params.operationalKeystore       = mOperationalKeystore;
+        params.opCertStore               = mOpCertStore;
+        params.certificateValidityPolicy = mCertificateValidityPolicy;
     }
 
     return InitSystemState(params);
@@ -368,9 +370,10 @@ void DeviceControllerFactory::Shutdown()
         Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
-    mFabricIndependentStorage = nullptr;
-    mOperationalKeystore      = nullptr;
-    mOpCertStore              = nullptr;
+    mFabricIndependentStorage  = nullptr;
+    mOperationalKeystore       = nullptr;
+    mOpCertStore               = nullptr;
+    mCertificateValidityPolicy = nullptr;
 }
 
 void DeviceControllerSystemState::Shutdown()

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -251,11 +251,12 @@ private:
     CHIP_ERROR InitSystemState();
 
     uint16_t mListenPort;
-    DeviceControllerSystemState * mSystemState              = nullptr;
-    PersistentStorageDelegate * mFabricIndependentStorage   = nullptr;
-    Crypto::OperationalKeystore * mOperationalKeystore      = nullptr;
-    Credentials::OperationalCertificateStore * mOpCertStore = nullptr;
-    bool mEnableServerInteractions                          = false;
+    DeviceControllerSystemState * mSystemState                          = nullptr;
+    PersistentStorageDelegate * mFabricIndependentStorage               = nullptr;
+    Crypto::OperationalKeystore * mOperationalKeystore                  = nullptr;
+    Credentials::OperationalCertificateStore * mOpCertStore             = nullptr;
+    Credentials::CertificateValidityPolicy * mCertificateValidityPolicy = nullptr;
+    bool mEnableServerInteractions                                      = false;
 };
 
 } // namespace Controller


### PR DESCRIPTION
This is a cherry-pick of https://github.com/project-chip/connectedhomeip/pull/26526 to the v1.1 branch.

When we created a new system state, we lost track of the certificate validity policy (since it's not stored in the system state and was not copied from the old one to the new one).

Just store it in the controller factory like other things of that sort, so we make sure to propagate it to all system states.
