### PR TITLE
Added Operational Node discovery to the mDNS resolver.

### DIFF
--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include "lib/dnssd/Resolver.h"
 #include <controller/CHIPCommissionableNodeController.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/UnitTestRegistration.h>
@@ -37,6 +38,7 @@ public:
     void Shutdown() override {}
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
+    void SetOperationalBrowseDelegate(OperationalBrowseDeleagete * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return ResolveNodeIdStatus; }
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return DiscoverCommissionersStatus; }
@@ -44,6 +46,8 @@ public:
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -630,6 +630,12 @@ void DiscoveryImplPlatform::NodeIdResolutionNoLongerNeeded(const PeerId & peerId
     ChipDnssdResolveNoLongerNeeded(name);
 }
 
+CHIP_ERROR DiscoveryImplPlatform::DiscoverOperational(DiscoveryFilter filter)
+{
+    ReturnErrorOnFailure(InitImpl());
+    return mResolverProxy.DiscoverOperational(filter);
+}
+
 CHIP_ERROR DiscoveryImplPlatform::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(InitImpl());
@@ -704,6 +710,23 @@ void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
 ResolverProxy::~ResolverProxy()
 {
     Shutdown();
+}
+
+CHIP_ERROR ResolverProxy::DiscoverOperational(DiscoveryFilter filter)
+{
+    StopDiscovery();
+
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mDelegate->Retain();
+
+    char serviceName[kMaxCommissionerServiceNameSize];
+    ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kOperational));
+
+    intptr_t browseIdentifier;
+    ReturnErrorOnFailure(ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny,
+                                         Inet::InterfaceId::Null(), HandleNodeBrowse, mDelegate, &browseIdentifier));
+    mDiscoveryContext.Emplace(browseIdentifier);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -55,10 +55,17 @@ public:
     {
         mResolverProxy.SetCommissioningDelegate(delegate);
     }
+
+    void SetOperationalBrowseDelegate(OperationalBrowseDeleagete * delegate) override
+    {
+        mResolverProxy.SetOperationalBrowseDelegate(delegate);
+    }
+
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -330,6 +330,19 @@ public:
     virtual void OnNodeDiscovered(const DiscoveredNodeData & nodeData) = 0;
 };
 
+/// Callback for Browsing for nodes without resolving the DNS records
+///
+class OperationalBrowseDeleagete
+{
+public:
+    virtual ~OperationalBrowseDeleagete() = default;
+    /// Called within the CHIP event loop once a node is discovered.
+    ///
+    /// May be called multiple times as more nodes send their answer to a
+    /// multicast discovery query
+    virtual void OnOperationalNodeDiscovered(const OperationalNodeData & operationalData) = 0;
+};
+
 /**
  * Interface for resolving CHIP DNS-SD services
  */
@@ -362,6 +375,11 @@ public:
      * If nullptr is passed, the previously registered delegate is unregistered.
      */
     virtual void SetOperationalDelegate(OperationalResolveDelegate * delegate) = 0;
