### PR TITLE
[matter_yamltests] Replace python 3.9 list/tuple syntax with typing.List/typing.Tuple

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -18,6 +18,7 @@
 import re
 import string
 from abc import ABC, abstractmethod
+from typing import List
 
 from .errors import TestStepError
 
@@ -759,7 +760,7 @@ class _ConstraintAnyOf(BaseConstraint):
         return f'The response value "{value}" is not a value from {self._any_of}.'
 
 
-def get_constraints(constraints: dict) -> list[BaseConstraint]:
+def get_constraints(constraints: dict) -> List[BaseConstraint]:
     _constraints = []
     context = constraints
 

--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -161,17 +161,17 @@ class SpecDefinitions:
 
         return None
 
-    def get_command_names(self, cluster_name: str) -> list[str]:
+    def get_command_names(self, cluster_name: str) -> List[str]:
         targets = self.__get_targets_by_cluster_name(
             cluster_name, _ItemType.Request)
         return [] if targets is None else [name for name in targets]
 
-    def get_event_names(self, cluster_name: str) -> list[str]:
+    def get_event_names(self, cluster_name: str) -> List[str]:
         targets = self.__get_targets_by_cluster_name(
             cluster_name, _ItemType.Event)
         return [] if targets is None else [name for name in targets]
 
-    def get_attribute_names(self, cluster_name: str) -> list[str]:
+    def get_attribute_names(self, cluster_name: str) -> List[str]:
         targets = self.__get_targets_by_cluster_name(
             cluster_name, _ItemType.Attribute)
         return [] if targets is None else [name for name in targets]

--- a/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser_builder.py
@@ -16,6 +16,7 @@
 import copy
 import time
 from dataclasses import dataclass, field
+from typing import List
 
 from .hooks import TestParserHooks
 from .parser import TestParser, TestParserConfig
