### PR TITLE
[Darwin] Fix for MTRDevice attribute report omitting errors

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -912,7 +912,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceExpectedValueFieldIndex) {
         NSError * attributeError = attributeReponseValue[MTRErrorKey];
 
         // sanity check either data value or error must exist
-        if (!attributeDataValue && attributeError) {
+        if (!attributeDataValue && !attributeError) {
+            MTR_LOG_INFO("%@ report %@ no data value or error: %@", self, attributePath, attributeReponseValue);
             continue;
         }
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1495,6 +1495,19 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // nonexistent attribute
     [self waitForExpectations:@[ expectedValueReportedExpectation, expectedValueRemovedExpectation ] timeout:5 enforceOrder:YES];
 
+    // Test if errors are properly received
+    XCTestExpectation * attributeReportErrorExpectation = [self expectationWithDescription:@"Attribute read error"];
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        for (NSDictionary<NSString *, id> * attributeReponseValue in data) {
+            if (attributeReponseValue[MTRErrorKey]) {
+                [attributeReportErrorExpectation fulfill];
+            }
+        }
+    };
+    // use the nonexistent attribute and expect read error
+    [device readAttributeWithEndpointID:testEndpointID clusterID:testClusterID attributeID:testAttributeID params:nil];
+    [self waitForExpectations:@[ attributeReportErrorExpectation ] timeout:10];
+
     // reset the onAttributeDataReceived to validate the following resubscribe test
     delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
         attributeReportsReceived += data.count;


### PR DESCRIPTION
Thanks to @bzbarsky-apple for noticing this bug where MTRDevice does not report attribute read errors.

This change fixes it and adds a test as part of `MTRDeviceTests/test017_TestMTRDeviceBasics`