### PR TITLE
[Tests] Improving initalizaiton in TestInetCommonPosix

### DIFF
--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -161,20 +161,31 @@ void ShutdownTestInetCommon()
 
 void InitSystemLayer()
 {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && !(CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT)
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    // LwIP implementation uses the event loop for servicing events.
+    // The CHIP stack initialization is required then.
+    chip::DeviceLayer::PlatformMgr().InitChipStack();
+#ifndef CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT
     AcquireLwIP();
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && !(CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT)
+#endif // !CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     gSystemLayer.Init();
 }
 
 void ShutdownSystemLayer()
 {
+
     gSystemLayer.Shutdown();
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && !(CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT)
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    // LwIP implementation uses the event loop for servicing events.
+    // The CHIP stack shutdown is required then.
+    chip::DeviceLayer::PlatformMgr().Shutdown();
+#ifndef CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT
     ReleaseLwIP();
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && !(CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT)
+#endif // !CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !(CHIP_SYSTEM_CONFIG_LWIP_SKIP_INIT)

--- a/src/transport/raw/tests/NetworkTestHelpers.cpp
+++ b/src/transport/raw/tests/NetworkTestHelpers.cpp
@@ -32,8 +32,7 @@ CHIP_ERROR IOContext::Init()
     CHIP_ERROR err = Platform::MemoryInit();
     chip::DeviceLayer::SetConfigurationMgr(&chip::DeviceLayer::ConfigurationMgrImpl());
 
-    gSystemLayer.Init();
-
+    InitSystemLayer();
     InitNetwork();
 
     mSystemLayer        = &gSystemLayer;


### PR DESCRIPTION
Add CHIP stack initialization/shutdown for LwIP event service. It uses an event loop mechanism that requires a CHIP stack ready for use.
Use InitSystemLayer() function in IOContext:Init() to fully initialize the SystemLayer for testing.

