### PR TITLE
[Silabs] Fix MBEDTLS_USE_PSA_CRYPTO not being include for the GSDK build section

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -540,6 +540,7 @@ template("efr32_sdk") {
       "${chip_root}/src/platform/silabs/efr32/psa_crypto_config.h",
     ]
 
+    public_configs = [ "${chip_root}/src:includes" ]
     public_deps = [ "${chip_root}/src/crypto:crypto_buildconfig" ]
   }
 


### PR DESCRIPTION
add a `public_config` in the `efr32_mbedtls_config` source set to fix a chain of define issue that led to MBEDTLS_USE_PSA_CRYPTO not being defined in the GSDK build section

`${chip_root}/src:includes` config defines `CHIP_HAVE_CONFIG_H` 
The absence of this config in the efr32_sdk template led to the following code in
`src/platform/silabs/efr32/efr32-chip-mbedtls-config.h` to not define `MBEDTLS_USE_PSA_CRYPTO`

```
#if CHIP_HAVE_CONFIG_H
#include <crypto/CryptoBuildConfig.h>
#endif // CHIP_HAVE_CONFIG_H

#if CHIP_CRYPTO_PLATFORM
#define MBEDTLS_USE_PSA_CRYPTO
#endif
```

