### PR TITLE
[Silabs][Pigweed-RPC] Make sure RPC sends response and reboots when factory reset command is received

### DIFF
--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -295,9 +295,8 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     // When called from an RPC, the following reset occurs before the RPC can respond,
     // which breaks tests (because it looks like the RPC hasn't successfully completed).
-    // One way to fix this is to reduce the priority of this task, to allow logging to
-    // complete before the reset occurs.
-    vTaskPrioritySet(NULL, 0);
+    // Block the task for 500 ms before the reset occurs to allow RPC response to be sent
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     NVIC_SystemReset();
 }


### PR DESCRIPTION
vTaskPrioritySet(NULL, 0) doesn't always fix the issue it was trying to address and could even prevent the current task to be run again. Use a vTaskDelay of 500 ms to address the missing response issue and also make sure the task can execute the device reset.

