### PR TITLE
Fix the various MessageDef EndOf* functions to return CHIP_ERROR.

### DIFF
--- a/src/app/AttributeAccessInterface.cpp
+++ b/src/app/AttributeAccessInterface.cpp
@@ -44,15 +44,15 @@ CHIP_ERROR AttributeReportBuilder::PrepareAttribute(AttributeReportIBs::Builder 
         attributePathIBBuilder.ListIndex(DataModel::Nullable<ListIndex>());
     }
 
-    ReturnErrorOnFailure(attributePathIBBuilder.EndOfAttributePathIB().GetError());
+    ReturnErrorOnFailure(attributePathIBBuilder.EndOfAttributePathIB());
 
     return attributeDataIBBuilder.GetError();
 }
 
 CHIP_ERROR AttributeReportBuilder::FinishAttribute(AttributeReportIBs::Builder & aAttributeReportIBsBuilder)
 {
-    ReturnErrorOnFailure(aAttributeReportIBsBuilder.GetAttributeReport().GetAttributeData().EndOfAttributeDataIB().GetError());
-    return aAttributeReportIBsBuilder.GetAttributeReport().EndOfAttributeReportIB().GetError();
+    ReturnErrorOnFailure(aAttributeReportIBsBuilder.GetAttributeReport().GetAttributeData().EndOfAttributeDataIB());
+    return aAttributeReportIBsBuilder.GetAttributeReport().EndOfAttributeReportIB();
 }
 
 namespace {

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -569,9 +569,8 @@ CHIP_ERROR ClusterStateCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs
         SuccessOrExit(err = aDataVersionFilterIBsBuilder.GetError());
         ClusterPathIB::Builder & filterPath = filterIB.CreatePath();
         SuccessOrExit(err = filterIB.GetError());
-        SuccessOrExit(
-            err = filterPath.Endpoint(filter.first.mEndpointId).Cluster(filter.first.mClusterId).EndOfClusterPathIB().GetError());
-        SuccessOrExit(err = filterIB.DataVersion(filter.first.mDataVersion.Value()).EndOfDataVersionFilterIB().GetError());
+        SuccessOrExit(err = filterPath.Endpoint(filter.first.mEndpointId).Cluster(filter.first.mClusterId).EndOfClusterPathIB());
+        SuccessOrExit(err = filterIB.DataVersion(filter.first.mDataVersion.Value()).EndOfDataVersionFilterIB());
         ChipLogProgress(DataManagement, "Update DataVersionFilter: Endpoint=%u Cluster=" ChipLogFormatMEI " Version=%" PRIu32,
                         filter.first.mEndpointId, ChipLogValueMEI(filter.first.mClusterId), filter.first.mDataVersion.Value());
 

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -516,10 +516,10 @@ CHIP_ERROR CommandHandler::FinishCommand(bool aStartDataStruct)
     {
         ReturnErrorOnFailure(commandData.GetWriter()->EndContainer(mDataElementContainerType));
     }
-    ReturnErrorOnFailure(commandData.EndOfCommandDataIB().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.EndOfInvokeResponseMessage().GetError());
+    ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.EndOfInvokeResponseMessage());
     MoveToState(State::AddedCommand);
     return CHIP_NO_ERROR;
 }
@@ -547,11 +547,10 @@ CHIP_ERROR CommandHandler::PrepareStatus(const ConcreteCommandPath & aCommandPat
 CHIP_ERROR CommandHandler::FinishStatus()
 {
     VerifyOrReturnError(mState == State::AddingCommand, CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(
-        mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetStatus().EndOfCommandStatusIB().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses().GetError());
-    ReturnErrorOnFailure(mInvokeResponseBuilder.EndOfInvokeResponseMessage().GetError());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetStatus().EndOfCommandStatusIB());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses());
+    ReturnErrorOnFailure(mInvokeResponseBuilder.EndOfInvokeResponseMessage());
     MoveToState(State::AddedCommand);
     return CHIP_NO_ERROR;
 }

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -382,9 +382,9 @@ CHIP_ERROR CommandSender::FinishCommand(bool aEndDataStruct)
         ReturnErrorOnFailure(commandData.GetWriter()->EndContainer(mDataElementContainerType));
     }
 
-    ReturnErrorOnFailure(commandData.EndOfCommandDataIB().GetError());
-    ReturnErrorOnFailure(mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests().GetError());
-    ReturnErrorOnFailure(mInvokeRequestBuilder.EndOfInvokeRequestMessage().GetError());
+    ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
+    ReturnErrorOnFailure(mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests());
+    ReturnErrorOnFailure(mInvokeRequestBuilder.EndOfInvokeRequestMessage());
 
     MoveToState(State::AddedCommand);
 

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -301,11 +301,11 @@ CHIP_ERROR EventManagement::ConstructEvent(EventLoadOutContext * apContext, Even
     EventPathIB::Builder & eventPathBuilder = eventDataIBBuilder.CreatePath();
     ReturnErrorOnFailure(eventDataIBBuilder.GetError());
 
-    eventPathBuilder.Endpoint(apOptions->mPath.mEndpointId)
-        .Cluster(apOptions->mPath.mClusterId)
-        .Event(apOptions->mPath.mEventId)
-        .EndOfEventPathIB();
-    ReturnErrorOnFailure(eventPathBuilder.GetError());
+    CHIP_ERROR err = eventPathBuilder.Endpoint(apOptions->mPath.mEndpointId)
+                         .Cluster(apOptions->mPath.mClusterId)
+                         .Event(apOptions->mPath.mEventId)
+                         .EndOfEventPathIB();
+    ReturnErrorOnFailure(err);
     eventDataIBBuilder.EventNumber(apContext->mCurrentEventNumber).Priority(chip::to_underlying(apContext->mPriority));
     ReturnErrorOnFailure(eventDataIBBuilder.GetError());
 
@@ -330,10 +330,8 @@ CHIP_ERROR EventManagement::ConstructEvent(EventLoadOutContext * apContext, Even
     {
         apContext->mWriter.Put(TLV::ProfileTag(kEventManagementProfile, kFabricIndexTag), apOptions->mFabricIndex);
     }
-    eventDataIBBuilder.EndOfEventDataIB();
-    ReturnErrorOnFailure(eventDataIBBuilder.GetError());
-    eventReportBuilder.EndOfEventReportIB();
-    ReturnErrorOnFailure(eventReportBuilder.GetError());
+    ReturnErrorOnFailure(eventDataIBBuilder.EndOfEventDataIB());
+    ReturnErrorOnFailure(eventReportBuilder.EndOfEventReportIB());
     ReturnErrorOnFailure(apContext->mWriter.Finalize());
     apContext->mFirst = false;
     return CHIP_NO_ERROR;

--- a/src/app/MessageDef/AttributeDataIB.cpp
+++ b/src/app/MessageDef/AttributeDataIB.cpp
@@ -127,10 +127,10 @@ AttributeDataIB::Builder & AttributeDataIB::Builder::DataVersion(const chip::Dat
     return *this;
 }
 
-AttributeDataIB::Builder & AttributeDataIB::Builder::EndOfAttributeDataIB()
+CHIP_ERROR AttributeDataIB::Builder::EndOfAttributeDataIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -101,9 +101,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeDataIB
      *
-     *  @return A reference to *this
+     *  @return Our The builder's final status.
      */
-    AttributeDataIB::Builder & EndOfAttributeDataIB();
+    CHIP_ERROR EndOfAttributeDataIB();
 
 private:
     AttributePathIB::Builder mPath;

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -101,11 +101,11 @@ AttributeDataIB::Builder & AttributeDataIBs::Builder::GetAttributeDataIBBuilder(
     return mAttributeDataIBBuilder;
 }
 
-AttributeDataIBs::Builder & AttributeDataIBs::Builder::EndOfAttributeDataIBs()
+CHIP_ERROR AttributeDataIBs::Builder::EndOfAttributeDataIBs()
 {
     EndOfContainer();
 
-    return *this;
+    return GetError();
 }
 
 }; // namespace app

--- a/src/app/MessageDef/AttributeDataIBs.h
+++ b/src/app/MessageDef/AttributeDataIBs.h
@@ -60,9 +60,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeDataIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributeDataIBs::Builder & EndOfAttributeDataIBs();
+    CHIP_ERROR EndOfAttributeDataIBs();
 
 private:
     AttributeDataIB::Builder mAttributeDataIBBuilder;

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -336,10 +336,10 @@ AttributePathIB::Builder & AttributePathIB::Builder::ListIndex(const chip::ListI
     return *this;
 }
 
-AttributePathIB::Builder & AttributePathIB::Builder::EndOfAttributePathIB()
+CHIP_ERROR AttributePathIB::Builder::EndOfAttributePathIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR AttributePathIB::Builder::Encode(const AttributePathParams & aAttributePathParams)
@@ -364,8 +364,7 @@ CHIP_ERROR AttributePathIB::Builder::Encode(const AttributePathParams & aAttribu
         ListIndex(aAttributePathParams.mListIndex);
     }
 
-    EndOfAttributePathIB();
-    return GetError();
+    return EndOfAttributePathIB();
 }
 
 CHIP_ERROR AttributePathIB::Builder::Encode(const ConcreteDataAttributePath & aAttributePath)
