### PR TITLE
ESP32: Add a menuconfig option to enable/disable route hook in matter

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -203,6 +203,10 @@ if (CONFIG_ENABLE_ROTATING_DEVICE_ID)
     chip_gn_arg_append("chip_enable_rotating_device_id"            "true")
 endif()
 
+if (CONFIG_ENABLE_ROUTE_HOOK)
+    chip_gn_arg_append("chip_enable_route_hook"   "true")
+endif()
+
 if (CONFIG_CHIP_ENABLE_EXTERNAL_PLATFORM)
     chip_gn_arg_append("chip_device_platform"   "\"external\"")
     if (CONFIG_ENABLE_CHIP_SHELL)

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -163,6 +163,13 @@ menu "CHIP Core"
 
                 A value of 0 disables automatic closing of idle connections.
 
+        config ENABLE_ROUTE_HOOK
+            bool "Enable route hook"
+            depends on LWIP_HOOK_IP6_ROUTE_DEFAULT && LWIP_HOOK_ND6_GET_GW_DEFAULT
+            default y
+            help
+                Enable this option to use LwIP default IPv6 route hook for Route Information Option(RIO) feature.
+
     endmenu # "Networking Options"
 
     menu "System Options"

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -31,6 +31,7 @@ declare_args() {
   chip_use_secure_cert_dac_provider = false
   chip_use_esp32_ecdsa_peripheral = false
   chip_enable_ethernet = false
+  chip_enable_route_hook = false
 }
 
 defines = [
@@ -119,15 +120,19 @@ static_library("ESP32") {
       "ConnectivityManagerImpl_WiFi.cpp",
       "NetworkCommissioningDriver.cpp",
       "NetworkCommissioningDriver.h",
-      "route_hook/ESP32RouteHook.c",
-      "route_hook/ESP32RouteHook.h",
-      "route_hook/ESP32RouteTable.c",
-      "route_hook/ESP32RouteTable.h",
     ]
     if (chip_mdns == "platform") {
       sources += [
         "WiFiDnssdImpl.cpp",
         "WiFiDnssdImpl.h",
+      ]
+    }
+    if (chip_enable_route_hook) {
+      sources += [
+        "route_hook/ESP32RouteHook.c",
+        "route_hook/ESP32RouteHook.h",
+        "route_hook/ESP32RouteTable.c",
+        "route_hook/ESP32RouteTable.h",
       ]
     }
   }

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -1104,8 +1104,9 @@ void ConnectivityManagerImpl::OnStationIPv6AddressAvailable(const ip_event_got_i
     event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
     event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV6_Assigned;
     PlatformMgr().PostEventOrDie(&event);
-
+#if CONFIG_ENABLE_ROUTE_HOOK
     esp_route_hook_init(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
+#endif
 }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
### Problem
We need to add a menuconfig option so that we can disable route hook and realize it in other task.

### Changes
Add the menuconfig option to enable/disable route hook in matter.