### PR TITLE
[ZAP] Code gen copyright year should be updated to current year

### DIFF
--- a/src/app/zap-templates/partials/header.zapt
+++ b/src/app/zap-templates/partials/header.zapt
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2022 Project CHIP Authors
+ *    Copyright (c) 2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just noticed the ZAP copyright year is behind. This is to update it to 2023.