### PR TITLE
Make output class directory unique for java

### DIFF
--- a/build/chip/java/config.gni
+++ b/build/chip/java/config.gni
@@ -16,7 +16,7 @@ java_path = getenv("JAVA_PATH")
 declare_args() {
   java_matter_controller_dependent_paths = []
   build_java_matter_controller = false
-  if (java_path != "") {
+  if (java_path != "" && current_os != "android") {
     java_matter_controller_dependent_paths += [ "${java_path}/include/" ]
 
     if (current_os == "mac") {

--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -21,8 +21,8 @@ kotlinc_runner = "${chip_root}/build/chip/java/kotlinc_runner.py"
 jar_runner = "${chip_root}/build/chip/java/jar_runner.py"
 write_build_config = "${chip_root}/build/chip/java/write_build_config.py"
 
-assert(android_sdk_root != "" || matter_enable_java_compilation,
-       "android_sdk_root must be specified or JAVA_PATH must be set.")
+assert(android_sdk_root != "" || build_java_matter_controller,
+       "android_sdk_root or java_path must be specified")
 
 # Declare a java library target
 #

--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -21,8 +21,8 @@ kotlinc_runner = "${chip_root}/build/chip/java/kotlinc_runner.py"
 jar_runner = "${chip_root}/build/chip/java/jar_runner.py"
 write_build_config = "${chip_root}/build/chip/java/write_build_config.py"
 
-assert(android_sdk_root != "" || build_java_matter_controller,
-       "android_sdk_root or java_path must be specified")
+assert(android_sdk_root != "" || matter_enable_java_compilation,
+       "android_sdk_root must be specified or JAVA_PATH must be set.")
 
 # Declare a java library target
 #
@@ -127,7 +127,7 @@ template("java_library") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _javac_target_name = target_name + "__javac"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_javac_target_name) {
       sources = _java_files
@@ -284,7 +284,7 @@ template("java_binary") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _javac_target_name = target_name + "__javac"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_javac_target_name) {
       sources = _java_files
@@ -441,7 +441,7 @@ template("kotlin_library") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _kotlinc_target_name = target_name + "__kotlinc"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_kotlinc_target_name) {
       sources = _kotlin_files
@@ -598,7 +598,7 @@ template("kotlin_binary") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _kotlinc_target_name = target_name + "__kotlinc"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_kotlinc_target_name) {
       sources = _kotlin_files

--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -127,7 +127,8 @@ template("java_library") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _javac_target_name = target_name + "__javac"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" +
+                 target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_javac_target_name) {
       sources = _java_files
@@ -284,7 +285,8 @@ template("java_binary") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _javac_target_name = target_name + "__javac"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" +
+                 target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_javac_target_name) {
       sources = _java_files
@@ -441,7 +443,8 @@ template("kotlin_library") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _kotlinc_target_name = target_name + "__kotlinc"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" +
+                 target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_kotlinc_target_name) {
       sources = _kotlin_files
@@ -598,7 +601,8 @@ template("kotlin_binary") {
 
     # Compiles the given files into a directory and generates a 'class list'
     _kotlinc_target_name = target_name + "__kotlinc"
-    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" + target_name + "/classes"
+    _class_dir = rebase_path(target_out_dir, root_build_dir) + "/" +
+                 target_name + "/classes"
     _class_list_file = "$target_gen_dir/$target_name.classlist"
     action(_kotlinc_target_name) {
       sources = _kotlin_files

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -227,6 +227,7 @@ class AndroidBuilder(Builder):
             "CHIPController.jar": "src/controller/java/CHIPController.jar",
             "SetupPayloadParser.jar": "src/setup_payload/java/SetupPayloadParser.jar",
             "AndroidPlatform.jar": "src/platform/android/AndroidPlatform.jar",
+            "libCHIPTlv.jar": "src/controller/java/libCHIPTlv.jar",
         }
 
         for jarName in jars.keys():
@@ -519,6 +520,9 @@ class AndroidBuilder(Builder):
                 ),
                 "CHIPController.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/CHIPController.jar"
+                ),
+                "libChipTlv.jar": os.path.join(
+                    self.output_dir, "lib", "src/controller/java/libCHIPTlv.jar"
                 ),
                 "AndroidPlatform.jar": os.path.join(
                     self.output_dir, "lib", "src/platform/android/AndroidPlatform.jar"

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -153,7 +153,8 @@ class AndroidBuilder(Builder):
         if not (
             os.path.isfile(sdk_manager) and os.access(sdk_manager, os.X_OK)
         ) and not (
-            os.path.isfile(new_sdk_manager) and os.access(new_sdk_manager, os.X_OK)
+            os.path.isfile(new_sdk_manager) and os.access(
+                new_sdk_manager, os.X_OK)
         ):
             raise Exception(
                 "'%s' and '%s' is not executable by the current user"
@@ -268,7 +269,8 @@ class AndroidBuilder(Builder):
         # App compilation
         self._Execute(
             [
-                "%s/examples/android/%s/gradlew" % (self.root, self.app.AppName()),
+                "%s/examples/android/%s/gradlew" % (
+                    self.root, self.app.AppName()),
                 "-p",
                 "%s/examples/android/%s" % (self.root, self.app.AppName()),
                 "-PmatterBuildSrcDir=%s" % self.output_dir,
@@ -296,7 +298,8 @@ class AndroidBuilder(Builder):
                         "-PbuildDir=%s/%s" % (self.output_dir, module),
                         ":%s:assembleDebug" % module,
                     ],
-                    title="Building Example %s, module %s" % (self.identifier, module),
+                    title="Building Example %s, module %s" % (
+                        self.identifier, module),
                 )
         else:
             self._Execute(
@@ -304,7 +307,8 @@ class AndroidBuilder(Builder):
                     "%s/examples/%s/android/App/gradlew"
                     % (self.root, self.app.ExampleName()),
                     "-p",
-                    "%s/examples/%s/android/App/" % (self.root, self.app.ExampleName()),
+                    "%s/examples/%s/android/App/" % (self.root,
+                                                     self.app.ExampleName()),
                     "-PmatterBuildSrcDir=%s" % self.output_dir,
                     "-PmatterSdkSourceBuild=false",
                     "-PbuildDir=%s" % self.output_dir,
@@ -360,7 +364,8 @@ class AndroidBuilder(Builder):
 
             exampleName = self.app.ExampleName()
             if exampleName is not None:
-                gn_gen += ["--root=%s/examples/%s/android/" % (self.root, exampleName)]
+                gn_gen += ["--root=%s/examples/%s/android/" %
+                           (self.root, exampleName)]
 
             if self.board.IsIde():
                 gn_gen += [
@@ -379,7 +384,8 @@ class AndroidBuilder(Builder):
             )
             if os.path.isfile(new_sdk_manager) and os.access(new_sdk_manager, os.X_OK):
                 self._Execute(
-                    ["bash", "-c", "yes | %s --licenses >/dev/null" % new_sdk_manager],
+                    ["bash", "-c", "yes | %s --licenses >/dev/null" %
+                        new_sdk_manager],
                     title="Accepting NDK licenses @ cmdline-tools",
                 )
             else:
@@ -415,7 +421,8 @@ class AndroidBuilder(Builder):
             # TODO: Android Gradle with module and -PbuildDir= will caused issue, remove -PbuildDir=
             self._Execute(
                 [
-                    "%s/examples/android/%s/gradlew" % (self.root, self.app.AppName()),
+                    "%s/examples/android/%s/gradlew" % (
+                        self.root, self.app.AppName()),
                     "-p",
                     "%s/examples/android/%s" % (self.root, self.app.AppName()),
                     "-PmatterBuildSrcDir=%s" % self.output_dir,
@@ -471,7 +478,8 @@ class AndroidBuilder(Builder):
                     self.root, "examples/", self.app.ExampleName(), "android/App/app/libs"
                 )
 
-                libs = ["libSetupPayloadParser.so", "libc++_shared.so", "libTvApp.so"]
+                libs = ["libSetupPayloadParser.so",
+                        "libc++_shared.so", "libTvApp.so"]
 
                 jars = {
                     "SetupPayloadParser.jar": "third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar",
@@ -521,7 +529,7 @@ class AndroidBuilder(Builder):
                 "CHIPController.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/CHIPController.jar"
                 ),
-                "libChipTlv.jar": os.path.join(
+                "libCHIPTlv.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/libCHIPTlv.jar"
                 ),
                 "AndroidPlatform.jar": os.path.join(

--- a/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
+++ b/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
@@ -31,5 +31,7 @@ cp {out}/android-arm64-chip-tool/lib/src/setup_payload/java/SetupPayloadParser.j
 
 cp {out}/android-arm64-chip-tool/lib/src/platform/android/AndroidPlatform.jar {root}/examples/android/CHIPTool/app/libs/AndroidPlatform.jar
 
+cp {out}/android-arm64-chip-tool/lib/src/controller/java/libCHIPTlv.jar {root}/examples/android/CHIPTool/app/libs/libCHIPTlv.jar
+
 # Building APP android-arm64-chip-tool
 {root}/examples/android/CHIPTool/gradlew -p {root}/examples/android/CHIPTool -PmatterBuildSrcDir={out}/android-arm64-chip-tool -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm64-chip-tool assembleDebug

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -95,7 +95,7 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
                    f'{tool_path}/lib/*',
                    f'{tool_path}/lib/third_party/connectedhomeip/src/controller/java/*',
                    f'{tool_path}/bin/java-matter-controller',
-                   ]),
+               ]),
                'com.matter.controller.MainKt']
 
     if tool_cluster == 'pairing':

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -88,7 +88,11 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         DumpProgramOutputToQueue(
             log_cooking_threads, Fore.GREEN + "APP " + Style.RESET_ALL, app_process, log_queue)
 
-    command = ['java', '-Djava.library.path=' + tool_path + '/lib/jni', '-jar', tool_path + '/bin/java-matter-controller']
+    command = ['java',
+               '-Djava.library.path=' + tool_path + '/lib/jni',
+               '-cp',
+               f'{tool_path}/lib/*:{tool_path}/bin/java-matter-controller',
+               'com.matter.controller.MainKt']
 
     if tool_cluster == 'pairing':
         logging.info("Testing pairing cluster")

--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -89,9 +89,13 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
             log_cooking_threads, Fore.GREEN + "APP " + Style.RESET_ALL, app_process, log_queue)
 
     command = ['java',
-               '-Djava.library.path=' + tool_path + '/lib/jni',
+               f'-Djava.library.path={tool_path}/lib/jni',
                '-cp',
-               f'{tool_path}/lib/*:{tool_path}/bin/java-matter-controller',
+               ':'.join([
+                   f'{tool_path}/lib/*',
+                   f'{tool_path}/lib/third_party/connectedhomeip/src/controller/java/*',
+                   f'{tool_path}/bin/java-matter-controller',
+                   ]),
                'com.matter.controller.MainKt']
 
     if tool_cluster == 'pairing':


### PR DESCRIPTION
This looks to fix the `chip.jsontlv.toJsonString` error that we seem to be getting (i.e. fixes #26815)

From what I can tell, each compilation used to codegen under `classes` subdirectory, so if different classes compile things, we may end up with different versions of the same code.

From my local tests, applying this change fixed an always-reproducible fromJsonString error, so I assume this works on current codebase as well.

Before this change, every jar file built ended up containing *ALL* the class files that were built for all targets (but random content because racy). After this change I see the correct content, like:

```
❯ unzip -l out/linux-x64-tests/lib/src/controller/java/libCHIPJson.jar
Archive:  out/linux-x64-tests/lib/src/controller/java/libCHIPJson.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2023-05-26 19:08   META-INF/
       64  2023-05-26 19:08   META-INF/MANIFEST.MF
       75  2023-05-26 19:08   META-INF/main.kotlin_module
        0  2023-05-26 19:08   chip/
        0  2023-05-26 19:08   chip/jsontlv/
     8303  2023-05-26 19:08   chip/jsontlv/TlvToJsonKt.class
    11857  2023-05-26 19:08   chip/jsontlv/JsonToTlvKt.class
     1306  2023-05-26 19:08   chip/jsontlv/TypesKt.class
---------                     -------
    21605                     8 files
```

As a sideffect now, `CHIPController.jar` does not contain tlv classes anymore, so had to:
  - update build scripts to also copy libCHIPtlv.jar to the `libs` folder.
  - update run_java_test.py script to set a proper classpath

The classpath iterations could use some more revisions ... they feel a bit hardcoded now, I would rather expect our builds to be able to output some form of dependencies to automate things.