### PR TITLE
Remove dependency of test codegen on controller-clusters.zapt state.

### DIFF
--- a/examples/chip-tool/templates/tests/commands.zapt
+++ b/examples/chip-tool/templates/tests/commands.zapt
@@ -18,7 +18,7 @@ public:
     TestList() : Command("list") {};
     CHIP_ERROR Run() override
     {
-        {{#chip_tests "../../../../src/app/tests/suites/ciTests.json"}}printf("{{filename}}\n");{{/chip_tests}}
+        {{#chip_tests "../../../../src/app/tests/suites/ciTests.json" includeAllClusters=true}}printf("{{filename}}\n");{{/chip_tests}}
 
         return CHIP_NO_ERROR;
     }
@@ -30,7 +30,7 @@ public:
     ManualTestList() : Command("list-manual") {};
     CHIP_ERROR Run() override
     {
-        {{#chip_tests "../../../../src/app/tests/suites/manualTests.json"}}printf("{{filename}}\n");{{/chip_tests}}
+        {{#chip_tests "../../../../src/app/tests/suites/manualTests.json" includeAllClusters=true}}printf("{{filename}}\n");{{/chip_tests}}
 
         return CHIP_NO_ERROR;
     }
@@ -49,10 +49,10 @@ void registerCommandsTests(Commands & commands, CredentialIssuerCommands * creds
 #if CONFIG_ENABLE_YAML_TESTS
         make_unique<TestList>(),
         make_unique<ManualTestList>(),
-      {{#chip_tests "../../../../src/app/tests/suites/ciTests.json"}}
+      {{#chip_tests "../../../../src/app/tests/suites/ciTests.json" includeAllClusters=true}}
         make_unique<{{filename}}Suite>(credsIssuerConfig),
       {{/chip_tests}}
-      {{#chip_tests "../../../../src/app/tests/suites/manualTests.json"}}
+      {{#chip_tests "../../../../src/app/tests/suites/manualTests.json" includeAllClusters=true}}
         make_unique<{{filename}}Suite>(credsIssuerConfig),
       {{/chip_tests}}
 #endif // CONFIG_ENABLE_YAML_TESTS

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -1,4 +1,4 @@
-{{#chip_tests tests}}
+{{#chip_tests tests includeAllClusters=true}}
 class {{filename}}Suite: public TestCommand
 {
 public:

--- a/examples/darwin-framework-tool/templates/tests/commands.zapt
+++ b/examples/darwin-framework-tool/templates/tests/commands.zapt
@@ -19,7 +19,7 @@ public:
     TestList() : Command("list") {};
     CHIP_ERROR Run() override
     {
-        {{#chip_tests "ciTests.json"}}printf("{{filename}}\n");{{/chip_tests}}
+        {{#chip_tests "ciTests.json" includeAllClusters=true}}printf("{{filename}}\n");{{/chip_tests}}
 
         return CHIP_NO_ERROR;
     }
@@ -31,7 +31,7 @@ public:
     ManualTestList() : Command("list-manual") {};
     CHIP_ERROR Run() override
     {
-        {{#chip_tests "manualTests.json"}}printf("{{filename}}\n");{{/chip_tests}}
+        {{#chip_tests "manualTests.json" includeAllClusters=true}}printf("{{filename}}\n");{{/chip_tests}}
 
         return CHIP_NO_ERROR;
     }
@@ -50,10 +50,10 @@ void registerCommandsTests(Commands & commands)
 #if CONFIG_ENABLE_YAML_TESTS
         make_unique<TestList>(),
         make_unique<ManualTestList>(),
-      {{#chip_tests "ciTests.json"}}
+      {{#chip_tests "ciTests.json" includeAllClusters=true}}
         make_unique<{{filename}}>(),
       {{/chip_tests}}
-      {{#chip_tests "manualTests.json"}}
+      {{#chip_tests "manualTests.json" includeAllClusters=true}}
         make_unique<{{filename}}>(),
       {{/chip_tests}}
 #endif // CONFIG_ENABLE_YAML_TESTS

--- a/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
@@ -1,4 +1,4 @@
-{{#chip_tests tests useSynthesizeWaitForReport=true}}
+{{#chip_tests tests useSynthesizeWaitForReport=true includeAllClusters=true}}
 class {{filename}}: public TestCommandBridge
 {
   public:

--- a/examples/placeholder/templates/tests-commands.zapt
+++ b/examples/placeholder/templates/tests-commands.zapt
@@ -10,7 +10,7 @@
 
 std::unique_ptr<TestCommand>GetTestCommand(std::string testName)
 {
-  {{#chip_tests "../linux/apps/app1/ciTests.json"}}
+  {{#chip_tests "../linux/apps/app1/ciTests.json" includeAllClusters=true}}
   if (testName == "{{filename}}")
   {
       return std::unique_ptr<{{filename}}Suite>(new {{filename}}Suite());
@@ -22,7 +22,7 @@ std::unique_ptr<TestCommand>GetTestCommand(std::string testName)
 
 void PrintTestCommands()
 {
-  {{#chip_tests "../linux/apps/app1/ciTests.json"}}
+  {{#chip_tests "../linux/apps/app1/ciTests.json" includeAllClusters=true}}
   {{#first}}
   ChipLogError(chipTool, "Supported commands:");
   {{/first}}

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -7,7 +7,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.05.16-nightly
+ARG ZAP_VERSION=v2023.05.22-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -9,7 +9,7 @@
                 "mac-arm64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.05.16-nightly.1"]
+            "tags": ["version:2@v2023.05.22-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.05.16-nightly
+v2023.05.22-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.5.16'
+MIN_ZAP_VERSION = '2023.5.22'
 
 
 class ZapTool:

--- a/src/app/tests/suites/examples/TestGenExample.zapt
+++ b/src/app/tests/suites/examples/TestGenExample.zapt
@@ -1,4 +1,4 @@
-{{#chip_tests "ciTests.json"}}
+{{#chip_tests "ciTests.json" includeAllClusters=true}}
 {{#chip_tests_config}}
 "Argument Name {{name}}"
 "Argument Type {{type}}"

--- a/src/app/tests/suites/templates/simulated-cluster-objects.zapt
+++ b/src/app/tests/suites/templates/simulated-cluster-objects.zapt
@@ -7,7 +7,7 @@
 
 namespace chip {
 
-{{#chip_tests_only_clusters}}
+{{#chip_tests_only_clusters includeAllClusters=true}}
 {{#chip_tests_only_cluster_commands}}
 
 struct {{name}}Command


### PR DESCRIPTION
Depends on https://github.com/project-chip/zap/pull/1035 to actually ignore that state.
