### PR TITLE
[ESP32] Kconfig fixes and link error fix for h2 (v1.1 cherrypick of PR26825)

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -359,6 +359,9 @@ endif()
 if(CONFIG_OPENTHREAD_ENABLED)
     idf_component_get_property(openthread_lib openthread COMPONENT_LIB)
     list(APPEND chip_libraries $<TARGET_FILE:${openthread_lib}>)
+
+    idf_component_get_property(ieee802154_lib ieee802154 COMPONENT_LIB)
+    list(APPEND chip_libraries $<TARGET_FILE:${ieee802154_lib}>)
 endif()
 
 if((NOT CONFIG_USE_MINIMAL_MDNS) AND (CONFIG_ENABLE_WIFI_STATION OR CONFIG_ENABLE_WIFI_AP))
@@ -435,6 +438,12 @@ list(APPEND chip_libraries $<TARGET_FILE:${soc_lib}>)
 
 idf_component_get_property(efuse_lib efuse COMPONENT_LIB)
 list(APPEND chip_libraries $<TARGET_FILE:${efuse_lib}>)
+
+idf_component_get_property(vfs_lib vfs COMPONENT_LIB)
+list(APPEND chip_libraries $<TARGET_FILE:${vfs_lib}>)
+
+idf_component_get_property(driver_lib driver COMPONENT_LIB)
+list(APPEND chip_libraries $<TARGET_FILE:${driver_lib}>)
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group
                                                 ${chip_libraries}

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -705,12 +705,9 @@ menu "CHIP Device Layer"
             depends on SEC_CERT_DAC_PROVIDER && SOC_ECDSA_SUPPORTED
             default y
             select MBEDTLS_HARDWARE_ECDSA_SIGN
-            select ENABLE_ESP32_FACTORY_DATA_PROVIDER
-            select ENABLE_ESP32_DEVICE_INSTANCE_INFO_PROVIDER
             help
                 If DAC is being read from secure cert and SOC supports ECDSA signing using on-chip peripheral
-                then this option gets enabled. This option also selects few more that are required for commissioning
-                the device.
+                then this option gets enabled.
                 Also, please disable ESP_SECURE_CERT_DS_PERIPHERAL from the menuconfig when this option is disabled
 
     endmenu


### PR DESCRIPTION
* Do not select factory data provider and device instance info provider when secure cert dac provider is selected

* Fix the linker error when building for esp32h2
