### PR TITLE
Fix reporting of event path errors in MTRBaseDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -819,12 +819,14 @@ private:
         //
         VerifyOrDie(!aPath.IsListItemOperation());
 
-        VerifyOrExit(aStatus.IsSuccess(), err = aStatus.ToChipError());
         VerifyOrExit(
             std::find_if(mAttributePathParamsList, mAttributePathParamsList + mAttributePathParamsSize,
                 [aPath](app::AttributePathParams & pathParam) -> bool { return pathParam.IsAttributePathSupersetOf(aPath); })
                 != mAttributePathParamsList + mAttributePathParamsSize,
             err = CHIP_ERROR_SCHEMA_MISMATCH);
+
+        VerifyOrExit(aStatus.IsSuccess(), err = aStatus.ToChipError());
+
         VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
         SuccessOrExit(err = app::DataModel::Decode(*apData, value));
@@ -852,6 +854,9 @@ private:
                          })
                 != mEventPathParamsList + mEventPathParamsSize,
             err = CHIP_ERROR_SCHEMA_MISMATCH);
+
+        VerifyOrExit(apStatus == nullptr, err = apStatus->ToChipError());
+
         VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
         SuccessOrExit(err = app::DataModel::Decode(*apData, value));
@@ -1366,7 +1371,7 @@ exit:
                            ConcreteEventPath pathCopy(*eventPath);
                            dispatch_async(queue, ^{
                                reportHandler(@[ @ {
-                                   MTRAttributePathKey : [[MTREventPath alloc] initWithPath:pathCopy],
+                                   MTREventPathKey : [[MTREventPath alloc] initWithPath:pathCopy],
                                    MTRErrorKey : [MTRError errorForCHIPErrorCode:error]
                                } ],
                                    nil);


### PR DESCRIPTION
Two main fixes here:

* Don't lose the prceise error if we have one in OnEventData.
* Use the right path key in our report dictionary for event errors.

The path key problem has not been shipped in any releases before, so no backports needed.

The other changes are just aligning the attribute and event cases on checking "is this a path we expected a report for?" before actually looking at the report we got.
