### PR TITLE
[ESP32] Fix generation of encrypted factory partition

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -488,7 +488,7 @@ def generate_nvs_bin(encrypt, size, csv_filename, bin_filename):
     if encrypt:
         nvs_args.keygen = True
         nvs_args.keyfile = NVS_KEY_PARTITION_BIN
-        nvs_args.inputkey = None,
+        nvs_args.inputkey = None
         nvs_partition_gen.encrypt(nvs_args)
     else:
         nvs_partition_gen.generate(nvs_args)


### PR DESCRIPTION
Generation of encrypted factory partition failed due the an unwanted comma at the end.

Removed the comma at the end and was able to build the partition successfully.