### PR TITLE
Add support for implementing different ethernet boards for esp32

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -178,6 +178,10 @@ if (CONFIG_ENABLE_ESP32_BLE_CONTROLLER)
     chip_gn_arg_append("chip_enable_ble_controller"             "true")
 endif()
 
+if (CONFIG_ENABLE_ETHERNET_TELEMETRY)
+    chip_gn_arg_append("chip_enable_ethernet"                   "true")
+endif()
+
 if (CONFIG_ENABLE_MATTER_OVER_THREAD)
     chip_gn_arg_append("chip_enable_openthread"                 "true")
 else()

--- a/docs/guides/esp32/build_app_and_commission.md
+++ b/docs/guides/esp32/build_app_and_commission.md
@@ -200,8 +200,9 @@ Note: In order to commission an ethernet device, from all-clusters-app enable
 these config options: select `ESP32-Ethernet-Kit` under `Demo->Device Type` and
 select `On-Network` rendezvous mode under `Demo->Rendezvous Mode`. Currently
 default ethernet board supported is IP101, if you want to use other types of
-ethernet board then override the current implementation under
-`ConnectivityManagerImpl::InitEthernet`
+ethernet board then you can extend the `ESPEthernetDriver` class in your
+application and override the current implementation under
+`ESPEthernetDriver::Init`
 
 #### Commissioning Parameters
 

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -30,6 +30,7 @@ declare_args() {
   chip_enable_ble_controller = false
   chip_use_secure_cert_dac_provider = false
   chip_use_esp32_ecdsa_peripheral = false
+  chip_enable_ethernet = false
 }
 
 defines = [
@@ -45,7 +46,6 @@ static_library("ESP32") {
     "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
-    "ConnectivityManagerImpl_Ethernet.cpp",
     "DiagnosticDataProviderImpl.cpp",
     "DiagnosticDataProviderImpl.h",
     "ESP32Config.cpp",
@@ -134,6 +134,13 @@ static_library("ESP32") {
 
   if (chip_mdns == "platform") {
     sources += [ "DnssdImpl.cpp" ]
+  }
+
+  if (chip_enable_ethernet) {
+    sources += [
+      "ConnectivityManagerImpl_Ethernet.cpp",
+      "NetworkCommissioningDriver_Ethernet.cpp",
+    ]
   }
 
   if (chip_enable_openthread) {

--- a/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
@@ -39,8 +39,6 @@
 #include <lwip/nd6.h>
 #include <lwip/netif.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
@@ -53,26 +51,6 @@ CHIP_ERROR ConnectivityManagerImpl::InitEthernet()
 {
     // Initialize TCP/IP network interface (should be called for all Ethernet boards)
     ESP_ERROR_CHECK(esp_netif_init());
-    esp_netif_config_t cfg  = ESP_NETIF_DEFAULT_ETH();
-    esp_netif_t * eth_netif = esp_netif_new(&cfg);
-
-    // Init MAC and PHY configs to default
-    eth_mac_config_t mac_config  = ETH_MAC_DEFAULT_CONFIG();
-    eth_phy_config_t phy_config  = ETH_PHY_DEFAULT_CONFIG();
-    phy_config.phy_addr          = CONFIG_ETH_PHY_ADDR;
-    phy_config.reset_gpio_num    = CONFIG_ETH_PHY_RST_GPIO;
-    mac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
-    mac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
-    esp_eth_mac_t * mac          = esp_eth_mac_new_esp32(&mac_config);
-    esp_eth_phy_t * phy          = esp_eth_phy_new_ip101(&phy_config);
-
-    esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);
-    esp_eth_handle_t eth_handle = NULL;
-    ESP_ERROR_CHECK(esp_eth_driver_install(&config, &eth_handle));
-    /* attach Ethernet driver to TCP/IP stack */
-    ESP_ERROR_CHECK(esp_netif_attach(eth_netif, esp_eth_new_netif_glue(eth_handle)));
-
-    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
     return CHIP_NO_ERROR;
 }
 
@@ -99,4 +77,3 @@ void ConnectivityManagerImpl::OnEthernetPlatformEvent(const ChipDeviceEvent * ev
 
 } // namespace DeviceLayer
 } // namespace chip
-#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -136,7 +136,7 @@ private:
     uint16_t mLastDisconnectedReason;
 };
 
-class ESPEthernetDriver final : public EthernetDriver
+class ESPEthernetDriver : public EthernetDriver
 {
 public:
     class EthernetNetworkIterator final : public NetworkIterator
@@ -170,11 +170,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new EthernetNetworkIterator(this); }
     uint8_t GetMaxNetworks() { return 1; }
-    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
-    {
-        // TODO: This method can be implemented if Ethernet is used along with Wifi/Thread.
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     void Shutdown()
     {
         // TODO: This method can be implemented if Ethernet is used along with Wifi/Thread.

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <platform/ESP32/NetworkCommissioningDriver.h>
+
+using namespace ::chip;
+using namespace ::chip::DeviceLayer::Internal;
+namespace chip {
+namespace DeviceLayer {
+namespace NetworkCommissioning {
+
+CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
+{
+    /* Currently default ethernet board supported is IP101, if you want to use other types of
+     * ethernet board then you can override this function in your application. */
+
+    esp_netif_config_t cfg  = ESP_NETIF_DEFAULT_ETH();
+    esp_netif_t * eth_netif = esp_netif_new(&cfg);
+
+    // Init MAC and PHY configs to default
+    eth_mac_config_t mac_config  = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config  = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.phy_addr          = CONFIG_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num    = CONFIG_ETH_PHY_RST_GPIO;
+    mac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
+    mac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
+    esp_eth_mac_t * mac          = esp_eth_mac_new_esp32(&mac_config);
+    esp_eth_phy_t * phy          = esp_eth_phy_new_ip101(&phy_config);
+
+    esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);
+    esp_eth_handle_t eth_handle = NULL;
+    ESP_ERROR_CHECK(esp_eth_driver_install(&config, &eth_handle));
+    /* attach Ethernet driver to TCP/IP stack */
+    ESP_ERROR_CHECK(esp_netif_attach(eth_netif, esp_eth_new_netif_glue(eth_handle)));
+
+    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace NetworkCommissioning
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
- This PR includes changes for enabling someone to implement any type of ethernet board they want 
- One can override ESP32Ethernet Driver's methods to set up their own configuration of ethernet board

####Testing
- Tested Commissioning and control