@@ -388,8 +387,7 @@ CHIP_ERROR AttributePathIB::Builder::Encode(const ConcreteDataAttributePath & aA
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    EndOfAttributePathIB();
-    return GetError();
+    return EndOfAttributePathIB();
 }
 
 } // namespace app

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -227,9 +227,9 @@ public:
     /**
      *  @brief Mark the end of this AttributePathIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributePathIB::Builder & EndOfAttributePathIB();
+    CHIP_ERROR EndOfAttributePathIB();
 
     CHIP_ERROR Encode(const AttributePathParams & aAttributePathParams);
     CHIP_ERROR Encode(const ConcreteDataAttributePath & aAttributePathParams);

--- a/src/app/MessageDef/AttributePathIBs.cpp
+++ b/src/app/MessageDef/AttributePathIBs.cpp
@@ -82,10 +82,10 @@ AttributePathIB::Builder & AttributePathIBs::Builder::CreatePath()
 }
 
 // Mark the end of this array and recover the type for outer container
-AttributePathIBs::Builder & AttributePathIBs::Builder::EndOfAttributePathIBs()
+CHIP_ERROR AttributePathIBs::Builder::EndOfAttributePathIBs()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/AttributePathIBs.h
+++ b/src/app/MessageDef/AttributePathIBs.h
@@ -53,9 +53,9 @@ public:
     /**
      *  @brief Mark the end of this AttributePathIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributePathIBs::Builder & EndOfAttributePathIBs();
+    CHIP_ERROR EndOfAttributePathIBs();
 
 private:
     AttributePathIB::Builder mAttributePath;

--- a/src/app/MessageDef/AttributeReportIB.cpp
+++ b/src/app/MessageDef/AttributeReportIB.cpp
@@ -118,10 +118,10 @@ AttributeDataIB::Builder & AttributeReportIB::Builder::CreateAttributeData()
     return mAttributeData;
 }
 
-AttributeReportIB::Builder & AttributeReportIB::Builder::EndOfAttributeReportIB()
+CHIP_ERROR AttributeReportIB::Builder::EndOfAttributeReportIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/AttributeReportIB.h
+++ b/src/app/MessageDef/AttributeReportIB.h
@@ -89,9 +89,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeReportIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributeReportIB::Builder & EndOfAttributeReportIB();
+    CHIP_ERROR EndOfAttributeReportIB();
 
 private:
     AttributeStatusIB::Builder mAttributeStatus;

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -78,10 +78,10 @@ AttributeReportIB::Builder & AttributeReportIBs::Builder::CreateAttributeReport(
     return mAttributeReport;
 }
 
-AttributeReportIBs::Builder & AttributeReportIBs::Builder::EndOfAttributeReportIBs()
+CHIP_ERROR AttributeReportIBs::Builder::EndOfAttributeReportIBs()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR AttributeReportIBs::Builder::EncodeAttributeStatus(const ConcreteReadAttributePath & aPath, const StatusIB & aStatus)
@@ -103,8 +103,8 @@ CHIP_ERROR AttributeReportIBs::Builder::EncodeAttributeStatus(const ConcreteRead
     statusIBBuilder.EncodeStatusIB(aStatus);
     ReturnErrorOnFailure(statusIBBuilder.GetError());
 
-    ReturnErrorOnFailure(attributeStatusIBBuilder.EndOfAttributeStatusIB().GetError());
-    return attributeReport.EndOfAttributeReportIB().GetError();
+    ReturnErrorOnFailure(attributeStatusIBBuilder.EndOfAttributeStatusIB());
+    return attributeReport.EndOfAttributeReportIB();
 }
 
 } // namespace app

--- a/src/app/MessageDef/AttributeReportIBs.h
+++ b/src/app/MessageDef/AttributeReportIBs.h
@@ -62,9 +62,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeReportIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributeReportIBs::Builder & EndOfAttributeReportIBs();
+    CHIP_ERROR EndOfAttributeReportIBs();
 
     /**
      * Encode an AttributeReportIB containing an AttributeStatus.

--- a/src/app/MessageDef/AttributeStatusIB.cpp
+++ b/src/app/MessageDef/AttributeStatusIB.cpp
@@ -117,10 +117,10 @@ StatusIB::Builder & AttributeStatusIB::Builder::CreateErrorStatus()
     return mErrorStatus;
 }
 
-AttributeStatusIB::Builder & AttributeStatusIB::Builder::EndOfAttributeStatusIB()
+CHIP_ERROR AttributeStatusIB::Builder::EndOfAttributeStatusIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/AttributeStatusIB.h
+++ b/src/app/MessageDef/AttributeStatusIB.h
@@ -88,9 +88,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeStatusIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributeStatusIB::Builder & EndOfAttributeStatusIB();
+    CHIP_ERROR EndOfAttributeStatusIB();
 
 private:
     AttributePathIB::Builder mPath;

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -38,10 +38,10 @@ AttributeStatusIB::Builder & AttributeStatusIBs::Builder::CreateAttributeStatus(
     return mAttributeStatus;
 }
 
-AttributeStatusIBs::Builder & AttributeStatusIBs::Builder::EndOfAttributeStatuses()
+CHIP_ERROR AttributeStatusIBs::Builder::EndOfAttributeStatuses()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 #if CHIP_CONFIG_IM_PRETTY_PRINT

--- a/src/app/MessageDef/AttributeStatusIBs.h
+++ b/src/app/MessageDef/AttributeStatusIBs.h
@@ -45,9 +45,9 @@ public:
     /**
      *  @brief Mark the end of this AttributeStatusIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    AttributeStatusIBs::Builder & EndOfAttributeStatuses();
+    CHIP_ERROR EndOfAttributeStatuses();
 
 private:
     AttributeStatusIB::Builder mAttributeStatus;

--- a/src/app/MessageDef/ClusterPathIB.cpp
+++ b/src/app/MessageDef/ClusterPathIB.cpp
@@ -142,10 +142,10 @@ ClusterPathIB::Builder & ClusterPathIB::Builder::Cluster(const ClusterId aCluste
     return *this;
 }
 
-ClusterPathIB::Builder & ClusterPathIB::Builder::EndOfClusterPathIB()
+CHIP_ERROR ClusterPathIB::Builder::EndOfClusterPathIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/ClusterPathIB.h
+++ b/src/app/MessageDef/ClusterPathIB.h
@@ -112,9 +112,9 @@ public:
     /**
      *  @brief Mark the end of this ClusterPathIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    ClusterPathIB::Builder & EndOfClusterPathIB();
+    CHIP_ERROR EndOfClusterPathIB();
 };
 } // namespace ClusterPathIB
 } // namespace app

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -102,10 +102,10 @@ CommandPathIB::Builder & CommandDataIB::Builder::CreatePath()
     return mPath;
 }
 
-CommandDataIB::Builder & CommandDataIB::Builder::EndOfCommandDataIB()
+CHIP_ERROR CommandDataIB::Builder::EndOfCommandDataIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/CommandDataIB.h
+++ b/src/app/MessageDef/CommandDataIB.h
@@ -81,9 +81,9 @@ public:
     /**
      *  @brief Mark the end of this CommandDataIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    CommandDataIB::Builder & EndOfCommandDataIB();
+    CHIP_ERROR EndOfCommandDataIB();
 
 private:
     CommandPathIB::Builder mPath;

--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -144,10 +144,10 @@ CommandPathIB::Builder & CommandPathIB::Builder::CommandId(const chip::CommandId
     return *this;
 }
 
-CommandPathIB::Builder & CommandPathIB::Builder::EndOfCommandPathIB()
+CHIP_ERROR CommandPathIB::Builder::EndOfCommandPathIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR CommandPathIB::Builder::Encode(const CommandPathParams & aCommandPathParams)
@@ -157,17 +157,15 @@ CHIP_ERROR CommandPathIB::Builder::Encode(const CommandPathParams & aCommandPath
         EndpointId(aCommandPathParams.mEndpointId);
     }
 
-    ClusterId(aCommandPathParams.mClusterId).CommandId(aCommandPathParams.mCommandId).EndOfCommandPathIB();
-    return GetError();
+    return ClusterId(aCommandPathParams.mClusterId).CommandId(aCommandPathParams.mCommandId).EndOfCommandPathIB();
 }
 
 CHIP_ERROR CommandPathIB::Builder::Encode(const ConcreteCommandPath & aConcreteCommandPath)
 {
-    EndpointId(aConcreteCommandPath.mEndpointId)
+    return EndpointId(aConcreteCommandPath.mEndpointId)
         .ClusterId(aConcreteCommandPath.mClusterId)
         .CommandId(aConcreteCommandPath.mCommandId)
         .EndOfCommandPathIB();
-    return GetError();
 }
 
 }; // namespace app

--- a/src/app/MessageDef/CommandPathIB.h
+++ b/src/app/MessageDef/CommandPathIB.h
@@ -114,9 +114,9 @@ public:
     /**
      *  @brief Mark the end of this CommandPathIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    CommandPathIB::Builder & EndOfCommandPathIB();
+    CHIP_ERROR EndOfCommandPathIB();
 
     CHIP_ERROR Encode(const CommandPathParams & aCommandPathParams);
     CHIP_ERROR Encode(const ConcreteCommandPath & aConcreteCommandPath);

--- a/src/app/MessageDef/CommandStatusIB.cpp
+++ b/src/app/MessageDef/CommandStatusIB.cpp
@@ -126,10 +126,10 @@ StatusIB::Builder & CommandStatusIB::Builder::CreateErrorStatus()
     return mErrorStatus;
 }
 
-CommandStatusIB::Builder & CommandStatusIB::Builder::EndOfCommandStatusIB()
+CHIP_ERROR CommandStatusIB::Builder::EndOfCommandStatusIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/CommandStatusIB.h
+++ b/src/app/MessageDef/CommandStatusIB.h
@@ -89,9 +89,9 @@ public:
     /**
      *  @brief Mark the end of this CommandStatusIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    CommandStatusIB::Builder & EndOfCommandStatusIB();
+    CHIP_ERROR EndOfCommandStatusIB();
 
 private:
     CommandPathIB::Builder mPath;

--- a/src/app/MessageDef/DataVersionFilterIB.cpp
+++ b/src/app/MessageDef/DataVersionFilterIB.cpp
@@ -121,10 +121,10 @@ DataVersionFilterIB::Builder & DataVersionFilterIB::Builder::DataVersion(const c
     return *this;
 }
 
-DataVersionFilterIB::Builder & DataVersionFilterIB::Builder::EndOfDataVersionFilterIB()
+CHIP_ERROR DataVersionFilterIB::Builder::EndOfDataVersionFilterIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/DataVersionFilterIB.h
+++ b/src/app/MessageDef/DataVersionFilterIB.h
@@ -89,9 +89,9 @@ public:
     /**
      *  @brief Mark the end of this DataVersionFilterIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    DataVersionFilterIB::Builder & EndOfDataVersionFilterIB();
+    CHIP_ERROR EndOfDataVersionFilterIB();
 
 private:
     ClusterPathIB::Builder mPath;

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -69,10 +69,10 @@ DataVersionFilterIB::Builder & DataVersionFilterIBs::Builder::CreateDataVersionF
     return mDataVersionFilter;
 }
 
-DataVersionFilterIBs::Builder & DataVersionFilterIBs::Builder::EndOfDataVersionFilterIBs()
+CHIP_ERROR DataVersionFilterIBs::Builder::EndOfDataVersionFilterIBs()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/DataVersionFilterIBs.h
+++ b/src/app/MessageDef/DataVersionFilterIBs.h
@@ -57,9 +57,9 @@ public:
     /**
      *  @brief Mark the end of this DataVersionFilterIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    DataVersionFilterIBs::Builder & EndOfDataVersionFilterIBs();
+    CHIP_ERROR EndOfDataVersionFilterIBs();
 
 private:
     DataVersionFilterIB::Builder mDataVersionFilter;

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -362,10 +362,10 @@ EventDataIB::Builder & EventDataIB::Builder::DeltaSystemTimestamp(const uint64_t
 }
 
 // Mark the end of this element and recover the type for outer container
-EventDataIB::Builder & EventDataIB::Builder::EndOfEventDataIB()
+CHIP_ERROR EventDataIB::Builder::EndOfEventDataIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventDataIB.h
+++ b/src/app/MessageDef/EventDataIB.h
@@ -227,9 +227,9 @@ public:
     /**
      *  @brief Mark the end of this EventDataIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventDataIB::Builder & EndOfEventDataIB();
+    CHIP_ERROR EndOfEventDataIB();
 
 private:
     EventPathIB::Builder mPath;

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -119,10 +119,10 @@ EventFilterIB::Builder & EventFilterIB::Builder::EventMin(const uint64_t aEventM
     return *this;
 }
 
-EventFilterIB::Builder & EventFilterIB::Builder::EndOfEventFilterIB()
+CHIP_ERROR EventFilterIB::Builder::EndOfEventFilterIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/EventFilterIB.h
+++ b/src/app/MessageDef/EventFilterIB.h
@@ -96,9 +96,9 @@ public:
     /**
      *  @brief Mark the end of this EventFilterIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventFilterIB::Builder & EndOfEventFilterIB();
+    CHIP_ERROR EndOfEventFilterIB();
 };
 }; // namespace EventFilterIB
 }; // namespace app

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -69,18 +69,18 @@ EventFilterIB::Builder & EventFilterIBs::Builder::CreateEventFilter()
     return mEventFilter;
 }
 
-EventFilterIBs::Builder & EventFilterIBs::Builder::EndOfEventFilters()
+CHIP_ERROR EventFilterIBs::Builder::EndOfEventFilters()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR EventFilterIBs::Builder::GenerateEventFilter(EventNumber aEventNumber)
 {
     EventFilterIB::Builder & eventFilter = CreateEventFilter();
     ReturnErrorOnFailure(GetError());
-    ReturnErrorOnFailure(eventFilter.EventMin(aEventNumber).EndOfEventFilterIB().GetError());
-    ReturnErrorOnFailure(EndOfEventFilters().GetError());
+    ReturnErrorOnFailure(eventFilter.EventMin(aEventNumber).EndOfEventFilterIB());
+    ReturnErrorOnFailure(EndOfEventFilters());
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/MessageDef/EventFilterIBs.h
+++ b/src/app/MessageDef/EventFilterIBs.h
@@ -57,9 +57,9 @@ public:
     /**
      *  @brief Mark the end of this EventFilterIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventFilterIBs::Builder & EndOfEventFilters();
+    CHIP_ERROR EndOfEventFilters();
 
     /**
      *  @brief Generate single event filter

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -251,10 +251,10 @@ EventPathIB::Builder & EventPathIB::Builder::IsUrgent(const bool aIsUrgent)
     return *this;
 }
 
-EventPathIB::Builder & EventPathIB::Builder::EndOfEventPathIB()
+CHIP_ERROR EventPathIB::Builder::EndOfEventPathIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR EventPathIB::Builder::Encode(const EventPathParams & aEventPathParams)
@@ -278,8 +278,7 @@ CHIP_ERROR EventPathIB::Builder::Encode(const EventPathParams & aEventPathParams
     {
         IsUrgent(aEventPathParams.mIsUrgentEvent);
     }
-    EndOfEventPathIB();
-    return GetError();
+    return EndOfEventPathIB();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -175,9 +175,9 @@ public:
     /**
      *  @brief Mark the end of this EventPath
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventPathIB::Builder & EndOfEventPathIB();
+    CHIP_ERROR EndOfEventPathIB();
 
     CHIP_ERROR Encode(const EventPathParams & aEventPathParams);
 };

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -77,10 +77,10 @@ EventPathIB::Builder & EventPathIBs::Builder::CreatePath()
     return mEventPath;
 }
 
-EventPathIBs::Builder & EventPathIBs::Builder::EndOfEventPaths()
+CHIP_ERROR EventPathIBs::Builder::EndOfEventPaths()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/EventPathIBs.h
+++ b/src/app/MessageDef/EventPathIBs.h
@@ -54,9 +54,9 @@ public:
     /**
      *  @brief Mark the end of this EventPathIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventPathIBs::Builder & EndOfEventPaths();
+    CHIP_ERROR EndOfEventPaths();
 
 private:
     EventPathIB::Builder mEventPath;

--- a/src/app/MessageDef/EventReportIB.cpp
+++ b/src/app/MessageDef/EventReportIB.cpp
@@ -118,10 +118,10 @@ EventDataIB::Builder & EventReportIB::Builder::CreateEventData()
     return mEventData;
 }
 
-EventReportIB::Builder & EventReportIB::Builder::EndOfEventReportIB()
+CHIP_ERROR EventReportIB::Builder::EndOfEventReportIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 
 CHIP_ERROR EventReportIB::ConstructEventStatusIB(TLV::TLVWriter & aWriter, const ConcreteEventPath & aEvent, StatusIB aStatus)
@@ -132,16 +132,13 @@ CHIP_ERROR EventReportIB::ConstructEventStatusIB(TLV::TLVWriter & aWriter, const
     ReturnErrorOnFailure(eventReportIBBuilder.GetError());
     EventPathIB::Builder & eventPathIBBuilder = eventStatusIBBuilder.CreatePath();
     ReturnErrorOnFailure(eventStatusIBBuilder.GetError());
-    ReturnErrorOnFailure(eventPathIBBuilder.Endpoint(aEvent.mEndpointId)
-                             .Cluster(aEvent.mClusterId)
-                             .Event(aEvent.mEventId)
-                             .EndOfEventPathIB()
-                             .GetError());
+    ReturnErrorOnFailure(
+        eventPathIBBuilder.Endpoint(aEvent.mEndpointId).Cluster(aEvent.mClusterId).Event(aEvent.mEventId).EndOfEventPathIB());
 
     ReturnErrorOnFailure(eventStatusIBBuilder.CreateErrorStatus().EncodeStatusIB(aStatus).GetError());
 
-    ReturnErrorOnFailure(eventStatusIBBuilder.EndOfEventStatusIB().GetError());
-    ReturnErrorOnFailure(eventReportIBBuilder.EndOfEventReportIB().GetError());
+    ReturnErrorOnFailure(eventStatusIBBuilder.EndOfEventStatusIB());
+    ReturnErrorOnFailure(eventReportIBBuilder.EndOfEventReportIB());
     ReturnErrorOnFailure(aWriter.Finalize());
     return CHIP_NO_ERROR;
 }

--- a/src/app/MessageDef/EventReportIB.h
+++ b/src/app/MessageDef/EventReportIB.h
@@ -88,9 +88,9 @@ public:
     /**
      *  @brief Mark the end of this EventReportIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventReportIB::Builder & EndOfEventReportIB();
+    CHIP_ERROR EndOfEventReportIB();
 
 private:
     EventStatusIB::Builder mEventStatus;

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -78,10 +78,10 @@ EventReportIB::Builder & EventReportIBs::Builder::CreateEventReport()
     return mEventReport;
 }
 
-EventReportIBs::Builder & EventReportIBs::Builder::EndOfEventReports()
+CHIP_ERROR EventReportIBs::Builder::EndOfEventReports()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventReportIBs.h
+++ b/src/app/MessageDef/EventReportIBs.h
@@ -58,9 +58,9 @@ public:
     /**
      *  @brief Mark the end of this EventReportIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventReportIBs::Builder & EndOfEventReports();
+    CHIP_ERROR EndOfEventReports();
 
 private:
     EventReportIB::Builder mEventReport;

--- a/src/app/MessageDef/EventStatusIB.cpp
+++ b/src/app/MessageDef/EventStatusIB.cpp
@@ -117,10 +117,10 @@ StatusIB::Builder & EventStatusIB::Builder::CreateErrorStatus()
     return mErrorStatus;
 }
 
-EventStatusIB::Builder & EventStatusIB::Builder::EndOfEventStatusIB()
+CHIP_ERROR EventStatusIB::Builder::EndOfEventStatusIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventStatusIB.h
+++ b/src/app/MessageDef/EventStatusIB.h
@@ -88,9 +88,9 @@ public:
     /**
      *  @brief Mark the end of this EventStatusIB
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    EventStatusIB::Builder & EndOfEventStatusIB();
+    CHIP_ERROR EndOfEventStatusIB();
 
 private:
     EventPathIB::Builder mPath;

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -140,7 +140,7 @@ InvokeRequests::Builder & InvokeRequestMessage::Builder::CreateInvokeRequests()
     return mInvokeRequests;
 }
 
-InvokeRequestMessage::Builder & InvokeRequestMessage::Builder::EndOfInvokeRequestMessage()
+CHIP_ERROR InvokeRequestMessage::Builder::EndOfInvokeRequestMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -150,7 +150,7 @@ InvokeRequestMessage::Builder & InvokeRequestMessage::Builder::EndOfInvokeReques
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -102,9 +102,9 @@ public:
     /**
      *  @brief Mark the end of this InvokeRequestMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    InvokeRequestMessage::Builder & EndOfInvokeRequestMessage();
+    CHIP_ERROR EndOfInvokeRequestMessage();
 
 private:
     InvokeRequests::Builder mInvokeRequests;

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -79,10 +79,10 @@ CommandDataIB::Builder & InvokeRequests::Builder::CreateCommandData()
     return mCommandData;
 }
 
-InvokeRequests::Builder & InvokeRequests::Builder::EndOfInvokeRequests()
+CHIP_ERROR InvokeRequests::Builder::EndOfInvokeRequests()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -57,9 +57,9 @@ public:
     /**
      *  @brief Mark the end of this InvokeRequests
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    InvokeRequests::Builder & EndOfInvokeRequests();
+    CHIP_ERROR EndOfInvokeRequests();
 
 private:
     CommandDataIB::Builder mCommandData;

--- a/src/app/MessageDef/InvokeResponseIB.cpp
+++ b/src/app/MessageDef/InvokeResponseIB.cpp
@@ -115,10 +115,10 @@ CommandStatusIB::Builder & InvokeResponseIB::Builder::CreateStatus()
     return mStatus;
 }
 
-InvokeResponseIB::Builder & InvokeResponseIB::Builder::EndOfInvokeResponseIB()
+CHIP_ERROR InvokeResponseIB::Builder::EndOfInvokeResponseIB()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeResponseIB.h
+++ b/src/app/MessageDef/InvokeResponseIB.h
@@ -96,9 +96,9 @@ public:
     /**
      *  @brief Mark the end of this InvokeCommand
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    InvokeResponseIB::Builder & EndOfInvokeResponseIB();
+    CHIP_ERROR EndOfInvokeResponseIB();
 
 private:
     CommandDataIB::Builder mCommand;

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -79,10 +79,10 @@ InvokeResponseIB::Builder & InvokeResponseIBs::Builder::CreateInvokeResponse()
     return mInvokeResponse;
 }
 
-InvokeResponseIBs::Builder & InvokeResponseIBs::Builder::EndOfInvokeResponses()
+CHIP_ERROR InvokeResponseIBs::Builder::EndOfInvokeResponses()
 {
     EndOfContainer();
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -57,9 +57,9 @@ public:
     /**
      *  @brief Mark the end of this InvokeResponseIBs
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    InvokeResponseIBs::Builder & EndOfInvokeResponses();
+    CHIP_ERROR EndOfInvokeResponses();
 
 private:
     InvokeResponseIB::Builder mInvokeResponse;

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -116,7 +116,7 @@ InvokeResponseIBs::Builder & InvokeResponseMessage::Builder::CreateInvokeRespons
     return mInvokeResponses;
 }
 
-InvokeResponseMessage::Builder & InvokeResponseMessage::Builder::EndOfInvokeResponseMessage()
+CHIP_ERROR InvokeResponseMessage::Builder::EndOfInvokeResponseMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -126,7 +126,7 @@ InvokeResponseMessage::Builder & InvokeResponseMessage::Builder::EndOfInvokeResp
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -89,9 +89,9 @@ public:
     /**
      *  @brief Mark the end of this InvokeResponseMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    InvokeResponseMessage::Builder & EndOfInvokeResponseMessage();
+    CHIP_ERROR EndOfInvokeResponseMessage();
 
 private:
     InvokeResponseIBs::Builder mInvokeResponses;

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -196,7 +196,7 @@ ReadRequestMessage::Builder & ReadRequestMessage::Builder::IsFabricFiltered(cons
     return *this;
 }
 
-ReadRequestMessage::Builder & ReadRequestMessage::Builder::EndOfReadRequestMessage()
+CHIP_ERROR ReadRequestMessage::Builder::EndOfReadRequestMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -206,7 +206,7 @@ ReadRequestMessage::Builder & ReadRequestMessage::Builder::EndOfReadRequestMessa
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/ReadRequestMessage.h
+++ b/src/app/MessageDef/ReadRequestMessage.h
@@ -135,9 +135,9 @@ public:
     /**
      *  @brief Mark the end of this ReadRequestMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    ReadRequestMessage::Builder & EndOfReadRequestMessage();
+    CHIP_ERROR EndOfReadRequestMessage();
 
 private:
     AttributePathIBs::Builder mAttributeRequests;

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -212,7 +212,7 @@ ReportDataMessage::Builder & ReportDataMessage::Builder::MoreChunkedMessages(con
     return *this;
 }
 
-ReportDataMessage::Builder & ReportDataMessage::Builder::EndOfReportDataMessage()
+CHIP_ERROR ReportDataMessage::Builder::EndOfReportDataMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -222,7 +222,7 @@ ReportDataMessage::Builder & ReportDataMessage::Builder::EndOfReportDataMessage(
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/ReportDataMessage.h
+++ b/src/app/MessageDef/ReportDataMessage.h
@@ -158,9 +158,9 @@ public:
     /**
      *  @brief Mark the end of this ReportDataMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    ReportDataMessage::Builder & EndOfReportDataMessage();
+    CHIP_ERROR EndOfReportDataMessage();
 
 private:
     AttributeReportIBs::Builder mAttributeReportIBsBuilder;

--- a/src/app/MessageDef/SubscribeRequestMessage.cpp
+++ b/src/app/MessageDef/SubscribeRequestMessage.cpp
@@ -261,7 +261,7 @@ SubscribeRequestMessage::Builder & SubscribeRequestMessage::Builder::IsFabricFil
     return *this;
 }
 
-SubscribeRequestMessage::Builder & SubscribeRequestMessage::Builder::EndOfSubscribeRequestMessage()
+CHIP_ERROR SubscribeRequestMessage::Builder::EndOfSubscribeRequestMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -271,7 +271,7 @@ SubscribeRequestMessage::Builder & SubscribeRequestMessage::Builder::EndOfSubscr
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/SubscribeRequestMessage.h
+++ b/src/app/MessageDef/SubscribeRequestMessage.h
@@ -140,7 +140,7 @@ public:
     /**
      *  @brief Mark the end of this SubscribeRequestMessage
      */
