### PR TITLE
Make chip::Logging::GetModuleName public

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -154,12 +154,13 @@ static const char ModuleNames[kLogModule_Max][kMaxModuleNameLen + 1] = {
     "CSM", // CASESessionManager
 };
 
-static char const * GetModuleName(LogModule module)
+
+} // namespace
+
+const char * GetModuleName(LogModule module)
 {
     return ModuleNames[(module < kLogModule_Max) ? module : kLogModule_NotSpecified];
 }
-
-} // namespace
 
 void SetLogRedirectCallback(LogRedirectCallback_t callback)
 {

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -154,7 +154,6 @@ static const char ModuleNames[kLogModule_Max][kMaxModuleNameLen + 1] = {
     "CSM", // CASESessionManager
 };
 
-
 } // namespace
 
 const char * GetModuleName(LogModule module)

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -83,6 +83,9 @@ using ByteSpan = Span<const uint8_t>;
 
 namespace Logging {
 
+// Get the module name associated with a LogModule, or "-" on invalid value.
+const char * GetModuleName(LogModule module);
+
 // Log redirection
 using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, const char * msg, va_list args);
 DLL_EXPORT void SetLogRedirectCallback(LogRedirectCallback_t callback);


### PR DESCRIPTION
Problem:
- Platform LogV receives the module name string
- To make any choices based on module, the module names must be visible
- Somehow the module names getter was not public

This PR:
- Make the function public (no functional change)

Testing done:
- Still builds, unit tests pass
