### PR TITLE
TC-TIMESYNC-2.4: Wrong validAt time in step 10

### DIFF
--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -98,7 +98,7 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
             ret = await self.send_set_time_zone_cmd(tz=tz)
 
         self.print_step(10, "Send SetTimeZone command - bad validAt time")
-        tz = [tz_struct(offset=3600, validAt=0, name="Europe/Dublin")]
+        tz = [tz_struct(offset=3600, validAt=utc_time_in_matter_epoch(), name="Europe/Dublin")]
         await self.send_set_time_zone_cmd_expect_error(tz=tz, error=Status.ConstraintError)
 
         self.print_step(11, "Send SetTimeZone command - bad second entry")


### PR DESCRIPTION
Fesseha found a bug while testing against the SDK. 

