### PR TITLE
Change Server to not validate certificate expiration by default. (v1.1 cherry-pick of PR 26530)

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -128,7 +128,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mOperationalKeystore           = initParams.operationalKeystore;
     mOpCertStore                   = initParams.opCertStore;
 
-    mCertificateValidityPolicy.Init(initParams.certificateValidityPolicy);
+    if (initParams.certificateValidityPolicy)
+    {
+        mCertificateValidityPolicy.Init(initParams.certificateValidityPolicy);
+    }
+    else
+    {
+        mCertificateValidityPolicy.Init(&sDefaultCertValidityPolicy);
+    }
 
 #if defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT)
     VerifyOrDie(chip::audit::ExecutePersistentStorageApiAudit(*mDeviceStorage));
@@ -531,11 +538,12 @@ void Server::ResumeSubscriptions()
 }
 #endif
 
+Credentials::IgnoreCertificateValidityPeriodPolicy Server::sDefaultCertValidityPolicy;
+
 KvsPersistentStorageDelegate CommonCaseDeviceServerInitParams::sKvsPersistenStorageDelegate;
 PersistentStorageOperationalKeystore CommonCaseDeviceServerInitParams::sPersistentStorageOperationalKeystore;
 Credentials::PersistentStorageOpCertStore CommonCaseDeviceServerInitParams::sPersistentStorageOpCertStore;
 Credentials::GroupDataProviderImpl CommonCaseDeviceServerInitParams::sGroupDataProvider;
-Credentials::IgnoreCertificateValidityPeriodPolicy CommonCaseDeviceServerInitParams::sDefaultCertValidityPolicy;
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
 SimpleSessionResumptionStorage CommonCaseDeviceServerInitParams::sSessionResumptionStorage;
 #endif

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -233,10 +233,6 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
         // Inject ACL storage. (Don't initialize it.)
         this->aclStorage = &sAclStorage;
 
-        // Inject certificate validation policy compatible with non-wall-clock-time-synced
-        // embedded systems.
-        this->certificateValidityPolicy = &sDefaultCertValidityPolicy;
-
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
         ChipLogProgress(AppServer, "Initializing subscription resumption storage...");
         ReturnErrorOnFailure(sSubscriptionResumptionStorage.Init(this->persistentStorageDelegate));
@@ -253,7 +249,6 @@ private:
     static PersistentStorageOperationalKeystore sPersistentStorageOperationalKeystore;
     static Credentials::PersistentStorageOpCertStore sPersistentStorageOpCertStore;
     static Credentials::GroupDataProviderImpl sGroupDataProvider;
-    static Credentials::IgnoreCertificateValidityPeriodPolicy sDefaultCertValidityPolicy;
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
     static SimpleSessionResumptionStorage sSessionResumptionStorage;
 #endif
@@ -553,6 +548,10 @@ private:
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif
+
+    // By default, use a certificate validation policy compatible with non-wall-clock-time-synced
+    // embedded systems.
+    static Credentials::IgnoreCertificateValidityPeriodPolicy sDefaultCertValidityPolicy;
 
     ServerTransportMgr mTransports;
     SessionManager mSessions;


### PR DESCRIPTION
This is a cherry-pick of https://github.com/project-chip/connectedhomeip/pull/26530 to the v1.1 branch.

If an explicit validity policy is injected that validates notBefore/notAfter, we will do that, but if the app author just doesn't think about time-based validation default to not validating, because there's a good chance it will just lead to unexpected failures due to bad clocks and whatnot.
