### PR TITLE
Add Darwin availability annotation for new Thermostat feature bit.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -7779,6 +7779,9 @@
           Scenes:
               Feature:
                   - SceneNames
+          Thermostat:
+              Feature:
+                  - LocalTemperatureNotExposed
           HEPAFilterMonitoring:
               Feature:
                   - Condition


### PR DESCRIPTION
This was added in https://github.com/project-chip/connectedhomeip/pull/26686
