### PR TITLE
Add ways to construct cluster structs from the shared superclass.

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -58,6 +58,10 @@ namespace {{asUpperCamelCase name}} {
 
 using Fields = Clusters::detail::Structs::{{asUpperCamelCase name}}::Fields;
 
+// This is a struct type shared across multiple clusters.  Create a type-safe
+// declaration in this cluster namespace (so not just pulling in the shared
+// implementation via "using", but make sure we can initialize our
+// Type/DecodableType from the generic Type/DecodableType as needed.
 struct Type : public Clusters::detail::Structs::{{asUpperCamelCase name}}::Type
 {
 private:

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -60,11 +60,23 @@ using Fields = Clusters::detail::Structs::{{asUpperCamelCase name}}::Fields;
 
 struct Type : public Clusters::detail::Structs::{{asUpperCamelCase name}}::Type
 {
+private:
+    using Super = Clusters::detail::Structs::{{asUpperCamelCase name}}::Type;
+public:
+    constexpr Type() = default;
+    constexpr Type(const Super & arg) : Super(arg) {}
+    constexpr Type(Super && arg) : Super(std::move(arg)) {}
 };
 
 {{#if struct_contains_array}}
 struct DecodableType : public Clusters::detail::Structs::{{asUpperCamelCase name}}::DecodableType
 {
+private:
+    using Super = Clusters::detail::Structs::{{asUpperCamelCase name}}::DecodableType;
+public:
+    DecodableType() = default;
+    DecodableType(const Super & arg) : Super(arg) {}
+    DecodableType(Super && arg) : Super(std::move(arg)) {}
 };
 {{else}}
 using DecodableType = Type;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -13179,6 +13179,10 @@ namespace LabelStruct {
 
 using Fields = Clusters::detail::Structs::LabelStruct::Fields;
 
+// This is a struct type shared across multiple clusters.  Create a type-safe
+// declaration in this cluster namespace (so not just pulling in the shared
+// implementation via "using", but make sure we can initialize our
+// Type/DecodableType from the generic Type/DecodableType as needed.
 struct Type : public Clusters::detail::Structs::LabelStruct::Type
 {
 private:
@@ -13273,6 +13277,10 @@ namespace LabelStruct {
 
 using Fields = Clusters::detail::Structs::LabelStruct::Fields;
 
+// This is a struct type shared across multiple clusters.  Create a type-safe
+// declaration in this cluster namespace (so not just pulling in the shared
+// implementation via "using", but make sure we can initialize our
+// Type/DecodableType from the generic Type/DecodableType as needed.
 struct Type : public Clusters::detail::Structs::LabelStruct::Type
 {
 private:
@@ -27026,6 +27034,10 @@ namespace ApplicationStruct {
 
 using Fields = Clusters::detail::Structs::ApplicationStruct::Fields;
 
+// This is a struct type shared across multiple clusters.  Create a type-safe
+// declaration in this cluster namespace (so not just pulling in the shared
+// implementation via "using", but make sure we can initialize our
+// Type/DecodableType from the generic Type/DecodableType as needed.
 struct Type : public Clusters::detail::Structs::ApplicationStruct::Type
 {
 private:
@@ -27319,6 +27331,10 @@ namespace ApplicationStruct {
 
 using Fields = Clusters::detail::Structs::ApplicationStruct::Fields;
 
+// This is a struct type shared across multiple clusters.  Create a type-safe
+// declaration in this cluster namespace (so not just pulling in the shared
+// implementation via "using", but make sure we can initialize our
+// Type/DecodableType from the generic Type/DecodableType as needed.
 struct Type : public Clusters::detail::Structs::ApplicationStruct::Type
 {
 private:

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -13181,6 +13181,13 @@ using Fields = Clusters::detail::Structs::LabelStruct::Fields;
 
 struct Type : public Clusters::detail::Structs::LabelStruct::Type
 {
+private:
+    using Super = Clusters::detail::Structs::LabelStruct::Type;
+
+public:
+    constexpr Type() = default;
+    constexpr Type(const Super & arg) : Super(arg) {}
+    constexpr Type(Super && arg) : Super(std::move(arg)) {}
 };
 
 using DecodableType = Type;
@@ -13268,6 +13275,13 @@ using Fields = Clusters::detail::Structs::LabelStruct::Fields;
 
 struct Type : public Clusters::detail::Structs::LabelStruct::Type
 {
+private:
+    using Super = Clusters::detail::Structs::LabelStruct::Type;
+
+public:
+    constexpr Type() = default;
+    constexpr Type(const Super & arg) : Super(arg) {}
+    constexpr Type(Super && arg) : Super(std::move(arg)) {}
 };
 
 using DecodableType = Type;
@@ -27014,6 +27028,13 @@ using Fields = Clusters::detail::Structs::ApplicationStruct::Fields;
 
 struct Type : public Clusters::detail::Structs::ApplicationStruct::Type
 {
+private:
+    using Super = Clusters::detail::Structs::ApplicationStruct::Type;
+
+public:
+    constexpr Type() = default;
+    constexpr Type(const Super & arg) : Super(arg) {}
+    constexpr Type(Super && arg) : Super(std::move(arg)) {}
 };
 
 using DecodableType = Type;
@@ -27300,6 +27321,13 @@ using Fields = Clusters::detail::Structs::ApplicationStruct::Fields;
 
 struct Type : public Clusters::detail::Structs::ApplicationStruct::Type
 {
+private:
+    using Super = Clusters::detail::Structs::ApplicationStruct::Type;
+
+public:
+    constexpr Type() = default;
+    constexpr Type(const Super & arg) : Super(arg) {}
+    constexpr Type(Super && arg) : Super(std::move(arg)) {}
 };
 
 using DecodableType = Type;


### PR DESCRIPTION
This is only relevant when a struct is being shared across multiple clusters.