### PR TITLE
Make sure we propagate TLV decode errors to consumers in Darwin framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -571,7 +571,7 @@ id _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data
             chip::TLV::Tag tag = data->GetTag();
             id value = MTRDecodeDataValueDictionaryFromCHIPTLV(data);
             if (value == nullptr) {
-                MTR_LOG_ERROR("Error when decoding TLV container");
+                MTR_LOG_ERROR("Error when decoding TLV container of type %s", typeName.UTF8String);
                 return nil;
             }
             NSMutableDictionary * arrayElement = [NSMutableDictionary dictionary];

--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -69,6 +69,13 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
      * expected schema.
      */
     MTRErrorCodeSchemaMismatch MTR_NEWLY_AVAILABLE = 13,
+    /**
+     * MTRErrorCodeTLVDecodeFailed means that the TLV being decoded was malformed in
+     * some way.  This can include things like lengths running past the end of
+     * the buffer, strings that are not actually UTF-8, and various other
+     * TLV-level failures.
+     */
+    MTRErrorCodeTLVDecodeFailed MTR_NEWLY_AVAILABLE = 14,
 };
 // clang-format on
 

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -89,6 +89,9 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
         [userInfo addEntriesFromDictionary:@{
             NSLocalizedDescriptionKey : NSLocalizedString(@"The device is already a member of this fabric.", nil)
         }];
+    } else if (errorCode == CHIP_ERROR_DECODE_FAILED) {
+        code = MTRErrorCodeTLVDecodeFailed;
+        [userInfo addEntriesFromDictionary:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"TLV decoding failed.", nil) }];
     } else {
         code = MTRErrorCodeGeneralError;
         [userInfo addEntriesFromDictionary:@{


### PR DESCRIPTION
In particular, in MTRDevice we should cache that we had a decode failure instead of leaving the cache un-filled.

