### PR TITLE
Include missing datatype header to make GCC 13.1 happy

### DIFF
--- a/src/setup_payload/AdditionalDataPayload.h
+++ b/src/setup_payload/AdditionalDataPayload.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace chip {
 namespace SetupPayloadData {


### PR DESCRIPTION
It seems that newer GCC's (at least 13.1.1) require the proper include in this header file, otherwise compiling the controler seems to fail with:

```
In file included from ../../src/setup_payload/AdditionalDataPayloadParser.h:26,
                 from ../../src/setup_payload/AdditionalDataPayloadParser.cpp:24:
../../src/setup_payload/AdditionalDataPayload.h:42:11: error: ‘uint8_t’ does not name a type
   42 | constexpr uint8_t kRotatingDeviceIdLength = 18;
      |           ^~~~~~~
../../src/setup_payload/AdditionalDataPayload.h:38:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   37 | #include <string>
  +++ |+#include <cstdint>
   38 |
../../src/setup_payload/AdditionalDataPayload.h:43:11: error: ‘uint8_t’ does not name a type
   43 | constexpr uint8_t kRotatingDeviceIdTag    = 0x00;
      |           ^~~~~~~
../../src/setup_payload/AdditionalDataPayload.h:43:11: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
../../src/setup_payload/AdditionalDataPayloadParser.cpp: In member function ‘CHIP_ERROR chip::AdditionalDataPayloadParser::populatePayload(chip::SetupPayloadData::AdditionalDataPayload&)’:
../../src/setup_payload/AdditionalDataPayloadParser.cpp:50:86: error: ‘kRotatingDeviceIdTag’ is not a member of ‘chip::SetupPayloadData’
   50 |     if (innerReader.Next(TLV::kTLVType_ByteString, TLV::ContextTag(SetupPayloadData::kRotatingDeviceIdTag)) == CHIP_NO_ERROR)
      |                                                                                      ^~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
```
