### PR TITLE
[python] Remove dependency only used in testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -487,7 +487,7 @@ jobs:
             - name: Build Python REPL and example apps
               timeout-minutes: 50
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env --extra_packages "mobly"'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test \

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -166,7 +166,7 @@ if [ -n "$include_yamltests" ]; then
 fi
 
 if [ -n "$extra_packages" ]; then
-    WHEEL+=(${extra_packages})
+    WHEEL+=("$extra_packages")
 fi
 
 if [ "$install_wheel" = "no" ]; then

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -63,6 +63,7 @@ Input Options:
                                                             no: Do not install
                                                             build-env: install to virtual env for build matter
                                                             separate: install to another virtual env (out/python_env)
+  --extra_packages PACKAGES                                 Install extra Python packages from PyPI
   --include_yamltests                                       Whether to install the matter_yamltests wheel.
   -z --pregen_dir DIRECTORY                                 Directory where generated zap files have been pre-generated.
 "
@@ -94,6 +95,10 @@ while (($#)); do
             ;;
         --install_wheel | -i)
             install_wheel=$2
+            shift
+            ;;
+        --extra_packages)
+            extra_packages=$2
             shift
             ;;
         --include_yamltests)
@@ -158,6 +163,10 @@ if [ -n "$include_yamltests" ]; then
     WHEEL+=(
         "$(ls -tr "$(wheel_output_dir "$YAMLTESTS_GN_LABEL")"/*.whl | head -n 1)"
     )
+fi
+
+if [ -n "$extra_packages" ]; then
+    WHEEL+=(${extra_packages})
 fi
 
 if [ "$install_wheel" = "no" ]; then

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -306,7 +306,6 @@ chip_python_wheel_action("chip-core") {
     "pyyaml",
     "ipdb",
     "deprecation",
-    "mobly",
     "cryptography",
     "ecdsa",
   ]
@@ -428,7 +427,6 @@ chip_python_wheel_action("chip-repl") {
     "ipython!=8.1.0",
     "rich",
     "ipykernel",
-    "mobly",
   ]
 
   if (current_os == "mac") {


### PR DESCRIPTION
PR #21567 added mobly as a default dependency of the Python Core CHIP library. The mobly package is only used by the Python testing framework in `src/python_testing/`. Allow to install extra dependency via `script/build_python.sh` flag and install them only when needed.