### PR TITLE
[python] Fix Cluster objects datatypes on Python 3.11

### DIFF
--- a/src/controller/python/chip/clusters/Types.py
+++ b/src/controller/python/chip/clusters/Types.py
@@ -15,10 +15,6 @@
 #    limitations under the License.
 #
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
 class Nullable():
     def __repr__(self):
         return 'Null'

--- a/src/controller/python/chip/clusters/Types.py
+++ b/src/controller/python/chip/clusters/Types.py
@@ -32,6 +32,11 @@ class Nullable():
         return True
 
     def __hash__(self):
+        ''' Explicitly implement __hash__() to imply immutability when used in
+            dataclasses.
+
+            See also: https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass
+        '''
         return 0
 
 

--- a/src/controller/python/chip/clusters/Types.py
+++ b/src/controller/python/chip/clusters/Types.py
@@ -32,5 +32,7 @@ class Nullable():
     def __lt__(self, other):
         return True
 
+    def __hash__(self):
+        return 0
 
 NullValue = Nullable()

--- a/src/controller/python/chip/clusters/Types.py
+++ b/src/controller/python/chip/clusters/Types.py
@@ -15,7 +15,9 @@
 #    limitations under the License.
 #
 
+from dataclasses import dataclass
 
+@dataclass(frozen=True)
 class Nullable():
     def __repr__(self):
         return 'Null'

--- a/src/controller/python/chip/clusters/Types.py
+++ b/src/controller/python/chip/clusters/Types.py
@@ -17,6 +17,7 @@
 
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class Nullable():
     def __repr__(self):
@@ -36,5 +37,6 @@ class Nullable():
 
     def __hash__(self):
         return 0
+
 
 NullValue = Nullable()


### PR DESCRIPTION
It seems that Python 3.11 requires the custom data type Nullable to implement the `__hash__()` function, otherwise initializing dataclass annotated objects fail with the following stack trace:

```
  File "/home/sag/projects/project-chip/connectedhomeip-v1.1/.environment/pigweed-venv/lib/python3.11/site-packages/chip/clusters/Objects.py", line 385, in Commands
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1223, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1213, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'chip.clusters.Types.Nullable'> for field capacity is not allowed: use default_factory
```

Since all instances of Nullable are the same "value", we can return a static 0 as hash value.