-    SubscribeRequestMessage::Builder & EndOfSubscribeRequestMessage();
+    CHIP_ERROR EndOfSubscribeRequestMessage();
 
 private:
     AttributePathIBs::Builder mAttributeRequests;

--- a/src/app/MessageDef/SubscribeResponseMessage.cpp
+++ b/src/app/MessageDef/SubscribeResponseMessage.cpp
@@ -107,7 +107,7 @@ SubscribeResponseMessage::Builder & SubscribeResponseMessage::Builder::MaxInterv
     return *this;
 }
 
-SubscribeResponseMessage::Builder & SubscribeResponseMessage::Builder::EndOfSubscribeResponseMessage()
+CHIP_ERROR SubscribeResponseMessage::Builder::EndOfSubscribeResponseMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -117,7 +117,7 @@ SubscribeResponseMessage::Builder & SubscribeResponseMessage::Builder::EndOfSubs
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/SubscribeResponseMessage.h
+++ b/src/app/MessageDef/SubscribeResponseMessage.h
@@ -74,7 +74,7 @@ public:
     /**
      *  @brief Mark the end of this SubscribeResponseMessage
      */
-    SubscribeResponseMessage::Builder & EndOfSubscribeResponseMessage();
+    CHIP_ERROR EndOfSubscribeResponseMessage();
 };
 } // namespace SubscribeResponseMessage
 } // namespace app

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -172,7 +172,7 @@ WriteRequestMessage::Builder & WriteRequestMessage::Builder::MoreChunkedMessages
     return *this;
 }
 
