### PR TITLE
[Tizen] Use heap-based object pool

### DIFF
--- a/src/platform/Tizen/SystemPlatformConfig.h
+++ b/src/platform/Tizen/SystemPlatformConfig.h
@@ -38,7 +38,7 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_NO_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
-
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
+#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1
 
 // ========== Platform-specific Configuration Overrides =========


### PR DESCRIPTION
Heap based pool configuration is used on Linux and Darwin. Since Tizen is also a fully-featured OS, we can use such configutaion as well.

### Testing

Tested BLE commissioning locally. Everything works as before. Freshly started lighting application uses ~50kB less memory.