### PR TITLE
Fix unresolved reference: fromJsonString build error

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
@@ -55,11 +55,11 @@ class OnboardingPayloadParser {
 
   /** Get QR code string from [OnboardingPayload].  */
   @Throws(OnboardingPayloadException::class)
-  external fun getQrCodeFromPayload(payload: OnboardingPayload): String?
+  external fun getQrCodeFromPayload(payload: OnboardingPayload): String
 
   /** Get Manual Pairing Code string from [OnboardingPayload].  */
   @Throws(OnboardingPayloadException::class)
-  external fun getManualPairingCodeFromPayload(payload: OnboardingPayload): String?
+  external fun getManualPairingCodeFromPayload(payload: OnboardingPayload): String
 
   @Throws(UnrecognizedQrCodeException::class, OnboardingPayloadException::class)
   private external fun fetchPayloadFromQrCode(

--- a/src/controller/java/src/chip/onboardingpayload/OptionalQRCodeInfo.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OptionalQRCodeInfo.kt
@@ -1,6 +1,11 @@
 package chip.onboardingpayload
 
-class OptionalQRCodeInfo {
+data class OptionalQRCodeInfo(
+  var tag: Int = 0,
+  var type: OptionalQRCodeInfoType = OptionalQRCodeInfoType.TYPE_UNKNOWN,
+  var data: String? = null,
+  var int32: Int = 0
+) {
   enum class OptionalQRCodeInfoType {
     TYPE_UNKNOWN,
     TYPE_STRING,
@@ -9,9 +14,4 @@ class OptionalQRCodeInfo {
     TYPE_UINT32,
     TYPE_UINT64
   }
-
-  var tag = 0
-  var type: OptionalQRCodeInfoType? = null
-  var data: String? = null
-  var int32 = 0
 }

--- a/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt
+++ b/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt
@@ -24,9 +24,9 @@ import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import chip.tlv.*
 import chip.jsontlv.fromJsonString
 import chip.jsontlv.toJsonString
+import chip.tlv.*
 
 @RunWith(JUnit4::class)
 class JsonToTlvToJsonTest {


### PR DESCRIPTION
Hit following build error when build and run json_to_tlv_to_json_test

```
2023-05-23 19:54:47 INFO    FAILED: gen/third_party/connectedhomeip/src/controller/java/json_to_tlv_to_json_test.classlist 
2023-05-23 19:54:47 INFO    python ../../examples/java-matter-controller/third_party/connectedhomeip/build/chip/java/kotlinc_runner.py --classdir obj/third_party/connectedhomeip/src/controller/java/classes --outfile gen/third_party/connectedhomeip/src/controller/java/json_to_tlv_to_json_test.classlist --build-config gen/third_party/connectedhomeip/src/controller/java/json_to_tlv_to_json_test.json -- -d obj/third_party/connectedhomeip/src/controller/java/classes @gen/third_party/connectedhomeip/src/controller/java/json_to_tlv_to_json_test.sources -Werror -Xlint:all -Xlint:deprecation
2023-05-23 19:54:47 INFO    warning: flag is not supported by this version of the compiler: -Xlint:all
2023-05-23 19:54:47 INFO    warning: flag is not supported by this version of the compiler: -Xlint:deprecation
2023-05-23 19:54:47 INFO    /home/yufengw/connectedhomeip/examples/java-matter-controller/third_party/connectedhomeip/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt:28:21: error: unresolved reference: fromJsonString
2023-05-23 19:54:47 INFO    import chip.jsontlv.fromJsonString
2023-05-23 19:54:47 INFO                        ^
2023-05-23 19:54:47 INFO    /home/yufengw/connectedhomeip/examples/java-matter-controller/third_party/connectedhomeip/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt:29:21: error: unresolved reference: toJsonString
2023-05-23 19:54:47 INFO    import chip.jsontlv.toJsonString
```


