### PR TITLE
Add missing include of `cstdint`

### DIFF
--- a/src/setup_payload/AdditionalDataPayload.h
+++ b/src/setup_payload/AdditionalDataPayload.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace chip {


### PR DESCRIPTION
Fixes build failure with Clang 15 due to the usage of `uint8_t` without proper inclusion of `cstdint`.

