### PR TITLE
Fix cross compile path (missing minor version)

### DIFF
--- a/integrations/docker/images/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/chip-build-crosscompile/Dockerfile
@@ -28,6 +28,6 @@ RUN set -x \
 
 FROM connectedhomeip/chip-build:${VERSION}
 
-COPY --from=build /opt/ubuntu-22.04.1-aarch64-sysroot/ /opt/ubuntu-22.04-aarch64-sysroot/
+COPY --from=build /opt/ubuntu-22.04.1-aarch64-sysroot/ /opt/ubuntu-22.04.1-aarch64-sysroot/
 
 ENV SYSROOT_AARCH64=/opt/ubuntu-22.04.1-aarch64-sysroot

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.8 Version bump reason: Update crosscompile sysroot to Ubuntu 22.04.01
+0.7.9 Version bump reason: Fix path for sysroot for crosscompile image


### PR DESCRIPTION
Typo in cross compile path resulted in invalid sysroot path as well as inability to build the vscode image.