-WriteRequestMessage::Builder & WriteRequestMessage::Builder::EndOfWriteRequestMessage()
+CHIP_ERROR WriteRequestMessage::Builder::EndOfWriteRequestMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -182,7 +182,7 @@ WriteRequestMessage::Builder & WriteRequestMessage::Builder::EndOfWriteRequestMe
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/WriteRequestMessage.h
+++ b/src/app/MessageDef/WriteRequestMessage.h
@@ -125,9 +125,9 @@ public:
     /**
      *  @brief Mark the end of this WriteRequestMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    WriteRequestMessage::Builder & EndOfWriteRequestMessage();
+    CHIP_ERROR EndOfWriteRequestMessage();
 
 private:
     AttributeDataIBs::Builder mWriteRequests;

--- a/src/app/MessageDef/WriteResponseMessage.cpp
+++ b/src/app/MessageDef/WriteResponseMessage.cpp
@@ -98,7 +98,7 @@ AttributeStatusIBs::Builder & WriteResponseMessage::Builder::GetWriteResponses()
     return mWriteResponses;
 }
 
-WriteResponseMessage::Builder & WriteResponseMessage::Builder::EndOfWriteResponseMessage()
+CHIP_ERROR WriteResponseMessage::Builder::EndOfWriteResponseMessage()
 {
     if (mError == CHIP_NO_ERROR)
     {
@@ -108,7 +108,7 @@ WriteResponseMessage::Builder & WriteResponseMessage::Builder::EndOfWriteRespons
     {
         EndOfContainer();
     }
-    return *this;
+    return GetError();
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/WriteResponseMessage.h
+++ b/src/app/MessageDef/WriteResponseMessage.h
@@ -71,9 +71,9 @@ public:
     /**
      *  @brief Mark the end of this WriteResponseMessage
      *
-     *  @return A reference to *this
+     *  @return The builder's final status.
      */
