### PR TITLE
Add JAVA_PATH to our dockerfile environment variables

### DIFF
--- a/integrations/docker/images/chip-build-java/Dockerfile
+++ b/integrations/docker/images/chip-build-java/Dockerfile
@@ -11,3 +11,4 @@ RUN set -x \
     && : # last line
 
 ENV PATH $PATH:/usr/lib/kotlinc/bin
+ENV JAVA_PATH=/usr/lib/jvm/java-8-openjdk-amd64

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -98,6 +98,7 @@ ENV SILABS_BOARD=BRD4161A
 ENV IDF_PATH=/opt/espressif/esp-idf/
 ENV IDF_TOOLS_PATH=/opt/espressif/tools
 ENV IMX_SDK_ROOT=/opt/fsl-imx-xwayland/5.15-kirkstone/
+ENV JAVA_PATH=/usr/lib/jvm/java-8-openjdk-amd64
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
 ENV NXP_K32W0_SDK_ROOT=/opt/k32w_sdk
 ENV OPENOCD_PATH=/opt/openocd/

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.14 Version bump reason: [Telink] Update Docker image (drivers update)
+0.7.15 Version bump reason: [Java] Set JAVA_PATH in chip-build-java and vscode


### PR DESCRIPTION
This allows vscode image and our java image to build java things by default.

Prepares ability to compile unit tests using kotlin/java by default in these images.

