### PR TITLE
Remove no-longer-needed Darwin removal annotations.

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.04.27-nightly
+ARG ZAP_VERSION=v2023.05.16-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/configure
+++ b/scripts/configure
@@ -254,14 +254,19 @@ function finalize_build_env() {
 }
 
 function download_zap() {
-    local version platform
+    local version platform arch
     read -r version <"${CHIP_ROOT}/scripts/setup/zap.version"
     case "$OSTYPE" in
     linux*) platform=linux ;;
     darwin*) platform=mac ;;
     *) fail "Unable to determine zap platform for OSTYPE='$OSTYPE'" ;;
     esac
-    local url="https://github.com/project-chip/zap/releases/download/${version}/zap-${platform}.zip"
+    case "$(uname -m)" in
+    arm64) arch=arm64 ;;
+    x86_64) arch=x64 ;;
+    *) fail "Unable to determine zap architecture for 'uname -m'='$(uname -m)'" ;;
+    esac
+    local url="https://github.com/project-chip/zap/releases/download/${version}/zap-${platform}-${arch}.zip"
 
     progress "Installing zap-cli from $url"
     call_impl download_and_extract_zip "$url" "${BUILD_ENV_PATH}/bin" zap-cli

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -4,11 +4,12 @@
             "path": "fuchsia/third_party/zap/${platform}",
             "platforms": [
                 "linux-amd64",
+                "linux-arm64",
                 "mac-amd64",
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.04.27-nightly.1"]
+            "tags": ["version:2@v2023.05.16-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.04.27-nightly
+v2023.05.16-nightly

--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -110,7 +110,15 @@ def _SetupReleaseZap(install_directory: str, zap_version: str):
     else:
         raise Exception('Unknown platform - do not know what zip file to download.')
 
-    url = f"https://github.com/project-chip/zap/releases/download/{zap_version}/zap-{zap_platform}.zip"
+    arch = os.uname().machine
+    if arch == 'arm64':
+        zap_arch = 'arm64'
+    elif arch == 'x86_64':
+        zap_arch = 'x64'
+    else:
+        raise Exception(f'Unknown architecture "${arch}" - do not know what zip file to download.')
+
+    url = f"https://github.com/project-chip/zap/releases/download/{zap_version}/zap-{zap_platform}-{zap_arch}.zip"
 
     logging.info("Fetching: %s", url)
 

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.4.27'
+MIN_ZAP_VERSION = '2023.5.16'
 
 
 class ZapTool:

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -6174,19 +6174,7 @@
       enum values:
           EthernetNetworkDiagnostics:
               # Both the enum and the values got renamed, so don't output the
-              # new values with the old enum name or the old values with the
-              # new enum name.
-              PHYRateType:
-                  - Rate10M
-                  - Rate100M
-                  - Rate1G
-                  - Rate25G
-                  - Rate5G
-                  - Rate10G
-                  - Rate40G
-                  - Rate100G
-                  - Rate200G
-                  - Rate400G
+              # old values with the new enum name.
               PHYRateEnum:
                   - 10M
                   - 100M
@@ -6199,19 +6187,13 @@
                   - 200G
                   - 400G
           OperationalCredentials:
-              # Both the enum and the values got renamed, so don't output the
-              # new value with the old enum name or the old value with the
-              # new enum name.
+              # Both the enum and the value got renamed, so don't output the
+              # old value with the new enum name.
               NodeOperationalCertStatusEnum:
                   - SUCCESS
-              OperationalCertStatus:
-                  - OK
           DoorLock:
               # Both the enum and the values got renamed, so don't output the
-              # new values with the old enum name or the old values with the
-              # new enum name.
-              DlCredentialRule:
-                  - Dual
+              # old value with the new enum name.
               CredentialRuleEnum:
                   - Double
   renames:
@@ -6976,14 +6958,6 @@
               - EventList
           FaultInjection:
               - EventList
-  removed:
-      enum values:
-          DoorLock:
-              DlLockDataType:
-                  # These values never existed for this enum name so, don't
-                  # start exposing them.  They're exposed for LockDataTypeEnum
-                  - FingerVein
-                  - Face
   renames:
       attributes:
           TimeSynchronization:
@@ -7531,6 +7505,10 @@
                   - DefaultNTP
                   - NTPServerAvailable
   deprecated:
+      clusters:
+          # We apparently forgot to deprecate BridgedDeviceBasic when we
+          # introduced BridgedDeviceBasicInformation.
+          - BridgedDeviceBasic
       bitmaps:
           Groups:
               - GroupClusterFeature
@@ -7538,35 +7516,6 @@
               - PressureFeature
           PumpConfigurationAndControl:
               - PumpFeature
-  removed:
-      attributes:
-          # The ProductAppearance bits never happened for the old Basic and
-          # BridgedDeviceBasic cluster names.
-          Basic:
-              - ProductAppearance
-          BridgedDeviceBasic:
-              - ProductAppearance
-      structs:
-          # The ProductAppearance bits never happened for the old Basic and
-          # BridgedDeviceBasic cluster names.
-          Basic:
-              - ProductAppearanceStruct
-          BridgedDeviceBasic:
-              - ProductAppearanceStruct
-      enums:
-          # The ProductAppearance bits never happened for the old Basic and
-          # BridgedDeviceBasic cluster names.
-          Basic:
-              - ProductFinishEnum
-              - ColorEnum
-          BridgedDeviceBasic:
-              - ProductFinishEnum
-              - ColorEnum
-      enum values:
-          # Unlatch was never present for the old operation type enum name.
-          DoorLock:
-              DlLockOperationType:
-                  - Unlatch
   renames:
       attributes:
           TimeSynchronization:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -20520,6 +20520,7 @@ MTR_DEPRECATED(
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRBaseClusterBridgedDeviceBasicInformation")
 @interface MTRBaseClusterBridgedDeviceBasic : MTRBaseClusterBridgedDeviceBasicInformation
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -7666,6 +7666,7 @@ MTR_DEPRECATED(
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRClusterBridgedDeviceBasicInformation")
 @interface MTRClusterBridgedDeviceBasic : MTRClusterBridgedDeviceBasicInformation
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -513,6 +513,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterStartUpEvent")
 @interface MTRBridgedDeviceBasicClusterStartUpEvent : MTRBridgedDeviceBasicInformationClusterStartUpEvent
 @end
 
@@ -521,6 +522,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterShutDownEvent")
 @interface MTRBridgedDeviceBasicClusterShutDownEvent : MTRBridgedDeviceBasicInformationClusterShutDownEvent
 @end
 
@@ -529,6 +531,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterLeaveEvent")
 @interface MTRBridgedDeviceBasicClusterLeaveEvent : MTRBridgedDeviceBasicInformationClusterLeaveEvent
 @end
 
@@ -538,6 +541,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+MTR_NEWLY_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterReachableChangedEvent")
 @interface MTRBridgedDeviceBasicClusterReachableChangedEvent : MTRBridgedDeviceBasicInformationClusterReachableChangedEvent
 @end
 


### PR DESCRIPTION
Now that isSupported returns false for things that are introduced after a container's deprecation, a bunch of removal annotations are no longer needed.

Also:

* Adds the missing deprecation for BridgedDeviceBasic.
* Adds linux-arm64 ZAP now that it's available.
