### PR TITLE
Force fetching x64 zap for mac even on arm.

### DIFF
--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -11,7 +11,7 @@
             "tags": ["version:2@v2023.05.22-nightly.1"]
         },
         {
-            "_comment": "Always get the arm64 version on mac until usable arm64 zap build is available",
+            "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": [
                 "mac-arm64"

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -6,8 +6,15 @@
                 "linux-amd64",
                 "linux-arm64",
                 "mac-amd64",
-                "mac-arm64",
                 "windows-amd64"
+            ],
+            "tags": ["version:2@v2023.05.22-nightly.1"]
+        }
+        {
+            "_comment": "Always get the arm64 version on mac until usable arm64 zap build is available",
+            "path": "fuchsia/third_party/zap/mac-amd64",
+            "platforms": [
+                "mac-arm64",
             ],
             "tags": ["version:2@v2023.05.22-nightly.1"]
         }

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -13,9 +13,7 @@
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
-            "platforms": [
-                "mac-arm64"
-            ],
+            "platforms": ["mac-arm64"],
             "tags": ["version:2@v2023.05.22-nightly.1"]
         }
     ]

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -9,7 +9,7 @@
                 "windows-amd64"
             ],
             "tags": ["version:2@v2023.05.22-nightly.1"]
-        }
+        },
         {
             "_comment": "Always get the arm64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -14,7 +14,7 @@
             "_comment": "Always get the arm64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": [
-                "mac-arm64",
+                "mac-arm64"
             ],
             "tags": ["version:2@v2023.05.22-nightly.1"]
         }


### PR DESCRIPTION
Apparently arm64 version of zap was pulled.
Rosetta can run x64 just fine, so start
using that instead.
