### PR TITLE
[python] update cached attributes incrementally

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -454,7 +454,7 @@ class AttributeCache:
 
                 attributeType = _AttributeIndex[(clusterId, attributeId)][0]
 
-                if (attributeType not in clusterCache):
+                if attributeType not in clusterCache:
                     clusterCache[attributeType] = {}
 
                 if isinstance(value, ValueDecodeFailure):

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -420,7 +420,7 @@ class AttributeCache:
 
             clusterType = _ClusterIndex[cluster]
 
-            if (clusterType not in endpointCache):
+            if clusterType not in endpointCache:
                 endpointCache[clusterType] = {}
 
             clusterCache = endpointCache[clusterType]

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -402,58 +402,57 @@ class AttributeCache:
         attributeCache = self.attributeCache
 
         for attributePath in changedPathSet:
-            endpoint = attributePath.EndpointId
+            endpointId = attributePath.EndpointId
 
-            if (endpoint not in attributeCache):
-                attributeCache[endpoint] = {}
+            if endpointId not in attributeCache:
+                attributeCache[endpointId] = {}
 
-            endpointCache = attributeCache[endpoint]
+            endpointCache = attributeCache[endpointId]
 
-            cluster = attributePath.ClusterId
+            clusterId = attributePath.ClusterId
 
-            if cluster not in _ClusterIndex:
+            if clusterId not in _ClusterIndex:
                 #
                 # #22599 tracks dealing with unknown clusters more
                 # gracefully so that clients can still access this data.
                 #
                 continue
 
-            clusterType = _ClusterIndex[cluster]
+            clusterType = _ClusterIndex[clusterId]
 
             if clusterType not in endpointCache:
                 endpointCache[clusterType] = {}
 
             clusterCache = endpointCache[clusterType]
             clusterDataVersion = self.versionList.get(
-                endpoint, {}).get(cluster, None)
+                endpointId, {}).get(clusterId, None)
 
-            if (self.returnClusterObject):
+            if self.returnClusterObject:
                 try:
                     # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
                     endpointCache[clusterType] = clusterType.FromDict(
-                        data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
+                        data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpointId][clusterId]))
                     endpointCache[clusterType].SetDataVersion(
                         clusterDataVersion)
                 except Exception as ex:
                     decodedValue = ValueDecodeFailure(
-                        tlvCache[endpoint][cluster], ex)
+                        tlvCache[endpointId][clusterId], ex)
                     endpointCache[clusterType] = decodedValue
             else:
                 clusterCache[DataVersion] = clusterDataVersion
 
-                attribute = attributePath.AttributeId
+                attributeId = attributePath.AttributeId
 
-                value = tlvCache[endpoint][cluster][attribute]
+                value = tlvCache[endpointId][clusterId][attributeId]
 
-                if (cluster, attribute) not in _AttributeIndex:
+                if (clusterId, attributeId) not in _AttributeIndex:
                     #
                     # #22599 tracks dealing with unknown clusters more
                     # gracefully so that clients can still access this data.
                     #
                     continue
 
-                attributeType = _AttributeIndex[(
-                    cluster, attribute)][0]
+                attributeType = _AttributeIndex[(clusterId, attributeId)][0]
 
                 if (attributeType not in clusterCache):
                     clusterCache[attributeType] = {}
@@ -463,7 +462,7 @@ class AttributeCache:
                 else:
                     try:
                         decodedValue = attributeType.FromTagDictOrRawValue(
-                            tlvCache[endpoint][cluster][attribute])
+                            tlvCache[endpointId][clusterId][attributeId])
                     except Exception as ex:
                         decodedValue = ValueDecodeFailure(value, ex)
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -383,7 +383,7 @@ class AttributeCache:
 
         clusterCache[path.AttributeId] = data
 
