### PR TITLE
[matter_yamltests] Increase the keep alive timeout for websockets

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
@@ -22,6 +22,8 @@ import websockets
 from .hooks import WebSocketRunnerHooks
 from .runner import TestRunner
 
+_KEEP_ALIVE_TIMEOUT_IN_SECONDS = 40
+
 
 @dataclass
 class WebSocketRunnerConfig:
@@ -65,7 +67,7 @@ class WebSocketRunner(TestRunner):
             start = time.time()
             try:
                 self._hooks.connecting(url)
-                connection = await websockets.connect(url)
+                connection = await websockets.connect(url, ping_timeout=_KEEP_ALIVE_TIMEOUT_IN_SECONDS)
                 duration = round((time.time() - start) * 1000, 0)
                 self._hooks.success(duration)
                 return connection


### PR DESCRIPTION
#### Problem

When running the YAML tests over WebSocket in CI it seems that we are sometimes loosing the TCP connection with an error:
```
websockets.exceptions.ConnectionClosedError: sent 1011 (unexpected error) keepalive ping timeout; no close frame received
```

Some examples of such failures are https://github.com/project-chip/connectedhomeip/actions/runs/5074186491/jobs/9114097979 and https://github.com/project-chip/connectedhomeip/actions/runs/5080391093/jobs/9127295759?pr=26822

My current theory is that keep-alive ping-pong takes times on some CI runs because of the machine where it is running beeing under heavy load and the commissioner and commissionee are already busy sending pairing messages.
If that is, incrementing the keep-alive timeout should be enough to solve the issue. This PR raise the default keep-alive timeout from `20` to `40` seconds.
