### PR TITLE
[ESP32] Provision to use the ESP32H2 ECDSA Peripheral

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -238,7 +238,7 @@ if (CONFIG_SEC_CERT_DAC_PROVIDER)
     chip_gn_arg_append("chip_use_secure_cert_dac_provider"                 "true")
 endif()
 
-if (CONFIG_SOC_ECDSA_SUPPORTED)
+if (CONFIG_USE_ESP32_ECDSA_PERIPHERAL)
     chip_gn_arg_append("chip_use_esp32_ecdsa_peripheral" "true")
 endif()
 

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -238,6 +238,9 @@ if (CONFIG_SEC_CERT_DAC_PROVIDER)
     chip_gn_arg_append("chip_use_secure_cert_dac_provider"                 "true")
 endif()
 
+if (CONFIG_SOC_ECDSA_SUPPORTED)
+    chip_gn_arg_append("chip_use_esp32_ecdsa_peripheral" "true")
+endif()
 
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
 file(GENERATE OUTPUT "${args_gn_input}" CONTENT "${chip_gn_args}")

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -700,6 +700,19 @@ menu "CHIP Device Layer"
                 Use ESP32 Secure Cert DAC Provider which is  ESP32 DeviceAttestationCredentialsProvider implementation which reads attestation
                 information from the esp_secure_cert partition
 
+        config USE_ESP32_ECDSA_PERIPHERAL
+            bool
+            depends on SEC_CERT_DAC_PROVIDER && SOC_ECDSA_SUPPORTED
+            default y
+            select MBEDTLS_HARDWARE_ECDSA_SIGN
+            select ENABLE_ESP32_FACTORY_DATA_PROVIDER
+            select ENABLE_ESP32_DEVICE_INSTANCE_INFO_PROVIDER
+            help
+                If DAC is being read from secure cert and SOC supports ECDSA signing using on-chip peripheral
+                then this option gets enabled. This option also selects few more that are required for commissioning
+                the device.
+                Also, please disable ESP_SECURE_CERT_DS_PERIPHERAL from the menuconfig when this option is disabled
+
     endmenu
 
 

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -701,7 +701,7 @@ menu "CHIP Device Layer"
                 information from the esp_secure_cert partition
 
         config USE_ESP32_ECDSA_PERIPHERAL
-            bool
+            bool "Use ESP32 ECDSA Peripheral"
             depends on SEC_CERT_DAC_PROVIDER && SOC_ECDSA_SUPPORTED
             default y
             select MBEDTLS_HARDWARE_ECDSA_SIGN

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -7,6 +7,6 @@ dependencies:
             - if: "target != esp32h2"
 
     espressif/esp_secure_cert_mgr:
