### PR TITLE
Be a little more flexible about Span constructors.

### DIFF
--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -302,14 +302,48 @@ static void TestFromCharString(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, s1.data_equal(CharSpan(str, 3)));
 }
 
+static void TestConversionConstructors(nlTestSuite * inSuite, void * inContext)
+{
+    struct Foo
+    {
+        int member = 0;
+    };
+    struct Bar : public Foo
+    {
+    };
+
+    Bar objects[2];
+
+    // Check that various things here compile.
+    Span<Foo> span1(objects);
+    Span<Foo> span2(&objects[0], 1);
+    FixedSpan<Foo, 2> span3(objects);
+    FixedSpan<Foo, 1> span4(objects);
+
+    Span<Bar> testSpan1(objects);
+    FixedSpan<Bar, 2> testSpan2(objects);
+
+    Span<Foo> span5(testSpan1);
+    Span<Foo> span6(testSpan2);
+
+    FixedSpan<Foo, 2> span7(testSpan2);
+}
+
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan),       NL_TEST_DEF_FN(TestMutableByteSpan),
-                                 NL_TEST_DEF_FN(TestFixedByteSpan),  NL_TEST_DEF_FN(TestSpanOfPointers),
-                                 NL_TEST_DEF_FN(TestSubSpan),        NL_TEST_DEF_FN(TestFromZclString),
-                                 NL_TEST_DEF_FN(TestFromCharString), NL_TEST_SENTINEL() };
+static const nlTest sTests[] = {
+    NL_TEST_DEF_FN(TestByteSpan),
+    NL_TEST_DEF_FN(TestMutableByteSpan),
+    NL_TEST_DEF_FN(TestFixedByteSpan),
+    NL_TEST_DEF_FN(TestSpanOfPointers),
+    NL_TEST_DEF_FN(TestSubSpan),
+    NL_TEST_DEF_FN(TestFromZclString),
+    NL_TEST_DEF_FN(TestFromCharString),
+    NL_TEST_DEF_FN(TestConversionConstructors),
+    NL_TEST_SENTINEL(),
+};
 
 int TestSpan()
 {


### PR DESCRIPTION
Before this change, this code:

    struct X {
      int member;
    };

    struct Y : public X {
    };

    Y object;
    Span<X> span(&Y, 1);

would not compile, because we had std::is_same checks on the types (X and Y in this case).  But this code is in fact safe as long as sizeof(Y) == sizeof(X), so we don't get confused about our object boundaries.

This change replaces the std::is_same checks with sizeof() checks.  But that leads to some situations being ambiguous, because the "can this pointer actually work for us?" check happens after overload resolution, so we explicitly do the std::is_convertible checks alongside sizeof to make sure that the pointer passed to our Span constructor will work.
