### PR TITLE
[python] make enum part of cluster wheel

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -214,7 +214,6 @@ chip_python_wheel_action("chip-core") {
         "chip/clusters/Attribute.py",
         "chip/clusters/Command.py",
         "chip/clusters/__init__.py",
-        "chip/clusters/enum.py",
         "chip/commissioning/__init__.py",
         "chip/commissioning/commissioning_flow_blocks.py",
         "chip/commissioning/pase.py",
@@ -300,7 +299,6 @@ chip_python_wheel_action("chip-core") {
   }
 
   py_package_reqs = [
-    "aenum",
     "coloredlogs",
     "construct",
     "dacite",
@@ -358,6 +356,7 @@ chip_python_wheel_action("chip-clusters") {
         "chip/ChipUtility.py",
         "chip/clusters/CHIPClusters.py",
         "chip/clusters/ClusterObjects.py",
+        "chip/clusters/enum.py",
         "chip/clusters/Objects.py",
         "chip/clusters/TestObjects.py",
         "chip/clusters/Types.py",
@@ -378,7 +377,10 @@ chip_python_wheel_action("chip-clusters") {
     "chip.tlv",
   ]
 
-  py_package_reqs = [ "dacite" ]
+  py_package_reqs = [
+    "dacite",
+    "aenum",
+  ]
 
   py_package_name = "${chip_python_package_prefix}-clusters"
   py_package_output = string_replace(py_package_name, "-", "_")

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -356,10 +356,10 @@ chip_python_wheel_action("chip-clusters") {
         "chip/ChipUtility.py",
         "chip/clusters/CHIPClusters.py",
         "chip/clusters/ClusterObjects.py",
-        "chip/clusters/enum.py",
         "chip/clusters/Objects.py",
         "chip/clusters/TestObjects.py",
         "chip/clusters/Types.py",
+        "chip/clusters/enum.py",
         "chip/tlv/__init__.py",
       ]
     },


### PR DESCRIPTION
The new enum type is required in the Cluster objects. Make it and its dependency part of the Cluster CHIP wheel.

Fixes PR #24352.
