### PR TITLE
Add a lint for SuccessOrExit without assignment.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -215,6 +215,14 @@ jobs:
               run: |
                   git grep -n 'SuccessOrExit(CHIP_ERROR' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we want to exclude this file,
+            # to avoid our grep regexp matching itself.
+            - name: Check for use of "SuccessOrExit(something-without-assignment(", which should probably be "SuccessOrExit(err = something("
+              if: always()
+              run: |
+                  git grep -n 'SuccessOrExit([^=)]*(' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+
             - name: Check that our hardcoded SHA for clang-format on ARM mac matches the pigweed SHA.
               if: always()
               run: |

--- a/examples/platform/nxp/se05x/DeviceAttestationSe05xCredsExample_v2.cpp
+++ b/examples/platform/nxp/se05x/DeviceAttestationSe05xCredsExample_v2.cpp
@@ -196,7 +196,7 @@ CHIP_ERROR ExampleSe05xDACProviderv2::SignWithDeviceAttestationKey(const ByteSpa
     };
 
     tempBuf[0] = (uint8_t) TLV::TLVElementType::Structure;
-    SuccessOrExit(se05xSetCertificate(START_CONTAINER_SE05X_ID, tempBuf, 1));
+    SuccessOrExit(err = se05xSetCertificate(START_CONTAINER_SE05X_ID, tempBuf, 1));
 
     for (int i = 1; i <= NO_OF_DEV_ATTEST_MSG_TAGS_TO_PARSE; i++)
     {
@@ -206,6 +206,7 @@ CHIP_ERROR ExampleSe05xDACProviderv2::SignWithDeviceAttestationKey(const ByteSpa
         {
             continue;
         }
+        // TODO: Should this be setting err = tlverr?
         SuccessOrExit(tlverr);
 
         // Transient binary object ids starting from location 0x7D300005 (TAG1_ID) to 0x7D30000D (TAG3_VALUE_ID)
@@ -215,35 +216,35 @@ CHIP_ERROR ExampleSe05xDACProviderv2::SignWithDeviceAttestationKey(const ByteSpa
         taglen     = tagReader.GetLength();
         tempBuf[0] = tagReader.GetControlByte();
         tempBuf[1] = i;
-        SuccessOrExit(se05xSetCertificate(TAG1_ID + (3 /* tag + length + value ids */ * (i - 1)), tempBuf, 2));
+        SuccessOrExit(err = se05xSetCertificate(TAG1_ID + (3 /* tag + length + value ids */ * (i - 1)), tempBuf, 2));
         if (taglen > 256)
         {
             tempBuf[0] = taglen & 0xFF;
             tempBuf[1] = (taglen >> 8) & 0xFF;
-            SuccessOrExit(se05xSetCertificate(TAG1_LEN_ID + (3 * (i - 1)), tempBuf, 2));
+            SuccessOrExit(err = se05xSetCertificate(TAG1_LEN_ID + (3 * (i - 1)), tempBuf, 2));
         }
         else
         {
             tempBuf[0] = taglen;
-            SuccessOrExit(se05xSetCertificate(TAG1_LEN_ID + (3 * (i - 1)), tempBuf, 1));
+            SuccessOrExit(err = se05xSetCertificate(TAG1_LEN_ID + (3 * (i - 1)), tempBuf, 1));
         }
         if (taglen > 0)
         {
-            SuccessOrExit(tagReader.Get(tagvalue));
-            SuccessOrExit(se05xSetCertificate(TAG1_VALUE_ID + (3 * (i - 1)), tagvalue.data(), taglen));
+            SuccessOrExit(err = tagReader.Get(tagvalue));
+            SuccessOrExit(err = se05xSetCertificate(TAG1_VALUE_ID + (3 * (i - 1)), tagvalue.data(), taglen));
         }
     }
 
     tempBuf[0] = (uint8_t) TLV::TLVElementType::EndOfContainer;
-    SuccessOrExit(se05xSetCertificate(END_CONTAINER_SE05X_ID, tempBuf, 1));
+    SuccessOrExit(err = se05xSetCertificate(END_CONTAINER_SE05X_ID, tempBuf, 1));
 
     if ((tagReader.GetRemainingLength() + 1 /* End container */) >= 16)
     {
         /* Set attestation challenge */
-        SuccessOrExit(se05xSetCertificate(ATTEST_CHALLENGE_ID, (message_to_sign.end() - 16), 16));
+        SuccessOrExit(err = se05xSetCertificate(ATTEST_CHALLENGE_ID, (message_to_sign.end() - 16), 16));
     }
 
-    SuccessOrExit(se05xPerformInternalSign(DEV_ATTESTATION_KEY_SE05X_ID_IS, signature_se05x, &signature_se05x_len));
+    SuccessOrExit(err = se05xPerformInternalSign(DEV_ATTESTATION_KEY_SE05X_ID_IS, signature_se05x, &signature_se05x_len));
 
     err = chip::Crypto::EcdsaAsn1SignatureToRaw(chip::Crypto::kP256_FE_Length, ByteSpan{ signature_se05x, signature_se05x_len },
                                                 out_signature_buffer);

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -613,7 +613,10 @@ exit:
     {
         ChipLogError(DataManagement, "AccessControl: %s %" CHIP_ERROR_FORMAT, log, err.Format());
     }
-    ChipLogError(DataManagement, "AccessControl: %s", log);
+    else
+    {
+        ChipLogError(DataManagement, "AccessControl: %s", log);
+    }
     return false;
 }
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -555,11 +555,12 @@ bool AccessControl::IsValid(const Entry & entry)
     size_t subjectCount     = 0;
     size_t targetCount      = 0;
 
-    SuccessOrExit(entry.GetAuthMode(authMode));
-    SuccessOrExit(entry.GetFabricIndex(fabricIndex));
-    SuccessOrExit(entry.GetPrivilege(privilege));
-    SuccessOrExit(entry.GetSubjectCount(subjectCount));
-    SuccessOrExit(entry.GetTargetCount(targetCount));
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    SuccessOrExit(err = entry.GetAuthMode(authMode));
+    SuccessOrExit(err = entry.GetFabricIndex(fabricIndex));
+    SuccessOrExit(err = entry.GetPrivilege(privilege));
+    SuccessOrExit(err = entry.GetSubjectCount(subjectCount));
+    SuccessOrExit(err = entry.GetTargetCount(targetCount));
 
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
     ChipLogProgress(DataManagement, "AccessControl: validating f=%u p=%c a=%c s=%d t=%d", fabricIndex,
@@ -582,7 +583,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < subjectCount; ++i)
     {
         NodeId subject;
-        SuccessOrExit(entry.GetSubject(i, subject));
+        SuccessOrExit(err = entry.GetSubject(i, subject));
         const bool kIsCase  = authMode == AuthMode::kCase;
         const bool kIsGroup = authMode == AuthMode::kGroup;
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
@@ -594,7 +595,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < targetCount; ++i)
     {
         Entry::Target target;
-        SuccessOrExit(entry.GetTarget(i, target));
+        SuccessOrExit(err = entry.GetTarget(i, target));
         const bool kHasCluster    = target.flags & Entry::Target::kCluster;
         const bool kHasEndpoint   = target.flags & Entry::Target::kEndpoint;
         const bool kHasDeviceType = target.flags & Entry::Target::kDeviceType;
@@ -608,6 +609,10 @@ bool AccessControl::IsValid(const Entry & entry)
     return true;
 
 exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DataManagement, "AccessControl: %s %" CHIP_ERROR_FORMAT, log, err.Format());
+    }
     ChipLogError(DataManagement, "AccessControl: %s", log);
     return false;
 }

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -326,7 +326,7 @@ Status CommandHandler::ProcessCommandDataIB(CommandDataIB::Parser & aCommandElem
     {
         ChipLogDetail(DataManagement, "Received command for Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
                       concretePath.mEndpointId, ChipLogValueMEI(concretePath.mClusterId), ChipLogValueMEI(concretePath.mCommandId));
-        SuccessOrExit(MatterPreCommandReceivedCallback(concretePath, GetSubjectDescriptor()));
+        SuccessOrExit(err = MatterPreCommandReceivedCallback(concretePath, GetSubjectDescriptor()));
         mpCallback->DispatchCommand(*this, concretePath, commandDataReader);
         MatterPostCommandReceivedCallback(concretePath, GetSubjectDescriptor());
     }

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -460,7 +460,7 @@ CHIP_ERROR WriteClient::OnMessageReceived(Messaging::ExchangeContext * apExchang
         if (!mChunks.IsNull())
         {
             // Send the next chunk.
-            SuccessOrExit(SendWriteRequest());
+            SuccessOrExit(err = SendWriteRequest());
         }
     }
     else if (aPayloadHeader.HasMessageType(MsgType::StatusResponse))

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -529,7 +529,7 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
         }
     }
 
