### PR TITLE
Use controller exception in Java controller

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt
@@ -57,7 +57,7 @@ class PairOnNetworkLongImSubscribeCommand(
   }
 
   private inner class InternalResubscriptionAttemptCallback : ResubscriptionAttemptCallback {
-    override fun onResubscriptionAttempt(terminationCause: Int, nextResubscribeIntervalMsec: Int) {
+    override fun onResubscriptionAttempt(terminationCause: Long, nextResubscribeIntervalMsec: Long) {
       logger.log(Level.INFO, "ResubscriptionAttemptCallback");
     }
   }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterError.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterError.java
@@ -20,15 +20,15 @@ package com.chip.casting;
 import java.util.Objects;
 
 public class MatterError {
-  private int errorCode;
+  private long errorCode;
   private String errorMessage;
 
   public static final MatterError DISCOVERY_SERVICE_LOST =
-      new MatterError(4, "Discovery service was lost.");
+      new MatterError(4L, "Discovery service was lost.");
 
   public static final MatterError NO_ERROR = new MatterError(0, null);
 
-  public MatterError(int errorCode, String errorMessage) {
+  public MatterError(long errorCode, String errorMessage) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }
@@ -37,7 +37,7 @@ public class MatterError {
     return this.equals(NO_ERROR);
   }
 
-  public int getErrorCode() {
+  public long getErrorCode() {
     return errorCode;
   }
 

--- a/src/controller/java/AndroidClusterExceptions.cpp
+++ b/src/controller/java/AndroidClusterExceptions.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 
 namespace chip {
 
-CHIP_ERROR AndroidClusterExceptions::CreateChipClusterException(JNIEnv * env, jint errorCode, jthrowable & outEx)
+CHIP_ERROR AndroidClusterExceptions::CreateChipClusterException(JNIEnv * env, uint32_t errorCode, jthrowable & outEx)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID exceptionConstructor;
@@ -34,10 +34,10 @@ CHIP_ERROR AndroidClusterExceptions::CreateChipClusterException(JNIEnv * env, ji
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     chip::JniClass clusterExceptionJniCls(clusterExceptionCls);
 
-    exceptionConstructor = env->GetMethodID(clusterExceptionCls, "<init>", "(I)V");
+    exceptionConstructor = env->GetMethodID(clusterExceptionCls, "<init>", "(J)V");
     VerifyOrReturnError(exceptionConstructor != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-    outEx = (jthrowable) env->NewObject(clusterExceptionCls, exceptionConstructor, errorCode);
+    outEx = (jthrowable) env->NewObject(clusterExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode));
     VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
     return err;

--- a/src/controller/java/AndroidClusterExceptions.h
+++ b/src/controller/java/AndroidClusterExceptions.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public:
     /**
      * Creates a Java ChipClusterException object in outEx.
      */
-    CHIP_ERROR CreateChipClusterException(JNIEnv * env, jint errorCode, jthrowable & outEx);
+    CHIP_ERROR CreateChipClusterException(JNIEnv * env, uint32_t errorCode, jthrowable & outEx);
 
     /**
      * Creates a Java IllegalStateException in outEx.

--- a/src/controller/java/AndroidControllerExceptions.cpp
+++ b/src/controller/java/AndroidControllerExceptions.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AndroidControllerExceptions.h"
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+namespace chip {
+
+CHIP_ERROR AndroidControllerExceptions::CreateAndroidControllerException(JNIEnv * env, const char * message, uint32_t errorCode,
+                                                                         jthrowable & outEx)
+{
+    jclass controllerExceptionCls;
+    CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipDeviceControllerException",
+                                                              controllerExceptionCls);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    JniClass controllerExceptionJniCls(controllerExceptionCls);
+
+    jmethodID exceptionConstructor = env->GetMethodID(controllerExceptionCls, "<init>", "(Jjava/lang/String;)V");
+    outEx = (jthrowable) env->NewObject(controllerExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode),
+                                        env->NewStringUTF(message));
+    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/controller/java/AndroidControllerExceptions.h
+++ b/src/controller/java/AndroidControllerExceptions.h
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+class AndroidControllerExceptions
+{
+public:
+    AndroidControllerExceptions(const AndroidControllerExceptions &)  = delete;
+    AndroidControllerExceptions(const AndroidControllerExceptions &&) = delete;
+    AndroidControllerExceptions & operator=(const AndroidControllerExceptions &) = delete;
+
+    static AndroidControllerExceptions & GetInstance()
+    {
+        static AndroidControllerExceptions androidControllerExceptions;
+        return androidControllerExceptions;
+    }
+
+    /**
+     * Creates a Java AndroidControllerException object in outEx.
+     */
+    CHIP_ERROR CreateAndroidControllerException(JNIEnv * env, const char * message, uint32_t errorCode, jthrowable & outEx);
+
+private:
+    AndroidControllerExceptions() {}
+};
+} // namespace chip

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -41,6 +41,8 @@ shared_library("jni") {
     "AndroidClusterExceptions.h",
     "AndroidCommissioningWindowOpener.cpp",
     "AndroidCommissioningWindowOpener.h",
+    "AndroidControllerExceptions.cpp",
+    "AndroidControllerExceptions.h",
     "AndroidCurrentFabricRemover.cpp",
     "AndroidCurrentFabricRemover.h",
     "AndroidDeviceControllerWrapper.cpp",

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
@@ -21,11 +21,11 @@ package chip.devicecontroller;
 public class ChipDeviceControllerException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
-  public int errorCode;
+  public long errorCode;
 
   public ChipDeviceControllerException() {}
 
-  public ChipDeviceControllerException(int errorCode, String message) {
+  public ChipDeviceControllerException(long errorCode, String message) {
     super(message != null ? message : String.format("Error Code %d", errorCode));
     this.errorCode = errorCode;
   }

--- a/src/controller/java/src/chip/devicecontroller/ResubscriptionAttemptCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/ResubscriptionAttemptCallback.java
@@ -18,5 +18,5 @@
 package chip.devicecontroller;
 
 public interface ResubscriptionAttemptCallback {
-  void onResubscriptionAttempt(int terminationCause, int nextResubscribeIntervalMsec);
+  void onResubscriptionAttempt(long terminationCause, long nextResubscribeIntervalMsec);
 }

--- a/src/controller/java/tests/chip/devicecontroller/GetConnectedDeviceCallbackJniTest.java
+++ b/src/controller/java/tests/chip/devicecontroller/GetConnectedDeviceCallbackJniTest.java
@@ -48,10 +48,10 @@ public final class GetConnectedDeviceCallbackJniTest {
   public void connectionFailure() {
     var callback = new FakeGetConnectedDeviceCallback();
     var jniCallback = new GetConnectedDeviceCallbackJni(callback);
-    callbackTestUtil.onDeviceConnectionFailure(jniCallback, 100);
+    callbackTestUtil.onDeviceConnectionFailure(jniCallback, 100L);
 
     assertThat(callback.error).isInstanceOf(ChipDeviceControllerException.class);
-    assertThat(((ChipDeviceControllerException) callback.error).errorCode).isEqualTo(100);
+    assertThat(((ChipDeviceControllerException) callback.error).errorCode).isEqualTo(100L);
   }
 
   class FakeGetConnectedDeviceCallback implements GetConnectedDeviceCallback {


### PR DESCRIPTION
--Use controller exception in Java controller so that the exception can have the error code inside when passing from C++ to Java/Kotlin
--Matter error is uint32_t, we should cast it to long in Java, fix this issue across.

