### PR TITLE
Fix ordering issue with subscribeToAttributesWithEndpointID over XPC.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
@@ -43,7 +43,7 @@ typedef void (^MTRGetProxyHandleHandler)(dispatch_queue_t queue, MTRDeviceContro
 @interface MTRDeviceControllerXPCConnection<MTRDeviceControllerClientProtocol> : NSObject
 
 /**
- * This method is just for test purpsoe.
+ * This method is just for test purpose.
  */
 + (MTRDeviceControllerXPCConnection *)connectionWithWorkQueue:(dispatch_queue_t)workQueue
                                                  connectBlock:(MTRXPCConnectBlock)connectBlock;
@@ -55,6 +55,7 @@ typedef void (^MTRGetProxyHandleHandler)(dispatch_queue_t queue, MTRDeviceContro
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
                                         nodeID:(NSNumber *)nodeID
                                     completion:(dispatch_block_t)completion;
+- (void)callSubscriptionEstablishedHandler:(dispatch_block_t)handler;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.mm
@@ -203,4 +203,11 @@
     });
 }
 
+- (void)callSubscriptionEstablishedHandler:(dispatch_block_t)handler
+{
+    // Call the handler from our _workQueue, so that we guarantee the same
+    // number of queue hops as for handleReportWithController.
+    dispatch_async(_workQueue, handler);
+}
+
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -272,14 +272,16 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
                                            maxInterval:params.maxInterval
                                                 params:[MTRDeviceController encodeXPCSubscribeParams:params]
                                     establishedHandler:^{
-                                        dispatch_async(queue, ^{
-                                            MTR_LOG_DEBUG("Subscription established");
-                                            subscriptionEstablishedHandler();
-                                            // The following captures the proxy handle in the closure so that the handle
-                                            // won't be released prior to block call.
-                                            __auto_type handleRetainer = handle;
-                                            (void) handleRetainer;
-                                        });
+                                        [self.xpcConnection callSubscriptionEstablishedHandler:^{
+                                            dispatch_async(queue, ^{
+                                                MTR_LOG_DEBUG("Subscription established");
+                                                subscriptionEstablishedHandler();
+                                                // The following captures the proxy handle in the closure so that the handle
+                                                // won't be released prior to block call.
+                                                __auto_type handleRetainer = handle;
+                                                (void) handleRetainer;
+                                            });
+                                        }];
                                     }];
     };
 


### PR DESCRIPTION
We had an extra queue hop for reports compared with the subscriptionEstablished notification, so the API consumer could get subscriptionEstablished before getting all the priming reports.

The fix is to just ensure that the code flows the same way, in terms of queue dispatch, for both priming reports and subscriptionEstablished.
