### PR TITLE
[CHIP-TOOL] Increase Group Limits

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -57,8 +57,8 @@ public:
     using PeerId                 = ::chip::PeerId;
     using PeerAddress            = ::chip::Transport::PeerAddress;
 
-    static constexpr uint16_t kMaxGroupsPerFabric    = 5;
-    static constexpr uint16_t kMaxGroupKeysPerFabric = 8;
+    static constexpr uint16_t kMaxGroupsPerFabric    = 50;
+    static constexpr uint16_t kMaxGroupKeysPerFabric = 25;
 
     CHIPCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds, const char * helpText = nullptr) :
         Command(commandName, helpText), mCredIssuerCmds(credIssuerCmds)


### PR DESCRIPTION
Since Chip-tool is mainly used for testing/debugging, the Max group per fabric shouldn't be as low as 5. Storage isn't an issue and it will help test corner cases.

