### PR TITLE
Use AsData and AsString more uniformly in Darwin code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -28,6 +28,8 @@
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"
 #import "MTRSetupPayload_Internal.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include "app/ConcreteAttributePath.h"
 #include "app/ConcreteCommandPath.h"
@@ -522,26 +524,27 @@ id _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data
             dictionaryWithObjectsAndKeys:MTRDoubleValueType, MTRTypeKey, [NSNumber numberWithDouble:val], MTRValueKey, nil];
     }
     case chip::TLV::kTLVType_UTF8String: {
-        uint32_t len = data->GetLength();
-        const uint8_t * ptr;
-        CHIP_ERROR err = data->GetDataPtr(ptr);
+        CharSpan stringValue;
+        CHIP_ERROR err = data->Get(stringValue);
         if (err != CHIP_NO_ERROR) {
             MTR_LOG_ERROR("Error(%s): TLV UTF8String decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary dictionaryWithObjectsAndKeys:MTRUTF8StringValueType, MTRTypeKey,
-                             [[NSString alloc] initWithBytes:ptr length:len encoding:NSUTF8StringEncoding], MTRValueKey, nil];
+        NSString * stringObj = AsString(stringValue);
+        if (stringObj == nil) {
+            MTR_LOG_ERROR("Error(%s): TLV UTF8String value is not actually UTF-8", err.AsString());
+            return nil;
+        }
+        return @ { MTRTypeKey : MTRUTF8StringValueType, MTRValueKey : stringObj };
     }
     case chip::TLV::kTLVType_ByteString: {
-        uint32_t len = data->GetLength();
-        const uint8_t * ptr;
-        CHIP_ERROR err = data->GetDataPtr(ptr);
+        ByteSpan bytesValue;
+        CHIP_ERROR err = data->Get(bytesValue);
         if (err != CHIP_NO_ERROR) {
             MTR_LOG_ERROR("Error(%s): TLV ByteString decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary dictionaryWithObjectsAndKeys:MTROctetStringValueType, MTRTypeKey,
-                             [NSData dataWithBytes:ptr length:len], MTRValueKey, nil];
+        return @ { MTRTypeKey : MTROctetStringValueType, MTRValueKey : AsData(bytesValue) };
     }
     case chip::TLV::kTLVType_Null: {
         return [NSDictionary dictionaryWithObjectsAndKeys:MTRNullValueType, MTRTypeKey, nil];
@@ -653,7 +656,7 @@ static CHIP_ERROR MTREncodeTLVFromDataValueDictionary(id object, chip::TLV::TLVW
             MTR_LOG_ERROR("Error: Object to encode has corrupt UTF8 string type: %@", [value class]);
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        return writer.PutString(tag, [value cStringUsingEncoding:NSUTF8StringEncoding]);
+        return writer.PutString(tag, [value UTF8String]);
     }
     if ([typeName isEqualToString:MTROctetStringValueType]) {
         if (![value isKindOfClass:[NSData class]]) {

--- a/src/darwin/Framework/CHIP/MTRFabricInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRFabricInfo.mm
@@ -65,7 +65,7 @@ static bool FetchCerts(MTRCertificateDERBytes __strong & cert, MTRCertificateTLV
         return nil;
     }
 
-    _rootPublicKey = [NSData dataWithBytes:publicKey.ConstBytes() length:publicKey.Length()];
+    _rootPublicKey = AsData(ByteSpan(publicKey.ConstBytes(), publicKey.Length()));
 
     _vendorID = @(fabricInfo.GetVendorId());
     _fabricID = @(fabricInfo.GetFabricId());

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -23,6 +23,9 @@
 
 #import "MTRKeypair.h"
 #import "MTRLogging_Internal.h"
+#import "NSDataSpanConversion.h"
+
+#include <lib/support/Span.h>
 
 using namespace chip::Crypto;
 
@@ -82,7 +85,7 @@ CHIP_ERROR MTRP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_
         MTR_LOG_ERROR("ECDSA sign msg failure: no keypair to sign with.");
         return CHIP_ERROR_INCORRECT_STATE;
     }
-    NSData * msgData = [NSData dataWithBytes:msg length:msg_length];
+    NSData * msgData = AsData(chip::ByteSpan(msg, msg_length));
     NSData * signature;
     if ([mKeypair respondsToSelector:@selector(signMessageECDSA_DER:)]) {
         signature = [mKeypair signMessageECDSA_DER:msgData];

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -23,9 +23,6 @@
 
 #import "MTRKeypair.h"
 #import "MTRLogging_Internal.h"
-#import "NSDataSpanConversion.h"
-
-#include <lib/support/Span.h>
 
 using namespace chip::Crypto;
 
@@ -85,7 +82,7 @@ CHIP_ERROR MTRP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_
         MTR_LOG_ERROR("ECDSA sign msg failure: no keypair to sign with.");
         return CHIP_ERROR_INCORRECT_STATE;
     }
-    NSData * msgData = AsData(chip::ByteSpan(msg, msg_length));
+    NSData * msgData = [NSData dataWithBytes:msg length:msg_length];
     NSData * signature;
     if ([mKeypair respondsToSelector:@selector(signMessageECDSA_DER:)]) {
         signature = [mKeypair signMessageECDSA_DER:msgData];

--- a/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
@@ -16,6 +16,7 @@
  */
 
 #import "MTRThreadOperationalDataset.h"
+#import "NSDataSpanConversion.h"
 
 #include "MTRLogging_Internal.h"
 #include <lib/support/Span.h>
@@ -62,7 +63,7 @@ size_t const MTRSizeThreadPANID = 2; // Thread's PAN ID is 2 bytes
 - (BOOL)_populateCppOperationalDataset
 {
     _cppThreadOperationalDataset.Clear();
-    _cppThreadOperationalDataset.SetNetworkName([self.networkName cStringUsingEncoding:NSUTF8StringEncoding]);
+    _cppThreadOperationalDataset.SetNetworkName(self.networkName.UTF8String);
 
     if (![self _checkDataLength:self.extendedPANID expectedLength:MTRSizeThreadExtendedPANID]) {
         MTR_LOG_ERROR("Invalid ExtendedPANID");
@@ -137,9 +138,9 @@ size_t const MTRSizeThreadPANID = 2; // Thread's PAN ID is 2 bytes
     panID = CFSwapInt16BigToHost(panID);
 
     return [self initWithNetworkName:[NSString stringWithUTF8String:networkName]
-                       extendedPANID:[NSData dataWithBytes:extendedPANID length:MTRSizeThreadExtendedPANID]
-                           masterKey:[NSData dataWithBytes:masterKey length:MTRSizeThreadMasterKey]
-                                PSKc:[NSData dataWithBytes:pskc length:MTRSizeThreadPSKc]
+                       extendedPANID:AsData(chip::ByteSpan(extendedPANID))
+                           masterKey:AsData(chip::ByteSpan(masterKey))
+                                PSKc:AsData(chip::ByteSpan(pskc))
                        channelNumber:@(channel)
                                panID:[NSData dataWithBytes:&panID length:sizeof(uint16_t)]];
 }
@@ -147,7 +148,7 @@ size_t const MTRSizeThreadPANID = 2; // Thread's PAN ID is 2 bytes
 - (NSData *)data
 {
     chip::ByteSpan span = _cppThreadOperationalDataset.AsByteSpan();
-    return [NSData dataWithBytes:span.data() length:span.size()];
+    return AsData(span);
 }
 
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -3,6 +3,8 @@
 #import "MTRAttributeTLVValueDecoder_Internal.h"
 
 #import "MTRStructsObjc.h"
+#import "NSStringSpanConversion.h"
+#import "NSDataSpanConversion.h"
 
 #include <app/data-model/Decode.h>
 #include <app/data-model/DecodableList.h>

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -4,6 +4,8 @@
 #import "MTRStructsObjc.h"
 #import "MTRCommandPayloadsObjc.h"
 #import "MTRCommandPayloads_Internal.h"
+#import "NSStringSpanConversion.h"
+#import "NSDataSpanConversion.h"
 
 #include <lib/support/TypeTraits.h>
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -5,6 +5,8 @@
 #import "MTRBaseDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
+#import "NSStringSpanConversion.h"
+#import "NSDataSpanConversion.h"
 
 #include <lib/core/TLV.h>
 #include <app/data-model/Decode.h>

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -3,6 +3,8 @@
 #import "MTREventTLVValueDecoder_Internal.h"
 
 #import "MTRStructsObjc.h"
+#import "NSStringSpanConversion.h"
+#import "NSDataSpanConversion.h"
 
 #include <app/data-model/Decode.h>
 #include <app/data-model/DecodableList.h>

--- a/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
@@ -39,9 +39,14 @@
       {{#if_is_strongly_typed_bitmap type}}
           {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}.Raw()];
       {{else if (isOctetString type)}}
-        {{target}} = [NSData dataWithBytes:{{source}}.data() length:{{source}}.size()];
+        {{target}} = AsData({{source}});
       {{else if (isCharString type)}}
-        {{target}} = [[NSString alloc] initWithBytes:{{source}}.data() length:{{source}}.size() encoding:NSUTF8StringEncoding];
+        {{target}} = AsString({{source}});
+        if ({{target}} == nil) {
+          {{! Invalid UTF-8.  Just make up an error for now. }}
+          CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+          {{errorCode}}
+        }
       {{else}}
         {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
       {{/if_is_strongly_typed_bitmap}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -18,6 +18,8 @@
 #import "MTRAttributeTLVValueDecoder_Internal.h"
 
 #import "MTRStructsObjc.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
@@ -1234,7 +1236,12 @@ static id _Nullable DecodeAttributeValueForBinaryInputBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::Description::Id: {
@@ -1245,7 +1252,12 @@ static id _Nullable DecodeAttributeValueForBinaryInputBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::InactiveText::Id: {
@@ -1256,7 +1268,12 @@ static id _Nullable DecodeAttributeValueForBinaryInputBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::OutOfService::Id: {
@@ -1993,7 +2010,7 @@ static id _Nullable DecodeAttributeValueForAccessControlCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRAccessControlClusterAccessControlExtensionStruct * newElement_0;
                 newElement_0 = [MTRAccessControlClusterAccessControlExtensionStruct new];
-                newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
+                newElement_0.data = AsData(entry_0.data);
                 newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
                 [array_0 addObject:newElement_0];
             }
@@ -2193,9 +2210,12 @@ static id _Nullable DecodeAttributeValueForActionsCluster(AttributeId aAttribute
                 MTRActionsClusterActionStruct * newElement_0;
                 newElement_0 = [MTRActionsClusterActionStruct new];
                 newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
                 newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
                 newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands.Raw()];
@@ -2227,9 +2247,12 @@ static id _Nullable DecodeAttributeValueForActionsCluster(AttributeId aAttribute
                 MTRActionsClusterEndpointListStruct * newElement_0;
                 newElement_0 = [MTRActionsClusterEndpointListStruct new];
                 newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
                 { // Scope for our temporary variables
                     auto * array_2 = [NSMutableArray new];
@@ -2266,7 +2289,12 @@ static id _Nullable DecodeAttributeValueForActionsCluster(AttributeId aAttribute
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::GeneratedCommandList::Id: {
@@ -2427,7 +2455,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::VendorID::Id: {
@@ -2449,7 +2482,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductID::Id: {
@@ -2471,7 +2509,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::Location::Id: {
@@ -2482,7 +2525,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::HardwareVersion::Id: {
@@ -2504,7 +2552,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::SoftwareVersion::Id: {
@@ -2526,7 +2579,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ManufacturingDate::Id: {
@@ -2537,7 +2595,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::PartNumber::Id: {
@@ -2548,7 +2611,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductURL::Id: {
@@ -2559,7 +2627,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductLabel::Id: {
@@ -2570,7 +2643,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::SerialNumber::Id: {
@@ -2581,7 +2659,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::LocalConfigDisabled::Id: {
@@ -2614,7 +2697,12 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::CapabilityMinima::Id: {
@@ -3138,7 +3226,12 @@ static id _Nullable DecodeAttributeValueForLocalizationConfigurationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::SupportedLocales::Id: {
@@ -3155,7 +3248,12 @@ static id _Nullable DecodeAttributeValueForLocalizationConfigurationCluster(
             while (iter_0.Next()) {
                 auto & entry_0 = iter_0.GetValue();
                 NSString * newElement_0;
-                newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+                newElement_0 = AsString(entry_0);
+                if (newElement_0 == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -3838,7 +3936,12 @@ static id _Nullable DecodeAttributeValueForPowerSourceCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::WiredAssessedInputVoltage::Id: {
@@ -4079,7 +4182,12 @@ static id _Nullable DecodeAttributeValueForPowerSourceCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::BatCommonDesignation::Id: {
@@ -4101,7 +4209,12 @@ static id _Nullable DecodeAttributeValueForPowerSourceCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::BatIECDesignation::Id: {
@@ -4112,7 +4225,12 @@ static id _Nullable DecodeAttributeValueForPowerSourceCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::BatApprovedChemistry::Id: {
@@ -4587,7 +4705,7 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRNetworkCommissioningClusterNetworkInfo * newElement_0;
                 newElement_0 = [MTRNetworkCommissioningClusterNetworkInfo new];
-                newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
+                newElement_0.networkID = AsData(entry_0.networkID);
                 newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
                 [array_0 addObject:newElement_0];
             }
@@ -4659,7 +4777,7 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [NSData dataWithBytes:cppValue.Value().data() length:cppValue.Value().size()];
+            value = AsData(cppValue.Value());
         }
         return value;
     }
@@ -4971,9 +5089,12 @@ static id _Nullable DecodeAttributeValueForGeneralDiagnosticsCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRGeneralDiagnosticsClusterNetworkInterface * newElement_0;
                 newElement_0 = [MTRGeneralDiagnosticsClusterNetworkInterface new];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.isOperational = [NSNumber numberWithBool:entry_0.isOperational];
                 if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
                     newElement_0.offPremiseServicesReachableIPv4 = nil;
@@ -4987,15 +5108,14 @@ static id _Nullable DecodeAttributeValueForGeneralDiagnosticsCluster(
                     newElement_0.offPremiseServicesReachableIPv6 =
                         [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
                 }
-                newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
-                                                              length:entry_0.hardwareAddress.size()];
+                newElement_0.hardwareAddress = AsData(entry_0.hardwareAddress);
                 { // Scope for our temporary variables
                     auto * array_2 = [NSMutableArray new];
                     auto iter_2 = entry_0.IPv4Addresses.begin();
                     while (iter_2.Next()) {
                         auto & entry_2 = iter_2.GetValue();
                         NSData * newElement_2;
-                        newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                        newElement_2 = AsData(entry_2);
                         [array_2 addObject:newElement_2];
                     }
                     CHIP_ERROR err = iter_2.GetStatus();
@@ -5011,7 +5131,7 @@ static id _Nullable DecodeAttributeValueForGeneralDiagnosticsCluster(
                     while (iter_2.Next()) {
                         auto & entry_2 = iter_2.GetValue();
                         NSData * newElement_2;
-                        newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                        newElement_2 = AsData(entry_2);
                         [array_2 addObject:newElement_2];
                     }
                     CHIP_ERROR err = iter_2.GetStatus();
@@ -5322,9 +5442,12 @@ static id _Nullable DecodeAttributeValueForSoftwareDiagnosticsCluster(
                 newElement_0 = [MTRSoftwareDiagnosticsClusterThreadMetricsStruct new];
                 newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
                 if (entry_0.name.HasValue()) {
-                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                                 length:entry_0.name.Value().size()
-                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.name = AsString(entry_0.name.Value());
+                    if (newElement_0.name == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.name = nil;
                 }
@@ -5567,9 +5690,12 @@ static id _Nullable DecodeAttributeValueForThreadNetworkDiagnosticsCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [[NSString alloc] initWithBytes:cppValue.Value().data()
-                                             length:cppValue.Value().size()
-                                           encoding:NSUTF8StringEncoding];
+            value = AsString(cppValue.Value());
+            if (value == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
         }
         return value;
     }
@@ -5614,7 +5740,7 @@ static id _Nullable DecodeAttributeValueForThreadNetworkDiagnosticsCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [NSData dataWithBytes:cppValue.Value().data() length:cppValue.Value().size()];
+            value = AsData(cppValue.Value());
         }
         return value;
     }
@@ -6323,7 +6449,7 @@ static id _Nullable DecodeAttributeValueForThreadNetworkDiagnosticsCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [NSData dataWithBytes:cppValue.Value().data() length:cppValue.Value().size()];
+            value = AsData(cppValue.Value());
         }
         return value;
     }
@@ -6530,7 +6656,7 @@ static id _Nullable DecodeAttributeValueForWiFiNetworkDiagnosticsCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [NSData dataWithBytes:cppValue.Value().data() length:cppValue.Value().size()];
+            value = AsData(cppValue.Value());
         }
         return value;
     }
@@ -7111,7 +7237,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::VendorID::Id: {
@@ -7133,7 +7264,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::NodeLabel::Id: {
@@ -7144,7 +7280,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::HardwareVersion::Id: {
@@ -7166,7 +7307,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::SoftwareVersion::Id: {
@@ -7188,7 +7334,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ManufacturingDate::Id: {
@@ -7199,7 +7350,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::PartNumber::Id: {
@@ -7210,7 +7366,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductURL::Id: {
@@ -7221,7 +7382,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductLabel::Id: {
@@ -7232,7 +7398,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::SerialNumber::Id: {
@@ -7243,7 +7414,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::Reachable::Id: {
@@ -7265,7 +7441,12 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductAppearance::Id: {
@@ -7790,11 +7971,11 @@ static id _Nullable DecodeAttributeValueForOperationalCredentialsCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTROperationalCredentialsClusterNOCStruct * newElement_0;
                 newElement_0 = [MTROperationalCredentialsClusterNOCStruct new];
-                newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
+                newElement_0.noc = AsData(entry_0.noc);
                 if (entry_0.icac.IsNull()) {
                     newElement_0.icac = nil;
                 } else {
-                    newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+                    newElement_0.icac = AsData(entry_0.icac.Value());
                 }
                 newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
                 [array_0 addObject:newElement_0];
@@ -7823,14 +8004,16 @@ static id _Nullable DecodeAttributeValueForOperationalCredentialsCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTROperationalCredentialsClusterFabricDescriptorStruct * newElement_0;
                 newElement_0 = [MTROperationalCredentialsClusterFabricDescriptorStruct new];
-                newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data()
-                                                            length:entry_0.rootPublicKey.size()];
+                newElement_0.rootPublicKey = AsData(entry_0.rootPublicKey);
                 newElement_0.vendorID = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0.vendorID)];
                 newElement_0.fabricID = [NSNumber numberWithUnsignedLongLong:entry_0.fabricID];
                 newElement_0.nodeID = [NSNumber numberWithUnsignedLongLong:entry_0.nodeID];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
+                newElement_0.label = AsString(entry_0.label);
+                if (newElement_0.label == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
                 [array_0 addObject:newElement_0];
             }
@@ -7879,7 +8062,7 @@ static id _Nullable DecodeAttributeValueForOperationalCredentialsCluster(
             while (iter_0.Next()) {
                 auto & entry_0 = iter_0.GetValue();
                 NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                newElement_0 = AsData(entry_0);
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -8103,9 +8286,12 @@ static id _Nullable DecodeAttributeValueForGroupKeyManagementCluster(
                     newElement_0.endpoints = array_2;
                 }
                 if (entry_0.groupName.HasValue()) {
-                    newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
-                                                                      length:entry_0.groupName.Value().size()
-                                                                    encoding:NSUTF8StringEncoding];
+                    newElement_0.groupName = AsString(entry_0.groupName.Value());
+                    if (newElement_0.groupName == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.groupName = nil;
                 }
@@ -8297,12 +8483,18 @@ static id _Nullable DecodeAttributeValueForFixedLabelCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRFixedLabelClusterLabelStruct * newElement_0;
                 newElement_0 = [MTRFixedLabelClusterLabelStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
-                                                            encoding:NSUTF8StringEncoding];
+                newElement_0.label = AsString(entry_0.label);
+                if (newElement_0.label == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                newElement_0.value = AsString(entry_0.value);
+                if (newElement_0.value == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -8467,12 +8659,18 @@ static id _Nullable DecodeAttributeValueForUserLabelCluster(AttributeId aAttribu
                 auto & entry_0 = iter_0.GetValue();
                 MTRUserLabelClusterLabelStruct * newElement_0;
                 newElement_0 = [MTRUserLabelClusterLabelStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
-                                                            encoding:NSUTF8StringEncoding];
+                newElement_0.label = AsString(entry_0.label);
+                if (newElement_0.label == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                newElement_0.value = AsString(entry_0.value);
+                if (newElement_0.value == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -8781,7 +8979,12 @@ static id _Nullable DecodeAttributeValueForModeSelectCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::StandardNamespace::Id: {
@@ -8814,9 +9017,12 @@ static id _Nullable DecodeAttributeValueForModeSelectCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRModeSelectClusterModeOptionStruct * newElement_0;
                 newElement_0 = [MTRModeSelectClusterModeOptionStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
+                newElement_0.label = AsString(entry_0.label);
+                if (newElement_0.label == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
                 { // Scope for our temporary variables
                     auto * array_2 = [NSMutableArray new];
@@ -9097,9 +9303,12 @@ static id _Nullable DecodeAttributeValueForTemperatureControlCluster(
                 auto & entry_0 = iter_0.GetValue();
                 MTRTemperatureControlClusterTemperatureLevelStruct * newElement_0;
                 newElement_0 = [MTRTemperatureControlClusterTemperatureLevelStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
+                newElement_0.label = AsString(entry_0.label);
+                if (newElement_0.label == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.temperatureLevel = [NSNumber numberWithUnsignedChar:entry_0.temperatureLevel];
                 [array_0 addObject:newElement_0];
             }
@@ -12264,7 +12473,12 @@ static id _Nullable DecodeAttributeValueForDoorLockCluster(AttributeId aAttribut
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::LEDSettings::Id: {
@@ -14944,7 +15158,12 @@ static id _Nullable DecodeAttributeValueForColorControlCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ColorTemperatureMireds::Id: {
@@ -15729,7 +15948,12 @@ static id _Nullable DecodeAttributeValueForBallastConfigurationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::LampManufacturer::Id: {
@@ -15740,7 +15964,12 @@ static id _Nullable DecodeAttributeValueForBallastConfigurationCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::LampRatedHours::Id: {
@@ -17273,7 +17502,12 @@ static id _Nullable DecodeAttributeValueForWakeOnLANCluster(AttributeId aAttribu
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::GeneratedCommandList::Id: {
@@ -17432,23 +17666,32 @@ static id _Nullable DecodeAttributeValueForChannelCluster(AttributeId aAttribute
                 newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
                 newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
                 if (entry_0.name.HasValue()) {
-                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                                 length:entry_0.name.Value().size()
-                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.name = AsString(entry_0.name.Value());
+                    if (newElement_0.name == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.name = nil;
                 }
                 if (entry_0.callSign.HasValue()) {
-                    newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
-                                                                     length:entry_0.callSign.Value().size()
-                                                                   encoding:NSUTF8StringEncoding];
+                    newElement_0.callSign = AsString(entry_0.callSign.Value());
+                    if (newElement_0.callSign == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.callSign = nil;
                 }
                 if (entry_0.affiliateCallSign.HasValue()) {
-                    newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
-                                                                              length:entry_0.affiliateCallSign.Value().size()
-                                                                            encoding:NSUTF8StringEncoding];
+                    newElement_0.affiliateCallSign = AsString(entry_0.affiliateCallSign.Value());
+                    if (newElement_0.affiliateCallSign == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.affiliateCallSign = nil;
                 }
@@ -17475,20 +17718,29 @@ static id _Nullable DecodeAttributeValueForChannelCluster(AttributeId aAttribute
             value = nil;
         } else {
             value = [MTRChannelClusterLineupInfoStruct new];
-            value.operatorName = [[NSString alloc] initWithBytes:cppValue.Value().operatorName.data()
-                                                          length:cppValue.Value().operatorName.size()
-                                                        encoding:NSUTF8StringEncoding];
+            value.operatorName = AsString(cppValue.Value().operatorName);
+            if (value.operatorName == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
             if (cppValue.Value().lineupName.HasValue()) {
-                value.lineupName = [[NSString alloc] initWithBytes:cppValue.Value().lineupName.Value().data()
-                                                            length:cppValue.Value().lineupName.Value().size()
-                                                          encoding:NSUTF8StringEncoding];
+                value.lineupName = AsString(cppValue.Value().lineupName.Value());
+                if (value.lineupName == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 value.lineupName = nil;
             }
             if (cppValue.Value().postalCode.HasValue()) {
-                value.postalCode = [[NSString alloc] initWithBytes:cppValue.Value().postalCode.Value().data()
-                                                            length:cppValue.Value().postalCode.Value().size()
-                                                          encoding:NSUTF8StringEncoding];
+                value.postalCode = AsString(cppValue.Value().postalCode.Value());
+                if (value.postalCode == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 value.postalCode = nil;
             }
@@ -17511,23 +17763,32 @@ static id _Nullable DecodeAttributeValueForChannelCluster(AttributeId aAttribute
             value.majorNumber = [NSNumber numberWithUnsignedShort:cppValue.Value().majorNumber];
             value.minorNumber = [NSNumber numberWithUnsignedShort:cppValue.Value().minorNumber];
             if (cppValue.Value().name.HasValue()) {
-                value.name = [[NSString alloc] initWithBytes:cppValue.Value().name.Value().data()
-                                                      length:cppValue.Value().name.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+                value.name = AsString(cppValue.Value().name.Value());
+                if (value.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 value.name = nil;
             }
             if (cppValue.Value().callSign.HasValue()) {
-                value.callSign = [[NSString alloc] initWithBytes:cppValue.Value().callSign.Value().data()
-                                                          length:cppValue.Value().callSign.Value().size()
-                                                        encoding:NSUTF8StringEncoding];
+                value.callSign = AsString(cppValue.Value().callSign.Value());
+                if (value.callSign == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 value.callSign = nil;
             }
             if (cppValue.Value().affiliateCallSign.HasValue()) {
-                value.affiliateCallSign = [[NSString alloc] initWithBytes:cppValue.Value().affiliateCallSign.Value().data()
-                                                                   length:cppValue.Value().affiliateCallSign.Value().size()
-                                                                 encoding:NSUTF8StringEncoding];
+                value.affiliateCallSign = AsString(cppValue.Value().affiliateCallSign.Value());
+                if (value.affiliateCallSign == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 value.affiliateCallSign = nil;
             }
@@ -17689,9 +17950,12 @@ static id _Nullable DecodeAttributeValueForTargetNavigatorCluster(
                 MTRTargetNavigatorClusterTargetInfoStruct * newElement_0;
                 newElement_0 = [MTRTargetNavigatorClusterTargetInfoStruct new];
                 newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -18112,12 +18376,18 @@ static id _Nullable DecodeAttributeValueForMediaInputCluster(
                 newElement_0 = [MTRMediaInputClusterInputInfoStruct new];
                 newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
                 newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
-                                                                          length:entry_0.description.size()
-                                                                        encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
+                newElement_0.descriptionString = AsString(entry_0.description);
+                if (newElement_0.descriptionString == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -18570,7 +18840,12 @@ static id _Nullable DecodeAttributeValueForContentLauncherCluster(
             while (iter_0.Next()) {
                 auto & entry_0 = iter_0.GetValue();
                 NSString * newElement_0;
-                newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+                newElement_0 = AsString(entry_0);
+                if (newElement_0 == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -18749,9 +19024,12 @@ static id _Nullable DecodeAttributeValueForAudioOutputCluster(
                 newElement_0 = [MTRAudioOutputClusterOutputInfoStruct new];
                 newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
                 newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name);
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -18953,9 +19231,12 @@ static id _Nullable DecodeAttributeValueForApplicationLauncherCluster(
             value = [MTRApplicationLauncherClusterApplicationEPStruct new];
             value.application = [MTRApplicationLauncherClusterApplicationStruct new];
             value.application.catalogVendorID = [NSNumber numberWithUnsignedShort:cppValue.Value().application.catalogVendorID];
-            value.application.applicationID = [[NSString alloc] initWithBytes:cppValue.Value().application.applicationID.data()
-                                                                       length:cppValue.Value().application.applicationID.size()
-                                                                     encoding:NSUTF8StringEncoding];
+            value.application.applicationID = AsString(cppValue.Value().application.applicationID);
+            if (value.application.applicationID == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
             if (cppValue.Value().endpoint.HasValue()) {
                 value.endpoint = [NSNumber numberWithUnsignedShort:cppValue.Value().endpoint.Value()];
             } else {
@@ -19111,7 +19392,12 @@ static id _Nullable DecodeAttributeValueForApplicationBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::VendorID::Id: {
@@ -19133,7 +19419,12 @@ static id _Nullable DecodeAttributeValueForApplicationBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::ProductID::Id: {
@@ -19157,9 +19448,12 @@ static id _Nullable DecodeAttributeValueForApplicationBasicCluster(
         MTRApplicationBasicClusterApplicationStruct * _Nonnull value;
         value = [MTRApplicationBasicClusterApplicationStruct new];
         value.catalogVendorID = [NSNumber numberWithUnsignedShort:cppValue.catalogVendorID];
-        value.applicationID = [[NSString alloc] initWithBytes:cppValue.applicationID.data()
-                                                       length:cppValue.applicationID.size()
-                                                     encoding:NSUTF8StringEncoding];
+        value.applicationID = AsString(cppValue.applicationID);
+        if (value.applicationID == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::Status::Id: {
@@ -19181,7 +19475,12 @@ static id _Nullable DecodeAttributeValueForApplicationBasicCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::AllowedVendorList::Id: {
@@ -21318,7 +21617,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             return nil;
         }
         NSData * _Nonnull value;
-        value = [NSData dataWithBytes:cppValue.data() length:cppValue.size()];
+        value = AsData(cppValue);
         return value;
     }
     case Attributes::ListInt8u::Id: {
@@ -21361,7 +21660,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             while (iter_0.Next()) {
                 auto & entry_0 = iter_0.GetValue();
                 NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                newElement_0 = AsData(entry_0);
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -21389,7 +21688,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                 MTRUnitTestingClusterTestListStructOctet * newElement_0;
                 newElement_0 = [MTRUnitTestingClusterTestListStructOctet new];
                 newElement_0.member1 = [NSNumber numberWithUnsignedLongLong:entry_0.member1];
-                newElement_0.member2 = [NSData dataWithBytes:entry_0.member2.data() length:entry_0.member2.size()];
+                newElement_0.member2 = AsData(entry_0.member2);
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -21409,7 +21708,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             return nil;
         }
         NSData * _Nonnull value;
-        value = [NSData dataWithBytes:cppValue.data() length:cppValue.size()];
+        value = AsData(cppValue);
         return value;
     }
     case Attributes::CharString::Id: {
@@ -21420,7 +21719,12 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::LongCharString::Id: {
@@ -21431,7 +21735,12 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             return nil;
         }
         NSString * _Nonnull value;
-        value = [[NSString alloc] initWithBytes:cppValue.data() length:cppValue.size() encoding:NSUTF8StringEncoding];
+        value = AsString(cppValue);
+        if (value == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         return value;
     }
     case Attributes::EpochUs::Id: {
@@ -21505,14 +21814,20 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                 if (entry_0.nullableString.IsNull()) {
                     newElement_0.nullableString = nil;
                 } else {
-                    newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
-                                                                           length:entry_0.nullableString.Value().size()
-                                                                         encoding:NSUTF8StringEncoding];
+                    newElement_0.nullableString = AsString(entry_0.nullableString.Value());
+                    if (newElement_0.nullableString == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 }
                 if (entry_0.optionalString.HasValue()) {
-                    newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
-                                                                           length:entry_0.optionalString.Value().size()
-                                                                         encoding:NSUTF8StringEncoding];
+                    newElement_0.optionalString = AsString(entry_0.optionalString.Value());
+                    if (newElement_0.optionalString == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                 } else {
                     newElement_0.optionalString = nil;
                 }
@@ -21520,10 +21835,12 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                     if (entry_0.nullableOptionalString.Value().IsNull()) {
                         newElement_0.nullableOptionalString = nil;
                     } else {
-                        newElement_0.nullableOptionalString =
-                            [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
-                                                     length:entry_0.nullableOptionalString.Value().Value().size()
-                                                   encoding:NSUTF8StringEncoding];
+                        newElement_0.nullableOptionalString = AsString(entry_0.nullableOptionalString.Value().Value());
+                        if (newElement_0.nullableOptionalString == nil) {
+                            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                            *aError = err;
+                            return nil;
+                        }
                     }
                 } else {
                     newElement_0.nullableOptionalString = nil;
@@ -21536,11 +21853,13 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                     newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
                     newElement_0.nullableStruct.c =
                         [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
-                    newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
-                                                                   length:entry_0.nullableStruct.Value().d.size()];
-                    newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
-                                                                             length:entry_0.nullableStruct.Value().e.size()
-                                                                           encoding:NSUTF8StringEncoding];
+                    newElement_0.nullableStruct.d = AsData(entry_0.nullableStruct.Value().d);
+                    newElement_0.nullableStruct.e = AsString(entry_0.nullableStruct.Value().e);
+                    if (newElement_0.nullableStruct.e == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                     newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
                     newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
                     newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
@@ -21551,11 +21870,13 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                     newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
                     newElement_0.optionalStruct.c =
                         [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
-                    newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
-                                                                   length:entry_0.optionalStruct.Value().d.size()];
-                    newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
-                                                                             length:entry_0.optionalStruct.Value().e.size()
-                                                                           encoding:NSUTF8StringEncoding];
+                    newElement_0.optionalStruct.d = AsData(entry_0.optionalStruct.Value().d);
+                    newElement_0.optionalStruct.e = AsString(entry_0.optionalStruct.Value().e);
+                    if (newElement_0.optionalStruct.e == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                     newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
                     newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
                     newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
@@ -21573,13 +21894,13 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                             [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
                         newElement_0.nullableOptionalStruct.c =
                             [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
-                        newElement_0.nullableOptionalStruct.d =
-                            [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
-                                           length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
-                        newElement_0.nullableOptionalStruct.e =
-                            [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
-                                                     length:entry_0.nullableOptionalStruct.Value().Value().e.size()
-                                                   encoding:NSUTF8StringEncoding];
+                        newElement_0.nullableOptionalStruct.d = AsData(entry_0.nullableOptionalStruct.Value().Value().d);
+                        newElement_0.nullableOptionalStruct.e = AsString(entry_0.nullableOptionalStruct.Value().Value().e);
+                        if (newElement_0.nullableOptionalStruct.e == nil) {
+                            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                            *aError = err;
+                            return nil;
+                        }
                         newElement_0.nullableOptionalStruct.f =
                             [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
                         newElement_0.nullableOptionalStruct.g =
@@ -21688,8 +22009,13 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
         value.a = [NSNumber numberWithUnsignedChar:cppValue.a];
         value.b = [NSNumber numberWithBool:cppValue.b];
         value.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.c)];
-        value.d = [NSData dataWithBytes:cppValue.d.data() length:cppValue.d.size()];
-        value.e = [[NSString alloc] initWithBytes:cppValue.e.data() length:cppValue.e.size() encoding:NSUTF8StringEncoding];
+        value.d = AsData(cppValue.d);
+        value.e = AsString(cppValue.e);
+        if (value.e == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            *aError = err;
+            return nil;
+        }
         value.f = [NSNumber numberWithUnsignedChar:cppValue.f.Raw()];
         value.g = [NSNumber numberWithFloat:cppValue.g];
         value.h = [NSNumber numberWithDouble:cppValue.h];
@@ -21753,7 +22079,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             while (iter_0.Next()) {
                 auto & entry_0 = iter_0.GetValue();
                 NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                newElement_0 = AsData(entry_0);
                 [array_0 addObject:newElement_0];
             }
             CHIP_ERROR err = iter_0.GetStatus();
@@ -21803,19 +22129,24 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
                 } else {
                     newElement_0.nullableOptionalFabricSensitiveInt8u = nil;
                 }
-                newElement_0.fabricSensitiveCharString = [[NSString alloc] initWithBytes:entry_0.fabricSensitiveCharString.data()
-                                                                                  length:entry_0.fabricSensitiveCharString.size()
-                                                                                encoding:NSUTF8StringEncoding];
+                newElement_0.fabricSensitiveCharString = AsString(entry_0.fabricSensitiveCharString);
+                if (newElement_0.fabricSensitiveCharString == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.fabricSensitiveStruct = [MTRUnitTestingClusterSimpleStruct new];
                 newElement_0.fabricSensitiveStruct.a = [NSNumber numberWithUnsignedChar:entry_0.fabricSensitiveStruct.a];
                 newElement_0.fabricSensitiveStruct.b = [NSNumber numberWithBool:entry_0.fabricSensitiveStruct.b];
                 newElement_0.fabricSensitiveStruct.c =
                     [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.fabricSensitiveStruct.c)];
-                newElement_0.fabricSensitiveStruct.d = [NSData dataWithBytes:entry_0.fabricSensitiveStruct.d.data()
-                                                                      length:entry_0.fabricSensitiveStruct.d.size()];
-                newElement_0.fabricSensitiveStruct.e = [[NSString alloc] initWithBytes:entry_0.fabricSensitiveStruct.e.data()
-                                                                                length:entry_0.fabricSensitiveStruct.e.size()
-                                                                              encoding:NSUTF8StringEncoding];
+                newElement_0.fabricSensitiveStruct.d = AsData(entry_0.fabricSensitiveStruct.d);
+                newElement_0.fabricSensitiveStruct.e = AsString(entry_0.fabricSensitiveStruct.e);
+                if (newElement_0.fabricSensitiveStruct.e == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
                 newElement_0.fabricSensitiveStruct.f = [NSNumber numberWithUnsignedChar:entry_0.fabricSensitiveStruct.f.Raw()];
                 newElement_0.fabricSensitiveStruct.g = [NSNumber numberWithFloat:entry_0.fabricSensitiveStruct.g];
                 newElement_0.fabricSensitiveStruct.h = [NSNumber numberWithDouble:entry_0.fabricSensitiveStruct.h];
@@ -22277,7 +22608,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [NSData dataWithBytes:cppValue.Value().data() length:cppValue.Value().size()];
+            value = AsData(cppValue.Value());
         }
         return value;
     }
@@ -22292,9 +22623,12 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
         if (cppValue.IsNull()) {
             value = nil;
         } else {
-            value = [[NSString alloc] initWithBytes:cppValue.Value().data()
-                                             length:cppValue.Value().size()
-                                           encoding:NSUTF8StringEncoding];
+            value = AsString(cppValue.Value());
+            if (value == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
         }
         return value;
     }
@@ -22328,10 +22662,13 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(
             value.a = [NSNumber numberWithUnsignedChar:cppValue.Value().a];
             value.b = [NSNumber numberWithBool:cppValue.Value().b];
             value.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.Value().c)];
-            value.d = [NSData dataWithBytes:cppValue.Value().d.data() length:cppValue.Value().d.size()];
-            value.e = [[NSString alloc] initWithBytes:cppValue.Value().e.data()
-                                               length:cppValue.Value().e.size()
-                                             encoding:NSUTF8StringEncoding];
+            value.d = AsData(cppValue.Value().d);
+            value.e = AsString(cppValue.Value().e);
+            if (value.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
             value.f = [NSNumber numberWithUnsignedChar:cppValue.Value().f.Raw()];
             value.g = [NSNumber numberWithFloat:cppValue.Value().g];
             value.h = [NSNumber numberWithDouble:cppValue.Value().h];

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
@@ -19,6 +19,8 @@
 #import "MTRCommandPayloadsObjc.h"
 #import "MTRCommandPayloads_Internal.h"
 #import "MTRStructsObjc.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include <lib/support/TypeTraits.h>
 
@@ -32,7 +34,7 @@ void MTRCommandSuccessCallbackBridge::OnSuccessFn(void * context, const chip::ap
 void MTROctetStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::ByteSpan value)
 {
     NSData * _Nonnull objCValue;
-    objCValue = [NSData dataWithBytes:value.data() length:value.size()];
+    objCValue = AsData(value);
     DispatchSuccess(context, objCValue);
 };
 
@@ -58,7 +60,7 @@ void MTRNullableOctetStringAttributeCallbackBridge::OnSuccessFn(
     if (value.IsNull()) {
         objCValue = nil;
     } else {
-        objCValue = [NSData dataWithBytes:value.Value().data() length:value.Value().size()];
+        objCValue = AsData(value.Value());
     }
     DispatchSuccess(context, objCValue);
 };
@@ -81,7 +83,12 @@ void MTRNullableOctetStringAttributeCallbackSubscriptionBridge::OnSubscriptionEs
 void MTRCharStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::CharSpan value)
 {
     NSString * _Nonnull objCValue;
-    objCValue = [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding];
+    objCValue = AsString(value);
+    if (objCValue == nil) {
+        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+        OnFailureFn(context, err);
+        return;
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -107,7 +114,12 @@ void MTRNullableCharStringAttributeCallbackBridge::OnSuccessFn(
     if (value.IsNull()) {
         objCValue = nil;
     } else {
-        objCValue = [[NSString alloc] initWithBytes:value.Value().data() length:value.Value().size() encoding:NSUTF8StringEncoding];
+        objCValue = AsString(value.Value());
+        if (objCValue == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            OnFailureFn(context, err);
+            return;
+        }
     }
     DispatchSuccess(context, objCValue);
 };
@@ -2478,7 +2490,7 @@ void MTRAccessControlExtensionListAttributeCallbackBridge::OnSuccessFn(void * co
             auto & entry_0 = iter_0.GetValue();
             MTRAccessControlClusterAccessControlExtensionStruct * newElement_0;
             newElement_0 = [MTRAccessControlClusterAccessControlExtensionStruct new];
-            newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
+            newElement_0.data = AsData(entry_0.data);
             newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
             [array_0 addObject:newElement_0];
         }
@@ -2671,9 +2683,12 @@ void MTRActionsActionListListAttributeCallbackBridge::OnSuccessFn(void * context
             MTRActionsClusterActionStruct * newElement_0;
             newElement_0 = [MTRActionsClusterActionStruct new];
             newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
             newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
             newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands.Raw()];
@@ -2717,9 +2732,12 @@ void MTRActionsEndpointListsListAttributeCallbackBridge::OnSuccessFn(void * cont
             MTRActionsClusterEndpointListStruct * newElement_0;
             newElement_0 = [MTRActionsClusterEndpointListStruct new];
             newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
             { // Scope for our temporary variables
                 auto * array_2 = [NSMutableArray new];
@@ -3478,7 +3496,12 @@ void MTRLocalizationConfigurationSupportedLocalesListAttributeCallbackBridge::On
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
             NSString * newElement_0;
-            newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+            newElement_0 = AsString(entry_0);
+            if (newElement_0 == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -4645,7 +4668,7 @@ void MTRNetworkCommissioningNetworksListAttributeCallbackBridge::OnSuccessFn(voi
             auto & entry_0 = iter_0.GetValue();
             MTRNetworkCommissioningClusterNetworkInfo * newElement_0;
             newElement_0 = [MTRNetworkCommissioningClusterNetworkInfo new];
-            newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
+            newElement_0.networkID = AsData(entry_0.networkID);
             newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
             [array_0 addObject:newElement_0];
         }
@@ -4990,9 +5013,12 @@ void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucces
             auto & entry_0 = iter_0.GetValue();
             MTRGeneralDiagnosticsClusterNetworkInterface * newElement_0;
             newElement_0 = [MTRGeneralDiagnosticsClusterNetworkInterface new];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.isOperational = [NSNumber numberWithBool:entry_0.isOperational];
             if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
                 newElement_0.offPremiseServicesReachableIPv4 = nil;
@@ -5006,15 +5032,14 @@ void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucces
                 newElement_0.offPremiseServicesReachableIPv6 =
                     [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
             }
-            newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
-                                                          length:entry_0.hardwareAddress.size()];
+            newElement_0.hardwareAddress = AsData(entry_0.hardwareAddress);
             { // Scope for our temporary variables
                 auto * array_2 = [NSMutableArray new];
                 auto iter_2 = entry_0.IPv4Addresses.begin();
                 while (iter_2.Next()) {
                     auto & entry_2 = iter_2.GetValue();
                     NSData * newElement_2;
-                    newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                    newElement_2 = AsData(entry_2);
                     [array_2 addObject:newElement_2];
                 }
                 CHIP_ERROR err = iter_2.GetStatus();
@@ -5030,7 +5055,7 @@ void MTRGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucces
                 while (iter_2.Next()) {
                     auto & entry_2 = iter_2.GetValue();
                     NSData * newElement_2;
-                    newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                    newElement_2 = AsData(entry_2);
                     [array_2 addObject:newElement_2];
                 }
                 CHIP_ERROR err = iter_2.GetStatus();
@@ -5348,9 +5373,12 @@ void MTRSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnSuccessFn
             newElement_0 = [MTRSoftwareDiagnosticsClusterThreadMetricsStruct new];
             newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
             if (entry_0.name.HasValue()) {
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                             length:entry_0.name.Value().size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name.Value());
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.name = nil;
             }
@@ -6757,11 +6785,11 @@ void MTROperationalCredentialsNOCsListAttributeCallbackBridge::OnSuccessFn(void 
             auto & entry_0 = iter_0.GetValue();
             MTROperationalCredentialsClusterNOCStruct * newElement_0;
             newElement_0 = [MTROperationalCredentialsClusterNOCStruct new];
-            newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
+            newElement_0.noc = AsData(entry_0.noc);
             if (entry_0.icac.IsNull()) {
                 newElement_0.icac = nil;
             } else {
-                newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+                newElement_0.icac = AsData(entry_0.icac.Value());
             }
             newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
             [array_0 addObject:newElement_0];
@@ -6803,13 +6831,16 @@ void MTROperationalCredentialsFabricsListAttributeCallbackBridge::OnSuccessFn(vo
             auto & entry_0 = iter_0.GetValue();
             MTROperationalCredentialsClusterFabricDescriptorStruct * newElement_0;
             newElement_0 = [MTROperationalCredentialsClusterFabricDescriptorStruct new];
-            newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data() length:entry_0.rootPublicKey.size()];
+            newElement_0.rootPublicKey = AsData(entry_0.rootPublicKey);
             newElement_0.vendorID = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0.vendorID)];
             newElement_0.fabricID = [NSNumber numberWithUnsignedLongLong:entry_0.fabricID];
             newElement_0.nodeID = [NSNumber numberWithUnsignedLongLong:entry_0.nodeID];
-            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                          length:entry_0.label.size()
-                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.label = AsString(entry_0.label);
+            if (newElement_0.label == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
             [array_0 addObject:newElement_0];
         }
@@ -6848,7 +6879,7 @@ void MTROperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
             NSData * newElement_0;
-            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            newElement_0 = AsData(entry_0);
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -7100,9 +7131,12 @@ void MTRGroupKeyManagementGroupTableListAttributeCallbackBridge::OnSuccessFn(voi
                 newElement_0.endpoints = array_2;
             }
             if (entry_0.groupName.HasValue()) {
-                newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
-                                                                  length:entry_0.groupName.Value().size()
-                                                                encoding:NSUTF8StringEncoding];
+                newElement_0.groupName = AsString(entry_0.groupName.Value());
+                if (newElement_0.groupName == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.groupName = nil;
             }
@@ -7297,12 +7331,18 @@ void MTRFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * conte
             auto & entry_0 = iter_0.GetValue();
             MTRFixedLabelClusterLabelStruct * newElement_0;
             newElement_0 = [MTRFixedLabelClusterLabelStruct new];
-            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                          length:entry_0.label.size()
-                                                        encoding:NSUTF8StringEncoding];
-            newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                          length:entry_0.value.size()
-                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.label = AsString(entry_0.label);
+            if (newElement_0.label == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
+            newElement_0.value = AsString(entry_0.value);
+            if (newElement_0.value == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -7493,12 +7533,18 @@ void MTRUserLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * contex
             auto & entry_0 = iter_0.GetValue();
             MTRUserLabelClusterLabelStruct * newElement_0;
             newElement_0 = [MTRUserLabelClusterLabelStruct new];
-            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                          length:entry_0.label.size()
-                                                        encoding:NSUTF8StringEncoding];
-            newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                          length:entry_0.value.size()
-                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.label = AsString(entry_0.label);
+            if (newElement_0.label == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
+            newElement_0.value = AsString(entry_0.value);
+            if (newElement_0.value == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -7955,9 +8001,12 @@ void MTRModeSelectSupportedModesListAttributeCallbackBridge::OnSuccessFn(void * 
             auto & entry_0 = iter_0.GetValue();
             MTRModeSelectClusterModeOptionStruct * newElement_0;
             newElement_0 = [MTRModeSelectClusterModeOptionStruct new];
-            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                          length:entry_0.label.size()
-                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.label = AsString(entry_0.label);
+            if (newElement_0.label == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
             { // Scope for our temporary variables
                 auto * array_2 = [NSMutableArray new];
@@ -8168,9 +8217,12 @@ void MTRTemperatureControlSupportedTemperatureLevelsListAttributeCallbackBridge:
             auto & entry_0 = iter_0.GetValue();
             MTRTemperatureControlClusterTemperatureLevelStruct * newElement_0;
             newElement_0 = [MTRTemperatureControlClusterTemperatureLevelStruct new];
-            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                          length:entry_0.label.size()
-                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.label = AsString(entry_0.label);
+            if (newElement_0.label == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.temperatureLevel = [NSNumber numberWithUnsignedChar:entry_0.temperatureLevel];
             [array_0 addObject:newElement_0];
         }
@@ -13399,23 +13451,32 @@ void MTRChannelChannelListListAttributeCallbackBridge::OnSuccessFn(void * contex
             newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
             newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
             if (entry_0.name.HasValue()) {
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                             length:entry_0.name.Value().size()
-                                                           encoding:NSUTF8StringEncoding];
+                newElement_0.name = AsString(entry_0.name.Value());
+                if (newElement_0.name == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.name = nil;
             }
             if (entry_0.callSign.HasValue()) {
-                newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
-                                                                 length:entry_0.callSign.Value().size()
-                                                               encoding:NSUTF8StringEncoding];
+                newElement_0.callSign = AsString(entry_0.callSign.Value());
+                if (newElement_0.callSign == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.callSign = nil;
             }
             if (entry_0.affiliateCallSign.HasValue()) {
-                newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
-                                                                          length:entry_0.affiliateCallSign.Value().size()
-                                                                        encoding:NSUTF8StringEncoding];
+                newElement_0.affiliateCallSign = AsString(entry_0.affiliateCallSign.Value());
+                if (newElement_0.affiliateCallSign == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.affiliateCallSign = nil;
             }
@@ -13454,20 +13515,29 @@ void MTRChannelLineupStructAttributeCallbackBridge::OnSuccessFn(void * context,
         objCValue = nil;
     } else {
         objCValue = [MTRChannelClusterLineupInfoStruct new];
-        objCValue.operatorName = [[NSString alloc] initWithBytes:value.Value().operatorName.data()
-                                                          length:value.Value().operatorName.size()
-                                                        encoding:NSUTF8StringEncoding];
+        objCValue.operatorName = AsString(value.Value().operatorName);
+        if (objCValue.operatorName == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            OnFailureFn(context, err);
+            return;
+        }
         if (value.Value().lineupName.HasValue()) {
-            objCValue.lineupName = [[NSString alloc] initWithBytes:value.Value().lineupName.Value().data()
-                                                            length:value.Value().lineupName.Value().size()
-                                                          encoding:NSUTF8StringEncoding];
+            objCValue.lineupName = AsString(value.Value().lineupName.Value());
+            if (objCValue.lineupName == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
         } else {
             objCValue.lineupName = nil;
         }
         if (value.Value().postalCode.HasValue()) {
-            objCValue.postalCode = [[NSString alloc] initWithBytes:value.Value().postalCode.Value().data()
-                                                            length:value.Value().postalCode.Value().size()
-                                                          encoding:NSUTF8StringEncoding];
+            objCValue.postalCode = AsString(value.Value().postalCode.Value());
+            if (objCValue.postalCode == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
         } else {
             objCValue.postalCode = nil;
         }
@@ -13502,23 +13572,32 @@ void MTRChannelCurrentChannelStructAttributeCallbackBridge::OnSuccessFn(void * c
         objCValue.majorNumber = [NSNumber numberWithUnsignedShort:value.Value().majorNumber];
         objCValue.minorNumber = [NSNumber numberWithUnsignedShort:value.Value().minorNumber];
         if (value.Value().name.HasValue()) {
-            objCValue.name = [[NSString alloc] initWithBytes:value.Value().name.Value().data()
-                                                      length:value.Value().name.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            objCValue.name = AsString(value.Value().name.Value());
+            if (objCValue.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
         } else {
             objCValue.name = nil;
         }
         if (value.Value().callSign.HasValue()) {
-            objCValue.callSign = [[NSString alloc] initWithBytes:value.Value().callSign.Value().data()
-                                                          length:value.Value().callSign.Value().size()
-                                                        encoding:NSUTF8StringEncoding];
+            objCValue.callSign = AsString(value.Value().callSign.Value());
+            if (objCValue.callSign == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
         } else {
             objCValue.callSign = nil;
         }
         if (value.Value().affiliateCallSign.HasValue()) {
-            objCValue.affiliateCallSign = [[NSString alloc] initWithBytes:value.Value().affiliateCallSign.Value().data()
-                                                                   length:value.Value().affiliateCallSign.Value().size()
-                                                                 encoding:NSUTF8StringEncoding];
+            objCValue.affiliateCallSign = AsString(value.Value().affiliateCallSign.Value());
+            if (objCValue.affiliateCallSign == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
         } else {
             objCValue.affiliateCallSign = nil;
         }
@@ -13706,9 +13785,12 @@ void MTRTargetNavigatorTargetListListAttributeCallbackBridge::OnSuccessFn(void *
             MTRTargetNavigatorClusterTargetInfoStruct * newElement_0;
             newElement_0 = [MTRTargetNavigatorClusterTargetInfoStruct new];
             newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -14087,12 +14169,18 @@ void MTRMediaInputInputListListAttributeCallbackBridge::OnSuccessFn(void * conte
             newElement_0 = [MTRMediaInputClusterInputInfoStruct new];
             newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
             newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
-            newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
-                                                                      length:entry_0.description.size()
-                                                                    encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
+            newElement_0.descriptionString = AsString(entry_0.description);
+            if (newElement_0.descriptionString == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -14586,7 +14674,12 @@ void MTRContentLauncherAcceptHeaderListAttributeCallbackBridge::OnSuccessFn(
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
             NSString * newElement_0;
-            newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+            newElement_0 = AsString(entry_0);
+            if (newElement_0 == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -14779,9 +14872,12 @@ void MTRAudioOutputOutputListListAttributeCallbackBridge::OnSuccessFn(void * con
             newElement_0 = [MTRAudioOutputClusterOutputInfoStruct new];
             newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
             newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.name = AsString(entry_0.name);
+            if (newElement_0.name == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -15010,9 +15106,12 @@ void MTRApplicationLauncherCurrentAppStructAttributeCallbackBridge::OnSuccessFn(
         objCValue = [MTRApplicationLauncherClusterApplicationEPStruct new];
         objCValue.application = [MTRApplicationLauncherClusterApplicationStruct new];
         objCValue.application.catalogVendorID = [NSNumber numberWithUnsignedShort:value.Value().application.catalogVendorID];
-        objCValue.application.applicationID = [[NSString alloc] initWithBytes:value.Value().application.applicationID.data()
-                                                                       length:value.Value().application.applicationID.size()
-                                                                     encoding:NSUTF8StringEncoding];
+        objCValue.application.applicationID = AsString(value.Value().application.applicationID);
+        if (objCValue.application.applicationID == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            OnFailureFn(context, err);
+            return;
+        }
         if (value.Value().endpoint.HasValue()) {
             objCValue.endpoint = [NSNumber numberWithUnsignedShort:value.Value().endpoint.Value()];
         } else {
@@ -15195,9 +15294,12 @@ void MTRApplicationBasicApplicationStructAttributeCallbackBridge::OnSuccessFn(
     MTRApplicationBasicClusterApplicationStruct * _Nonnull objCValue;
     objCValue = [MTRApplicationBasicClusterApplicationStruct new];
     objCValue.catalogVendorID = [NSNumber numberWithUnsignedShort:value.catalogVendorID];
-    objCValue.applicationID = [[NSString alloc] initWithBytes:value.applicationID.data()
-                                                       length:value.applicationID.size()
-                                                     encoding:NSUTF8StringEncoding];
+    objCValue.applicationID = AsString(value.applicationID);
+    if (objCValue.applicationID == nil) {
+        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+        OnFailureFn(context, err);
+        return;
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -15850,7 +15952,7 @@ void MTRUnitTestingListOctetStringListAttributeCallbackBridge::OnSuccessFn(
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
             NSData * newElement_0;
-            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            newElement_0 = AsData(entry_0);
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -15891,7 +15993,7 @@ void MTRUnitTestingListStructOctetStringListAttributeCallbackBridge::OnSuccessFn
             MTRUnitTestingClusterTestListStructOctet * newElement_0;
             newElement_0 = [MTRUnitTestingClusterTestListStructOctet new];
             newElement_0.member1 = [NSNumber numberWithUnsignedLongLong:entry_0.member1];
-            newElement_0.member2 = [NSData dataWithBytes:entry_0.member2.data() length:entry_0.member2.size()];
+            newElement_0.member2 = AsData(entry_0.member2);
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -15954,14 +16056,20 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
             if (entry_0.nullableString.IsNull()) {
                 newElement_0.nullableString = nil;
             } else {
-                newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
-                                                                       length:entry_0.nullableString.Value().size()
-                                                                     encoding:NSUTF8StringEncoding];
+                newElement_0.nullableString = AsString(entry_0.nullableString.Value());
+                if (newElement_0.nullableString == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             }
             if (entry_0.optionalString.HasValue()) {
-                newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
-                                                                       length:entry_0.optionalString.Value().size()
-                                                                     encoding:NSUTF8StringEncoding];
+                newElement_0.optionalString = AsString(entry_0.optionalString.Value());
+                if (newElement_0.optionalString == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
             } else {
                 newElement_0.optionalString = nil;
             }
@@ -15969,10 +16077,12 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
                 if (entry_0.nullableOptionalString.Value().IsNull()) {
                     newElement_0.nullableOptionalString = nil;
                 } else {
-                    newElement_0.nullableOptionalString =
-                        [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
-                                                 length:entry_0.nullableOptionalString.Value().Value().size()
-                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.nullableOptionalString = AsString(entry_0.nullableOptionalString.Value().Value());
+                    if (newElement_0.nullableOptionalString == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        OnFailureFn(context, err);
+                        return;
+                    }
                 }
             } else {
                 newElement_0.nullableOptionalString = nil;
@@ -15985,11 +16095,13 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
                 newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
                 newElement_0.nullableStruct.c =
                     [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
-                newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
-                                                               length:entry_0.nullableStruct.Value().d.size()];
-                newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
-                                                                         length:entry_0.nullableStruct.Value().e.size()
-                                                                       encoding:NSUTF8StringEncoding];
+                newElement_0.nullableStruct.d = AsData(entry_0.nullableStruct.Value().d);
+                newElement_0.nullableStruct.e = AsString(entry_0.nullableStruct.Value().e);
+                if (newElement_0.nullableStruct.e == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
                 newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
                 newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
                 newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
@@ -16000,11 +16112,13 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
                 newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
                 newElement_0.optionalStruct.c =
                     [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
-                newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
-                                                               length:entry_0.optionalStruct.Value().d.size()];
-                newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
-                                                                         length:entry_0.optionalStruct.Value().e.size()
-                                                                       encoding:NSUTF8StringEncoding];
+                newElement_0.optionalStruct.d = AsData(entry_0.optionalStruct.Value().d);
+                newElement_0.optionalStruct.e = AsString(entry_0.optionalStruct.Value().e);
+                if (newElement_0.optionalStruct.e == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    OnFailureFn(context, err);
+                    return;
+                }
                 newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
                 newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
                 newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
@@ -16022,13 +16136,13 @@ void MTRUnitTestingListNullablesAndOptionalsStructListAttributeCallbackBridge::O
                         [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
                     newElement_0.nullableOptionalStruct.c =
                         [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
-                    newElement_0.nullableOptionalStruct.d =
-                        [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
-                                       length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
-                    newElement_0.nullableOptionalStruct.e =
-                        [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
-                                                 length:entry_0.nullableOptionalStruct.Value().Value().e.size()
-                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.nullableOptionalStruct.d = AsData(entry_0.nullableOptionalStruct.Value().Value().d);
+                    newElement_0.nullableOptionalStruct.e = AsString(entry_0.nullableOptionalStruct.Value().Value().e);
+                    if (newElement_0.nullableOptionalStruct.e == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        OnFailureFn(context, err);
+                        return;
+                    }
                     newElement_0.nullableOptionalStruct.f =
                         [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
                     newElement_0.nullableOptionalStruct.g =
@@ -16138,8 +16252,13 @@ void MTRUnitTestingStructAttrStructAttributeCallbackBridge::OnSuccessFn(
     objCValue.a = [NSNumber numberWithUnsignedChar:value.a];
     objCValue.b = [NSNumber numberWithBool:value.b];
     objCValue.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.c)];
-    objCValue.d = [NSData dataWithBytes:value.d.data() length:value.d.size()];
-    objCValue.e = [[NSString alloc] initWithBytes:value.e.data() length:value.e.size() encoding:NSUTF8StringEncoding];
+    objCValue.d = AsData(value.d);
+    objCValue.e = AsString(value.e);
+    if (objCValue.e == nil) {
+        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+        OnFailureFn(context, err);
+        return;
+    }
     objCValue.f = [NSNumber numberWithUnsignedChar:value.f.Raw()];
     objCValue.g = [NSNumber numberWithFloat:value.g];
     objCValue.h = [NSNumber numberWithDouble:value.h];
@@ -16171,7 +16290,7 @@ void MTRUnitTestingListLongOctetStringListAttributeCallbackBridge::OnSuccessFn(
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
             NSData * newElement_0;
-            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            newElement_0 = AsData(entry_0);
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();
@@ -16233,19 +16352,24 @@ void MTRUnitTestingListFabricScopedListAttributeCallbackBridge::OnSuccessFn(void
             } else {
                 newElement_0.nullableOptionalFabricSensitiveInt8u = nil;
             }
-            newElement_0.fabricSensitiveCharString = [[NSString alloc] initWithBytes:entry_0.fabricSensitiveCharString.data()
-                                                                              length:entry_0.fabricSensitiveCharString.size()
-                                                                            encoding:NSUTF8StringEncoding];
+            newElement_0.fabricSensitiveCharString = AsString(entry_0.fabricSensitiveCharString);
+            if (newElement_0.fabricSensitiveCharString == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.fabricSensitiveStruct = [MTRUnitTestingClusterSimpleStruct new];
             newElement_0.fabricSensitiveStruct.a = [NSNumber numberWithUnsignedChar:entry_0.fabricSensitiveStruct.a];
             newElement_0.fabricSensitiveStruct.b = [NSNumber numberWithBool:entry_0.fabricSensitiveStruct.b];
             newElement_0.fabricSensitiveStruct.c =
                 [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.fabricSensitiveStruct.c)];
-            newElement_0.fabricSensitiveStruct.d = [NSData dataWithBytes:entry_0.fabricSensitiveStruct.d.data()
-                                                                  length:entry_0.fabricSensitiveStruct.d.size()];
-            newElement_0.fabricSensitiveStruct.e = [[NSString alloc] initWithBytes:entry_0.fabricSensitiveStruct.e.data()
-                                                                            length:entry_0.fabricSensitiveStruct.e.size()
-                                                                          encoding:NSUTF8StringEncoding];
+            newElement_0.fabricSensitiveStruct.d = AsData(entry_0.fabricSensitiveStruct.d);
+            newElement_0.fabricSensitiveStruct.e = AsString(entry_0.fabricSensitiveStruct.e);
+            if (newElement_0.fabricSensitiveStruct.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                OnFailureFn(context, err);
+                return;
+            }
             newElement_0.fabricSensitiveStruct.f = [NSNumber numberWithUnsignedChar:entry_0.fabricSensitiveStruct.f.Raw()];
             newElement_0.fabricSensitiveStruct.g = [NSNumber numberWithFloat:entry_0.fabricSensitiveStruct.g];
             newElement_0.fabricSensitiveStruct.h = [NSNumber numberWithDouble:entry_0.fabricSensitiveStruct.h];
@@ -16412,10 +16536,13 @@ void MTRUnitTestingNullableStructStructAttributeCallbackBridge::OnSuccessFn(void
         objCValue.a = [NSNumber numberWithUnsignedChar:value.Value().a];
         objCValue.b = [NSNumber numberWithBool:value.Value().b];
         objCValue.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value().c)];
-        objCValue.d = [NSData dataWithBytes:value.Value().d.data() length:value.Value().d.size()];
-        objCValue.e = [[NSString alloc] initWithBytes:value.Value().e.data()
-                                               length:value.Value().e.size()
-                                             encoding:NSUTF8StringEncoding];
+        objCValue.d = AsData(value.Value().d);
+        objCValue.e = AsString(value.Value().e);
+        if (objCValue.e == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            OnFailureFn(context, err);
+            return;
+        }
         objCValue.f = [NSNumber numberWithUnsignedChar:value.Value().f.Raw()];
         objCValue.g = [NSNumber numberWithFloat:value.Value().g];
         objCValue.h = [NSNumber numberWithDouble:value.Value().h];

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -20,6 +20,8 @@
 #import "MTRCommandPayloads_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include <app/data-model/Decode.h>
 #include <lib/core/TLV.h>
@@ -369,9 +371,11 @@ NS_ASSUME_NONNULL_BEGIN
         self.groupID = [NSNumber numberWithUnsignedShort:decodableStruct.groupID];
     }
     {
-        self.groupName = [[NSString alloc] initWithBytes:decodableStruct.groupName.data()
-                                                  length:decodableStruct.groupName.size()
-                                                encoding:NSUTF8StringEncoding];
+        self.groupName = AsString(decodableStruct.groupName);
+        if (self.groupName == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -1090,9 +1094,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.sceneName.HasValue()) {
-            self.sceneName = [[NSString alloc] initWithBytes:decodableStruct.sceneName.Value().data()
-                                                      length:decodableStruct.sceneName.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.sceneName = AsString(decodableStruct.sceneName.Value());
+            if (self.sceneName == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.sceneName = nil;
         }
@@ -2255,9 +2261,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.sceneName.HasValue()) {
-            self.sceneName = [[NSString alloc] initWithBytes:decodableStruct.sceneName.Value().data()
-                                                      length:decodableStruct.sceneName.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.sceneName = AsString(decodableStruct.sceneName.Value());
+            if (self.sceneName == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.sceneName = nil;
         }
@@ -3732,9 +3740,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.imageURI.HasValue()) {
-            self.imageURI = [[NSString alloc] initWithBytes:decodableStruct.imageURI.Value().data()
-                                                     length:decodableStruct.imageURI.Value().size()
-                                                   encoding:NSUTF8StringEncoding];
+            self.imageURI = AsString(decodableStruct.imageURI.Value());
+            if (self.imageURI == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.imageURI = nil;
         }
@@ -3748,17 +3758,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.softwareVersionString.HasValue()) {
-            self.softwareVersionString = [[NSString alloc] initWithBytes:decodableStruct.softwareVersionString.Value().data()
-                                                                  length:decodableStruct.softwareVersionString.Value().size()
-                                                                encoding:NSUTF8StringEncoding];
+            self.softwareVersionString = AsString(decodableStruct.softwareVersionString.Value());
+            if (self.softwareVersionString == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.softwareVersionString = nil;
         }
     }
     {
         if (decodableStruct.updateToken.HasValue()) {
-            self.updateToken = [NSData dataWithBytes:decodableStruct.updateToken.Value().data()
-                                              length:decodableStruct.updateToken.Value().size()];
+            self.updateToken = AsData(decodableStruct.updateToken.Value());
         } else {
             self.updateToken = nil;
         }
@@ -3772,8 +3783,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.metadataForRequestor.HasValue()) {
-            self.metadataForRequestor = [NSData dataWithBytes:decodableStruct.metadataForRequestor.Value().data()
-                                                       length:decodableStruct.metadataForRequestor.Value().size()];
+            self.metadataForRequestor = AsData(decodableStruct.metadataForRequestor.Value());
         } else {
             self.metadataForRequestor = nil;
         }
@@ -4137,9 +4147,11 @@ NS_ASSUME_NONNULL_BEGIN
         self.errorCode = [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.errorCode)];
     }
     {
-        self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.data()
-                                                  length:decodableStruct.debugText.size()
-                                                encoding:NSUTF8StringEncoding];
+        self.debugText = AsString(decodableStruct.debugText);
+        if (self.debugText == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -4263,9 +4275,11 @@ NS_ASSUME_NONNULL_BEGIN
         self.errorCode = [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.errorCode)];
     }
     {
-        self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.data()
-                                                  length:decodableStruct.debugText.size()
-                                                encoding:NSUTF8StringEncoding];
+        self.debugText = AsString(decodableStruct.debugText);
+        if (self.debugText == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -4379,9 +4393,11 @@ NS_ASSUME_NONNULL_BEGIN
         self.errorCode = [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.errorCode)];
     }
     {
-        self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.data()
-                                                  length:decodableStruct.debugText.size()
-                                                encoding:NSUTF8StringEncoding];
+        self.debugText = AsString(decodableStruct.debugText);
+        if (self.debugText == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -4510,9 +4526,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.debugText.HasValue()) {
-            self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.Value().data()
-                                                      length:decodableStruct.debugText.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.debugText = AsString(decodableStruct.debugText.Value());
+            if (self.debugText == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.debugText = nil;
         }
@@ -4527,8 +4545,8 @@ NS_ASSUME_NONNULL_BEGIN
                     MTRNetworkCommissioningClusterWiFiInterfaceScanResult * newElement_1;
                     newElement_1 = [MTRNetworkCommissioningClusterWiFiInterfaceScanResult new];
                     newElement_1.security = [NSNumber numberWithUnsignedChar:entry_1.security.Raw()];
-                    newElement_1.ssid = [NSData dataWithBytes:entry_1.ssid.data() length:entry_1.ssid.size()];
-                    newElement_1.bssid = [NSData dataWithBytes:entry_1.bssid.data() length:entry_1.bssid.size()];
+                    newElement_1.ssid = AsData(entry_1.ssid);
+                    newElement_1.bssid = AsData(entry_1.bssid);
                     newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
                     newElement_1.wiFiBand = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.wiFiBand)];
                     newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
@@ -4555,13 +4573,14 @@ NS_ASSUME_NONNULL_BEGIN
                     newElement_1 = [MTRNetworkCommissioningClusterThreadInterfaceScanResult new];
                     newElement_1.panId = [NSNumber numberWithUnsignedShort:entry_1.panId];
                     newElement_1.extendedPanId = [NSNumber numberWithUnsignedLongLong:entry_1.extendedPanId];
-                    newElement_1.networkName = [[NSString alloc] initWithBytes:entry_1.networkName.data()
-                                                                        length:entry_1.networkName.size()
-                                                                      encoding:NSUTF8StringEncoding];
+                    newElement_1.networkName = AsString(entry_1.networkName);
+                    if (newElement_1.networkName == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        return err;
+                    }
                     newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
                     newElement_1.version = [NSNumber numberWithUnsignedChar:entry_1.version];
-                    newElement_1.extendedAddress = [NSData dataWithBytes:entry_1.extendedAddress.data()
-                                                                  length:entry_1.extendedAddress.size()];
+                    newElement_1.extendedAddress = AsData(entry_1.extendedAddress);
                     newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
                     newElement_1.lqi = [NSNumber numberWithUnsignedChar:entry_1.lqi];
                     [array_1 addObject:newElement_1];
@@ -4773,9 +4792,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.debugText.HasValue()) {
-            self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.Value().data()
-                                                      length:decodableStruct.debugText.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.debugText = AsString(decodableStruct.debugText.Value());
+            if (self.debugText == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.debugText = nil;
         }
@@ -4911,9 +4932,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.debugText.HasValue()) {
-            self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.Value().data()
-                                                      length:decodableStruct.debugText.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.debugText = AsString(decodableStruct.debugText.Value());
+            if (self.debugText == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.debugText = nil;
         }
@@ -5092,7 +5115,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.status)];
     }
     {
-        self.logContent = [NSData dataWithBytes:decodableStruct.logContent.data() length:decodableStruct.logContent.size()];
+        self.logContent = AsData(decodableStruct.logContent);
     }
     {
         if (decodableStruct.UTCTimeStamp.HasValue()) {
@@ -5541,12 +5564,10 @@ NS_ASSUME_NONNULL_BEGIN
     (const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType &)decodableStruct
 {
     {
-        self.attestationElements = [NSData dataWithBytes:decodableStruct.attestationElements.data()
-                                                  length:decodableStruct.attestationElements.size()];
+        self.attestationElements = AsData(decodableStruct.attestationElements);
     }
     {
-        self.attestationSignature = [NSData dataWithBytes:decodableStruct.attestationSignature.data()
-                                                   length:decodableStruct.attestationSignature.size()];
+        self.attestationSignature = AsData(decodableStruct.attestationSignature);
     }
     return CHIP_NO_ERROR;
 }
@@ -5671,7 +5692,7 @@ NS_ASSUME_NONNULL_BEGIN
     (const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType &)decodableStruct
 {
     {
-        self.certificate = [NSData dataWithBytes:decodableStruct.certificate.data() length:decodableStruct.certificate.size()];
+        self.certificate = AsData(decodableStruct.certificate);
     }
     return CHIP_NO_ERROR;
 }
@@ -5791,12 +5812,10 @@ NS_ASSUME_NONNULL_BEGIN
     (const chip::app::Clusters::OperationalCredentials::Commands::CSRResponse::DecodableType &)decodableStruct
 {
     {
-        self.nocsrElements = [NSData dataWithBytes:decodableStruct.NOCSRElements.data()
-                                            length:decodableStruct.NOCSRElements.size()];
+        self.nocsrElements = AsData(decodableStruct.NOCSRElements);
     }
     {
-        self.attestationSignature = [NSData dataWithBytes:decodableStruct.attestationSignature.data()
-                                                   length:decodableStruct.attestationSignature.size()];
+        self.attestationSignature = AsData(decodableStruct.attestationSignature);
     }
     return CHIP_NO_ERROR;
 }
@@ -5975,9 +5994,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.debugText.HasValue()) {
-            self.debugText = [[NSString alloc] initWithBytes:decodableStruct.debugText.Value().data()
-                                                      length:decodableStruct.debugText.Value().size()
-                                                    encoding:NSUTF8StringEncoding];
+            self.debugText = AsString(decodableStruct.debugText.Value());
+            if (self.debugText == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.debugText = nil;
         }
@@ -6235,8 +6256,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (decodableStruct.groupKeySet.epochKey0.IsNull()) {
             self.groupKeySet.epochKey0 = nil;
         } else {
-            self.groupKeySet.epochKey0 = [NSData dataWithBytes:decodableStruct.groupKeySet.epochKey0.Value().data()
-                                                        length:decodableStruct.groupKeySet.epochKey0.Value().size()];
+            self.groupKeySet.epochKey0 = AsData(decodableStruct.groupKeySet.epochKey0.Value());
         }
         if (decodableStruct.groupKeySet.epochStartTime0.IsNull()) {
             self.groupKeySet.epochStartTime0 = nil;
@@ -6247,8 +6267,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (decodableStruct.groupKeySet.epochKey1.IsNull()) {
             self.groupKeySet.epochKey1 = nil;
         } else {
-            self.groupKeySet.epochKey1 = [NSData dataWithBytes:decodableStruct.groupKeySet.epochKey1.Value().data()
-                                                        length:decodableStruct.groupKeySet.epochKey1.Value().size()];
+            self.groupKeySet.epochKey1 = AsData(decodableStruct.groupKeySet.epochKey1.Value());
         }
         if (decodableStruct.groupKeySet.epochStartTime1.IsNull()) {
             self.groupKeySet.epochStartTime1 = nil;
@@ -6259,8 +6278,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (decodableStruct.groupKeySet.epochKey2.IsNull()) {
             self.groupKeySet.epochKey2 = nil;
         } else {
-            self.groupKeySet.epochKey2 = [NSData dataWithBytes:decodableStruct.groupKeySet.epochKey2.Value().data()
-                                                        length:decodableStruct.groupKeySet.epochKey2.Value().size()];
+            self.groupKeySet.epochKey2 = AsData(decodableStruct.groupKeySet.epochKey2.Value());
         }
         if (decodableStruct.groupKeySet.epochStartTime2.IsNull()) {
             self.groupKeySet.epochStartTime2 = nil;
@@ -7889,9 +7907,11 @@ NS_ASSUME_NONNULL_BEGIN
         if (decodableStruct.userName.IsNull()) {
             self.userName = nil;
         } else {
-            self.userName = [[NSString alloc] initWithBytes:decodableStruct.userName.Value().data()
-                                                     length:decodableStruct.userName.Value().size()
-                                                   encoding:NSUTF8StringEncoding];
+            self.userName = AsString(decodableStruct.userName.Value());
+            if (self.userName == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         }
     }
     {
@@ -9850,9 +9870,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.data.HasValue()) {
-            self.data = [[NSString alloc] initWithBytes:decodableStruct.data.Value().data()
-                                                 length:decodableStruct.data.Value().size()
-                                               encoding:NSUTF8StringEncoding];
+            self.data = AsString(decodableStruct.data.Value());
+            if (self.data == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.data = nil;
         }
@@ -10041,9 +10063,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.data.HasValue()) {
-            self.data = [[NSString alloc] initWithBytes:decodableStruct.data.Value().data()
-                                                 length:decodableStruct.data.Value().size()
-                                               encoding:NSUTF8StringEncoding];
+            self.data = AsString(decodableStruct.data.Value());
+            if (self.data == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.data = nil;
         }
@@ -10415,9 +10439,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.data.HasValue()) {
-            self.data = [[NSString alloc] initWithBytes:decodableStruct.data.Value().data()
-                                                 length:decodableStruct.data.Value().size()
-                                               encoding:NSUTF8StringEncoding];
+            self.data = AsString(decodableStruct.data.Value());
+            if (self.data == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.data = nil;
         }
@@ -10867,9 +10893,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.data.HasValue()) {
-            self.data = [[NSString alloc] initWithBytes:decodableStruct.data.Value().data()
-                                                 length:decodableStruct.data.Value().size()
-                                               encoding:NSUTF8StringEncoding];
+            self.data = AsString(decodableStruct.data.Value());
+            if (self.data == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.data = nil;
         }
@@ -11123,7 +11151,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     {
         if (decodableStruct.data.HasValue()) {
-            self.data = [NSData dataWithBytes:decodableStruct.data.Value().data() length:decodableStruct.data.Value().size()];
+            self.data = AsData(decodableStruct.data.Value());
         } else {
             self.data = nil;
         }
@@ -11237,9 +11265,11 @@ NS_ASSUME_NONNULL_BEGIN
     (const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType &)decodableStruct
 {
     {
-        self.setupPIN = [[NSString alloc] initWithBytes:decodableStruct.setupPIN.data()
-                                                 length:decodableStruct.setupPIN.size()
-                                               encoding:NSUTF8StringEncoding];
+        self.setupPIN = AsString(decodableStruct.setupPIN);
+        if (self.setupPIN == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -12086,10 +12116,12 @@ NS_ASSUME_NONNULL_BEGIN
         newElement_0.c.a = [NSNumber numberWithUnsignedChar:entry_0.c.a];
         newElement_0.c.b = [NSNumber numberWithBool:entry_0.c.b];
         newElement_0.c.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.c.c)];
-        newElement_0.c.d = [NSData dataWithBytes:entry_0.c.d.data() length:entry_0.c.d.size()];
-        newElement_0.c.e = [[NSString alloc] initWithBytes:entry_0.c.e.data()
-                                                    length:entry_0.c.e.size()
-                                                  encoding:NSUTF8StringEncoding];
+        newElement_0.c.d = AsData(entry_0.c.d);
+        newElement_0.c.e = AsString(entry_0.c.e);
+        if (newElement_0.c.e == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
         newElement_0.c.f = [NSNumber numberWithUnsignedChar:entry_0.c.f.Raw()];
         newElement_0.c.g = [NSNumber numberWithFloat:entry_0.c.g];
         newElement_0.c.h = [NSNumber numberWithDouble:entry_0.c.h];
@@ -12103,10 +12135,12 @@ NS_ASSUME_NONNULL_BEGIN
                 newElement_2.a = [NSNumber numberWithUnsignedChar:entry_2.a];
                 newElement_2.b = [NSNumber numberWithBool:entry_2.b];
                 newElement_2.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_2.c)];
-                newElement_2.d = [NSData dataWithBytes:entry_2.d.data() length:entry_2.d.size()];
-                newElement_2.e = [[NSString alloc] initWithBytes:entry_2.e.data()
-                                                          length:entry_2.e.size()
-                                                        encoding:NSUTF8StringEncoding];
+                newElement_2.d = AsData(entry_2.d);
+                newElement_2.e = AsString(entry_2.e);
+                if (newElement_2.e == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    return err;
+                }
                 newElement_2.f = [NSNumber numberWithUnsignedChar:entry_2.f.Raw()];
                 newElement_2.g = [NSNumber numberWithFloat:entry_2.g];
                 newElement_2.h = [NSNumber numberWithDouble:entry_2.h];
@@ -12139,7 +12173,7 @@ NS_ASSUME_NONNULL_BEGIN
             while (iter_2.Next()) {
                 auto & entry_2 = iter_2.GetValue();
                 NSData * newElement_2;
-                newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                newElement_2 = AsData(entry_2);
                 [array_2 addObject:newElement_2];
             }
             CHIP_ERROR err = iter_2.GetStatus();
@@ -12183,10 +12217,12 @@ NS_ASSUME_NONNULL_BEGIN
             newElement_0.a = [NSNumber numberWithUnsignedChar:entry_0.a];
             newElement_0.b = [NSNumber numberWithBool:entry_0.b];
             newElement_0.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.c)];
-            newElement_0.d = [NSData dataWithBytes:entry_0.d.data() length:entry_0.d.size()];
-            newElement_0.e = [[NSString alloc] initWithBytes:entry_0.e.data()
-                                                      length:entry_0.e.size()
-                                                    encoding:NSUTF8StringEncoding];
+            newElement_0.d = AsData(entry_0.d);
+            newElement_0.e = AsString(entry_0.e);
+            if (newElement_0.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
             newElement_0.f = [NSNumber numberWithUnsignedChar:entry_0.f.Raw()];
             newElement_0.g = [NSNumber numberWithFloat:entry_0.g];
             newElement_0.h = [NSNumber numberWithDouble:entry_0.h];
@@ -12914,9 +12950,11 @@ return CHIP_NO_ERROR;
     }
     {
         if (decodableStruct.nullableStringValue.HasValue()) {
-            self.nullableStringValue = [[NSString alloc] initWithBytes:decodableStruct.nullableStringValue.Value().data()
-                                                                length:decodableStruct.nullableStringValue.Value().size()
-                                                              encoding:NSUTF8StringEncoding];
+            self.nullableStringValue = AsString(decodableStruct.nullableStringValue.Value());
+            if (self.nullableStringValue == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.nullableStringValue = nil;
         }
@@ -12926,9 +12964,11 @@ return CHIP_NO_ERROR;
     }
     {
         if (decodableStruct.optionalStringValue.HasValue()) {
-            self.optionalStringValue = [[NSString alloc] initWithBytes:decodableStruct.optionalStringValue.Value().data()
-                                                                length:decodableStruct.optionalStringValue.Value().size()
-                                                              encoding:NSUTF8StringEncoding];
+            self.optionalStringValue = AsString(decodableStruct.optionalStringValue.Value());
+            if (self.optionalStringValue == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.optionalStringValue = nil;
         }
@@ -12945,10 +12985,11 @@ return CHIP_NO_ERROR;
     }
     {
         if (decodableStruct.nullableOptionalStringValue.HasValue()) {
-            self.nullableOptionalStringValue =
-                [[NSString alloc] initWithBytes:decodableStruct.nullableOptionalStringValue.Value().data()
-                                         length:decodableStruct.nullableOptionalStringValue.Value().size()
-                                       encoding:NSUTF8StringEncoding];
+            self.nullableOptionalStringValue = AsString(decodableStruct.nullableOptionalStringValue.Value());
+            if (self.nullableOptionalStringValue == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
         } else {
             self.nullableOptionalStringValue = nil;
         }
@@ -12963,11 +13004,12 @@ return CHIP_NO_ERROR;
             self.nullableStructValue.b = [NSNumber numberWithBool:decodableStruct.nullableStructValue.Value().b];
             self.nullableStructValue.c =
                 [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.nullableStructValue.Value().c)];
-            self.nullableStructValue.d = [NSData dataWithBytes:decodableStruct.nullableStructValue.Value().d.data()
-                                                        length:decodableStruct.nullableStructValue.Value().d.size()];
-            self.nullableStructValue.e = [[NSString alloc] initWithBytes:decodableStruct.nullableStructValue.Value().e.data()
-                                                                  length:decodableStruct.nullableStructValue.Value().e.size()
-                                                                encoding:NSUTF8StringEncoding];
+            self.nullableStructValue.d = AsData(decodableStruct.nullableStructValue.Value().d);
+            self.nullableStructValue.e = AsString(decodableStruct.nullableStructValue.Value().e);
+            if (self.nullableStructValue.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
             self.nullableStructValue.f = [NSNumber numberWithUnsignedChar:decodableStruct.nullableStructValue.Value().f.Raw()];
             self.nullableStructValue.g = [NSNumber numberWithFloat:decodableStruct.nullableStructValue.Value().g];
             self.nullableStructValue.h = [NSNumber numberWithDouble:decodableStruct.nullableStructValue.Value().h];
@@ -12985,11 +13027,12 @@ return CHIP_NO_ERROR;
             self.optionalStructValue.b = [NSNumber numberWithBool:decodableStruct.optionalStructValue.Value().b];
             self.optionalStructValue.c =
                 [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.optionalStructValue.Value().c)];
-            self.optionalStructValue.d = [NSData dataWithBytes:decodableStruct.optionalStructValue.Value().d.data()
-                                                        length:decodableStruct.optionalStructValue.Value().d.size()];
-            self.optionalStructValue.e = [[NSString alloc] initWithBytes:decodableStruct.optionalStructValue.Value().e.data()
-                                                                  length:decodableStruct.optionalStructValue.Value().e.size()
-                                                                encoding:NSUTF8StringEncoding];
+            self.optionalStructValue.d = AsData(decodableStruct.optionalStructValue.Value().d);
+            self.optionalStructValue.e = AsString(decodableStruct.optionalStructValue.Value().e);
+            if (self.optionalStructValue.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
             self.optionalStructValue.f = [NSNumber numberWithUnsignedChar:decodableStruct.optionalStructValue.Value().f.Raw()];
             self.optionalStructValue.g = [NSNumber numberWithFloat:decodableStruct.optionalStructValue.Value().g];
             self.optionalStructValue.h = [NSNumber numberWithDouble:decodableStruct.optionalStructValue.Value().h];
@@ -13015,13 +13058,12 @@ return CHIP_NO_ERROR;
             self.nullableOptionalStructValue.b = [NSNumber numberWithBool:decodableStruct.nullableOptionalStructValue.Value().b];
             self.nullableOptionalStructValue.c =
                 [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.nullableOptionalStructValue.Value().c)];
-            self.nullableOptionalStructValue.d =
-                [NSData dataWithBytes:decodableStruct.nullableOptionalStructValue.Value().d.data()
-                               length:decodableStruct.nullableOptionalStructValue.Value().d.size()];
-            self.nullableOptionalStructValue.e =
-                [[NSString alloc] initWithBytes:decodableStruct.nullableOptionalStructValue.Value().e.data()
-                                         length:decodableStruct.nullableOptionalStructValue.Value().e.size()
-                                       encoding:NSUTF8StringEncoding];
+            self.nullableOptionalStructValue.d = AsData(decodableStruct.nullableOptionalStructValue.Value().d);
+            self.nullableOptionalStructValue.e = AsString(decodableStruct.nullableOptionalStructValue.Value().e);
+            if (self.nullableOptionalStructValue.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                return err;
+            }
             self.nullableOptionalStructValue.f =
                 [NSNumber numberWithUnsignedChar:decodableStruct.nullableOptionalStructValue.Value().f.Raw()];
             self.nullableOptionalStructValue.g = [NSNumber numberWithFloat:decodableStruct.nullableOptionalStructValue.Value().g];
@@ -13343,10 +13385,12 @@ return CHIP_NO_ERROR;
         self.arg1.a = [NSNumber numberWithUnsignedChar:decodableStruct.arg1.a];
         self.arg1.b = [NSNumber numberWithBool:decodableStruct.arg1.b];
         self.arg1.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.arg1.c)];
-        self.arg1.d = [NSData dataWithBytes:decodableStruct.arg1.d.data() length:decodableStruct.arg1.d.size()];
-        self.arg1.e = [[NSString alloc] initWithBytes:decodableStruct.arg1.e.data()
-                                               length:decodableStruct.arg1.e.size()
-                                             encoding:NSUTF8StringEncoding];
+        self.arg1.d = AsData(decodableStruct.arg1.d);
+        self.arg1.e = AsString(decodableStruct.arg1.e);
+        if (self.arg1.e == nil) {
+            CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+            return err;
+        }
         self.arg1.f = [NSNumber numberWithUnsignedChar:decodableStruct.arg1.f.Raw()];
         self.arg1.g = [NSNumber numberWithFloat:decodableStruct.arg1.g];
         self.arg1.h = [NSNumber numberWithDouble:decodableStruct.arg1.h];

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -18,6 +18,8 @@
 #import "MTREventTLVValueDecoder_Internal.h"
 
 #import "MTRStructsObjc.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
@@ -291,8 +293,7 @@ static id _Nullable DecodeEventPayloadForAccessControlCluster(EventId aEventId, 
                 memberValue = nil;
             } else {
                 memberValue = [MTRAccessControlClusterAccessControlExtensionStruct new];
-                memberValue.data = [NSData dataWithBytes:cppValue.latestValue.Value().data.data()
-                                                  length:cppValue.latestValue.Value().data.size()];
+                memberValue.data = AsData(cppValue.latestValue.Value().data);
                 memberValue.fabricIndex = [NSNumber numberWithUnsignedChar:cppValue.latestValue.Value().fabricIndex];
             }
             value.latestValue = memberValue;
@@ -1045,9 +1046,12 @@ static id _Nullable DecodeEventPayloadForSoftwareDiagnosticsCluster(EventId aEve
         do {
             NSString * _Nullable memberValue;
             if (cppValue.name.HasValue()) {
-                memberValue = [[NSString alloc] initWithBytes:cppValue.name.Value().data()
-                                                       length:cppValue.name.Value().size()
-                                                     encoding:NSUTF8StringEncoding];
+                memberValue = AsString(cppValue.name.Value());
+                if (memberValue == nil) {
+                    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                    *aError = err;
+                    return nil;
+                }
             } else {
                 memberValue = nil;
             }
@@ -1056,8 +1060,7 @@ static id _Nullable DecodeEventPayloadForSoftwareDiagnosticsCluster(EventId aEve
         do {
             NSData * _Nullable memberValue;
             if (cppValue.faultRecording.HasValue()) {
-                memberValue = [NSData dataWithBytes:cppValue.faultRecording.Value().data()
-                                             length:cppValue.faultRecording.Value().size()];
+                memberValue = AsData(cppValue.faultRecording.Value());
             } else {
                 memberValue = nil;
             }
@@ -2731,10 +2734,13 @@ static id _Nullable DecodeEventPayloadForUnitTestingCluster(EventId aEventId, TL
             memberValue.a = [NSNumber numberWithUnsignedChar:cppValue.arg4.a];
             memberValue.b = [NSNumber numberWithBool:cppValue.arg4.b];
             memberValue.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.arg4.c)];
-            memberValue.d = [NSData dataWithBytes:cppValue.arg4.d.data() length:cppValue.arg4.d.size()];
-            memberValue.e = [[NSString alloc] initWithBytes:cppValue.arg4.e.data()
-                                                     length:cppValue.arg4.e.size()
-                                                   encoding:NSUTF8StringEncoding];
+            memberValue.d = AsData(cppValue.arg4.d);
+            memberValue.e = AsString(cppValue.arg4.e);
+            if (memberValue.e == nil) {
+                CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                *aError = err;
+                return nil;
+            }
             memberValue.f = [NSNumber numberWithUnsignedChar:cppValue.arg4.f.Raw()];
             memberValue.g = [NSNumber numberWithFloat:cppValue.arg4.g];
             memberValue.h = [NSNumber numberWithDouble:cppValue.arg4.h];
@@ -2752,10 +2758,13 @@ static id _Nullable DecodeEventPayloadForUnitTestingCluster(EventId aEventId, TL
                     newElement_0.a = [NSNumber numberWithUnsignedChar:entry_0.a];
                     newElement_0.b = [NSNumber numberWithBool:entry_0.b];
                     newElement_0.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.c)];
-                    newElement_0.d = [NSData dataWithBytes:entry_0.d.data() length:entry_0.d.size()];
-                    newElement_0.e = [[NSString alloc] initWithBytes:entry_0.e.data()
-                                                              length:entry_0.e.size()
-                                                            encoding:NSUTF8StringEncoding];
+                    newElement_0.d = AsData(entry_0.d);
+                    newElement_0.e = AsString(entry_0.e);
+                    if (newElement_0.e == nil) {
+                        CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+                        *aError = err;
+                        return nil;
+                    }
                     newElement_0.f = [NSNumber numberWithUnsignedChar:entry_0.f.Raw()];
                     newElement_0.g = [NSNumber numberWithFloat:entry_0.g];
                     newElement_0.h = [NSNumber numberWithDouble:entry_0.h];


### PR DESCRIPTION
Also adds error-checking for when AsString fails due to the string not actually being valid UTF-8.

