### PR TITLE
Remove acquiring matter context lock for canceling TimerExpiredCallback

### DIFF
--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -105,8 +105,7 @@ ChipDeviceScanner::~ChipDeviceScanner()
     StopScan();
 
     // mTimerExpired should only be set to true in the TimerExpiredCallback, which means we are in that callback
-    // right now so there is no need to cancel the timer. Doing so would result in deadlock trying to aquire the
-    // chip stack lock which we already currently have.
+    // right now so there is no need to cancel the timer.
     if (!mTimerExpired)
     {
         chip::DeviceLayer::SystemLayer().CancelTimer(TimerExpiredCallback, this);

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -109,10 +109,7 @@ ChipDeviceScanner::~ChipDeviceScanner()
     // chip stack lock which we already currently have.
     if (!mTimerExpired)
     {
-        // In case the timeout timer is still active
-        DeviceLayer::PlatformMgr().LockChipStack();
         chip::DeviceLayer::SystemLayer().CancelTimer(TimerExpiredCallback, this);
-        DeviceLayer::PlatformMgr().UnlockChipStack();
     }
 
     g_object_unref(mManager);


### PR DESCRIPTION
Fixes: https://github.com/project-chip/connectedhomeip/issues/26516

`BLEManagerImpl::InitiateScan(BleScanState scanType)` is scheduled work, and therefore runs in the matter context. On the line ` mDeviceScanner = Internal::ChipDeviceScanner::Create(mpEndpoint->mpAdapter, this);` it is possible, for destructor `ChipDeviceScanner::~ChipDeviceScanner()` to be called if there was previously an `mDeviceScanner` assigned. While most cases it is fine as the timer has already expired and therefore `CancelTimer` is not called. If there are back to back `BleLayer::NewBleConnection*` calls where the timer doesn't expire and you can get a deadlock.

This corner case is only possible to encounter if you are using chip-tool interactive or chip-repl, in a very particular way.

In previous PRs, I was attempting to fix segfaults and deadlock reported by various users under different usecases in a timely fashion. In one of these earlier PR iterations, while attempted to fix segfaults and deadlocks, the `LockChipStack()` and `UnlockChipStack()` was introduced as we knew for a fact that it was called in a thread not holding the matter context. But, since that lock acquisition code was added, even in that original use case, this destructor would be called from thread from a thread already holding the matter context. It just was not immediately caught as the timer has already expired and `mTimerExpired` was false.

Test:
* `chip-tool pairing ble-wifi 1 asdf asdf 20202021 3840`, no longer deadlocks
* In `chip-repl` issuing `asdf = chip.ble.DiscoverSync(timeoutMs=2000)` followed by `for x in asdf: print(f"TMsg {x}")` works.
* In `chip-repl`, issuing `devCtrl.CommissionWiFi(3840, 20202021, 1, "asdf", "asdf")` no longer deadlocks.

In each of the above 3 tests I attempted to perform `SIGINT`, and kill running application prior to 