### PR TITLE
[chiptool.py] Runner is not logging skipped steps as expected

### DIFF
--- a/scripts/tests/yaml/tests_logger.py
+++ b/scripts/tests/yaml/tests_logger.py
@@ -186,11 +186,12 @@ class TestRunnerLogger(TestRunnerHooks):
     def step_skipped(self, name: str, expression: str):
         print(self.__strings.step_skipped.format(index=self.__index, name=_strikethrough(name)))
 
+        if self.__use_test_harness_log_format:
+            print(self.__strings.test_harness_step_start.format(index=self.__index, name=name))
+            print(self.__strings.test_harness_step_skipped.format(expression=expression))
+
         self.__index += 1
         self.__skipped += 1
-
-        if self.__use_test_harness_log_format:
-            print(self.__strings.test_harness_step_skipped.format(expression=expression))
 
     def step_start(self, name: str):
         if self.__use_test_harness_log_format:


### PR DESCRIPTION
#### Problem

The CI log format is missing some logs when a test is skipped. This PR adds it.

fix #26638