### PR TITLE
Change OptionalQRCodeInfo to data class

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/DiscoveryCapability.kt
+++ b/src/controller/java/src/chip/onboardingpayload/DiscoveryCapability.kt
@@ -1,3 +1,20 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+ 
 package chip.onboardingpayload
 
 /**

--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
@@ -1,3 +1,20 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+ 
 package chip.onboardingpayload
 
 /** Class to hold the data from the scanned QR code or Manual Pairing Code.  */

--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
@@ -1,3 +1,20 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+ 
 package chip.onboardingpayload
 
 import java.util.logging.Level
@@ -55,11 +72,11 @@ class OnboardingPayloadParser {
 
   /** Get QR code string from [OnboardingPayload].  */
   @Throws(OnboardingPayloadException::class)
-  external fun getQrCodeFromPayload(payload: OnboardingPayload): String?
+  external fun getQrCodeFromPayload(payload: OnboardingPayload): String
 
   /** Get Manual Pairing Code string from [OnboardingPayload].  */
   @Throws(OnboardingPayloadException::class)
-  external fun getManualPairingCodeFromPayload(payload: OnboardingPayload): String?
+  external fun getManualPairingCodeFromPayload(payload: OnboardingPayload): String
 
   @Throws(UnrecognizedQrCodeException::class, OnboardingPayloadException::class)
   private external fun fetchPayloadFromQrCode(

--- a/src/controller/java/src/chip/onboardingpayload/OptionalQRCodeInfo.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OptionalQRCodeInfo.kt
@@ -1,6 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+ 
 package chip.onboardingpayload
 
-class OptionalQRCodeInfo {
+data class OptionalQRCodeInfo(
+  var tag: Int = 0,
+  var type: OptionalQRCodeInfoType = OptionalQRCodeInfoType.TYPE_UNKNOWN,
+  var data: String? = null,
+  var int32: Int = 0
+) {
   enum class OptionalQRCodeInfoType {
     TYPE_UNKNOWN,
     TYPE_STRING,
@@ -9,9 +31,4 @@ class OptionalQRCodeInfo {
     TYPE_UINT32,
     TYPE_UINT64
   }
-
-  var tag = 0
-  var type: OptionalQRCodeInfoType? = null
-  var data: String? = null
-  var int32 = 0
 }


### PR DESCRIPTION
Change OptionalQRCodeInfo to data class.

A data class is specifically designed to hold data/state and provide useful methods automatically.
It automatically generates equals(), hashCode(), toString(), and copy() methods based on the primary constructor's properties.
