### PR TITLE
[python] drop unnecessary dependency to pycrypto

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -309,10 +309,7 @@ chip_python_wheel_action("chip-core") {
     "ipdb",
     "deprecation",
     "mobly",
-
-    # Crypto libraries for complex tests and internal Python controller usage
     "cryptography",
-    "pycrypto",
     "ecdsa",
   ]
 


### PR DESCRIPTION
PR #21567 introduced an unnecessary dependency to pycrypto. From PyPI it seems that pycrypto is largely unmaintained, and I did not found a use in the Python bindings or in the Python tests.

Also drop the comment about cryptography and ecdsa usage as the library is meanwhile used in the core CHIP Python code.

