### PR TITLE
Update TI Docker image

### DIFF
--- a/integrations/docker/images/chip-build-ti/Dockerfile
+++ b/integrations/docker/images/chip-build-ti/Dockerfile
@@ -11,9 +11,9 @@ RUN set -x \
 
 # Install Sysconfig
 RUN set -x \
-    && wget https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-nsUM6f7Vvb/1.13.0.2553/sysconfig-1.13.0_2553-setup.run \
-    && chmod +x sysconfig-1.13.0_2553-setup.run \
-    && ./sysconfig-1.13.0_2553-setup.run --mode unattended \
+    && wget https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-nsUM6f7Vvb/1.15.0.2826/sysconfig-1.15.0_2826-setup.run \
+    && chmod +x sysconfig-1.15.0_2826-setup.run \
+    && ./sysconfig-1.15.0_2826-setup.run --mode unattended \
     && : # last line
 
-ENV TI_SYSCONFIG_ROOT=/opt/ti/sysconfig_1.13.0
+ENV TI_SYSCONFIG_ROOT=/opt/ti/sysconfig_1.15.0

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=k32w /opt/sdk /opt/k32w_sdk
 
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
 
-COPY --from=ti /opt/ti/sysconfig_1.13.0 /opt/ti/sysconfig_1.13.0
+COPY --from=ti /opt/ti/sysconfig_1.15.0 /opt/ti/sysconfig_1.15.0
 
 COPY --from=openiotsdk /opt/FVP_Corstone_SSE-300/ /opt/FVP_Corstone_SSE-300/
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.12 Version bump reason: [Tizen] Add platform certificate
+0.7.13 Version bump reason: [TI] Update TI Sysconfig Version


### PR DESCRIPTION
For our new SimpleLink SDK release, it is required that we use the latest TI Sysconfig version. This PR aims to update to the correct version.