-        version: "^2.2.1"
+        version: "^2.3.0"
         rules:
             - if: "idf_version >=4.3"

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -29,6 +29,7 @@ declare_args() {
   chip_bt_bluedroid_enabled = false
   chip_enable_ble_controller = false
   chip_use_secure_cert_dac_provider = false
+  chip_use_esp32_ecdsa_peripheral = false
 }
 
 defines = [
@@ -164,6 +165,13 @@ static_library("ESP32") {
     sources += [
       "ESP32SecureCertDACProvider.cpp",
       "ESP32SecureCertDACProvider.h",
+    ]
+  }
+
+  if (chip_use_esp32_ecdsa_peripheral) {
+    sources += [
+      "ESP32CHIPCryptoPAL.cpp",
+      "ESP32CHIPCryptoPAL.h",
     ]
   }
 

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -1,0 +1,147 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPSafeCasts.h>
+#include <platform/ESP32/ESP32CHIPCryptoPAL.h>
+
+#include <mbedtls/bignum.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/ecdsa.h>
+#include <mbedtls/ecp.h>
+#include <mbedtls/error.h>
+#include <ecdsa/ecdsa_alt.h>
+
+// In mbedTLS 3.0.0 direct access to structure fields was replaced with using MBEDTLS_PRIVATE macro.
+#if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+#define CHIP_CRYPTO_PAL_PRIVATE(x) MBEDTLS_PRIVATE(x)
+#else
+#define CHIP_CRYPTO_PAL_PRIVATE(x) x
+#endif
+
+#define MAX_ERROR_STR_LEN 128
+
+namespace {
+
+static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
+{
+    return (chip::Crypto::DRBG_get_bytes(out_buffer, out_length) == CHIP_NO_ERROR) ? 0 : 1;
+}
+
+static inline mbedtls_ecdsa_context * to_ecdsa_ctx(chip::Crypto::P256KeypairContext * context)
+{
+    return chip::SafePointerCast<mbedtls_ecdsa_context *>(context);
+}
+
+static void _log_mbedTLS_error(int error_code)
+{
+    if (error_code != 0)
+    {
+#if defined(MBEDTLS_ERROR_C)
+        char error_str[MAX_ERROR_STR_LEN];
+        mbedtls_strerror(error_code, error_str, sizeof(error_str));
+        ChipLogError(Crypto, "mbedTLS error: %s", error_str);
+#else
+        // Error codes defined in 16-bit negative hex numbers. Ease lookup by printing likewise
+        ChipLogError(Crypto, "mbedTLS error: -0x%04X", -static_cast<uint16_t>(error_code));
+#endif
+    }
+}
+
+} // anonymous namespace
+
+namespace chip {
+namespace Crypto {
+
+CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
+{
+    Clear();
+
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    mbedtls_ecdsa_context * ecdsa_ctx = to_ecdsa_ctx(&mKeypair);
+    mbedtls_ecdsa_init(ecdsa_ctx);
+
+    int status = mbedtls_ecp_group_load(&ecdsa_ctx->MBEDTLS_PRIVATE(grp), MBEDTLS_ECP_DP_SECP256R1);
+    VerifyOrExit(status == 0, error = CHIP_ERROR_INTERNAL);
+
+    status = esp_ecdsa_privkey_load_mpi(&ecdsa_ctx->MBEDTLS_PRIVATE(d), efuseBlock);
+    VerifyOrExit(status == 0, error = CHIP_ERROR_INTERNAL);
+
+    mInitialized = true;
+    ecdsa_ctx = nullptr;
+    return error;
+
+exit:
+    if (ecdsa_ctx)
+    {
+        mbedtls_ecdsa_free(ecdsa_ctx);
+        ecdsa_ctx = nullptr;
+    }
+    _log_mbedTLS_error(status);
+    return error;
+}
+
+CHIP_ERROR ESP32P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
+    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t digest[kSHA256_Hash_Length];
+    memset(&digest[0], 0, sizeof(digest));
+    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
+
+#if defined(MBEDTLS_ECDSA_C)
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    mbedtls_mpi r, s;
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+
+    mbedtls_ecdsa_context * ecdsa_ctx = to_ecdsa_ctx(&mKeypair);
+
+    result = mbedtls_ecdsa_sign(&ecdsa_ctx->CHIP_CRYPTO_PAL_PRIVATE(grp), &r, &s, &ecdsa_ctx->CHIP_CRYPTO_PAL_PRIVATE(d),
+                                Uint8::to_const_uchar(digest), sizeof(digest), CryptoRNG, nullptr);
+
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit((mbedtls_mpi_size(&r) <= kP256_FE_Length) && (mbedtls_mpi_size(&s) <= kP256_FE_Length),
+                 error = CHIP_ERROR_INTERNAL);
+
+    // Concatenate r and s to output. Sizes were checked above.
+    result = mbedtls_mpi_write_binary(&r, out_signature.Bytes() + 0u, kP256_FE_Length);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    result = mbedtls_mpi_write_binary(&s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    ecdsa_ctx = nullptr;
+    mbedtls_mpi_free(&s);
+    mbedtls_mpi_free(&r);
+    _log_mbedTLS_error(result);
+    return error;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.cpp
@@ -19,13 +19,13 @@
 #include <lib/core/CHIPSafeCasts.h>
 #include <platform/ESP32/ESP32CHIPCryptoPAL.h>
 
+#include <ecdsa/ecdsa_alt.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecdh.h>
 #include <mbedtls/ecdsa.h>
 #include <mbedtls/ecp.h>
 #include <mbedtls/error.h>
-#include <ecdsa/ecdsa_alt.h>
 
 // In mbedTLS 3.0.0 direct access to structure fields was replaced with using MBEDTLS_PRIVATE macro.
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
@@ -84,7 +84,7 @@ CHIP_ERROR ESP32P256Keypair::Initialize(ECPKeyTarget keyTarget, int efuseBlock)
     VerifyOrExit(status == 0, error = CHIP_ERROR_INTERNAL);
 
     mInitialized = true;
-    ecdsa_ctx = nullptr;
+    ecdsa_ctx    = nullptr;
     return error;
 
 exit:

--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.h
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This files overrides few APIs from mbedTLS based implementation of CHIP crypto primitives
+ *      for using ECDSA peripheral on ESP32 chips.
+ */
+#pragma once
+
+#include <crypto/CHIPCryptoPAL.h>
+
+namespace chip {
+namespace Crypto {
+
+class ESP32P256Keypair : public P256Keypair
+{
+public:
+    /**
+     * @brief Initialize the keypair with efuse block key
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Initialize(ECPKeyTarget keyTarget, int efuseBlock);
+
+    CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const override;
+};
+
+} // namespace Crypto
+} // namespace chip

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
                         ESP_LOGE(TAG, "Failed to get the type of private key from secure cert partition, esp_err:%d", esp_err));
 
     VerifyOrReturnError(keyType != ESP_SECURE_CERT_INVALID_KEY, CHIP_ERROR_INCORRECT_STATE,
-                        ESP_LOGE(TAG, "Private key type in secure cert partition in invalid"));
+                        ESP_LOGE(TAG, "Private key type in secure cert partition is invalid"));
 
     // This flow is for devices supporting ECDSA peripheral
     if (keyType == ESP_SECURE_CERT_ECDSA_PERIPHERAL_KEY)

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -159,6 +159,7 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
     }
     else // This flow is for devices which do not support ECDSA peripheral
     {
+#if !CONFIG_USE_ESP32_ECDSA_PERIPHERAL
         Crypto::P256Keypair keypair;
         char * sc_keypair       = NULL;
         uint32_t sc_keypair_len = 0;
@@ -178,6 +179,9 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
         VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError, esp_secure_cert_free_priv_key(sc_keypair));
 
         esp_secure_cert_free_priv_key(sc_keypair);
+#else
+        return CHIP_ERROR_INCORRECT_STATE;
+#endif // !CONFIG_USE_ESP32_ECDSA_PERIPHERAL
     }
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);
 }

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -23,6 +23,10 @@
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/ESP32/ESP32SecureCertDACProvider.h>
 
+#if CONFIG_SOC_ECDSA_SUPPORTED
+#include <platform/ESP32/ESP32CHIPCryptoPAL.h>
+#endif // CONFIG_SOC_ECDSA_SUPPORTED
+
 #define TAG "dac_provider"
 
 #if CONFIG_SEC_CERT_DAC_PROVIDER
@@ -111,20 +115,60 @@ CHIP_ERROR ESP32SecureCertDACProvider ::GetProductAttestationIntermediateCert(Mu
 CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteSpan & messageToSign,
                                                                      MutableByteSpan & outSignBuffer)
 {
+    esp_err_t esp_err;
+    esp_secure_cert_key_type_t keyType;
+
+    CHIP_ERROR chipError;
     Crypto::P256ECDSASignature signature;
-    Crypto::P256Keypair keypair;
-    char * sc_keypair       = NULL;
-    uint32_t sc_keypair_len = 0;
 
     VerifyOrReturnError(IsSpanUsable(outSignBuffer), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(IsSpanUsable(messageToSign), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(outSignBuffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    esp_err_t err = esp_secure_cert_get_priv_key(&sc_keypair, &sc_keypair_len);
-    if (err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0)
+    esp_err = esp_secure_cert_get_priv_key_type(&keyType);
+    VerifyOrReturnError(esp_err == ESP_OK, CHIP_ERROR_INCORRECT_STATE,
+                    ESP_LOGE(TAG, "Failed to get the type of private key from secure cert partition, esp_err:%d", esp_err));
+
+    VerifyOrReturnError(keyType != ESP_SECURE_CERT_INVALID_KEY, CHIP_ERROR_INCORRECT_STATE,
+                    ESP_LOGE(TAG, "Private key type in secure cert partition in invalid"));
+
+    // This flow is for devices supporting ECDSA peripheral
+    if (keyType == ESP_SECURE_CERT_ECDSA_PERIPHERAL_KEY)
     {
-        ESP_FAULT_ASSERT(err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0);
-        CHIP_ERROR chipError =
+#if CONFIG_SOC_ECDSA_SUPPORTED
+        Crypto::ESP32P256Keypair keypair;
+        uint8_t efuseBlockId;
+
+        esp_err = esp_secure_cert_get_priv_key_efuse_id(&efuseBlockId);
+        VerifyOrReturnError(esp_err == ESP_OK, CHIP_ERROR_INVALID_KEY_ID,
+                        ESP_LOGE(TAG, "Failed to get the private key efuse block id, esp_err:%d", esp_err));
+
+        ESP_LOGD(TAG, "efuse block id:%u", efuseBlockId);
+
+        chipError = keypair.Initialize(chip::Crypto::ECPKeyTarget::ECDSA, efuseBlockId);
+        VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError,
+                         ESP_LOGE(TAG, "Failed to initialize the keypair err:%" CHIP_ERROR_FORMAT, chipError.Format()));
+
+        chipError = keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature);
+        VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError,
+              ESP_LOGE(TAG, "Failed to sign with device attestation key, err:%" CHIP_ERROR_FORMAT, chipError.Format()));
+#else
+        return CHIP_ERROR_INCORRECT_STATE;
+#endif // CONFIG_SOC_ECDSA_SUPPORTED
+    }
+    else // This flow is for devices which do not support ECDSA peripheral
+    {
+        Crypto::P256Keypair keypair;
+        char * sc_keypair       = NULL;
+        uint32_t sc_keypair_len = 0;
+
+        esp_err = esp_secure_cert_get_priv_key(&sc_keypair, &sc_keypair_len);
+        VerifyOrReturnError(esp_err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0, CHIP_ERROR_INCORRECT_STATE,
+                ESP_LOGE(TAG, "esp_secure_cert_get_priv_key failed esp_err:%d", esp_err));
+
+        ESP_FAULT_ASSERT(esp_err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0);
+
+        chipError =
             LoadKeypairFromRaw(ByteSpan(reinterpret_cast<const uint8_t *>(sc_keypair + kPrivKeyOffset), kDACPrivateKeySize),
                                ByteSpan(reinterpret_cast<const uint8_t *>(sc_keypair + kPubKeyOffset), kDACPublicKeySize), keypair);
         VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError, esp_secure_cert_free_priv_key(sc_keypair));
@@ -133,12 +177,8 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
         VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError, esp_secure_cert_free_priv_key(sc_keypair));
 
         esp_secure_cert_free_priv_key(sc_keypair);
-        chipError = CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);
-        return chipError;
     }
-
-    ESP_LOGE(TAG, "esp_secure_cert_get_priv_key failed err:%d", err);
-    return CHIP_ERROR_INCORRECT_STATE;
+    return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);
 }
 
 } // namespace DeviceLayer

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -23,9 +23,9 @@
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/ESP32/ESP32SecureCertDACProvider.h>
 
-#if CONFIG_SOC_ECDSA_SUPPORTED
+#if CONFIG_USE_ESP32_ECDSA_PERIPHERAL
 #include <platform/ESP32/ESP32CHIPCryptoPAL.h>
-#endif // CONFIG_SOC_ECDSA_SUPPORTED
+#endif // CONFIG_USE_ESP32_ECDSA_PERIPHERAL
 
 #define TAG "dac_provider"
 

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -127,10 +127,10 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
 
     esp_err = esp_secure_cert_get_priv_key_type(&keyType);
     VerifyOrReturnError(esp_err == ESP_OK, CHIP_ERROR_INCORRECT_STATE,
-                    ESP_LOGE(TAG, "Failed to get the type of private key from secure cert partition, esp_err:%d", esp_err));
+                        ESP_LOGE(TAG, "Failed to get the type of private key from secure cert partition, esp_err:%d", esp_err));
 
     VerifyOrReturnError(keyType != ESP_SECURE_CERT_INVALID_KEY, CHIP_ERROR_INCORRECT_STATE,
-                    ESP_LOGE(TAG, "Private key type in secure cert partition in invalid"));
+                        ESP_LOGE(TAG, "Private key type in secure cert partition in invalid"));
 
     // This flow is for devices supporting ECDSA peripheral
     if (keyType == ESP_SECURE_CERT_ECDSA_PERIPHERAL_KEY)
@@ -141,17 +141,18 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
 
         esp_err = esp_secure_cert_get_priv_key_efuse_id(&efuseBlockId);
         VerifyOrReturnError(esp_err == ESP_OK, CHIP_ERROR_INVALID_KEY_ID,
-                        ESP_LOGE(TAG, "Failed to get the private key efuse block id, esp_err:%d", esp_err));
+                            ESP_LOGE(TAG, "Failed to get the private key efuse block id, esp_err:%d", esp_err));
 
         ESP_LOGD(TAG, "efuse block id:%u", efuseBlockId);
 
         chipError = keypair.Initialize(chip::Crypto::ECPKeyTarget::ECDSA, efuseBlockId);
         VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError,
-                         ESP_LOGE(TAG, "Failed to initialize the keypair err:%" CHIP_ERROR_FORMAT, chipError.Format()));
+                            ESP_LOGE(TAG, "Failed to initialize the keypair err:%" CHIP_ERROR_FORMAT, chipError.Format()));
 
         chipError = keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature);
-        VerifyOrReturnError(chipError == CHIP_NO_ERROR, chipError,
-              ESP_LOGE(TAG, "Failed to sign with device attestation key, err:%" CHIP_ERROR_FORMAT, chipError.Format()));
+        VerifyOrReturnError(
+            chipError == CHIP_NO_ERROR, chipError,
+            ESP_LOGE(TAG, "Failed to sign with device attestation key, err:%" CHIP_ERROR_FORMAT, chipError.Format()));
 #else
         return CHIP_ERROR_INCORRECT_STATE;
 #endif // CONFIG_SOC_ECDSA_SUPPORTED
@@ -164,7 +165,7 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
 
         esp_err = esp_secure_cert_get_priv_key(&sc_keypair, &sc_keypair_len);
         VerifyOrReturnError(esp_err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0, CHIP_ERROR_INCORRECT_STATE,
-                ESP_LOGE(TAG, "esp_secure_cert_get_priv_key failed esp_err:%d", esp_err));
+                            ESP_LOGE(TAG, "esp_secure_cert_get_priv_key failed esp_err:%d", esp_err));
 
         ESP_FAULT_ASSERT(esp_err == ESP_OK && sc_keypair != NULL && sc_keypair_len != 0);
 

--- a/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDACProvider.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
     // This flow is for devices supporting ECDSA peripheral
     if (keyType == ESP_SECURE_CERT_ECDSA_PERIPHERAL_KEY)
     {
-#if CONFIG_SOC_ECDSA_SUPPORTED
+#if CONFIG_USE_ESP32_ECDSA_PERIPHERAL
         Crypto::ESP32P256Keypair keypair;
         uint8_t efuseBlockId;
 
@@ -155,7 +155,7 @@ CHIP_ERROR ESP32SecureCertDACProvider ::SignWithDeviceAttestationKey(const ByteS
             ESP_LOGE(TAG, "Failed to sign with device attestation key, err:%" CHIP_ERROR_FORMAT, chipError.Format()));
 #else
         return CHIP_ERROR_INCORRECT_STATE;
-#endif // CONFIG_SOC_ECDSA_SUPPORTED
+#endif // CONFIG_USE_ESP32_ECDSA_PERIPHERAL
     }
     else // This flow is for devices which do not support ECDSA peripheral
     {


### PR DESCRIPTION
#### Change Overview
- ESP32H2 has the on-chip ECDSA peripheral, so using it to sign the message during commissioning process.
- Extended the `P256Keypair` class and and overloaded `Initialize()` and overrode`ECDSA_sign_msg()` methods for using ECDSA peripheral.
- Added the support for using the extended keypair in secure cert dac provider impl based on SOC capability.

#### Tests
- Generated the partition with efuse block id and flashed into secure cert partition and verified that commissioning works.
- This was tested on IDF commit from release/v5.1 branch 0ed84998987df2dfeafe695ffb8c71a2047135b7.
- Also, tested that building applications works on IDF v4.4.4
- To build the firmware for had to enable `CONFIG_SEC_CERT_DAC_PROVIDER` and disable `CONFIG_ESP_SECURE_CERT_DS_PERIPHERAL`.

#### Follow up work
- https://github.com/project-chip/connectedhomeip/issues/26656