### PR TITLE
add the MaxInterval parameter to the subscription callback interface

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -149,7 +149,7 @@ protected:
         ReportCommand(commandName, credsIssuerConfig)
     {}
 
-    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId) override
+    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId, uint16_t maxInterval) override
     {
         mSubscriptionEstablished = true;
         SetCommandExitStatus(CHIP_NO_ERROR);

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -809,7 +809,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"contentLauncher_subscribeSupportedStreamingProtocols"];
                 callback();
@@ -916,7 +916,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"levelControl_subscribeCurrentLevel"];
                 callback();
@@ -961,7 +961,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"levelControl_subscribeMinLevel"];
                 callback();
@@ -1006,7 +1006,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"levelControl_subscribeMaxLevel"];
                 callback();
@@ -1323,7 +1323,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeCurrentState"];
                 callback();
@@ -1368,7 +1368,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeStartTime"];
                 callback();
@@ -1413,7 +1413,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeDuration"];
                 callback();
@@ -1473,7 +1473,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeSampledPosition"];
                 callback();
@@ -1520,7 +1520,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribePlaybackSpeed"];
                 callback();
@@ -1567,7 +1567,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeSeekRangeEnd"];
                 callback();
@@ -1614,7 +1614,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"mediaPlayback_subscribeSeekRangeStart"];
                 callback();
@@ -1799,7 +1799,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"targetNavigator_subscribeTargetList"];
                 callback();
@@ -1846,7 +1846,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"targetNavigator_subscribeCurrentTarget"];
                 callback();
@@ -1920,7 +1920,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"applicationBasic_subscribeVendorName"];
                 callback();
@@ -1966,7 +1966,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"applicationBasic_subscribeVendorID"];
                 callback();
@@ -2014,7 +2014,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"applicationBasic_subscribeApplicationName"];
                 callback();
@@ -2060,7 +2060,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"applicationBasic_subscribeProductID"];
                 callback();
@@ -2109,7 +2109,7 @@
                 callback([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
             },
             minInterval, maxInterval,
-            [](void * context, chip::SubscriptionId subscriptionId) {
+            [](void * context, chip::SubscriptionId subscriptionId, uint16_t _maxInterval) {
                 void (^callback)() = [[CastingServerBridge getSharedInstance].subscriptionEstablishedCallbacks
                     objectForKey:@"applicationBasic_subscribeApplicationVersion"];
                 callback();

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -160,7 +160,7 @@ void OnCurrentStateReadResponseFailure(void * context, CHIP_ERROR err)
     ChipLogProgress(AppServer, "OnCurrentStateReadResponseFailure called with %" CHIP_ERROR_FORMAT, err.Format());
 }
 
-void OnCurrentStateSubscriptionEstablished(void * context, SubscriptionId aSubscriptionId)
+void OnCurrentStateSubscriptionEstablished(void * context, SubscriptionId aSubscriptionId, uint16_t aMaxInterval)
 {
     ChipLogProgress(AppServer, "OnCurrentStateSubscriptionEstablished called");
     if (context != nullptr)

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -81,9 +81,9 @@ private:
     }
 
     void OnDone(ReadClient * apReadClient) override { return mCallback.OnDone(apReadClient); }
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
-        mCallback.OnSubscriptionEstablished(aSubscriptionId);
+        mCallback.OnSubscriptionEstablished(aSubscriptionId, aMaxInterval);
     }
 
     CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -596,9 +596,9 @@ private:
         return mCallback.OnDone(apReadClient);
     }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
-        mCallback.OnSubscriptionEstablished(aSubscriptionId);
+        mCallback.OnSubscriptionEstablished(aSubscriptionId, aMaxInterval);
     }
 
     CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -919,7 +919,7 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
 
     MoveToState(ClientState::SubscriptionActive);
 
-    mpCallback.OnSubscriptionEstablished(subscriptionId);
+    mpCallback.OnSubscriptionEstablished(subscriptionId, mMaxInterval);
 
     mNumRetries = 0;
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -134,8 +134,9 @@ public:
          * receives an OnDone call to destroy the object.
          *
          * @param[in] aSubscriptionId The identifier of the subscription that was established.
+         * @param[in] aMaxInterval The reporting max interval of the subscription that was established
          */
