### PR TITLE
[ESP32] Fix the installation guide around gdbgui for macOS

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -564,6 +564,7 @@ FW
 gbl
 gcloud
 GDB
+gdbgui
 gdbserver
 GeneralCommissioning
 GeneralDiagnostics

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -73,9 +73,12 @@ For MacOS, `gdbgui` python package will not be installed using `bootstrap.sh`
 script as it is restricted only for x64 Linux platforms. It is restricted
 because, building wheels for `gevent` (dependency of `gdbgui`) fails on MacOS.
 
-Please run the below commands after every bootstrapping.
+For ARM-based Mac, no further installation steps are necessary if Python3
+version is greater than or equal to 3.11.
 
-Workaround is to install `gdbgui` wheels as binary:
+If Python3 version is less than 3.11 or you are using x86(Intel-based) Mac then
+please run the below commands after every bootstrapping to install gdbgui wheels
+as binary
 
 ```
 python3 -m pip install -c scripts/setup/constraints.txt --no-cache --prefer-binary gdbgui==0.13.2.0


### PR DESCRIPTION
Some time back the IDF version was bumped to v4.4.4 in https://github.com/project-chip/connectedhomeip/pull/26182. ESP-IDF v4.4.4 requires gdbgui only if Python version is less than 3.11.

https://github.com/project-chip/connectedhomeip/pull/26542 made installing gdbgui optional based on python version for Matter environment.

After trying to setup environment on different hosts below is the observations.
- For Arm arch based mac: Matter environment uses the system python and if its >=  3.11 then no need to install gdbgui. But if its less than 3.11 its required.
- For x86 arch based mac: Matter environment uses `Python 3.9.5+chromium.19` and we need to install gdbgui.

Changed the documentation as per observations.