### PR TITLE
[python tests] decode shell output as UTF-8

### DIFF
--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -55,7 +55,7 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
             raise Exception("Failed to remove /tmp/chip* for factory reset.")
 
         print("Contents of test directory: %s" % os.getcwd())
-        print(subprocess.check_output(["ls -l"], shell=True).decode('us-ascii'))
+        print(subprocess.check_output(["ls -l"], shell=True).decode('utf-8'))
 
         # Remove native app KVS if that was used
         kvs_match = re.search(r"--KVS (?P<kvs_path>[^ ]+)", app_args)

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -92,7 +92,7 @@ def main(app: str, factoryreset: bool, app_args: str, script: str, script_args: 
             raise Exception("Failed to remove /tmp/chip* for factory reset.")
 
         print("Contents of test directory: %s" % os.getcwd())
-        print(subprocess.check_output(["ls -l"], shell=True).decode('us-ascii'))
+        print(subprocess.check_output(["ls -l"], shell=True).decode('utf-8'))
 
         # Remove native app KVS if that was used
         kvs_match = re.search(r"--KVS (?P<kvs_path>[^ ]+)", app_args)


### PR DESCRIPTION
If tests are run on a platform which is returning special characters (e.g. date with months which contain an umlaut) runnig the test fails:

```
  File "/home/sag/projects/project-chip/connectedhomeip/./scripts/tests/run_python_test.py", line 95, in main
    print(subprocess.check_output(["ls -l"], shell=True).decode('us-ascii'))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1553: ordinal not in range(128)
```

Decode the output using UTF-8 by default.

