### PR TITLE
Make pigweed set up clang-format on M1/M2 macs as well.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -214,3 +214,8 @@ jobs:
               if: always()
               run: |
                   git grep -n 'SuccessOrExit(CHIP_ERROR' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+
+            - name: Check that our hardcoded SHA for clang-format on ARM mac matches the pigweed SHA.
+              if: always()
+              run: |
+                  ./scripts/lints/clang-format-version-matches.py

--- a/scripts/lints/clang-format-version-matches.py
+++ b/scripts/lints/clang-format-version-matches.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import json
+import os
+
+CHIP_ROOT_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), '../..'))
+
+
+def readClangRevision(jsonFileName):
+    with open(os.path.join(CHIP_ROOT_DIR, jsonFileName)) as file:
+        data = json.load(file)
+
+    packages = data['packages']
+    for package in packages:
+        if package['path'].startswith('fuchsia/third_party/clang/'):
+            return package['tags']
+
+    raise Exception('Could not find clang package in %s' % jsonFileName)
+
+
+pigweed_revision = readClangRevision('third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/pigweed.json')
+
+our_file = 'scripts/setup/clang.json'
+our_revision = readClangRevision(our_file)
+
+if our_revision != pigweed_revision:
+    raise Exception('In %s, "%s" should be changed to "%s"' % (our_file, our_revision, pigweed_revision))

--- a/scripts/setup/clang.json
+++ b/scripts/setup/clang.json
@@ -1,0 +1,9 @@
+{
+    "packages": [
+        {
+            "path": "fuchsia/third_party/clang/mac-arm64",
+            "platforms": ["mac-arm64"],
+            "tags": ["git_revision:3a20597776a5d2920e511d81653b4d2b6ca0c855"]
+        }
+    ]
+}

--- a/scripts/setup/environment.json
+++ b/scripts/setup/environment.json
@@ -2,6 +2,7 @@
     "cipd_package_files": [
         "third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
         "third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/pigweed.json",
+        "scripts/setup/clang.json",
         "scripts/setup/python.json",
         "scripts/setup/zap.json"
     ],


### PR DESCRIPTION
The way our codegen works right now expects everyone to be able to run the same version of clang-format from the pigweed setup. But pigweed by default does not install clang (and hence clang-format) on ARM macs.

This adds the ARM mac version of clang to the set of things we install in addition to the default pigweed bits.  The SHA is unfortunately hardcoded to match the current SHA that pigweed uses on other platforms, but the lint should make sure we don't break that.
