### PR TITLE
Fix ZAP ci job.

### DIFF
--- a/zzz_generated/darwin/controller-clusters/zap-generated/endpoint_config.h
+++ b/zzz_generated/darwin/controller-clusters/zap-generated/endpoint_config.h
@@ -59,7 +59,7 @@
 #define GENERATED_FUNCTION_ARRAYS
 
 // This is an array of EmberAfCluster structures.
-#define GENERATED_CLUSTER_COUNT 78
+#define GENERATED_CLUSTER_COUNT 79
 // clang-format off
 #define GENERATED_CLUSTERS { \
   { \
@@ -1098,7 +1098,7 @@
 // This is an array of EmberAfEndpointType structures.
 #define GENERATED_ENDPOINT_TYPES                                                                                                   \
     {                                                                                                                              \
-        { ZAP_CLUSTER_INDEX(0), 78, 0 },                                                                                           \
+        { ZAP_CLUSTER_INDEX(0), 79, 0 },                                                                                           \
     }
 
 // Largest attribute size is needed for various buffers


### PR DESCRIPTION
A bad merge happened between two PRs that each added a cluster.