### PR TITLE
[Ameba] use event handling for BLE disconnect event

### DIFF
--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -294,8 +294,8 @@ CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(uint16_t conn_id, uint16_t disc_c
     }
 
     ChipDeviceEvent event;
-    event.Type = DeviceEventType::kCHIPoBLEConnectionError;
-    event.CHIPoBLEConnectionError.ConId = conn_id;
+    event.Type                           = DeviceEventType::kCHIPoBLEConnectionError;
+    event.CHIPoBLEConnectionError.ConId  = conn_id;
     event.CHIPoBLEConnectionError.Reason = disconReason;
     PlatformMgr().PostEventOrDie(&event);
 

--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -292,7 +292,12 @@ CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(uint16_t conn_id, uint16_t disc_c
         disconReason = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
         break;
     }
-    HandleConnectionError(conn_id, disconReason);
+
+    ChipDeviceEvent event;
+    event.Type = DeviceEventType::kCHIPoBLEConnectionError;
+    event.CHIPoBLEConnectionError.ConId = conn_id;
+    event.CHIPoBLEConnectionError.Reason = disconReason;
+    PlatformMgr().PostEventOrDie(&event);
 
     // Force a reconfiguration of advertising in case we switched to non-connectable mode when
     // the BLE connection was established.


### PR DESCRIPTION
- callback dispatcher should just post event and return
- disconnect event will be handled by PlatformMgr => BLEMgr

