### PR TITLE
Disable c++ static destructors on exit

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/chip_xcode_build_connector.sh
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/chip_xcode_build_connector.sh
@@ -91,6 +91,8 @@ done
     target_cflags+=',"-flto"'
 }
 
+target_cflags+=',"-fno-c++-static-destructors"'
+
 declare -a args=(
     'default_configs_cosmetic=[]' # suppress colorization
     'chip_crypto="mbedtls"'


### PR DESCRIPTION
On iOS, tv casting mobile apps have been experiencing unexpected crashes after they were closed by users or the OS itself. The reason was mainly due to the ObjectLifeCycle state of properties within the static instances of SystemLayer, the UDPEndPointManager and TCPEndpointManager not being in the expected state (Uninitialized or Shutdown) upon c++  upon system exit(). This is because in the destructor of the static instances, there's a validation of state which is mismatching causing a crash through the chipDie call. For example, since the following code was not executed when applicationWillTerminate is invoked by the system, the c++ static destructors are invoked upon exit() and hence the internal logic for the ObjectLifeCycle class is hitting an assertion error.
```
chip::DeviceLayer::SystemLayer().Shutdown();
chip::DeviceLayer::UDPEndPointManager()->Shutdown();
chip::DeviceLayer::TCPEndPointManager()->Shutdown();
```

Given that iOS already handle memory clean up upon an app exit, the fix disables the C++ static destructors that is called when application is terminated. This prevents the app from crashing when it's already terminated (after exit() is invoked).