### PR TITLE
Increase timeout value for door lock test from 15s to 25s.

### DIFF
--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -18,7 +18,7 @@ config:
     nodeId: 0x12344321
     cluster: "Door Lock"
     endpoint: 1
-    timeout: 15
+    timeout: 25
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"


### PR DESCRIPTION
The test has a 10-second wait built in, and it's possible for us to spend more than 5s running the rest of it, at which point it times out.
