### PR TITLE
Fix removePeripheralsFromCache to iterate the right things.

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -698,7 +698,7 @@ namespace DeviceLayer {
 
 - (void)removePeripheralsFromCache
 {
-    for (CBPeripheral * peripheral in [_cachedPeripherals allValues]) {
+    for (CBPeripheral * peripheral in [_cachedPeripherals allKeys]) {
         [self removePeripheralFromCache:peripheral];
     }
 }


### PR DESCRIPTION
We're using the things we get out of the iterator as keys into the cache; these are not the values.