-    WriteResponseMessage::Builder & EndOfWriteResponseMessage();
+    CHIP_ERROR EndOfWriteResponseMessage();
 
 private:
     AttributeStatusIBs::Builder mWriteResponses;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -306,14 +306,14 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
     ReturnErrorOnFailure(dataVersionFilterListBuilder.GetWriter()->UnreserveBuffer(kReservedSizeForTLVEncodingOverhead));
     if (encodedDataVersionList)
     {
-        ReturnErrorOnFailure(dataVersionFilterListBuilder.EndOfDataVersionFilterIBs().GetError());
+        ReturnErrorOnFailure(dataVersionFilterListBuilder.EndOfDataVersionFilterIBs());
     }
     else
     {
         request.Rollback(backup);
     }
 
-    ReturnErrorOnFailure(request.EndOfReadRequestMessage().GetError());
+    ReturnErrorOnFailure(request.EndOfReadRequestMessage());
     ReturnErrorOnFailure(writer.Finalize(&msgBuf));
 
     VerifyOrReturnError(aReadPrepareParams.mSessionHolder, CHIP_ERROR_MISSING_SECURE_SESSION);
@@ -351,8 +351,7 @@ CHIP_ERROR ReadClient::GenerateEventPaths(EventPathIBs::Builder & aEventPathsBui
         ReturnErrorOnFailure(path.Encode(event));
     }
 
