### PR TITLE
[darwin] Add more logging when a device with a matching Matter UUID i…

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -350,11 +350,6 @@ namespace DeviceLayer {
         advertisementData:(NSDictionary *)advertisementData
                      RSSI:(NSNumber *)RSSI
 {
-    NSNumber * isConnectable = [advertisementData objectForKey:CBAdvertisementDataIsConnectable];
-    if ([isConnectable boolValue] == NO) {
-        return;
-    }
-
     NSDictionary * servicesData = [advertisementData objectForKey:CBAdvertisementDataServiceDataKey];
     NSData * serviceData;
     for (CBUUID * serviceUUID in servicesData) {
@@ -364,26 +359,53 @@ namespace DeviceLayer {
         }
     }
 
-    if (!serviceData || [serviceData length] != 8) {
+    if (!serviceData) {
+        return;
+    }
+
+    NSNumber * isConnectable = [advertisementData objectForKey:CBAdvertisementDataIsConnectable];
+    if ([isConnectable boolValue] == NO) {
+        ChipLogError(Ble, "A device (%p) with a matching Matter UUID has been discovered but it is not connectable.", peripheral);
         return;
     }
 
     const uint8_t * bytes = (const uint8_t *) [serviceData bytes];
+    if ([serviceData length] != 8) {
+        NSMutableString * hexString = [NSMutableString stringWithCapacity:([serviceData length] * 2)];
+        for (NSUInteger i = 0; i < [serviceData length]; i++) {
+            [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long) bytes[i]]];
+        }
+        ChipLogError(Ble,
+            "A device (%p) with a matching Matter UUID has been discovered but the service data len does not match our expectation "
+            "(serviceData = %s)",
+            peripheral, [hexString UTF8String]);
+        return;
+    }
+
     uint8_t opCode = bytes[0];
     if (opCode != 0 && opCode != 1) {
+        ChipLogError(Ble,
+            "A device (%p) with a matching Matter UUID has been discovered but the service data opCode not match our expectation "
+            "(opCode = %u).",
+            peripheral, opCode);
         return;
     }
 
     uint16_t discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;
 
-    if ([self isConnecting] and [self checkDiscriminator:discriminator]) {
+    if ([self isConnecting]) {
+        if (![self checkDiscriminator:discriminator]) {
+            ChipLogError(Ble,
+                "A device (%p) with a matching Matter UUID has been discovered but the service data discriminator not match our "
+                "expectation (discriminator = %u).",
+                peripheral, discriminator);
+            return;
+        }
+
         ChipLogProgress(Ble, "Connecting to device %p with discriminator: %d", peripheral, discriminator);
         [self connect:peripheral];
         [self stopScanning];
-        return;
-    }
-
-    if (![self isConnecting]) {
+    } else {
         [self addPeripheralToCache:peripheral data:serviceData];
     }
 }


### PR DESCRIPTION
…s discovered over BLE but some parts of the service data does not match

#### Problem

This PR adds yet more logging under Darwin when a device with a matching UUID is discovered but does not match the expectations for some other reasons.

