### PR TITLE
Tizen: Add platform certificate

### DIFF
--- a/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
+++ b/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
@@ -229,8 +229,16 @@ function install_tizen_sdk() {
         'capi-network-bluetooth-devel-*.armv7l.rpm'
         'capi-network-nsd-*.armv7l.rpm'
         'capi-network-thread-*.armv7l.rpm'
+        'capi-system-peripheral-io-*.armv7l.rpm'
+        'capi-system-peripheral-io-devel-*.armv7l.rpm'
         'capi-system-resource-1*.armv7l.rpm'
         'libnsd-dns-sd-*.armv7l.rpm')
+    download "$URL" "${PKG_ARR[@]}"
+
+    # Tizen Developer Platform Certificate
+    URL="http://download.tizen.org/sdk/extensions/Tizen_IoT_Headless/binary/"
+    PKG_ARR=(
+        "$TIZEN_VERSION-iot-things-add-ons_*_ubuntu-64.zip")
     download "$URL" "${PKG_ARR[@]}"
 
     # Install all
@@ -253,6 +261,10 @@ function install_tizen_sdk() {
     echo "TIZEN_SDK_INSTALLED_PATH=$TIZEN_SDK_ROOT" >"$TIZEN_SDK_ROOT/sdk.info"
     echo "TIZEN_SDK_DATA_PATH=$TIZEN_SDK_DATA_PATH" >>"$TIZEN_SDK_ROOT/sdk.info"
     ln -sf "$TIZEN_SDK_DATA_PATH/.tizen-cli-config" "$TIZEN_SDK_ROOT/tools/.tizen-cli-config"
+
+    # Use Tizen developer platform certificate as default
+    cp "${TIZEN_SDK_ROOT}"/tools/certificate-generator/certificates/distributor/sdk-platform/* \
+        "${TIZEN_SDK_ROOT}"/tools/certificate-generator/certificates/distributor/
 
     # Make symbolic links relative
     find "$TIZEN_SDK_SYSROOT/usr/lib" -maxdepth 1 -type l | while IFS= read -r LNK; do

--- a/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
+++ b/integrations/docker/images/chip-build-tizen/tizen-sdk-installer/install.sh
@@ -263,8 +263,8 @@ function install_tizen_sdk() {
     ln -sf "$TIZEN_SDK_DATA_PATH/.tizen-cli-config" "$TIZEN_SDK_ROOT/tools/.tizen-cli-config"
 
     # Use Tizen developer platform certificate as default
-    cp "${TIZEN_SDK_ROOT}"/tools/certificate-generator/certificates/distributor/sdk-platform/* \
-        "${TIZEN_SDK_ROOT}"/tools/certificate-generator/certificates/distributor/
+    cp "$TIZEN_SDK_ROOT"/tools/certificate-generator/certificates/distributor/sdk-platform/* \
+        "$TIZEN_SDK_ROOT"/tools/certificate-generator/certificates/distributor/
 
     # Make symbolic links relative
     find "$TIZEN_SDK_SYSROOT/usr/lib" -maxdepth 1 -type l | while IFS= read -r LNK; do

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.11 Version bump reason: [Telink] Update Docker image (Zephyr update)
+0.7.12 Version bump reason: [Tizen] Add platform certificate


### PR DESCRIPTION
## Problem
I would like to add support for GPIO in the lighting-app to manipulate LED connected to a device. To make it possible, I have to add a platform certificate to sign the Tizen application and peripheral packages to build it. 

## Testing

1. Builld chip-build-tizen docker image 
``` sh
docker build -t connectedhomeip/chip-build-tizen:local integrations/docker/images/chip-build-tizen
```

2. Run the container and build an example app
``` sh
docker run --rm -ti -v $(realpath .):/connectedhomeip \
  --workdir /connectedhomeip  \
  --name tizen-build connectedhomeip/chip-build-tizen:local bash
./scripts/build/build_examples.py --target tizen-arm-light --enable-flashbundle build
```

3. Install the app on the target. RPI example below
``` sh
ssh <rpi_device> pkgcmd -n org.tizen.matter.example.lighting -u
scp out/tizen-arm-light/org.tizen.matter.example.lighting/out/org.tizen.matter.example.lighting-1.0.0.tpk \
  <rpi_device>:/tmp \
  && ssh <rpi_device> pkgcmd -i -t tpk -p /tmp/org.tizen.matter.example.lighting-1.0.0.tpk
```