-    aEventPathsBuilder.EndOfEventPaths();
-    return aEventPathsBuilder.GetError();
+    return aEventPathsBuilder.EndOfEventPaths();
 }
 
 CHIP_ERROR ReadClient::GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
@@ -366,8 +365,7 @@ CHIP_ERROR ReadClient::GenerateAttributePaths(AttributePathIBs::Builder & aAttri
         ReturnErrorOnFailure(path.Encode(attribute));
     }
 
-    aAttributePathIBsBuilder.EndOfAttributePathIBs();
-    return aAttributePathIBsBuilder.GetError();
+    return aAttributePathIBsBuilder.EndOfAttributePathIBs();
 }
 
 CHIP_ERROR ReadClient::BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
@@ -399,9 +397,9 @@ CHIP_ERROR ReadClient::BuildDataVersionFilterList(DataVersionFilterIBs::Builder 
         ReturnErrorOnFailure(aDataVersionFilterIBsBuilder.GetError());
         ClusterPathIB::Builder & path = filterIB.CreatePath();
         ReturnErrorOnFailure(filterIB.GetError());
-        ReturnErrorOnFailure(path.Endpoint(filter.mEndpointId).Cluster(filter.mClusterId).EndOfClusterPathIB().GetError());
+        ReturnErrorOnFailure(path.Endpoint(filter.mEndpointId).Cluster(filter.mClusterId).EndOfClusterPathIB());
         VerifyOrReturnError(filter.mDataVersion.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
-        ReturnErrorOnFailure(filterIB.DataVersion(filter.mDataVersion.Value()).EndOfDataVersionFilterIB().GetError());
+        ReturnErrorOnFailure(filterIB.DataVersion(filter.mDataVersion.Value()).EndOfDataVersionFilterIB());
         aEncodedDataVersionList = true;
     }
     return CHIP_NO_ERROR;
@@ -1014,14 +1012,14 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     ReturnErrorOnFailure(dataVersionFilterListBuilder.GetWriter()->UnreserveBuffer(kReservedSizeForTLVEncodingOverhead));
     if (encodedDataVersionList)
     {
-        ReturnErrorOnFailure(dataVersionFilterListBuilder.EndOfDataVersionFilterIBs().GetError());
+        ReturnErrorOnFailure(dataVersionFilterListBuilder.EndOfDataVersionFilterIBs());
     }
     else
     {
         request.Rollback(backup);
     }
 
-    ReturnErrorOnFailure(request.EndOfSubscribeRequestMessage().GetError());
+    ReturnErrorOnFailure(request.EndOfSubscribeRequestMessage());
     ReturnErrorOnFailure(writer.Finalize(&msgBuf));
 
     VerifyOrReturnError(aReadPrepareParams.mSessionHolder, CHIP_ERROR_MISSING_SECURE_SESSION);

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -629,8 +629,7 @@ CHIP_ERROR ReadHandler::SendSubscribeResponse()
 
     SubscribeResponseMessage::Builder response;
     ReturnErrorOnFailure(response.Init(&writer));
-    response.SubscriptionId(mSubscriptionId).MaxInterval(mMaxInterval).EndOfSubscribeResponseMessage();
-    ReturnErrorOnFailure(response.GetError());
+    ReturnErrorOnFailure(response.SubscriptionId(mSubscriptionId).MaxInterval(mMaxInterval).EndOfSubscribeResponseMessage());
 
     ReturnErrorOnFailure(writer.Finalize(&packet));
     VerifyOrReturnLogError(mExchangeCtx, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -118,7 +118,7 @@ CHIP_ERROR WriteClient::PrepareAttributeIB(const ConcreteDataAttributePath & aPa
             return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
         }
     }
-    ReturnErrorOnFailure(path.EndOfAttributePathIB().GetError());
+    ReturnErrorOnFailure(path.EndOfAttributePathIB());
 
     return CHIP_NO_ERROR;
 }