-    def UpdateCachedData(self):
+    def UpdateCachedData(self, changedPathSet: set[AttributePath]):
         ''' This converts the raw TLV data into a cluster object format.
 
             Two formats are available:
@@ -401,68 +401,73 @@ class AttributeCache:
         tlvCache = self.attributeTLVCache
         attributeCache = self.attributeCache
 
-        for endpoint in tlvCache:
+        for attributePath in changedPathSet:
+            endpoint = attributePath.EndpointId
+
             if (endpoint not in attributeCache):
                 attributeCache[endpoint] = {}
 
             endpointCache = attributeCache[endpoint]
 
-            for cluster in tlvCache[endpoint]:
-                if cluster not in _ClusterIndex:
+            cluster = attributePath.ClusterId
+
+            if cluster not in _ClusterIndex:
+                #
+                # #22599 tracks dealing with unknown clusters more
+                # gracefully so that clients can still access this data.
+                #
+                continue
+
+            clusterType = _ClusterIndex[cluster]
+
+            if (clusterType not in endpointCache):
+                endpointCache[clusterType] = {}
+
+            clusterCache = endpointCache[clusterType]
+            clusterDataVersion = self.versionList.get(
+                endpoint, {}).get(cluster, None)
+
+            if (self.returnClusterObject):
+                try:
+                    # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
+                    endpointCache[clusterType] = clusterType.FromDict(
+                        data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
+                    endpointCache[clusterType].SetDataVersion(
+                        clusterDataVersion)
+                except Exception as ex:
+                    decodedValue = ValueDecodeFailure(
+                        tlvCache[endpoint][cluster], ex)
+                    endpointCache[clusterType] = decodedValue
+            else:
+                clusterCache[DataVersion] = clusterDataVersion
+
+                attribute = attributePath.AttributeId
+
+                value = tlvCache[endpoint][cluster][attribute]
+
+                if (cluster, attribute) not in _AttributeIndex:
                     #
                     # #22599 tracks dealing with unknown clusters more
                     # gracefully so that clients can still access this data.
                     #
                     continue
 
-                clusterType = _ClusterIndex[cluster]
+                attributeType = _AttributeIndex[(
+                    cluster, attribute)][0]
 
-                if (clusterType not in endpointCache):
-                    endpointCache[clusterType] = {}
+                if (attributeType not in clusterCache):
+                    clusterCache[attributeType] = {}
 
-                clusterCache = endpointCache[clusterType]
-                clusterDataVersion = self.versionList.get(
-                    endpoint, {}).get(cluster, None)
-
-                if (self.returnClusterObject):
-                    try:
-                        # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
-                        endpointCache[clusterType] = clusterType.FromDict(
-                            data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
-                        endpointCache[clusterType].SetDataVersion(
-                            clusterDataVersion)
-                    except Exception as ex:
-                        decodedValue = ValueDecodeFailure(
-                            tlvCache[endpoint][cluster], ex)
-                        endpointCache[clusterType] = decodedValue
+                if isinstance(value, ValueDecodeFailure):
+                    clusterCache[attributeType] = value
                 else:
-                    clusterCache[DataVersion] = clusterDataVersion
-                    for attribute in tlvCache[endpoint][cluster]:
-                        value = tlvCache[endpoint][cluster][attribute]
+                    try:
+                        decodedValue = attributeType.FromTagDictOrRawValue(
+                            tlvCache[endpoint][cluster][attribute])
+                    except Exception as ex:
+                        decodedValue = ValueDecodeFailure(value, ex)
 
-                        if (cluster, attribute) not in _AttributeIndex:
-                            #
-                            # #22599 tracks dealing with unknown clusters more
-                            # gracefully so that clients can still access this data.
-                            #
-                            continue
-
-                        attributeType = _AttributeIndex[(
-                            cluster, attribute)][0]
-
-                        if (attributeType not in clusterCache):
-                            clusterCache[attributeType] = {}
-
-                        if (type(value) is ValueDecodeFailure):
-                            clusterCache[attributeType] = value
-                        else:
-                            try:
-                                decodedValue = attributeType.FromTagDictOrRawValue(
-                                    tlvCache[endpoint][cluster][attribute])
-                            except Exception as ex:
-                                decodedValue = ValueDecodeFailure(value, ex)
-
-                            clusterCache[attributeType] = decodedValue
+                    clusterCache[attributeType] = decodedValue
 
 
 class SubscriptionTransaction:
@@ -765,7 +770,7 @@ class AsyncReadTransaction:
         pass
 
     def _handleReportEnd(self):
-        self._cache.UpdateCachedData()
+        self._cache.UpdateCachedData(self._changedPathSet)
 
         if (self._subscription_handler is not None):
             for change in self._changedPathSet:

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -204,7 +204,7 @@ class ClusterObjectTests:
     @ base.test_case
     async def TestAttributeCacheAttributeView(cls, devCtrl):
         logger.info("Test AttributeCache Attribute-View")
-        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=False, reportInterval=(0, 10))
+        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=False, reportInterval=(3, 10))
 
         event = asyncio.Event()
 
@@ -242,7 +242,7 @@ class ClusterObjectTests:
     @ base.test_case
     async def TestAttributeCacheClusterView(cls, devCtrl):
         logger.info("Test AttributeCache Cluster-View")
-        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=True, reportInterval=(0, 10))
+        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=True, reportInterval=(3, 10))
 
         event = asyncio.Event()
 

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -238,7 +238,6 @@ class ClusterObjectTests:
         finally:
             sub.Shutdown()
 
-
     @ classmethod
     @ base.test_case
     async def TestAttributeCacheClusterView(cls, devCtrl):
@@ -279,7 +278,6 @@ class ClusterObjectTests:
             raise AssertionError("Did not receive updated attribute")
         finally:
             sub.Shutdown()
-
 
     @ classmethod
     @ base.test_case

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -202,6 +202,87 @@ class ClusterObjectTests:
 
     @ classmethod
     @ base.test_case
+    async def TestAttributeCacheAttributeView(cls, devCtrl):
+        logger.info("Test AttributeCache Attribute-View")
+        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=False, reportInterval=(0, 10))
+
+        event = asyncio.Event()
+
+        def subUpdate(path: TypedAttributePath, transaction: SubscriptionTransaction):
+            event.set()
+
+        sub.SetAttributeUpdateCallback(subUpdate)
+
+        try:
+            data = sub.GetAttributes()
+            req = Clusters.OnOff.Commands.On()
+            await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
+
+            await asyncio.wait_for(event.wait(), timeout=11)
+
+            if (data[1][Clusters.OnOff][Clusters.OnOff.Attributes.OnOff] != 1):
+                raise ValueError("Current On/Off state should be 1")
+
+            event.clear()
+
+            req = Clusters.OnOff.Commands.Off()
+            await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
+
+            await asyncio.wait_for(event.wait(), timeout=11)
+
+            if (data[1][Clusters.OnOff][Clusters.OnOff.Attributes.OnOff] != 0):
+                raise ValueError("Current On/Off state should be 0")
+
+        except TimeoutError:
+            raise AssertionError("Did not receive updated attribute")
+        finally:
+            sub.Shutdown()
+
+
+    @ classmethod
+    @ base.test_case
+    async def TestAttributeCacheClusterView(cls, devCtrl):
+        logger.info("Test AttributeCache Cluster-View")
+        sub: SubscriptionTransaction = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=[(1, Clusters.OnOff.Attributes.OnOff)], returnClusterObject=True, reportInterval=(0, 10))
+
+        event = asyncio.Event()
+
+        def subUpdate(path: TypedAttributePath, transaction: SubscriptionTransaction):
+            event.set()
+
+        sub.SetAttributeUpdateCallback(subUpdate)
+
+        try:
+            data = sub.GetAttributes()
+
+            req = Clusters.OnOff.Commands.On()
+            await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
+
+            await asyncio.wait_for(event.wait(), timeout=11)
+
+            cluster: Clusters.OnOff = data[1][Clusters.OnOff]
+            if (not cluster.onOff):
+                raise ValueError("Current On/Off state should be True")
+
+            event.clear()
+
+            req = Clusters.OnOff.Commands.Off()
+            await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
+
+            await asyncio.wait_for(event.wait(), timeout=11)
+
+            cluster: Clusters.OnOff = data[1][Clusters.OnOff]
+            if (cluster.onOff):
+                raise ValueError("Current On/Off state should be False")
+
+        except TimeoutError:
+            raise AssertionError("Did not receive updated attribute")
+        finally:
+            sub.Shutdown()
+
+
+    @ classmethod
+    @ base.test_case
     async def TestSubscribeZeroMinInterval(cls, devCtrl):
         '''
         This validates receiving subscription reports for two attributes at a time in quick succession after
@@ -638,6 +719,8 @@ class ClusterObjectTests:
             await cls.TestReadAttributeRequests(devCtrl)
             await cls.TestSubscribeZeroMinInterval(devCtrl)
             await cls.TestSubscribeAttribute(devCtrl)
+            await cls.TestAttributeCacheAttributeView(devCtrl)
+            await cls.TestAttributeCacheClusterView(devCtrl)
             await cls.TestMixedReadAttributeAndEvents(devCtrl)
             # Note: Write will change some attribute values, always put it after read tests
             await cls.TestWriteRequest(devCtrl)

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -99,7 +99,7 @@ class TestPythonController(CHIPVirtualHome):
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                   "--args python3 {} -t 240 -a {} --paa-trust-store-path {}").format(
+                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/mobile-device-test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))


### PR DESCRIPTION
Instead of rebuilding the cache from scratch on every report, just update the Endpoint/Cluster/Attributes which actually changed. Obviously, this is significantly faster, especially for small updates.