### PR TITLE
[Darwin] MTRDevice estimate start time based on General Diagnostics UpTime attribute when present

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -396,12 +396,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
     }
 }
 
-- (void)_handleAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)fromSubscription
+- (void)_handleAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
 {
     os_unfair_lock_lock(&self->_lock);
 
     // _getAttributesToReportWithReportedValues will log attribute paths reported
-    [self _reportAttributes:[self _getAttributesToReportWithReportedValues:attributeReport fromSubscription:fromSubscription]];
+    [self _reportAttributes:[self _getAttributesToReportWithReportedValues:attributeReport]];
 
     os_unfair_lock_unlock(&self->_lock);
 }
@@ -416,8 +416,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
         MTREventPath * eventPath = eventDict[MTREventPathKey];
         BOOL isStartUpEvent = (eventPath.cluster.unsignedLongValue == MTRClusterIDTypeBasicInformationID)
             && (eventPath.event.unsignedLongValue == MTREventIDTypeClusterBasicInformationEventStartUpID);
-        // StartUp event would be received when server resumes subscription
         if (isStartUpEvent && (_state == MTRDeviceStateReachable)) {
+            // StartUp event received when server resumes subscription
             if (_estimatedStartTimeFromGeneralDiagnosticsUpTime) {
                 // If UpTime was received, make use of it as mark of system start time
                 MTR_LOG_INFO("%@ StartUp event: set estimated start time forward to %@", self,
@@ -531,7 +531,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
                            MTR_LOG_INFO("%@ got attribute report %@", self, value);
                            dispatch_async(self.queue, ^{
                                // OnAttributeData (after OnReportEnd)
-                               [self _handleAttributeReport:value fromSubscription:YES];
+                               [self _handleAttributeReport:value];
                            });
                        },
                        ^(NSArray * value) {
@@ -639,7 +639,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
                                       // Since the format is the same data-value dictionary, this looks like an attribute
                                       // report
                                       MTR_LOG_INFO("%@ completion values %@", logPrefix, values);
-                                      [self _handleAttributeReport:values fromSubscription:NO];
+                                      [self _handleAttributeReport:values];
                                   }
 
                                   // TODO: better retry logic
@@ -915,7 +915,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
 
 // assume lock is held
 - (NSArray *)_getAttributesToReportWithReportedValues:(NSArray<NSDictionary<NSString *, id> *> *)reportedAttributeValues
-                                     fromSubscription:(BOOL)fromSubscription
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
@@ -973,24 +972,15 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
                     NSNumber * upTimeNumber = attributeDataValue[MTRValueKey];
                     NSTimeInterval upTime = upTimeNumber.unsignedLongLongValue; // UpTime unit is defined as seconds in the spec
                     NSDate * potentialSystemStartTime = [NSDate dateWithTimeIntervalSinceNow:-upTime];
-
-                    if (!fromSubscription || (_state != MTRDeviceStateReachable)) {
-                        // When UpTime comes from a direct read, or is part of priming report, the new estimate should be used to
-                        // update estimate backwards (more accurate)
-                        NSDate * oldSystemStartTime = _estimatedStartTime;
-                        if (!_estimatedStartTime
-                            || ([potentialSystemStartTime compare:_estimatedStartTime] == NSOrderedAscending)) {
-                            MTR_LOG_INFO("%@ General Diagnostics UpTime %.3lf: estimated start time %@ => %@", self, upTime,
-                                oldSystemStartTime, potentialSystemStartTime);
-                            _estimatedStartTime = potentialSystemStartTime;
-                        }
-                    } else {
-                        // Otherwise it's a result from subscription report, which implies it's a resumed subscription,
-                        // because it's a "Changes Omitted" attribute. In this case:
-                        //   * Save UpTime-derived estimate
-                        //   * At StartUp event, update the estimated start time forward to the saved value
-                        _estimatedStartTimeFromGeneralDiagnosticsUpTime = potentialSystemStartTime;
+                    NSDate * oldSystemStartTime = _estimatedStartTime;
+                    if (!_estimatedStartTime || ([potentialSystemStartTime compare:_estimatedStartTime] == NSOrderedAscending)) {
+                        MTR_LOG_INFO("%@ General Diagnostics UpTime %.3lf: estimated start time %@ => %@", self, upTime,
+                            oldSystemStartTime, potentialSystemStartTime);
+                        _estimatedStartTime = potentialSystemStartTime;
                     }
+
+                    // Save estimate in the subscription resumption case, for when StartUp event uses it
+                    _estimatedStartTimeFromGeneralDiagnosticsUpTime = potentialSystemStartTime;
                 }
             }
         }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -980,7 +980,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
                     NSDate * oldSystemStartTime = _estimatedStartTimeFromGeneralDiagnosticsUpTime;
                     NSDate * potentialSystemStartTime = [NSDate dateWithTimeIntervalSinceNow:-upTime];
                     if (!_estimatedStartTimeFromGeneralDiagnosticsUpTime
-                        || ([potentialSystemStartTime compare:_estimatedStartTime] == NSOrderedAscending)) {
+                        || ([potentialSystemStartTime compare:_estimatedStartTimeFromGeneralDiagnosticsUpTime]
+                            == NSOrderedAscending)) {
                         MTR_LOG_INFO("%@ General Diagnostics UpTime %.3lf: estimated start time %@ => %@", self, upTime,
                             oldSystemStartTime, potentialSystemStartTime);
                         _estimatedStartTimeFromGeneralDiagnosticsUpTime = potentialSystemStartTime;

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1519,7 +1519,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                          subscriptionEstablished:^() {
                          }];
 
-    [self waitForExpectations:@[ subscriptionDroppedExpectation, resubscriptionExpectation ] timeout:60 enforceOrder:YES];
+    [self waitForExpectations:@[ subscriptionDroppedExpectation ] timeout:60];
+
+    // Check that device resets start time on subscription drop
+    XCTAssertNil(device.estimatedStartTime);
+
+    [self waitForExpectations:@[ resubscriptionExpectation ] timeout:60];
 
     // Now make sure we ignore later tests.  Ideally we would just unsubscribe
     // or remove the delegate, but there's no good way to do that.
@@ -1533,9 +1538,6 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // with data versions) during the resubscribe.
     XCTAssertEqual(attributeReportsReceived, 0);
     XCTAssertEqual(eventReportsReceived, 0);
-
-    // Check that device resets start time on subscription drop
-    XCTAssertNil(device.estimatedStartTime);
 }
 
 - (void)test018_SubscriptionErrorWhenNotResubscribing


### PR DESCRIPTION
MTRDevice currently estimates device start time (for devices that don't have a wall clock) by subtracting the event time value from "now". This estimate can get better over time as events get reported, but initially could be off by a lot, if there are no freshly generated events in the priming report at subscription establishment time.

This change improves the estimate by making an estimated start time if the General Diagnostics UpTime attribute is seen in the priming report, and at OnSubscriptionEstablished callback, update the estimate if it's better.

Note for reviewer: the `MTRTimeIntervalForEventTimestampValue` function needed to be moved so the compiler is not confused about multiple definitions, now that it's exported for `MTRDevice.mm` to also use.