@@ -126,8 +126,7 @@ CHIP_ERROR WriteClient::PrepareAttributeIB(const ConcreteDataAttributePath & aPa
 CHIP_ERROR WriteClient::FinishAttributeIB()
 {
     AttributeDataIB::Builder & attributeDataIB = mWriteRequestBuilder.GetWriteRequests().GetAttributeDataIBBuilder();
-    attributeDataIB.EndOfAttributeDataIB();
-    ReturnErrorOnFailure(attributeDataIB.GetError());
+    ReturnErrorOnFailure(attributeDataIB.EndOfAttributeDataIB());
     MoveToState(State::AddAttribute);
     return CHIP_NO_ERROR;
 }
@@ -146,11 +145,9 @@ CHIP_ERROR WriteClient::FinalizeMessage(bool aHasMoreChunks)
     ReturnErrorCodeIf(writer == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(writer->UnreserveBuffer(kReservedSizeForTLVEncodingOverhead));
 
-    AttributeDataIBs::Builder & attributeDataIBsBuilder = mWriteRequestBuilder.GetWriteRequests().EndOfAttributeDataIBs();
-    ReturnErrorOnFailure(attributeDataIBsBuilder.GetError());
+    ReturnErrorOnFailure(mWriteRequestBuilder.GetWriteRequests().EndOfAttributeDataIBs());
 
-    mWriteRequestBuilder.MoreChunkedMessages(aHasMoreChunks).EndOfWriteRequestMessage();
-    ReturnErrorOnFailure(mWriteRequestBuilder.GetError());
+    ReturnErrorOnFailure(mWriteRequestBuilder.MoreChunkedMessages(aHasMoreChunks).EndOfWriteRequestMessage());
     ReturnErrorOnFailure(mMessageWriter.Finalize(&packet));
     mChunks.AddToEnd(std::move(packet));
     return CHIP_NO_ERROR;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -159,10 +159,8 @@ void WriteHandler::OnResponseTimeout(Messaging::ExchangeContext * apExchangeCont
 CHIP_ERROR WriteHandler::FinalizeMessage(System::PacketBufferTLVWriter && aMessageWriter, System::PacketBufferHandle & packet)
 {
     VerifyOrReturnError(mState == State::AddStatus, CHIP_ERROR_INCORRECT_STATE);
-    AttributeStatusIBs::Builder & attributeStatusIBs = mWriteResponseBuilder.GetWriteResponses().EndOfAttributeStatuses();
-    ReturnErrorOnFailure(attributeStatusIBs.GetError());
-    mWriteResponseBuilder.EndOfWriteResponseMessage();
-    ReturnErrorOnFailure(mWriteResponseBuilder.GetError());
+    ReturnErrorOnFailure(mWriteResponseBuilder.GetWriteResponses().EndOfAttributeStatuses());
+    ReturnErrorOnFailure(mWriteResponseBuilder.EndOfWriteResponseMessage());
     ReturnErrorOnFailure(aMessageWriter.Finalize(&packet));
     return CHIP_NO_ERROR;
 }
@@ -639,8 +637,7 @@ CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, cons
     ReturnErrorOnFailure(attributeStatusIB.GetError());
     statusIBBuilder.EncodeStatusIB(aStatus);
     ReturnErrorOnFailure(statusIBBuilder.GetError());
-    attributeStatusIB.EndOfAttributeStatusIB();
-    ReturnErrorOnFailure(attributeStatusIB.GetError());
+    ReturnErrorOnFailure(attributeStatusIB.EndOfAttributeStatusIB());
 
     MoveToState(State::AddStatus);
     return CHIP_NO_ERROR;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -260,8 +260,7 @@ exit:
     {
         attributeReportIBs.GetWriter()->UnreserveBuffer(kReservedSizeEndOfReportIBs);
 
-        attributeReportIBs.EndOfAttributeReportIBs();
-        err = attributeReportIBs.GetError();
+        err = attributeReportIBs.EndOfAttributeReportIBs();
 
         //
         // We reserved space for this earlier - consequently, the call to end the ReportIBs should
@@ -413,8 +412,7 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
         }
 
         SuccessOrExit(err = eventReportIBs.GetWriter()->UnreserveBuffer(kReservedSizeEndOfReportIBs));
-        eventReportIBs.EndOfEventReports();
-        SuccessOrExit(err = eventReportIBs.GetError());
+        SuccessOrExit(err = eventReportIBs.EndOfEventReports());
     }
     ChipLogDetail(DataManagement, "Fetched %u events", static_cast<unsigned int>(eventCount));
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1364,12 +1364,11 @@ void TestCommandInteraction::TestCommandHandlerRejectMultipleCommands(nlTestSuit
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == invokeRequest.GetWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
             NL_TEST_ASSERT(apSuite,
                            CHIP_NO_ERROR == invokeRequest.GetWriter()->EndContainer(commandSender.mDataElementContainerType));
-            NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == invokeRequest.EndOfCommandDataIB().GetError());
+            NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == invokeRequest.EndOfCommandDataIB());
         }
 
