### PR TITLE
Do not re-download java dependencies every time.

### DIFF
--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -24,10 +24,10 @@ function download_maven_jar() {
   _MAVEN_PATH=$1
   _JAR_NAME=$2
 
-  if [ ! -f "third_party/java_deps/artifacts/${_JAR_NAME}" ]; then
+  if [ ! -f "third_party/java_deps/artifacts/$_JAR_NAME" ]; then
     curl --fail --location --silent --show-error \
-         "https://repo1.maven.org/maven2/${_MAVEN_PATH}/${_JAR_NAME}" \
-         -o "third_party/java_deps/artifacts/${_JAR_NAME}"
+         "https://repo1.maven.org/maven2/$_MAVEN_PATH/$_JAR_NAME" \
+         -o "third_party/java_deps/artifacts/$_JAR_NAME"
   fi
 }
 

--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -21,14 +21,14 @@ set -e
 mkdir -p third_party/java_deps/artifacts
 
 function download_maven_jar() {
-  _MAVEN_PATH=$1
-  _JAR_NAME=$2
+    _MAVEN_PATH=$1
+    _JAR_NAME=$2
 
-  if [ ! -f "third_party/java_deps/artifacts/$_JAR_NAME" ]; then
-    curl --fail --location --silent --show-error \
-         "https://repo1.maven.org/maven2/$_MAVEN_PATH/$_JAR_NAME" \
-         -o "third_party/java_deps/artifacts/$_JAR_NAME"
-  fi
+    if [ ! -f "third_party/java_deps/artifacts/$_JAR_NAME" ]; then
+        curl --fail --location --silent --show-error \
+            "https://repo1.maven.org/maven2/$_MAVEN_PATH/$_JAR_NAME" \
+            -o "third_party/java_deps/artifacts/$_JAR_NAME"
+    fi
 }
 
 download_maven_jar "com/google/code/findbugs/jsr305/3.0.2" "jsr305-3.0.2.jar"

--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -16,12 +16,26 @@
 #    limitations under the License.
 #
 
+set -e
+
 mkdir -p third_party/java_deps/artifacts
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar -o third_party/java_deps/artifacts/jsr305-3.0.2.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar -o third_party/java_deps/artifacts/json-20220924.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.10/kotlin-stdlib-1.8.10.jar -o third_party/java_deps/artifacts/kotlin-stdlib-1.8.10.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-test/1.8.10/kotlin-test-1.8.10.jar -o third_party/java_deps/artifacts/kotlin-test-1.8.10.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.22.0/protobuf-java-3.22.0.jar -o third_party/java_deps/artifacts/protobuf-java-3.22.0.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/truth/truth/1.1.3/truth-1.1.3.jar -o third_party/java_deps/artifacts/truth-1.1.3.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar -o third_party/java_deps/artifacts/junit-4.13.2.jar
-curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.1/gson-2.9.1.jar -o third_party/java_deps/artifacts/gson-2.9.1.jar
+
+function download_maven_jar() {
+  _MAVEN_PATH=$1
+  _JAR_NAME=$2
+
+  if [ ! -f "third_party/java_deps/artifacts/${_JAR_NAME}" ]; then
+    curl --fail --location --silent --show-error \
+         "https://repo1.maven.org/maven2/${_MAVEN_PATH}/${_JAR_NAME}" \
+         -o "third_party/java_deps/artifacts/${_JAR_NAME}"
+  fi
+}
+
+download_maven_jar "com/google/code/findbugs/jsr305/3.0.2" "jsr305-3.0.2.jar"
+download_maven_jar "org/json/json/20220924" "json-20220924.jar"
+download_maven_jar "org/jetbrains/kotlin/kotlin-stdlib/1.8.10" "kotlin-stdlib-1.8.10.jar"
+download_maven_jar "org/jetbrains/kotlin/kotlin-test/1.8.10" "kotlin-test-1.8.10.jar"
+download_maven_jar "com/google/protobuf/protobuf-java/3.22.0" "protobuf-java-3.22.0.jar"
+download_maven_jar "com/google/truth/truth/1.1.3" "truth-1.1.3.jar"
+download_maven_jar "junit/junit/4.13.2" "junit-4.13.2.jar"
+download_maven_jar "com/google/code/gson/gson/2.9.1" "gson-2.9.1.jar"


### PR DESCRIPTION
This moves java dependency download time from 800ms to 15ms after the initial download.
If we get more dependencies, the savings should be even better.

Changes:
  - check if the destination file exists before attempting to re-download the file
  - make the script error out if any of the downloads fail
