### PR TITLE
Fix thread names for k32w's DiagnosticDataProvider.

### DIFF
--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
@@ -110,8 +110,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
         {
             ThreadMetrics * thread = (ThreadMetrics *) pvPortMalloc(sizeof(ThreadMetrics));
 
-            strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
-            thread->NameBuf[kMaxThreadNameLength] = '\0';
+            Platform::CopyString(thread->NameBuf, taskStatusArray[x].pcTaskName);
             thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
             thread->id = taskStatusArray[x].xTaskNumber;
 


### PR DESCRIPTION
The old code was copying in N-1 chars, then creating a string of length N from them, so ending up with a random byte in the string, which could lead to the string not being valid UTF-8.

Fixes https://github.com/project-chip/connectedhomeip/issues/26891