-        NL_TEST_ASSERT(apSuite,
-                       CHIP_NO_ERROR == commandSender.mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests().GetError());
-        NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.mInvokeRequestBuilder.EndOfInvokeRequestMessage().GetError());
+        NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests());
+        NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.mInvokeRequestBuilder.EndOfInvokeRequestMessage());
 
         commandSender.MoveToState(app::CommandSender::State::AddedCommand);
     }

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -232,14 +232,13 @@ void ParseEventFilters(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 void BuildAttributePathIB(nlTestSuite * apSuite, AttributePathIB::Builder & aAttributePathBuilder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    aAttributePathBuilder.EnableTagCompression(false)
-        .Node(1)
-        .Endpoint(2)
-        .Cluster(3)
-        .Attribute(4)
-        .ListIndex(5)
-        .EndOfAttributePathIB();
-    err = aAttributePathBuilder.GetError();
+    err            = aAttributePathBuilder.EnableTagCompression(false)
+              .Node(1)
+              .Endpoint(2)
+              .Cluster(3)
+              .Attribute(4)
+              .ListIndex(5)
+              .EndOfAttributePathIB();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -279,9 +279,8 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
         ReturnErrorOnFailure(attributeStatus.GetError());
         errorStatus.EncodeStatusIB(StatusIB(Protocols::InteractionModel::Status::UnsupportedAttribute));
         ReturnErrorOnFailure(errorStatus.GetError());
-        attributeStatus.EndOfAttributeStatusIB();
-        ReturnErrorOnFailure(attributeStatus.GetError());
-        return attributeReport.EndOfAttributeReportIB().GetError();
+        ReturnErrorOnFailure(attributeStatus.EndOfAttributeStatusIB());
+        return attributeReport.EndOfAttributeReportIB();
     }
 
     return AttributeValueEncoder(aAttributeReports, 0, aPath, 0).Encode(kTestFieldValue1);
@@ -3867,7 +3866,7 @@ void TestReadInteraction::TestReadHandlerMalformedReadRequest2(nlTestSuite * apS
         chip::app::InitWriterWithSpaceReserved(writer, 0);
         err = request.Init(&writer);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(apSuite, request.EndOfReadRequestMessage().GetError() == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(apSuite, request.EndOfReadRequestMessage() == CHIP_NO_ERROR);
         err = writer.Finalize(&msgBuf);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         auto exchange = readClient.mpExchangeMgr->NewContext(readPrepareParams.mSessionHolder.Get().Value(), &readClient);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -160,13 +160,12 @@ void TestWriteInteraction::GenerateWriteRequest(nlTestSuite * apSuite, void * ap
     NL_TEST_ASSERT(apSuite, attributeDataIBBuilder.GetError() == CHIP_NO_ERROR);
     AttributePathIB::Builder & attributePathBuilder = attributeDataIBBuilder.CreatePath();
     NL_TEST_ASSERT(apSuite, attributePathBuilder.GetError() == CHIP_NO_ERROR);
-    attributePathBuilder.Node(1)
-        .Endpoint(2)
-        .Cluster(3)
-        .Attribute(4)
-        .ListIndex(DataModel::Nullable<ListIndex>())
-        .EndOfAttributePathIB();
-    err = attributePathBuilder.GetError();
+    err = attributePathBuilder.Node(1)
+              .Endpoint(2)
+              .Cluster(3)
+              .Attribute(4)
+              .ListIndex(DataModel::Nullable<ListIndex>())
+              .EndOfAttributePathIB();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     // Construct attribute data
@@ -211,13 +210,12 @@ void TestWriteInteraction::GenerateWriteResponse(nlTestSuite * apSuite, void * a
 
     AttributePathIB::Builder & attributePathBuilder = attributeStatusIBBuilder.CreatePath();
     NL_TEST_ASSERT(apSuite, attributePathBuilder.GetError() == CHIP_NO_ERROR);
-    attributePathBuilder.Node(1)
-        .Endpoint(2)
-        .Cluster(3)
-        .Attribute(4)
-        .ListIndex(DataModel::Nullable<ListIndex>())
-        .EndOfAttributePathIB();
-    err = attributePathBuilder.GetError();
+    err = attributePathBuilder.Node(1)
+              .Endpoint(2)
+              .Cluster(3)
+              .Attribute(4)
+              .ListIndex(DataModel::Nullable<ListIndex>())
+              .EndOfAttributePathIB();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     StatusIB::Builder & statusIBBuilder = attributeStatusIBBuilder.CreateErrorStatus();

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -644,7 +644,7 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
     ReturnErrorOnFailure(errorStatus.GetError());
     attributeStatus.EndOfAttributeStatusIB();
     ReturnErrorOnFailure(attributeStatus.GetError());
-    return attributeReport.EndOfAttributeReportIB().GetError();
+    return attributeReport.EndOfAttributeReportIB();
 }
 
 const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -282,8 +282,8 @@ void IncreaseClusterDataVersion(const ConcreteClusterPath & aConcreteClusterPath
 
 CHIP_ERROR SendSuccessStatus(AttributeReportIB::Builder & aAttributeReport, AttributeDataIB::Builder & aAttributeDataIBBuilder)
 {
-    ReturnErrorOnFailure(aAttributeDataIBBuilder.EndOfAttributeDataIB().GetError());
-    return aAttributeReport.EndOfAttributeReportIB().GetError();
+    ReturnErrorOnFailure(aAttributeDataIBBuilder.EndOfAttributeDataIB());
+    return aAttributeReport.EndOfAttributeReportIB();
 }
 
 CHIP_ERROR SendFailureStatus(const ConcreteAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
@@ -598,11 +598,11 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
     AttributePathIB::Builder & attributePathIBBuilder = attributeDataIBBuilder.CreatePath();
     ReturnErrorOnFailure(attributeDataIBBuilder.GetError());
 
-    attributePathIBBuilder.Endpoint(aPath.mEndpointId)
-        .Cluster(aPath.mClusterId)
-        .Attribute(aPath.mAttributeId)
-        .EndOfAttributePathIB();
-    ReturnErrorOnFailure(attributePathIBBuilder.GetError());
+    CHIP_ERROR err = attributePathIBBuilder.Endpoint(aPath.mEndpointId)
+                         .Cluster(aPath.mClusterId)
+                         .Attribute(aPath.mAttributeId)
+                         .EndOfAttributePathIB();
+    ReturnErrorOnFailure(err);
 
     EmberAfAttributeSearchRecord record;
     record.endpoint           = aPath.mEndpointId;

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -313,9 +313,8 @@ CHIP_ERROR ReadSingleMockClusterData(FabricIndex aAccessingFabricIndex, const Co
         ReturnErrorOnFailure(attributeStatus.GetError());
         errorStatus.EncodeStatusIB(StatusIB(Protocols::InteractionModel::Status::UnsupportedAttribute));
         ReturnErrorOnFailure(errorStatus.GetError());
-        attributeStatus.EndOfAttributeStatusIB();
-        ReturnErrorOnFailure(attributeStatus.GetError());
-        return attributeReport.EndOfAttributeReportIB().GetError();
+        ReturnErrorOnFailure(attributeStatus.EndOfAttributeStatusIB());
+        return attributeReport.EndOfAttributeReportIB();
     }
 
     // Attribute 4 acts as a large attribute to trigger chunking.
@@ -374,9 +373,8 @@ CHIP_ERROR ReadSingleMockClusterData(FabricIndex aAccessingFabricIndex, const Co
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
 
-    attributeData.EndOfAttributeDataIB();
-    ReturnErrorOnFailure(attributeData.GetError());
-    return attributeReport.EndOfAttributeReportIB().GetError();
+    ReturnErrorOnFailure(attributeData.EndOfAttributeDataIB());
+    return attributeReport.EndOfAttributeReportIB();
 }
 
 } // namespace Test

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -191,8 +191,8 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
         ReturnErrorOnFailure(attributePath.GetError());
 
         ReturnErrorOnFailure(DataModel::Encode(*(attributeData.GetWriter()), TLV::ContextTag(AttributeDataIB::Tag::kData), value));
-        ReturnErrorOnFailure(attributeData.EndOfAttributeDataIB().GetError());
-        return attributeReport.EndOfAttributeReportIB().GetError();
+        ReturnErrorOnFailure(attributeData.EndOfAttributeDataIB());
+        return attributeReport.EndOfAttributeReportIB();
     }
 
     for (size_t i = 0; i < (responseDirective == kSendTwoDataErrors ? 2 : 1); ++i)
@@ -209,7 +209,7 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
         errorStatus.EncodeStatusIB(StatusIB(Protocols::InteractionModel::Status::Busy));
         attributeStatus.EndOfAttributeStatusIB();
         ReturnErrorOnFailure(attributeStatus.GetError());
-        ReturnErrorOnFailure(attributeReport.EndOfAttributeReportIB().GetError());
+        ReturnErrorOnFailure(attributeReport.EndOfAttributeReportIB());
     }
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Simplifies consumers and makes it clearer you're not supposed to use the object any more after the EndOf... call.

Fixes https://github.com/project-chip/connectedhomeip/issues/8309