-        virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) {}
+        virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) {}
 
         /**
          * OnResubscriptionNeeded will be called when a subscription that was started with SendAutoResubscribeRequest has terminated

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -134,7 +134,7 @@ public:
     void OnEventData(const chip::app::EventHeader & aEventHeader, chip::TLV::TLVReader * apData,
                      const chip::app::StatusIB * apStatus) override
     {}
-    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
         if (mReadClient->IsSubscriptionType())
         {

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -163,7 +163,7 @@ void InteractionModel::OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPr
     InteractionModelReports::OnDeallocatePaths(std::move(aReadPrepareParams));
 }
 
-void InteractionModel::OnSubscriptionEstablished(SubscriptionId subscriptionId)
+void InteractionModel::OnSubscriptionEstablished(SubscriptionId subscriptionId, uint16_t maxInterval)
 {
     ContinueOnChipMainThread(CHIP_NO_ERROR);
 }

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -672,7 +672,7 @@ public:
                      const chip::app::StatusIB * status) override;
     void OnError(CHIP_ERROR error) override;
     void OnDone(chip::app::ReadClient * aReadClient) override;
-    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId) override;
+    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId, uint16_t maxInterval) override;
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override;
     /////////// WriteClient Callback Interface /////////
     void OnResponse(const chip::app::WriteClient * client, const chip::app::ConcreteDataAttributePath & path,

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -50,7 +50,7 @@ template <typename T>
 using ReadResponseSuccessCallback     = void (*)(void * context, T responseData);
 using ReadResponseFailureCallback     = void (*)(void * context, CHIP_ERROR err);
 using ReadDoneCallback                = void (*)(void * context);
-using SubscriptionEstablishedCallback = void (*)(void * context, SubscriptionId subscriptionId);
+using SubscriptionEstablishedCallback = void (*)(void * context, SubscriptionId subscriptionId, uint16_t maxInterval);
 using ResubscriptionAttemptCallback   = void (*)(void * context, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec);
 using SubscriptionOnDoneCallback      = std::function<void(void)>;
 
@@ -299,10 +299,11 @@ public:
         };
 
         auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient,
-                                                                                SubscriptionId subscriptionId) {
+                                                                                SubscriptionId subscriptionId,
+                                                                                uint16_t maxInterval) {
             if (subscriptionEstablishedCb != nullptr)
             {
-                subscriptionEstablishedCb(context, subscriptionId);
+                subscriptionEstablishedCb(context, subscriptionId, maxInterval);
             }
         };
 
@@ -379,10 +380,11 @@ public:
         };
 
         auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient,
-                                                                                SubscriptionId subscriptionId) {
+                                                                                SubscriptionId subscriptionId,
+                                                                                uint16_t maxInterval) {
             if (subscriptionEstablishedCb != nullptr)
             {
-                subscriptionEstablishedCb(context, subscriptionId);
+                subscriptionEstablishedCb(context, subscriptionId, maxInterval);
             }
         };
 

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -53,7 +53,7 @@ public:
     using OnErrorCallbackType = std::function<void(const app::ConcreteDataAttributePath * aPath, CHIP_ERROR aError)>;
     using OnDoneCallbackType  = std::function<void(TypedReadAttributeCallback * callback)>;
     using OnSubscriptionEstablishedCallbackType =
-        std::function<void(const app::ReadClient & readClient, SubscriptionId aSubscriptionId)>;
+        std::function<void(const app::ReadClient & readClient, SubscriptionId aSubscriptionId, uint16_t aMaxInterval)>;
     using OnResubscriptionAttemptCallbackType =
         std::function<void(const app::ReadClient & readClient, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec)>;
     TypedReadAttributeCallback(ClusterId aClusterId, AttributeId aAttributeId, OnSuccessCallbackType aOnSuccess,
@@ -124,11 +124,11 @@ private:
 
     void OnDone(app::ReadClient *) override { mOnDone(this); }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
         if (mOnSubscriptionEstablished)
         {
-            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId);
+            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId, aMaxInterval);
         }
     }
 
@@ -177,7 +177,7 @@ public:
     using OnErrorCallbackType   = std::function<void(const app::EventHeader * apEventHeader, CHIP_ERROR aError)>;
     using OnDoneCallbackType    = std::function<void(app::ReadClient * apReadClient)>;
     using OnSubscriptionEstablishedCallbackType =
-        std::function<void(const app::ReadClient & aReadClient, SubscriptionId aSubscriptionId)>;
+        std::function<void(const app::ReadClient & aReadClient, SubscriptionId aSubscriptionId, uint16_t aMaxInterval)>;
     using OnResubscriptionAttemptCallbackType =
         std::function<void(const app::ReadClient & aReadClient, CHIP_ERROR aError, uint32_t aNextResubscribeIntervalMsec)>;
 
@@ -258,11 +258,11 @@ private:
         chip::Platform::Delete<app::EventPathParams>(aReadPrepareParams.mpEventPathParamsList);
     }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
         if (mOnSubscriptionEstablished)
         {
-            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId);
+            mOnSubscriptionEstablished(*mReadClient.get(), aSubscriptionId, aMaxInterval);
         }
     }
 

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -542,10 +542,10 @@ void ReportCallback::OnDone(app::ReadClient *)
     JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mWrapperCallbackRef);
 }
 
-void ReportCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
+void ReportCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval)
 {
     DeviceLayer::StackUnlock unlock;
-    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId);
+    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId, aMaxInterval);
 }
 
 CHIP_ERROR ReportCallback::OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
@@ -797,10 +797,10 @@ void ReportEventCallback::OnDone(app::ReadClient *)
     JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mWrapperCallbackRef);
 }
 
-void ReportEventCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
+void ReportEventCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval)
 {
     chip::DeviceLayer::StackUnlock unlock;
-    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId);
+    JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef, aSubscriptionId, aMaxInterval);
 }
 
 CHIP_ERROR ReportEventCallback::OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause)

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -65,7 +65,7 @@ struct ReportCallback : public app::ClusterStateCache::Callback
 
     void OnDone(app::ReadClient *) override;
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override;
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override;
 
     CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
@@ -109,7 +109,7 @@ struct ReportEventCallback : public app::ReadClient::Callback
 
     void OnDone(app::ReadClient *) override;
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override;
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override;
 
     CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -75,7 +75,7 @@ using OnReadEventDataCallback           = void (*)(PyObject * appContext, chip::
                                          chip::EventId eventId, chip::EventNumber eventNumber, uint8_t priority, uint64_t timestamp,
                                          uint8_t timestampType, uint8_t * data, uint32_t dataLen,
                                          std::underlying_type_t<Protocols::InteractionModel::Status> imstatus);
-using OnSubscriptionEstablishedCallback = void (*)(PyObject * appContext, SubscriptionId subscriptionId);
+using OnSubscriptionEstablishedCallback = void (*)(PyObject * appContext, SubscriptionId subscriptionId, uint16_t maxInterval);
 using OnResubscriptionAttemptedCallback = void (*)(PyObject * appContext, PyChipError aTerminationCause,
                                                    uint32_t aNextResubscribeIntervalMsec);
 using OnReadErrorCallback               = void (*)(PyObject * appContext, PyChipError chiperror);
@@ -142,9 +142,9 @@ public:
                                      to_underlying(aStatus.mStatus), buffer.get(), size);
     }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
-        gOnSubscriptionEstablishedCallback(mAppContext, aSubscriptionId);
+        gOnSubscriptionEstablishedCallback(mAppContext, aSubscriptionId, aMaxInterval);
     }
 
     CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -158,7 +158,10 @@ public:
 
     void OnReportEnd() override { mOnReportEnd = true; }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
+    {
+        mOnSubscriptionEstablished = true;
+    }
 
     uint32_t mAttributeCount        = 0;
     uint32_t mEventCount            = 0;

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -136,7 +136,10 @@ public:
 
     void OnReportEnd() override { mOnReportEnd = true; }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
+    {
+        mOnSubscriptionEstablished = true;
+    }
 
     uint32_t mAttributeCount        = 0;
     bool mOnReportEnd               = false;
@@ -311,7 +314,10 @@ public:
 
     void OnReportEnd() override { mOnReportEnd = true; }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
+    {
+        mOnSubscriptionEstablished = true;
+    }
 
     uint32_t mAttributeCount = 0;
     // We record every dataversion field from every attribute IB.

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1628,7 +1628,10 @@ public:
         mLastError = aError;
     }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablishedCount++; }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
+    {
+        mOnSubscriptionEstablishedCount++;
+    }
 
     CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
@@ -1831,10 +1834,9 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptions(nlTestSuite * ap
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
 
     //
     // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
@@ -1898,10 +1900,9 @@ void TestReadInteraction::TestReadHandler_SubscriptionAppRejection(nlTestSuite *
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
 
     //
     // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
@@ -1964,7 +1965,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest1(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2040,7 +2042,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest2(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2116,7 +2119,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest3(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2191,10 +2195,9 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest4(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
 
     //
     // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
@@ -2258,7 +2261,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest5(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2334,7 +2338,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest6(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2410,7 +2415,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest7(nl
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
+                                                                                    chip::SubscriptionId aSubscriptionId,
+                                                                                    uint16_t aMaxInterval) {
         uint16_t minInterval = 0, maxInterval = 0;
 
         CHIP_ERROR err = readClient.GetReportingIntervals(minInterval, maxInterval);
@@ -2484,10 +2490,9 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest8(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
     //
     // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
     // callbacks.
@@ -2548,10 +2553,9 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest9(nl
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
 
     //
     // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
@@ -2658,15 +2662,15 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite, &aCtx, aSubscribeCount, aReadCount,
-                                        &numReadSuccessCalls, &numReadFailureCalls](const app::ReadClient & readClient,
-                                                                                    chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-        if (numSubscriptionEstablishedCalls == aSubscribeCount)
-        {
-            MultipleReadHelperInternal(apSuite, aCtx, aReadCount, numReadSuccessCalls, numReadFailureCalls);
-        }
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls, &apSuite, &aCtx, aSubscribeCount, aReadCount, &numReadSuccessCalls,
+         &numReadFailureCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId, uint16_t aMaxInterval) {
+            numSubscriptionEstablishedCalls++;
+            if (numSubscriptionEstablishedCalls == aSubscribeCount)
+            {
+                MultipleReadHelperInternal(apSuite, aCtx, aReadCount, numReadSuccessCalls, numReadFailureCalls);
+            }
+        };
 
     for (size_t i = 0; i < aSubscribeCount; ++i)
     {
@@ -2757,10 +2761,9 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFi
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
-                                                                          chip::SubscriptionId aSubscriptionId) {
-        numSubscriptionEstablishedCalls++;
-    };
+    auto onSubscriptionEstablishedCb =
+        [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient, chip::SubscriptionId aSubscriptionId,
+                                           uint16_t aMaxInterval) { numSubscriptionEstablishedCalls++; };
 
     //
     // Try to issue parallel subscriptions that will exceed the value for app::InteractionModelEngine::kReadHandlerPoolSize.
@@ -2964,7 +2967,10 @@ public:
         mLastError = aError;
     }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablishedCount++; }
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
+    {
+        mOnSubscriptionEstablishedCount++;
+    }
 
     void ClearCounters()
     {

--- a/src/darwin/Framework/CHIP/MTRBaseClusterUtils.h
+++ b/src/darwin/Framework/CHIP/MTRBaseClusterUtils.h
@@ -139,7 +139,10 @@ private:
         }
     }
 
-    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId) override { this->mBridge->OnSubscriptionEstablished(); }
+    void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId, uint16_t maxInterval) override
+    {
+        this->mBridge->OnSubscriptionEstablished();
+    }
 
     void OnDone(chip::app::ReadClient * readClient) override
     {

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -863,7 +863,7 @@ private:
 
     void OnDone(ReadClient *) override { mOnDone(this); }
 
-    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
+    void OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override
     {
         if (mOnSubscriptionEstablished) {
             mOnSubscriptionEstablished();

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -116,7 +116,7 @@ private:
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override;
 
-    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId) override;
+    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId, uint16_t aMaxInterval) override;
 
     CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -90,7 +90,7 @@ void MTRBaseSubscriptionCallback::OnDeallocatePaths(ReadPrepareParams && aReadPr
     }
 }
 
-void MTRBaseSubscriptionCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
+void MTRBaseSubscriptionCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId, uint16_t aMaxInterval)
 {
     if (mSubscriptionEstablishedHandler) {
         auto subscriptionEstablishedHandler = mSubscriptionEstablishedHandler;


### PR DESCRIPTION
In step 1 of `TC-IDM-4.2` (and others), it is necessary to judge the MaxInterval in the response content of the subscription message, which is not returned in the current callback interface, and this `PR` returns this field.
