### PR TITLE
Properly round-trip serialNumber in MTRSetupPayload.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -355,9 +355,18 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     payload.rendezvousInformation = [MTRSetupPayload convertDiscoveryCapabilities:self.discoveryCapabilities];
     payload.discriminator.SetLongValue([self.discriminator unsignedShortValue]);
     payload.setUpPINCode = [self.setupPasscode unsignedIntValue];
+    if (self.serialNumber != nil) {
+        CHIP_ERROR err = payload.addSerialNumber(self.serialNumber.UTF8String);
+        if (err != CHIP_NO_ERROR) {
+            if (error != nil) {
+                *error = [MTRError errorForCHIPErrorCode:err];
+            }
+            return nil;
+        }
+    }
 
-    std::string outDecimalString;
-    CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(outDecimalString);
+    std::string outQRCodeString;
+    CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38RepresentationWithAutoTLVBuffer(outQRCodeString);
 
     if (err != CHIP_NO_ERROR) {
         if (error != nil) {
@@ -366,7 +375,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
         return nil;
     }
 
-    return [NSString stringWithUTF8String:outDecimalString.c_str()];
+    return [NSString stringWithUTF8String:outQRCodeString.c_str()];
 }
 
 + (nullable NSNumber *)_boxDiscoveryCapabilities:(MTRDiscoveryCapabilities)discoveryCapabilities

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -250,4 +250,29 @@
     XCTAssertEqualObjects(payload.setUpPINCode, @(2));
 }
 
+- (void)testSerialNumberRoundTrip
+{
+    NSError * error;
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+                                                     error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(payload);
+
+    XCTAssertEqualObjects(payload.serialNumber, @"123456789");
+
+    NSString * serialNumber = @"12345";
+    payload.serialNumber = serialNumber;
+
+    NSString * qrCode = [payload qrCodeString:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(qrCode);
+
+    MTRSetupPayload * newPayload = [MTRSetupPayload setupPayloadWithOnboardingPayload:qrCode error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(newPayload);
+
+    XCTAssertEqualObjects(newPayload.serialNumber, serialNumber);
+}
+
 @end


### PR DESCRIPTION
Without this when we convert to QRCode we are dropping the serialNumber.

Fixes https://github.com/project-chip/connectedhomeip/issues/26684