@@ -50,7 +51,7 @@ class TestParserBuilderConfig:
            parsing. It may may allow the callers to gain insights about the
            current parsing state.
     """
-    tests: list[str] = field(default_factory=list)
+    tests: List[str] = field(default_factory=list)
     parser_config: TestParserConfig = field(default_factory=TestParserConfig)
     hooks: TestParserHooks = TestParserHooks()
     options: TestParserBuilderOptions = field(

--- a/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pics_checker.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 
 import unicodedata
+from typing import List
 
 _COMMENT_CHARACTER = '#'
 _VALUE_SEPARATOR = '='
@@ -78,7 +79,7 @@ class PICSChecker():
                 line = f.readline()
         return pics
 
-    def __evaluate_expression(self, tokens: list[str], pics: dict):
+    def __evaluate_expression(self, tokens: List[str], pics: dict):
         leftExpr = self.__evaluate_sub_expression(tokens, pics)
         if self.__expression_index >= len(tokens):
             return leftExpr
@@ -102,7 +103,7 @@ class PICSChecker():
 
         raise InvalidPICSParsingError(f'Unknown token: {token}')
 
-    def __evaluate_sub_expression(self, tokens: list[str], pics: dict):
+    def __evaluate_sub_expression(self, tokens: List[str], pics: dict):
         token = tokens[self.__expression_index]
         if token == '(':
             self.__expression_index += 1

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from typing import List
+
 from .clusters.commissioner_commands import CommissionerCommands
 from .clusters.delay_commands import DelayCommands
 from .clusters.discovery_commands import DiscoveryCommands
@@ -22,7 +24,7 @@ from .pseudo_cluster import PseudoCluster
 
 
 class PseudoClusters:
-    def __init__(self, clusters: list[PseudoCluster]):
+    def __init__(self, clusters: List[PseudoCluster]):
         self.clusters = clusters
 
     def supports(self, request) -> bool:

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -13,7 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import Union
+from typing import Tuple, Union
 
 from .errors import (TestStepError, TestStepGroupResponseError, TestStepInvalidTypeError, TestStepKeyError,
                      TestStepNodeIdAndGroupIdError, TestStepValueAndValuesError, TestStepVerificationStandaloneError,
@@ -33,7 +33,7 @@ import yaml
 class YamlLoader:
     """This class loads a file from the disk and validates that the content is a well formed yaml test."""
 
-    def load(self, yaml_file: str) -> tuple[str, Union[list, str], dict, list]:
+    def load(self, yaml_file: str) -> Tuple[str, Union[list, str], dict, list]:
         filename = ''
         name = ''
         pics = None

--- a/scripts/tests/yaml/chiptool.py
+++ b/scripts/tests/yaml/chiptool.py
@@ -19,6 +19,7 @@ import relative_importer  # isort: split # noqa: F401
 import asyncio
 import json
 import sys
+from typing import List
 
 import click
 from matter_chip_tool_adapter.decoder import MatterLog
@@ -31,7 +32,7 @@ _DEFAULT_EXTENSIONS_DIR = 'scripts/tests/yaml/extensions'
 
 
 @click.pass_context
-def send_yaml_command(ctx, test_name: str, server_path: str, server_arguments: str, pics: str, additional_pseudo_clusters_directory: str, commands: list[str]):
+def send_yaml_command(ctx, test_name: str, server_path: str, server_arguments: str, pics: str, additional_pseudo_clusters_directory: str, commands: List[str]):
     kwargs = {'test_name': test_name, 'pics': pics, 'additional_pseudo_clusters_directory': additional_pseudo_clusters_directory}
 
     index = 0
@@ -125,7 +126,7 @@ def maybe_update_stop_on_error(ctx):
 @click.argument('commands', nargs=-1)
 @chiptool_runner_options
 @click.pass_context
-def chiptool_py(ctx, commands: list[str], server_path: str, server_name: str, server_arguments: str, trace_file: str, trace_decode: bool, delay_in_ms: int, continueonfailure: bool, pics: str, additional_pseudo_clusters_directory: str):
+def chiptool_py(ctx, commands: List[str], server_path: str, server_name: str, server_arguments: str, trace_file: str, trace_decode: bool, delay_in_ms: int, continueonfailure: bool, pics: str, additional_pseudo_clusters_directory: str):
     success = False
 
     server_arguments = maybe_update_server_arguments(ctx)

--- a/scripts/tests/yaml/tests_finder.py
+++ b/scripts/tests/yaml/tests_finder.py
@@ -15,6 +15,7 @@
 
 import json
 import os.path
+from typing import List
 
 import click
 
@@ -40,7 +41,7 @@ class TestsFinder:
     def get_default_configuration_name() -> str:
         return _CI_CONFIGURATION_NAME
 
-    def get(self, test_name: str) -> list[str]:
+    def get(self, test_name: str) -> List[str]:
         test_names = []
 
         if self.__test_collections and test_name == _KEYWORD_ALL_TESTS:
@@ -54,7 +55,7 @@ class TestsFinder:
 
         return self.__get_paths(test_names)
 
-    def __get_collections(self, configuration_directory: str, configuration_name: str) -> list[str]:
+    def __get_collections(self, configuration_directory: str, configuration_name: str) -> List[str]:
         if os.path.isfile(configuration_name):
             configuration_filepath = configuration_name
         elif os.path.isfile(os.path.join(configuration_directory, configuration_name + _JSON_FILE_EXTENSION)):
@@ -82,7 +83,7 @@ class TestsFinder:
 
         return collections
 
-    def __get_paths(self, test_names: list[str]) -> list[str]:
+    def __get_paths(self, test_names: List[str]) -> List[str]:
         paths = []
 
         for name in test_names:


### PR DESCRIPTION
#### Problem

In `scripts/py_matter_yamltests/matter_yamltests/__init__.py` the minimum python version is `3.7` but `scripts/py_matter_yamltests/matter_yamltests` seems to contains specific python `3.9` syntax which makes it impossible to run.

