### PR TITLE
Make java UTF-8 decode more lenient

### DIFF
--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -410,7 +410,8 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
     // As a result call:
     //   onMalformedInput(CodingErrorAction.REPLACE)
     //   onUnmappableCharacter(CodingErrorAction.REPLACE)
-    jobject replaceAction = env->GetStaticObjectField(env->GetStaticFieldID(env->FindClass("java/nio/charset/CodingErrorAction"),
+    jclass codingErrorActionClass =env->FindClass("java/nio/charset/CodingErrorAction");
+    jobject replaceAction = env->GetStaticObjectField(codingErrorActionClass, env->GetStaticFieldID(codingErrorActionClass,
                                                                             "REPLACE", "Ljava/nio/charset/CodingErrorAction"));
     {
         jmethodID onMalformedInput = env->GetMethodID(charSetDocoderClass, "onMalformedInput",
@@ -437,7 +438,7 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
         // an error will be reported.
         ChipLogError(Support, "Exception encountered trying to decode a UTF string.");
         env->ExceptionDescribe();
-        env->ClearException();
+        env->ExceptionClear();
         return CHIP_JNI_ERROR_EXCEPTION_THROWN;
     }
 

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -410,9 +410,9 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
     // As a result call:
     //   onMalformedInput(CodingErrorAction.REPLACE)
     //   onUnmappableCharacter(CodingErrorAction.REPLACE)
-    jclass codingErrorActionClass =env->FindClass("java/nio/charset/CodingErrorAction");
-    jobject replaceAction = env->GetStaticObjectField(codingErrorActionClass, env->GetStaticFieldID(codingErrorActionClass,
-                                                                            "REPLACE", "Ljava/nio/charset/CodingErrorAction;"));
+    jclass codingErrorActionClass = env->FindClass("java/nio/charset/CodingErrorAction");
+    jobject replaceAction         = env->GetStaticObjectField(
+        codingErrorActionClass, env->GetStaticFieldID(codingErrorActionClass, "REPLACE", "Ljava/nio/charset/CodingErrorAction;"));
     {
         jmethodID onMalformedInput = env->GetMethodID(charSetDocoderClass, "onMalformedInput",
                                                       "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -412,7 +412,7 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
     //   onUnmappableCharacter(CodingErrorAction.REPLACE)
     jclass codingErrorActionClass =env->FindClass("java/nio/charset/CodingErrorAction");
     jobject replaceAction = env->GetStaticObjectField(codingErrorActionClass, env->GetStaticFieldID(codingErrorActionClass,
-                                                                            "REPLACE", "Ljava/nio/charset/CodingErrorAction"));
+                                                                            "REPLACE", "Ljava/nio/charset/CodingErrorAction;"));
     {
         jmethodID onMalformedInput = env->GetMethodID(charSetDocoderClass, "onMalformedInput",
                                                       "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -408,17 +408,19 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
     // like in a very common 'subscribe *')
     //
     // As a result call:
-    //   onMalformedInput(CodingErrorAction.REPLACE) 
+    //   onMalformedInput(CodingErrorAction.REPLACE)
     //   onUnmappableCharacter(CodingErrorAction.REPLACE)
     jobject replaceAction = env->GetStaticObjectField(env->GetStaticFieldID(env->FindClass("java/nio/charset/CodingErrorAction"),
-                                                                            "REPLACE",
-                                                                            "Ljava/nio/charset/CodingErrorAction"));
+                                                                            "REPLACE", "Ljava/nio/charset/CodingErrorAction"));
     {
-        jmethodID onMalformedInput = env->GetMethodID(charSetDocoderClass, "onMalformedInput", "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");
-        decoderObject = env->CallObjectMethod(decoderObject, onMalformedInput, replaceAction);
+        jmethodID onMalformedInput = env->GetMethodID(charSetDocoderClass, "onMalformedInput",
+                                                      "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");
+        decoderObject              = env->CallObjectMethod(decoderObject, onMalformedInput, replaceAction);
     }
     {
-        jmethodID onUnmappableCharacter = env->GetMethodID(charSetDocoderClass, "onUnmappableCharacter", "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");
+        jmethodID onUnmappableCharacter =
+            env->GetMethodID(charSetDocoderClass, "onUnmappableCharacter",
+                             "(Ljava/nio/charset/CodingErrorAction;)Ljava/nio/charset/CharsetDecoder;");
         decoderObject = env->CallObjectMethod(decoderObject, onUnmappableCharacter, replaceAction);
     }
 
@@ -429,7 +431,8 @@ CHIP_ERROR JniReferences::CharToStringUTF(const chip::CharSpan & charSpan, jobje
     // If decode exception occur, outStr will be set null.
     outStr = nullptr;
 
-    if (env->ExceptionCheck()) {
+    if (env->ExceptionCheck())
+    {
         // If there is an exception, decode will not fail. Instead just
         // an error will be reported.
         ChipLogError(Support, "Exception encountered trying to decode a UTF string.");


### PR DESCRIPTION
Previous code would throw an exception on invalid UTF8 characters and we found certified devices sending out such invalid data (even though spec mandates utf8). Before this change we would see (with modified test app):

```
Exception in thread "main" [1685120698.530851][107326:107328] CHIP:SPT: Exception encountered trying to decode a UTF string.
java.nio.charset.MalformedInputException: Input length = 1
        at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
        at java.nio.charset.CharsetDecoder.decode(CharsetDecoder.java:816)
...
```

after this we can decode:

```
DATA: startup�
```

for a string of  `char bad[] = {0x73, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, (char)0x91, 0x00};`
.

Also fixed environment exception check: an exception check was done without clearing the current active exception. Updated code to correctly clear the active exception.

Testing:
  - manually tested by modfying src/controller/java/CHIPDeviceController-JNI.cpp to attempt an invaloid utf8 string conversion and see the result. It failed before the change, succeeded after.

