### PR TITLE
Remove includes of CHIPClusters.h in Darwin code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCluster_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCluster_Internal.h
@@ -21,7 +21,6 @@
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCluster.h"
 
-#import "zap-generated/CHIPClusters.h"
 #import "zap-generated/MTRBaseClusters.h"
 
 #include <app/ReadPrepareParams.h>

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -12,8 +12,10 @@
 #import "MTRDevice_Internal.h"
 #import "MTRStructsObjc.h"
 
+#include <controller/CHIPCluster.h>
 #include <lib/support/CHIPListUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+
 #include <type_traits>
 
 using chip::Callback::Callback;
@@ -194,7 +196,7 @@ MTR{{cluster}}Cluster{{command}}Params
         TypeInfo::Type cppValue;
         {{>encode_value target="cppValue" source="value" cluster=parent.name errorCode="return CHIP_ERROR_INVALID_ARGUMENT;" depth=0}}
 
-        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cppCluster(exchangeManager, session, self->_endpoint);
+        chip::Controller::ClusterBase cppCluster(exchangeManager, session, self->_endpoint);
         return cppCluster.WriteAttribute<TypeInfo>(cppValue, bridge, successCb, failureCb, timedWriteTimeout);
     });
     std::move(*bridge).DispatchAction(self.device);

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
@@ -5,8 +5,6 @@
 #import "MTRBaseClusters.h"
 #import "MTRBaseDevice.h"
 
-#include <zap-generated/CHIPClusters.h>
-
 {{#zcl_clusters}}
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
@@ -6,8 +6,6 @@
 #import "MTRDevice.h"
 #import "MTRDevice_Internal.h"
 
-#include <zap-generated/CHIPClusters.h>
-
 {{#zcl_clusters}}
 
 {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Internal.h
@@ -20,8 +20,6 @@
 #import "MTRBaseClusters.h"
 #import "MTRBaseDevice.h"
 
-#include <zap-generated/CHIPClusters.h>
-
 @interface MTRBaseClusterIdentify ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters_Internal.h
@@ -21,8 +21,6 @@
 #import "MTRDevice.h"
 #import "MTRDevice_Internal.h"
 
-#include <zap-generated/CHIPClusters.h>
-
 @interface MTRClusterIdentify ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice * device;


### PR DESCRIPTION
Darwin bits don't use CHIPClusters anymore.