+
+    /**
+     * If nullptr is passed, the previously registered delegate is unregistered.
+     */
+    virtual void SetOperationalBrowseDelegate(OperationalBrowseDeleagete * delegate) = 0;
 
     /**
      * If nullptr is passed, the previously registered delegate is unregistered.
@@ -423,7 +441,21 @@ public:
     virtual CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
     /**
-     * Stop discovery (of commissionable or commissioner nodes).
+     * @brief Start Browising for operational devices
+     *
+     * This will start periodical brwosing of operational devices. The when a new node is
+     * found the delegate set with SetOperationalBrowseDelegate is called. The mDNS queryies
+     * will continue unitil StopDiscovery is called.
+     *
+     * Note, this will locate all the Operational devices on the network. Typically an
+     * application would filter the found nodes by relevant fabrics.
+     *
+     * If needed a discovery filter may be specified to narrow the search.
+     */
+    virtual CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter()) = 0;
+
+    /**
+     * Stop discovery (of operational, commissionable or commissioner nodes).
      *
      * Some back ends may not support stopping discovery, so consumers should
      * not assume they will stop getting callbacks after calling this.

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "Resolver.h"
+#include "lib/dnssd/minimal_mdns/core/Constants.h"
 
+#include <cstddef>
 #include <limits>
 
 #include <lib/core/CHIPConfig.h>
@@ -284,17 +286,22 @@ public:
     void Shutdown() override;
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override { mCommissioningDelegate = delegate; }
+    void SetOperationalBrowseDelegate(OperationalBrowseDeleagete * delegate) override { mBrowseOperationalDeleagete = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter()) override;
+
     CHIP_ERROR StopDiscovery() override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
 private:
-    OperationalResolveDelegate * mOperationalDelegate     = nullptr;
-    CommissioningResolveDelegate * mCommissioningDelegate = nullptr;
-    System::Layer * mSystemLayer                          = nullptr;
+    OperationalResolveDelegate * mOperationalDelegate        = nullptr;
+    CommissioningResolveDelegate * mCommissioningDelegate    = nullptr;
+    OperationalBrowseDeleagete * mBrowseOperationalDeleagete = nullptr;
+
+    System::Layer * mSystemLayer = nullptr;
     ActiveResolveAttempts mActiveResolves;
     PacketParser mPacketParser;
 
@@ -425,7 +432,6 @@ void MinMdnsResolver::AdvancePendingResolverStates()
         {
             MATTER_TRACE_SCOPE("Active operational delegate call", "MinMdnsResolver");
             ResolvedNodeData nodeData;
-
             CHIP_ERROR err = resolver->Take(nodeData);
             if (err != CHIP_NO_ERROR)
             {
@@ -433,6 +439,12 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             }
 
             mActiveResolves.Complete(nodeData.operationalData.peerId);
+
+            if (mBrowseOperationalDeleagete != nullptr)
+            {
+                mBrowseOperationalDeleagete->OnOperationalNodeDiscovered(nodeData.operationalData);
+            }
+
             if (mOperationalDelegate != nullptr)
             {
                 mOperationalDelegate->OnOperationalNodeResolved(nodeData);
@@ -680,6 +692,11 @@ CHIP_ERROR MinMdnsResolver::DiscoverCommissioners(DiscoveryFilter filter)
     return BrowseNodes(DiscoveryType::kCommissionerNode, filter);
 }
 
+CHIP_ERROR MinMdnsResolver::DiscoverOperational(DiscoveryFilter filter)
+{
+    return BrowseNodes(DiscoveryType::kOperational, filter);
+}
+
 CHIP_ERROR MinMdnsResolver::StopDiscovery()
 {
     return mActiveResolves.CompleteAllBrowses();
@@ -780,6 +797,13 @@ CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
     chip::Dnssd::Resolver::Instance().SetCommissioningDelegate(mDelegate);
     return chip::Dnssd::Resolver::Instance().DiscoverCommissioners(filter);
 }
+
+CHIP_ERROR ResolverProxy::DiscoverOperational(DiscoveryFilter filter)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    chip::Dnssd::Resolver::Instance().SetOperationalBrowseDelegate(mDelegate);
+    return chip::Dnssd::Resolver::Instance().DiscoverOperational(filter);
+};
 
 CHIP_ERROR ResolverProxy::StopDiscovery()
 {

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -32,6 +32,7 @@ public:
     void Shutdown() override {}
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
+    void SetOperationalBrowseDelegate(OperationalBrowseDeleagete * delegate) override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override
     {
@@ -47,6 +48,8 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
@@ -81,6 +84,11 @@ CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ResolverProxy::DiscoverOperational(DiscoveryFilter filter)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
Added Interface for starting a general Operational Discovery. This is used for enumerating commissioned matter devices on the fabric. As the Operational discovery is a forever ongoing process, adding support for multiple delegates was also needed.

I also considered implementing this in the ResolverProxy, but honestly, I think implementing this could make the Resolver Proxy Obsolete.
