### PR TITLE
Fix up openiot support from chip-build-vscode.

### DIFF
--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -50,7 +50,6 @@ COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
 
 COPY --from=ti /opt/ti/sysconfig_1.13.0 /opt/ti/sysconfig_1.13.0
 
-COPY --from=openiotsdk /opt/gcc-arm-none-eabi-10.3-2021.10/ /opt/gcc-arm-none-eabi-10.3-2021.10/
 COPY --from=openiotsdk /opt/FVP_Corstone_SSE-300/ /opt/FVP_Corstone_SSE-300/
 
 COPY --from=bouffalolab /opt/bouffalolab_sdk /opt/bouffalolab_sdk


### PR DESCRIPTION
Remove copy of gcc since #26503 removed this

No version update since image was not compiling anyway and no settings were updated.
