### PR TITLE
[chip-tool] Add AnyCommands aliases

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -95,11 +95,14 @@ class Decoder:
                     # Raise an error since the other fields probably needs to be translated too.
                     raise KeyError(f'Error: field "{key}" not supported')
 
-                if value is None and (key == _CLUSTER or key == _RESPONSE or key == _ATTRIBUTE or key == _EVENT):
+                if value is None and (key == _CLUSTER or key == _RESPONSE or key == _ATTRIBUTE or key == _EVENT) and _ERROR not in payload:
                     # If the definition for this cluster/command/attribute/event is missing, there is not
                     # much we can do to convert the response to the proper format. It usually indicates that
                     # the cluster definition is missing something. So we just raise an exception to tell the
                     # user something is wrong and the cluster definition needs to be updated.
+                    # The only exception being when the definition can not be found but the returned payload
+                    # contains an error. It could be because the payload is for an unknown cluster/command/attribute/event
+                    # in which case we obviously don't have a definition for it.
                     cluster_code = hex(payload[_CLUSTER_ID])
                     if key == _CLUSTER:
                         raise KeyError(

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -24,6 +24,18 @@ from .errors import TestStepError, TestStepKeyError, TestStepValueNameError
 from .pics_checker import PICSChecker
 from .yaml_loader import YamlLoader
 
+ANY_COMMANDS_CLUSTER_NAME = 'AnyCommands'
+ANY_COMMANDS_LIST = [
+    'CommandById',
+    'ReadById',
+    'WriteById',
+    'SubscribeById',
+    'ReadEventById',
+    'SubscribeEventById',
+    'ReadAll',
+    'SubscribeAll',
+]
+
 
 class UnknownPathQualifierError(TestStepError):
     """Raise when an attribute/command/event name is not found in the definitions."""
@@ -235,7 +247,7 @@ class _TestStepWithPlaceholders:
 
     def _update_mappings(self, test: dict, definitions: SpecDefinitions):
         cluster_name = self.cluster
-        if definitions is None or not definitions.has_cluster_by_name(cluster_name):
+        if definitions is None or not definitions.has_cluster_by_name(cluster_name) or cluster_name == ANY_COMMANDS_CLUSTER_NAME or self.command in ANY_COMMANDS_LIST:
             self.argument_mapping = None
             self.response_mapping = None
             self.response_mapping_name = None
@@ -756,7 +768,7 @@ class TestStep:
                 break
 
             received_value = received_response.get('value')
-            if not self.is_attribute and not self.is_event:
+            if not self.is_attribute and not self.is_event and not (self.command in ANY_COMMANDS_LIST):
                 expected_name = value.get('name')
                 if expected_name not in received_value:
                     result.error(check_type, error_name_does_not_exist.format(

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -128,17 +128,16 @@ def _GetSlowTests() -> Set[str]:
 
 
 def _GetInDevelopmentTests() -> Set[str]:
-    """Tests that fail in YAML for some reason.
-
-       Currently this is empty and returns an empty set, but this is kept around in case
-       there are tests that are a work in progress.
-    """
+    """Tests that fail in YAML for some reason."""
     return {
         "Test_AddNewFabricFromExistingFabric.yaml",     # chip-repl does not support GetCommissionerRootCertificate and IssueNocChain command
         "TestEqualities.yaml",              # chip-repl does not support pseudo-cluster commands that return a value
         "TestExampleCluster.yaml",          # chip-repl does not load custom pseudo clusters
         "TestClientMonitoringCluster.yaml",  # Client Monitoring Tests need a rework after the XML update
-        "Test_TC_TIMESYNC_1_1.yaml"         # Time sync SDK is not yet ready
+        "Test_TC_TIMESYNC_1_1.yaml",         # Time sync SDK is not yet ready
+        "TestAttributesById.yaml",           # chip-repl does not support AnyCommands (06/06/2023)
+        "TestCommandsById.yaml",             # chip-repl does not support AnyCommands (06/06/2023)
+        "TestEventsById.yaml",               # chip-repl does not support AnyCommands (06/06/2023)
     }
 
 

--- a/src/app/tests/suites/TestAttributesById.yaml
+++ b/src/app/tests/suites/TestAttributesById.yaml
@@ -1,0 +1,280 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Attributes Tests
+
+config:
+    nodeId: 0x12344321
+    endpoint: 1
+    cluster: "Unit Testing"
+
+    UnsupportedCluster: 0xFFF1FC06
+    UnsupportedAttribute: 0xFFF11FFF
+    UnsupportedEndPoint: 254
+
+    AttributeRequestMessage.Cluster: 0xFFF1FC05
+    AttributeRequestMessage.Attribute: 0x0000
+    AttributeRequestMessage.EndPoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label:
+          "Read Request Message with a path that indicates a specific endpoint
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadById"
+      endpoint: UnsupportedEndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+      response:
+          error: UNSUPPORTED_ENDPOINT
+
+    - label:
+          "Read Request Message with a path that indicates a specific cluster
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: UnsupportedCluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+      response:
+          error: UNSUPPORTED_CLUSTER
+
+    - label:
+          "Read Request Message with a path that indicates a specific command
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: UnsupportedAttribute
+      response:
+          error: UNSUPPORTED_ATTRIBUTE
+
+    - label:
+          "Read Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute"
+      cluster: "AnyCommands"
+      command: "ReadById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+      response:
+          value: false
+
+    - label:
+          "Write Request Message with a path that indicates a specific endpoint
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: UnsupportedEndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: true
+      response:
+          error: UNSUPPORTED_ENDPOINT
+
+    - label:
+          "Write Request Message with a path that indicates a specific cluster
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: UnsupportedCluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: true
+      response:
+          error: UNSUPPORTED_CLUSTER
+
+    - label:
+          "Write Request Message with a path that indicates a specific command
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: UnsupportedAttribute
+              - name: "Value"
+                value: true
+      response:
+          error: UNSUPPORTED_ATTRIBUTE
+
+    - label:
+          "Write Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: true
+
+    - label:
+          "Write Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute and set it back to defaults."
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: false
+
+    - label:
+          "Subscribe Request Message with a path that indicates a specific
+          endpoint that is unsupported"
+      cluster: "AnyCommands"
+      command: "SubscribeById"
+      endpoint: UnsupportedEndPoint
+      minInterval: 2
+      maxInterval: 5
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+      response:
+          error: INVALID_ACTION
+
+    - label:
+          "Subscribe Request Message with a path that indicates a specific
+          cluster that is unsupported"
+      cluster: "AnyCommands"
+      command: "SubscribeById"
+      endpoint: AttributeRequestMessage.EndPoint
+      minInterval: 2
+      maxInterval: 5
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: UnsupportedCluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+      response:
+          error: INVALID_ACTION
+
+    - label:
+          "Subscribe Request Message with a path that indicates a specific
+          command that is unsupported"
+      cluster: "AnyCommands"
+      command: "SubscribeById"
+      endpoint: AttributeRequestMessage.EndPoint
+      minInterval: 2
+      maxInterval: 5
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: UnsupportedAttribute
+      response:
+          error: INVALID_ACTION
+
+    - label:
+          "Subscribe Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute"
+      cluster: "AnyCommands"
+      command: "SubscribeById"
+      endpoint: AttributeRequestMessage.EndPoint
+      minInterval: 2
+      maxInterval: 5
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+
+    - label:
+          "Write Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: true
+
+    - label: "Check for attribute report"
+      command: "waitForReport"
+      attribute: "boolean"
+      response:
+          value: true
+
+    - label:
+          "Write Request Message with a valid path that indicates a specific
+          endpoint/cluster/attribute and set it back to defaults."
+      cluster: "AnyCommands"
+      command: "WriteById"
+      endpoint: AttributeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: AttributeRequestMessage.Cluster
+              - name: "AttributeId"
+                value: AttributeRequestMessage.Attribute
+              - name: "Value"
+                value: false

--- a/src/app/tests/suites/TestCommandsById.yaml
+++ b/src/app/tests/suites/TestCommandsById.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Commands Tests
+
+config:
+    nodeId: 0x12344321
+    endpoint: 1
+    cluster: "Unit Testing"
+
+    UnsupportedCluster: 0xFFF11FFF
+    UnsupportedCommand: 0xFFF11FFF
+    UnsupportedEndPoint: 254
+
+    InvokeRequestMessage.Cluster: 0x00000006
+    InvokeRequestMessage.Command: 0x00000000
+    InvokeRequestMessage.EndPoint: 1
+    InvokeRequestMessage.Payload: {}
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label:
+          "Invoke Request Message with a path that indicates a specific endpoint
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "CommandById"
+      endpoint: UnsupportedEndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: InvokeRequestMessage.Cluster
+              - name: "CommandId"
+                value: InvokeRequestMessage.Command
+              - name: "Payload"
+                value: InvokeRequestMessage.Payload
+      response:
+          error: UNSUPPORTED_ENDPOINT
+
+    - label:
+          "Invoke Request Message with a path that indicates a specific cluster
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "CommandById"
+      endpoint: InvokeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: UnsupportedCluster
+              - name: "CommandId"
+                value: InvokeRequestMessage.Command
+              - name: "Payload"
+                value: InvokeRequestMessage.Payload
+      response:
+          error: UNSUPPORTED_CLUSTER
+
+    - label:
+          "Invoke Request Message with a path that indicates a specific command
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "CommandById"
+      endpoint: InvokeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: InvokeRequestMessage.Cluster
+              - name: "CommandId"
+                value: UnsupportedCommand
+              - name: "Payload"
+                value: InvokeRequestMessage.Payload
+      response:
+          error: UNSUPPORTED_COMMAND
+
+    - label:
+          "Invoke Request Message with a valid path that indicates a specific
+          endpoint/cluster/command"
+      cluster: "AnyCommands"
+      command: "CommandById"
+      endpoint: InvokeRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: InvokeRequestMessage.Cluster
+              - name: "CommandId"
+                value: InvokeRequestMessage.Command
+              - name: "Payload"
+                value: InvokeRequestMessage.Payload

--- a/src/app/tests/suites/TestEventsById.yaml
+++ b/src/app/tests/suites/TestEventsById.yaml
@@ -1,0 +1,264 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Events Tests
+
+config:
+    nodeId: 0x12344321
+    endpoint: 1
+    cluster: "Unit Testing"
+
+    UnsupportedCluster: 0xFFF11FFF
+    UnsupportedEvent: 0xFFF11FFF
+    UnsupportedEndPoint: 254
+
+    ReadRequestMessage.Cluster: 0xFFF1FC05
+    ReadRequestMessage.Event: 0x0001
+    ReadRequestMessage.EndPoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label:
+          "Read Request Message with a path that indicates a specific endpoint
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: UnsupportedEndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response: []
+
+    - label:
+          "Read Request Message with a path that indicates a specific cluster
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: UnsupportedCluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response: []
+
+    - label:
+          "Read Request Message with a path that indicates a specific endpoint
+          that is unsupported"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: UnsupportedEvent
+      response: []
+
+    - label:
+          "Read Request Message with a path that indicates an event with no
+          results"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response: []
+
+    - label: "Create an event on the accessory"
+      command: "TestEmitTestEventRequest"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "arg1"
+                value: 1
+              - name: "arg2"
+                value: 2
+              - name: "arg3"
+                value: true
+      response:
+          values:
+              - name: "value"
+                saveAs: eventNumber
+
+    - label: "Read the event back"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response:
+          value: { arg1: 1, arg2: 2, arg3: true }
+
+    - label: "Read the event with eventNumber set to the event value"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      eventNumber: eventNumber
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response:
+          value: { arg1: 1, arg2: 2, arg3: true }
+
+    - label: "Read the event with eventNumber set to the event value + 1"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      eventNumber: eventNumber + 1
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response: []
+
+    - label: "Generate a second event on the accessory"
+      command: "TestEmitTestEventRequest"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "arg1"
+                value: 3
+              - name: "arg2"
+                value: 1
+              - name: "arg3"
+                value: false
+      response:
+          values:
+              - name: "value"
+                value: eventNumber + 1
+
+    - label: "Read the event back"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 1, arg3: false }
+
+    - label: "Subscribe to the event"
+      cluster: "AnyCommands"
+      command: "SubscribeEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      minInterval: 3
+      maxInterval: 5
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: ReadRequestMessage.Event
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 1, arg3: false }
+
+    - label: "Generate a third event on the accessory"
+      command: "TestEmitTestEventRequest"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "arg1"
+                value: 4
+              - name: "arg2"
+                value: 3
+              - name: "arg3"
+                value: true
+      response:
+          values:
+              - name: "value"
+                value: eventNumber + 2
+
+    - label: "Check for event report"
+      command: "waitForReport"
+      event: "TestEvent"
+      endpoint: ReadRequestMessage.EndPoint
+      response:
+          values:
+              - name: "TestEvent"
+                value: { arg1: 4, arg2: 3, arg3: true }
+
+    - label:
+          "Read Request Message with a path that indicates a specific
+          endpoint/cluster and a wildcard event"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: ReadRequestMessage.Cluster
+              - name: "EventId"
+                value: "*"
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 1, arg3: false }
+          - values:
+                - value: { arg1: 4, arg2: 3, arg3: true }
+
+    - label:
+          "Read Request Message with a path that indicates a specific
+          endpoint/event and a wildcard cluster"
+      cluster: "AnyCommands"
+      command: "ReadEventById"
+      endpoint: ReadRequestMessage.EndPoint
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: "*"
+              - name: "EventId"
+                value: ReadRequestMessage.EndPoint
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 1, arg3: false }
+          - values:
+                - value: { arg1: 4, arg2: 3, arg3: true }


### PR DESCRIPTION
#### Problem


This PR adds some supports for sending commands by id with YAML. It allows using invalid ids or the `0xffffffff` specifier.