-    SuccessOrExit(reportDataBuilder.GetError());
+    SuccessOrExit(err = reportDataBuilder.GetError());
     SuccessOrExit(err = reportDataWriter.UnreserveBuffer(kReservedSizeForMoreChunksFlag + kReservedSizeForIMRevision +
                                                          kReservedSizeForEndOfReportMessage));
     if (hasMoreChunks)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 
     // Set up attribute persistence before we try to bring up the data model
     // handler.
-    SuccessOrExit(mAttributePersister.Init(mDeviceStorage));
+    SuccessOrExit(err = mAttributePersister.Init(mDeviceStorage));
     SetAttributePersistenceProvider(&mAttributePersister);
 
     {

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -347,7 +347,7 @@ CHIP_ERROR SendReadRequest()
         chip::Platform::MakeUnique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(), &gExchangeManager,
                                                           gMockDelegate, chip::app::ReadClient::InteractionType::Read);
 
-    SuccessOrExit(readClient->SendRequest(readPrepareParams));
+    SuccessOrExit(err = readClient->SendRequest(readPrepareParams));
 
     gMockDelegate.AdoptReadClient(std::move(readClient));
 

--- a/src/controller/java/AndroidCommissioningWindowOpener.cpp
+++ b/src/controller/java/AndroidCommissioningWindowOpener.cpp
@@ -121,8 +121,8 @@ void AndroidCommissioningWindowOpener::OnOpenCommissioningWindowResponse(void * 
         std::string QRCode;
         std::string manualPairingCode;
 
-        SuccessOrExit(ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode));
-        SuccessOrExit(QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode));
+        SuccessOrExit(status = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode));
+        SuccessOrExit(status = QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode));
 
         if (self->mOnSuccessMethod != nullptr)
         {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1605,7 +1605,7 @@ JNI_METHOD(void, write)
     VerifyOrExit(device != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(device->GetSecureSession().HasValue(), err = CHIP_ERROR_MISSING_SECURE_SESSION);
     VerifyOrExit(attributeList != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    SuccessOrExit(JniReferences::GetInstance().GetListSize(attributeList, listSize));
+    SuccessOrExit(err = JniReferences::GetInstance().GetListSize(attributeList, listSize));
 
     writeClient = Platform::New<app::WriteClient>(device->GetExchangeManager(), callback->GetChunkedWriteCallback(),
                                                   timedRequestTimeoutMs != 0 ? Optional<uint16_t>(timedRequestTimeoutMs)
@@ -1757,7 +1757,8 @@ JNI_METHOD(void, invoke)
                                                                 "()Lchip/devicecontroller/model/ChipPathId;", &getClusterIdMethod));
     SuccessOrExit(err = JniReferences::GetInstance().FindMethod(env, invokeElement, "getCommandId",
                                                                 "()Lchip/devicecontroller/model/ChipPathId;", &getCommandIdMethod));
-    SuccessOrExit(JniReferences::GetInstance().FindMethod(env, invokeElement, "getTlvByteArray", "()[B", &getTlvByteArrayMethod));
+    SuccessOrExit(
+        err = JniReferences::GetInstance().FindMethod(env, invokeElement, "getTlvByteArray", "()[B", &getTlvByteArrayMethod));
 
     endpointIdObj = env->CallObjectMethod(invokeElement, getEndpointIdMethod);
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -153,7 +153,7 @@ PyChipError pychip_CommandSender_SendCommand(void * appContext, DeviceProxy * de
         VerifyOrExit(writer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
         reader.Init(payload, length);
         reader.Next();
-        SuccessOrExit(writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
+        SuccessOrExit(err = writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
     }
 
     SuccessOrExit(err = sender->FinishCommand(timedRequestTimeoutMs != 0 ? Optional<uint16_t>(timedRequestTimeoutMs)
@@ -197,7 +197,7 @@ PyChipError pychip_CommandSender_SendGroupCommand(chip::GroupId groupId, chip::C
         VerifyOrExit(writer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
         reader.Init(payload, length);
         reader.Next();
-        SuccessOrExit(writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
+        SuccessOrExit(err = writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
     }
 
     SuccessOrExit(err = sender->FinishCommand(Optional<uint16_t>::Missing()));

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -183,17 +183,17 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
             commissionerParams.controllerICAC                 = icacSpan;
             commissionerParams.controllerNOC                  = nocSpan;
 
-            SuccessOrExit(DeviceControllerFactory::GetInstance().Init(factoryParams));
-            err = DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, *result);
+            SuccessOrExit(err = DeviceControllerFactory::GetInstance().Init(factoryParams));
+            SuccessOrExit(err = DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, *result));
 
-            SuccessOrExit(result->GetCompressedFabricIdBytes(compressedFabricIdSpan));
+            SuccessOrExit(err = result->GetCompressedFabricIdBytes(compressedFabricIdSpan));
             ChipLogProgress(Support, "Setting up group data for Fabric Index %u with Compressed Fabric ID:",
                             static_cast<unsigned>(result->GetFabricIndex()));
             ChipLogByteSpan(Support, compressedFabricIdSpan);
 
             defaultIpk = chip::GroupTesting::DefaultIpkValue::GetDefaultIpk();
-            SuccessOrExit(chip::Credentials::SetSingleIpkEpochKey(&gGroupDataProvider, result->GetFabricIndex(), defaultIpk,
-                                                                  compressedFabricIdSpan));
+            SuccessOrExit(err = chip::Credentials::SetSingleIpkEpochKey(&gGroupDataProvider, result->GetFabricIndex(), defaultIpk,
+                                                                        compressedFabricIdSpan));
         }
     exit:
         ChipLogProgress(Controller, "Commissioner initialization status: %s", chip::ErrorStr(err));

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -940,7 +940,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     out_buf_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
     result         = EVP_PKEY_derive(context, out_secret.Bytes(), &out_buf_length);
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-    SuccessOrExit(out_secret.SetLength(out_buf_length));
+    SuccessOrExit(error = out_secret.SetLength(out_buf_length));
 
 exit:
     if (ec_key != nullptr)

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -589,7 +589,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     status = psa_raw_key_agreement(PSA_ALG_ECDH, context.key_id, remote_public_key.ConstBytes(), remote_public_key.Length(),
                                    out_secret.Bytes(), outputSize, &outputLength);
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
-    SuccessOrExit(out_secret.SetLength(outputLength));
+    SuccessOrExit(error = out_secret.SetLength(outputLength));
 
 exit:
     logPsaError(status);
@@ -1420,7 +1420,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -653,7 +653,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
 
     result = mbedtls_mpi_write_binary(&mpi_secret, out_secret.Bytes(), secret_length);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-    SuccessOrExit(out_secret.SetLength(secret_length));
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
 
 exit:
     keypair = nullptr;
@@ -1537,7 +1537,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
@@ -190,7 +190,7 @@ CHIP_ERROR P256KeypairHSM::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length
     error = EcdsaAsn1SignatureToRaw(kP256_FE_Length, ByteSpan{ signature_se05x, signature_se05x_len }, out_raw_sig_span);
     SuccessOrExit(error);
 
-    SuccessOrExit(out_signature.SetLength(2 * kP256_FE_Length));
+    SuccessOrExit(error = out_signature.SetLength(2 * kP256_FE_Length));
 
     error = CHIP_NO_ERROR;
 exit:

--- a/src/platform/Infineon/CYW30739/FactoryDataProvider.cpp
+++ b/src/platform/Infineon/CYW30739/FactoryDataProvider.cpp
@@ -111,8 +111,8 @@ CHIP_ERROR FactoryDataProvider::LoadKeypairFromDer(const ByteSpan & der_buffer, 
     mbedtls_result = mbedtls_ecp_write_key(ecp, private_key.data(), private_key.size());
     VerifyOrExit(mbedtls_result == 0, error = CHIP_ERROR_INTERNAL);
 
-    SuccessOrExit(serializedKeypair.SetLength(public_key.size() + private_key.size()));
-    SuccessOrExit(keypair.Deserialize(serializedKeypair));
+    SuccessOrExit(error = serializedKeypair.SetLength(public_key.size() + private_key.size()));
+    SuccessOrExit(error = keypair.Deserialize(serializedKeypair));
 
 exit:
     if (mbedtls_result != 0)

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -770,7 +770,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR(chip::ChipError::Range::kOS, mbed_err));
 
     dev_id_info.Init();
-    SuccessOrExit(ConfigurationMgr().GetBLEDeviceIdentificationInfo(dev_id_info));
+    SuccessOrExit(err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(dev_id_info));
     mbed_err = adv_data_builder.setServiceData(
         ShortUUID_CHIPoBLEService, mbed::make_Span<const uint8_t>(reinterpret_cast<uint8_t *>(&dev_id_info), sizeof dev_id_info));
     VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR(chip::ChipError::Range::kOS, mbed_err));

--- a/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
@@ -599,7 +599,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     result = uECC_shared_secret(remote_public_key.ConstBytes() + 1, keypair->private_key, out_secret.Bytes());
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-    SuccessOrExit(out_secret.SetLength(secret_length));
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
 
 exit:
     keypair = nullptr;
@@ -1377,7 +1377,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/platform/nxp/k32w/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
+++ b/src/platform/nxp/k32w/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
@@ -594,7 +594,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
                                       out_secret.Bytes());
     VerifyOrExit(result == gSecEcdhSuccess_c, error = CHIP_ERROR_INTERNAL);
 
-    SuccessOrExit(out_secret.SetLength(secret_length));
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
 exit:
     keypair = nullptr;
     _log_mbedTLS_error(result);
@@ -1347,7 +1347,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
@@ -569,7 +569,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     result = uECC_shared_secret(remote_public_key.ConstBytes() + 1, keypair->private_key, out_secret.Bytes());
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-    SuccessOrExit(out_secret.SetLength(secret_length));
+    SuccessOrExit(error = out_secret.SetLength(secret_length));
 
 exit:
     keypair = nullptr;
@@ -1378,7 +1378,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
@@ -773,7 +773,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
                                    &output_length);
 
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
-    SuccessOrExit(out_secret.SetLength(output_length));
+    SuccessOrExit(error = out_secret.SetLength(output_length));
 
 exit:
     _log_PSA_error(status);
@@ -1698,7 +1698,9 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         error  = CHIP_ERROR_CERT_NOT_TRUSTED;
         break;
     default:
-        SuccessOrExit((result = CertificateChainValidationResult::kInternalFrameworkError, error = CHIP_ERROR_INTERNAL));
+        result = CertificateChainValidationResult::kInternalFrameworkError;
+        error  = CHIP_ERROR_INTERNAL;
+        break;
     }
 
 exit:

--- a/src/platform/silabs/efr32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/silabs/efr32/Efr32PsaOpaqueKeypair.cpp
@@ -422,7 +422,7 @@ CHIP_ERROR EFR32OpaqueP256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t ms
     error = Sign(msg, msg_length, out_signature.Bytes(), out_signature.Capacity(), &output_length);
 
     SuccessOrExit(error);
-    SuccessOrExit(out_signature.SetLength(output_length));
+    SuccessOrExit(error = out_signature.SetLength(output_length));
 exit:
     return error;
 }
@@ -437,7 +437,7 @@ CHIP_ERROR EFR32OpaqueP256Keypair::ECDH_derive_secret(const P256PublicKey & remo
                    (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length(), &output_length);
 
     SuccessOrExit(error);
-    SuccessOrExit(out_secret.SetLength(output_length));
+    SuccessOrExit(error = out_secret.SetLength(output_length));
 exit:
     return error;
 }

--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -94,13 +94,13 @@ BufferWriter & TransferInit::WriteToBuffer(BufferWriter & aBuffer) const
 
 CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t proposedTransferCtl;
     uint32_t tmpUint32Value = 0; // Used for reading non-wide length and offset fields
     uint8_t * bufStart      = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
 
-    SuccessOrExit(bufReader.Read8(&proposedTransferCtl).Read8(mRangeCtlFlags.RawStorage()).Read16(&MaxBlockSize).StatusCode());
+    ReturnErrorOnFailure(
+        bufReader.Read8(&proposedTransferCtl).Read8(mRangeCtlFlags.RawStorage()).Read16(&MaxBlockSize).StatusCode());
 
     Version = proposedTransferCtl & kVersionMask;
     TransferCtlOptions.SetRaw(static_cast<uint8_t>(proposedTransferCtl & ~kVersionMask));
@@ -110,11 +110,11 @@ CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
     {
         if (mRangeCtlFlags.Has(RangeControlFlags::kWiderange))
         {
-            SuccessOrExit(bufReader.Read64(&StartOffset).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read64(&StartOffset).StatusCode());
         }
         else
         {
-            SuccessOrExit(bufReader.Read32(&tmpUint32Value).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read32(&tmpUint32Value).StatusCode());
             StartOffset = tmpUint32Value;
         }
     }
@@ -124,18 +124,18 @@ CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
     {
         if (mRangeCtlFlags.Has(RangeControlFlags::kWiderange))
         {
-            SuccessOrExit(bufReader.Read64(&MaxLength).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read64(&MaxLength).StatusCode());
         }
         else
         {
-            SuccessOrExit(bufReader.Read32(&tmpUint32Value).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read32(&tmpUint32Value).StatusCode());
             MaxLength = tmpUint32Value;
         }
     }
 
-    SuccessOrExit(bufReader.Read16(&FileDesLength).StatusCode());
+    ReturnErrorOnFailure(bufReader.Read16(&FileDesLength).StatusCode());
 
-    VerifyOrExit(bufReader.HasAtLeast(FileDesLength), err = CHIP_ERROR_MESSAGE_INCOMPLETE);
+    VerifyOrReturnError(bufReader.HasAtLeast(FileDesLength), CHIP_ERROR_MESSAGE_INCOMPLETE);
     FileDesignator = &bufStart[bufReader.OctetsRead()];
 
     // Rest of message is metadata (could be empty)
@@ -151,12 +151,7 @@ CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
     // Retain ownership of the packet buffer so that the FileDesignator and Metadata pointers remain valid.
     Buffer = std::move(aBuffer);
 
-exit:
-    if (bufReader.StatusCode() != CHIP_NO_ERROR)
-    {
-        err = bufReader.StatusCode();
-    }
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 size_t TransferInit::MessageSize() const
@@ -235,12 +230,11 @@ Encoding::LittleEndian::BufferWriter & SendAccept::WriteToBuffer(Encoding::Littl
 
 CHIP_ERROR SendAccept::Parse(System::PacketBufferHandle aBuffer)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
     uint8_t transferCtl = 0;
     uint8_t * bufStart  = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
 
-    SuccessOrExit(bufReader.Read8(&transferCtl).Read16(&MaxBlockSize).StatusCode());
+    ReturnErrorOnFailure(bufReader.Read8(&transferCtl).Read16(&MaxBlockSize).StatusCode());
 
     Version = transferCtl & kVersionMask;
 
@@ -259,12 +253,7 @@ CHIP_ERROR SendAccept::Parse(System::PacketBufferHandle aBuffer)
     // Retain ownership of the packet buffer so that the Metadata pointer remains valid.
     Buffer = std::move(aBuffer);
 
-exit:
-    if (bufReader.StatusCode() != CHIP_NO_ERROR)
-    {
-        err = bufReader.StatusCode();
-    }
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 size_t SendAccept::MessageSize() const
@@ -349,13 +338,12 @@ Encoding::LittleEndian::BufferWriter & ReceiveAccept::WriteToBuffer(Encoding::Li
 
 CHIP_ERROR ReceiveAccept::Parse(System::PacketBufferHandle aBuffer)
 {
-    CHIP_ERROR err          = CHIP_NO_ERROR;
     uint8_t transferCtl     = 0;
     uint32_t tmpUint32Value = 0; // Used for reading non-wide length and offset fields
     uint8_t * bufStart      = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
 
-    SuccessOrExit(bufReader.Read8(&transferCtl).Read8(mRangeCtlFlags.RawStorage()).Read16(&MaxBlockSize).StatusCode());
+    ReturnErrorOnFailure(bufReader.Read8(&transferCtl).Read8(mRangeCtlFlags.RawStorage()).Read16(&MaxBlockSize).StatusCode());
 
     Version = transferCtl & kVersionMask;
 
@@ -367,11 +355,11 @@ CHIP_ERROR ReceiveAccept::Parse(System::PacketBufferHandle aBuffer)
     {
         if (mRangeCtlFlags.Has(RangeControlFlags::kWiderange))
         {
-            SuccessOrExit(bufReader.Read64(&StartOffset).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read64(&StartOffset).StatusCode());
         }
         else
         {
-            SuccessOrExit(bufReader.Read32(&tmpUint32Value).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read32(&tmpUint32Value).StatusCode());
             StartOffset = tmpUint32Value;
         }
     }
@@ -381,11 +369,11 @@ CHIP_ERROR ReceiveAccept::Parse(System::PacketBufferHandle aBuffer)
     {
         if (mRangeCtlFlags.Has(RangeControlFlags::kWiderange))
         {
-            SuccessOrExit(bufReader.Read64(&Length).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read64(&Length).StatusCode());
         }
         else
         {
-            SuccessOrExit(bufReader.Read32(&tmpUint32Value).StatusCode());
+            ReturnErrorOnFailure(bufReader.Read32(&tmpUint32Value).StatusCode());
             Length = tmpUint32Value;
         }
     }
@@ -402,12 +390,7 @@ CHIP_ERROR ReceiveAccept::Parse(System::PacketBufferHandle aBuffer)
     // Retain ownership of the packet buffer so that the Metadata pointer remains valid.
     Buffer = std::move(aBuffer);
 
-exit:
-    if (bufReader.StatusCode() != CHIP_NO_ERROR)
-    {
-        err = bufReader.StatusCode();
-    }
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 size_t ReceiveAccept::MessageSize() const
@@ -507,11 +490,10 @@ Encoding::LittleEndian::BufferWriter & DataBlock::WriteToBuffer(Encoding::Little
 
 CHIP_ERROR DataBlock::Parse(System::PacketBufferHandle aBuffer)
 {
-    CHIP_ERROR err     = CHIP_NO_ERROR;
     uint8_t * bufStart = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
 
-    SuccessOrExit(bufReader.Read32(&BlockCounter).StatusCode());
+    ReturnErrorOnFailure(bufReader.Read32(&BlockCounter).StatusCode());
 
     // Rest of message is data
     Data       = nullptr;
@@ -525,12 +507,7 @@ CHIP_ERROR DataBlock::Parse(System::PacketBufferHandle aBuffer)
     // Retain ownership of the packet buffer so that the Data pointer remains valid.
     Buffer = std::move(aBuffer);
 
-exit:
-    if (bufReader.StatusCode() != CHIP_NO_ERROR)
-    {
-        err = bufReader.StatusCode();
-    }
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 size_t DataBlock::MessageSize() const
@@ -586,18 +563,10 @@ Encoding::LittleEndian::BufferWriter & BlockQueryWithSkip::WriteToBuffer(Encodin
 
 CHIP_ERROR BlockQueryWithSkip::Parse(System::PacketBufferHandle aBuffer)
 {
-    CHIP_ERROR err     = CHIP_NO_ERROR;
     uint8_t * bufStart = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
-    SuccessOrExit(bufReader.Read32(&BlockCounter).StatusCode());
-    SuccessOrExit(bufReader.Read64(&BytesToSkip).StatusCode());
 
-exit:
-    if (bufReader.StatusCode() != CHIP_NO_ERROR)
-    {
-        err = bufReader.StatusCode();
-    }
-    return err;
+    return bufReader.Read32(&BlockCounter).Read64(&BytesToSkip).StatusCode();
 }
 
 size_t BlockQueryWithSkip::MessageSize() const

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -2075,7 +2075,7 @@ CHIP_ERROR CASESession::OnMessageReceived(ExchangeContext * ec, const PayloadHea
         msgType == Protocols::SecureChannel::MsgType::CASE_Sigma2Resume ||
         msgType == Protocols::SecureChannel::MsgType::CASE_Sigma3)
     {
-        SuccessOrExit(mExchangeCtxt->FlushAcks());
+        SuccessOrExit(err = mExchangeCtxt->FlushAcks());
     }
 #endif // CHIP_CONFIG_SLOW_CRYPTO
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -829,7 +829,7 @@ CHIP_ERROR PASESession::OnMessageReceived(ExchangeContext * exchange, const Payl
     if (msgType == MsgType::PBKDFParamRequest || msgType == MsgType::PBKDFParamResponse || msgType == MsgType::PASE_Pake1 ||
         msgType == MsgType::PASE_Pake2 || msgType == MsgType::PASE_Pake3)
     {
-        SuccessOrExit(mExchangeCtxt->FlushAcks());
+        SuccessOrExit(err = mExchangeCtxt->FlushAcks());
     }
 #endif // CHIP_CONFIG_SLOW_CRYPTO
 


### PR DESCRIPTION
This is almost always a mistake, since it loses track of the error involved.

