### PR TITLE
Cherry-pick [ESP32] Use the backward compatible option for linking wifi libs

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -388,7 +388,7 @@ idf_component_get_property(lwip_lib lwip COMPONENT_LIB)
 list(APPEND chip_libraries $<TARGET_FILE:${lwip_lib}>)
 
 
-if (CONFIG_ESP_WIFI_ENABLED)
+if (CONFIG_ESP32_WIFI_ENABLED)
     idf_component_get_property(esp_wifi_lib esp_wifi COMPONENT_LIB)
     idf_component_get_property(esp_wifi_dir esp_wifi COMPONENT_DIR)
     list(APPEND chip_libraries $<TARGET_FILE:${esp_wifi_lib}>)


### PR DESCRIPTION
This is cherry pick for commit fc78bff46f1f03bac452379e3b70a1d133b18e52 (MR #26923) to `v1.1-branch`.