### PR TITLE
tests: add missing cstdint include for gcc13

### DIFF
--- a/src/app/tests/suites/pics/PICSBooleanExpressionParser.h
+++ b/src/app/tests/suites/pics/PICSBooleanExpressionParser.h
@@ -21,6 +21,7 @@
  *        implements PICS condition parsing for YAML tests.
  */
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
See also 853691dfe7

Another gcc13 breakage while doing initial install.sh on a fresh fedora 38 system.  Just add the missing cstdint include as in prior fixes.
