### PR TITLE
[Shell] Add vTaskDelay to release CPU usage

### DIFF
--- a/examples/platform/ameba/shell/launch_shell.cpp
+++ b/examples/platform/ameba/shell/launch_shell.cpp
@@ -27,9 +27,7 @@ namespace {
 
 void MatterShellTask(void * args)
 {
-    const TickType_t xDelay = 1000 / portTICK_PERIOD_MS;
     chip::Shell::Engine::Root().RunMainLoop();
-    vTaskDelay(xDelay);
 }
 
 } // namespace

--- a/examples/platform/ameba/shell/launch_shell.cpp
+++ b/examples/platform/ameba/shell/launch_shell.cpp
@@ -27,7 +27,9 @@ namespace {
 
 void MatterShellTask(void * args)
 {
+    const TickType_t xDelay = 1000 / portTICK_PERIOD_MS;
     chip::Shell::Engine::Root().RunMainLoop();
+    vTaskDelay(xDelay);
 }
 
 } // namespace

--- a/src/lib/shell/MainLoopAmeba.cpp
+++ b/src/lib/shell/MainLoopAmeba.cpp
@@ -146,6 +146,7 @@ void Engine::RunMainLoop()
             ProcessShellLine(reinterpret_cast<intptr_t>(line));
 #endif
         }
+        vTaskDelay(pdMS_TO_TICKS(10)); // delay 10ms
     }
 }
 


### PR DESCRIPTION
- Without TaskDelay, Matter Shell task will occupy over 80% of CPU.