### PR TITLE
[ESP32] Use the backward compatible option for linking wifi libs

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -392,7 +392,7 @@ idf_component_get_property(lwip_lib lwip COMPONENT_LIB)
 list(APPEND chip_libraries $<TARGET_FILE:${lwip_lib}>)
 
 
-if (CONFIG_ESP_WIFI_ENABLED)
+if (CONFIG_ESP32_WIFI_ENABLED)
     idf_component_get_property(esp_wifi_lib esp_wifi COMPONENT_LIB)
     idf_component_get_property(esp_wifi_dir esp_wifi COMPONENT_DIR)
     list(APPEND chip_libraries $<TARGET_FILE:${esp_wifi_lib}>)


### PR DESCRIPTION
#26608 added linking wifi libraries to chip library and wrapped it around `CONFIG_ESP_WIFI_ENABLED` option but this is newer renamed option in IDF branch `release/v5.1` and won't work with previous IDF releases, eg: tag v5.0.1.

So use the former `CONFIG_ESP32_WIFI_ENABLED`. This option is backward compatible as its in [sdkconfig.rename](https://github.com/espressif/esp-idf/blob/release/v5.1/components/esp_wifi/sdkconfig.rename#L5)

Tested building example on IDF versions ... v4.4.4, v5.0.1, and branch: release/v5.1