### PR TITLE
[Silabs] Consolidated Identify callback implementation to common file

### DIFF
--- a/examples/chef/silabs/include/AppTask.h
+++ b/examples/chef/silabs/include/AppTask.h
@@ -30,7 +30,6 @@
 #include "BaseApplication.h"
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -77,20 +76,6 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction) override;
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is received
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStart(Identify * identify);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is stopped or finished
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStop(Identify * identify);
 
 private:
     static AppTask sAppTask;

--- a/examples/light-switch-app/silabs/include/AppTask.h
+++ b/examples/light-switch-app/silabs/include/AppTask.h
@@ -30,7 +30,6 @@
 #include "BaseApplication.h"
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -77,20 +76,6 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is received
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStart(Identify * identify);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is stopped or finished
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStop(Identify * identify);
 
 private:
     static AppTask sAppTask;

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -46,8 +46,6 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
-#include <app/clusters/identify-server/identify-server.h>
-
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
 /**********************************************************
@@ -60,88 +58,14 @@
 #define APP_LIGHT_SWITCH 1
 
 namespace {
-
 constexpr chip::EndpointId kLightSwitchEndpoint   = 1;
 constexpr chip::EndpointId kGenericSwitchEndpoint = 2;
-
 } // namespace
 
 using namespace chip;
 using namespace chip::app;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
-
-namespace {
-
-/**********************************************************
- * Variable declarations
- *********************************************************/
-
-Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
-/**********************************************************
- * Identify Callbacks
- *********************************************************/
-
-namespace {
-void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
-{
-    ChipLogProgress(Zcl, "Trigger Identify Complete");
-    sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StopStatusLEDTimer();
-#endif
-}
-} // namespace
-
-void OnTriggerIdentifyEffect(Identify * identify)
-{
-    ChipLogProgress(Zcl, "Trigger Identify Effect");
-    sIdentifyEffect = identify->mCurrentEffectIdentifier;
-
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
-    {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect varriant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
-    }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StartStatusLEDTimer();
-#endif
-
-    switch (sIdentifyEffect)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kFinishEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(1), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kStopEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-    }
-}
-
-Identify gIdentify = {
-    chip::EndpointId{ 1 },
-    AppTask::GetAppTask().OnIdentifyStart,
-    AppTask::GetAppTask().OnIdentifyStop,
-    Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
-    OnTriggerIdentifyEffect,
-};
-
-} // namespace
 
 using namespace chip::TLV;
 using namespace ::chip::DeviceLayer;
@@ -161,7 +85,7 @@ CHIP_ERROR AppTask::Init()
     GetLCD().Init((uint8_t *) "Light Switch");
 #endif
 
-    err = BaseApplication::Init(&gIdentify);
+    err = BaseApplication::Init();
     if (err != CHIP_NO_ERROR)
     {
         SILABS_LOG("BaseApplication::Init() failed");
@@ -209,24 +133,6 @@ void AppTask::AppTaskMain(void * pvParameter)
             eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
     }
-}
-
-void AppTask::OnIdentifyStart(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStart");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StartStatusLEDTimer();
-#endif
-}
-
-void AppTask::OnIdentifyStop(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStop");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StopStatusLEDTimer();
-#endif
 }
 
 void AppTask::SwitchActionEventHandler(AppEvent * aEvent)

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -108,11 +108,9 @@ void OnTriggerIdentifyEffect(Identify * identify)
 {
     sIdentifyEffect = identify->mCurrentEffectIdentifier;
 
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
+    if (identify->mEffectVariant != Clusters::Identify::EffectVariantEnum::kDefault)
     {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect variant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
+        ChipLogDetail(AppServer, "Identify Effect Variant unsupported. Using default");
     }
 
     switch (sIdentifyEffect)
@@ -120,6 +118,7 @@ void OnTriggerIdentifyEffect(Identify * identify)
     case Clusters::Identify::EffectIdentifierEnum::kBlink:
     case Clusters::Identify::EffectIdentifierEnum::kBreathe:
     case Clusters::Identify::EffectIdentifierEnum::kOkay:
+    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
         SystemLayer().ScheduleLambda([identify] {
             (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
                                                                identify);

--- a/examples/lighting-app/silabs/include/AppTask.h
+++ b/examples/lighting-app/silabs/include/AppTask.h
@@ -31,7 +31,6 @@
 #include "FreeRTOS.h"
 #include "LightingManager.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -78,21 +77,6 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is received
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStart(Identify * identify);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is stopped or finished
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStop(Identify * identify);
-
     void PostLightActionRequest(int32_t aActor, LightingManager::Action_t aAction);
 
 private:

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -23,7 +23,6 @@
 
 #include "LEDWidget.h"
 
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -55,73 +54,8 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
 
 namespace {
-
 LEDWidget sLightLED;
-
-Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
-/**********************************************************
- * Identify Callbacks
- *********************************************************/
-
-namespace {
-void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
-{
-    ChipLogProgress(Zcl, "Trigger Identify Complete");
-    sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StopStatusLEDTimer();
-#endif
 }
-} // namespace
-
-void OnTriggerIdentifyEffect(Identify * identify)
-{
-    sIdentifyEffect = identify->mCurrentEffectIdentifier;
-
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
-    {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect varriant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
-    }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StartStatusLEDTimer();
-#endif
-
-    switch (sIdentifyEffect)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kFinishEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(1), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kStopEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-    }
-}
-
-Identify gIdentify = {
-    chip::EndpointId{ 1 },
-    AppTask::GetAppTask().OnIdentifyStart,
-    AppTask::GetAppTask().OnIdentifyStop,
-    Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
-    OnTriggerIdentifyEffect,
-};
-
-} // namespace
 
 using namespace chip::TLV;
 using namespace ::chip::DeviceLayer;
@@ -137,7 +71,7 @@ CHIP_ERROR AppTask::Init()
     GetLCD().Init((uint8_t *) "Lighting-App");
 #endif
 
-    err = BaseApplication::Init(&gIdentify);
+    err = BaseApplication::Init();
     if (err != CHIP_NO_ERROR)
     {
         SILABS_LOG("BaseApplication::Init() failed");
@@ -206,24 +140,6 @@ void AppTask::AppTaskMain(void * pvParameter)
             eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
     }
-}
-
-void AppTask::OnIdentifyStart(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStart");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StartStatusLEDTimer();
-#endif
-}
-
-void AppTask::OnIdentifyStop(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStop");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StopStatusLEDTimer();
-#endif
 }
 
 void AppTask::LightActionEventHandler(AppEvent * aEvent)

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -105,11 +105,9 @@ void OnTriggerIdentifyEffect(Identify * identify)
 {
     sIdentifyEffect = identify->mCurrentEffectIdentifier;
 
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
+    if (identify->mEffectVariant != Clusters::Identify::EffectVariantEnum::kDefault)
     {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect variant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
+        ChipLogDetail(AppServer, "Identify Effect Variant unsupported. Using default");
     }
 
     switch (sIdentifyEffect)
@@ -117,6 +115,7 @@ void OnTriggerIdentifyEffect(Identify * identify)
     case Clusters::Identify::EffectIdentifierEnum::kBlink:
     case Clusters::Identify::EffectIdentifierEnum::kBreathe:
     case Clusters::Identify::EffectIdentifierEnum::kOkay:
+    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
         SystemLayer().ScheduleLambda([identify] {
             (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
                                                                identify);

--- a/examples/lock-app/silabs/include/AppTask.h
+++ b/examples/lock-app/silabs/include/AppTask.h
@@ -31,7 +31,6 @@
 #include "FreeRTOS.h"
 #include "LockManager.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -86,20 +85,6 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is received
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStart(Identify * identify);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is stopped or finished
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStop(Identify * identify);
 
 private:
     static AppTask sAppTask;

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -37,7 +37,6 @@
 #include <app-common/zap-generated/cluster-objects.h>
 
 #include <app/clusters/door-lock-server/door-lock-server.h>
-#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -71,69 +70,6 @@ using namespace EFR32DoorLock::LockInitParams;
 
 namespace {
 LEDWidget sLockLED;
-
-Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-} // namespace
-/**********************************************************
- * Identify Callbacks
- *********************************************************/
-
-namespace {
-void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
-{
-    ChipLogProgress(Zcl, "Trigger Identify Complete");
-    sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StopStatusLEDTimer();
-#endif
-}
-
-void OnTriggerIdentifyEffect(Identify * identify)
-{
-    sIdentifyEffect = identify->mCurrentEffectIdentifier;
-
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
-    {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect varriant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
-    }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    AppTask::GetAppTask().StartStatusLEDTimer();
-#endif
-
-    switch (sIdentifyEffect)
-    {
-    case Clusters::Identify::EffectIdentifierEnum::kBlink:
-    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
-    case Clusters::Identify::EffectIdentifierEnum::kOkay:
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kFinishEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(1), OnTriggerIdentifyEffectCompleted,
-                                                           identify);
-        break;
-    case Clusters::Identify::EffectIdentifierEnum::kStopEffect:
-        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
-        sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-    }
-}
-
-Identify gIdentify = {
-    chip::EndpointId{ 1 },
-    AppTask::GetAppTask().OnIdentifyStart,
-    AppTask::GetAppTask().OnIdentifyStop,
-    Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
-    OnTriggerIdentifyEffect,
-};
-
 } // namespace
 
 using namespace chip::TLV;
@@ -151,7 +87,7 @@ CHIP_ERROR AppTask::Init()
     GetLCD().Init((uint8_t *) "Lock-App", true);
 #endif
 
-    err = BaseApplication::Init(&gIdentify);
+    err = BaseApplication::Init();
     if (err != CHIP_NO_ERROR)
     {
         SILABS_LOG("BaseApplication::Init() failed");
@@ -301,24 +237,6 @@ void AppTask::AppTaskMain(void * pvParameter)
             eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
     }
-}
-
-void AppTask::OnIdentifyStart(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStart");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StartStatusLEDTimer();
-#endif
-}
-
-void AppTask::OnIdentifyStop(Identify * identify)
-{
-    ChipLogProgress(Zcl, "onIdentifyStop");
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
-    sAppTask.StopStatusLEDTimer();
-#endif
 }
 
 void AppTask::LockActionEventHandler(AppEvent * aEvent)

--- a/examples/platform/silabs/efr32/BaseApplication.cpp
+++ b/examples/platform/silabs/efr32/BaseApplication.cpp
@@ -113,8 +113,6 @@ bool sIsAttached         = false;
 bool sHaveBLEConnections = false;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_SED
 
-Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-
 uint8_t sAppEventQueueBuffer[APP_EVENT_QUEUE_SIZE * sizeof(AppEvent)];
 StaticQueue_t sAppEventQueueStruct;
 
@@ -124,12 +122,22 @@ StaticTask_t appTaskStruct;
 BaseApplication::Function_t mFunction;
 bool mFunctionTimerActive;
 
-Identify * gIdentifyptr = nullptr;
-
 #ifdef DISPLAY_ENABLED
 SilabsLCD slLCD;
 #endif
 
+#ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
+Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
+
+Identify gIdentify = {
+    chip::EndpointId{ 1 },
+    BaseApplication::OnIdentifyStart,
+    BaseApplication::OnIdentifyStop,
+    Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
+    BaseApplication::OnTriggerIdentifyEffect,
+};
+
+#endif // EMBER_AF_PLUGIN_IDENTIFY_SERVER
 } // namespace
 
 /**********************************************************
@@ -156,17 +164,9 @@ CHIP_ERROR BaseApplication::StartAppTask(TaskFunction_t taskFunction)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BaseApplication::Init(Identify * identifyObj)
+CHIP_ERROR BaseApplication::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    if (identifyObj == nullptr)
-    {
-        SILABS_LOG("Invalid Identify Object!");
-        appError(CHIP_ERROR_INVALID_ARGUMENT);
-    }
-
-    gIdentifyptr = identifyObj;
 
 #ifdef SL_WIFI
     /*
@@ -299,6 +299,87 @@ void BaseApplication::FunctionEventHandler(AppEvent * aEvent)
     }
 }
 
+bool BaseApplication::ActivateStatusLedPatterns()
+{
+    bool isPatternSet = false;
+#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
+#ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
+    if (gIdentify.mActive)
+    {
+        // Identify in progress
+        // Do a steady blink on the status led
+        sStatusLED.Blink(250, 250);
+        isPatternSet = true;
+    }
+    else if (sIdentifyEffect != Clusters::Identify::EffectIdentifierEnum::kStopEffect)
+    {
+        // Identify trigger effect received. Do some on/off patterns on the status led
+        if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kBlink)
+        {
+            // Fast blink
+            sStatusLED.Blink(50, 50);
+        }
+        else if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kBreathe)
+        {
+            // Slow blink
+            sStatusLED.Blink(1000, 1000);
+        }
+        else if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kOkay)
+        {
+            // Pulse effect
+            sStatusLED.Blink(300, 700);
+        }
+        else if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
+        {
+            // Alternate between Short and Long pulses effect
+            static uint64_t mLastChangeTimeMS = 0;
+            static bool alternatePattern      = false;
+            uint32_t onTimeMS                 = alternatePattern ? 50 : 700;
+            uint32_t offTimeMS                = alternatePattern ? 950 : 300;
+
+            uint64_t nowMS = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+            if (nowMS >= mLastChangeTimeMS + 1000) // each pattern is done over a 1 second period
+            {
+                mLastChangeTimeMS = nowMS;
+                alternatePattern  = !alternatePattern;
+                sStatusLED.Blink(onTimeMS, offTimeMS);
+            }
+        }
+        isPatternSet = true;
+    }
+#endif // EMBER_AF_PLUGIN_IDENTIFY_SERVER
+
+#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
+    // Identify Patterns have priority over Status patterns
+    if (!isPatternSet)
+    {
+        // Apply different status feedbacks
+        if (sIsProvisioned && sIsEnabled)
+        {
+            if (sIsAttached)
+            {
+                sStatusLED.Set(true);
+            }
+            else
+            {
+                sStatusLED.Blink(950, 50);
+            }
+        }
+        else if (sHaveBLEConnections)
+        {
+            sStatusLED.Blink(100, 100);
+        }
+        else
+        {
+            sStatusLED.Blink(50, 950);
+        }
+        isPatternSet = true;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+#endif // ENABLE_WSTK_LEDS) && SL_CATALOG_SIMPLE_LED_LED1_PRESENT
+    return isPatternSet;
+}
+
 void BaseApplication::LightEventHandler()
 {
     // Collect connectivity and configuration state from the CHIP stack. Because
@@ -323,6 +404,7 @@ void BaseApplication::LightEventHandler()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_SED
 
+#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
     // Update the status LED if factory reset has not been initiated.
     //
     // If system has "full connectivity", keep the LED On constantly.
@@ -337,67 +419,11 @@ void BaseApplication::LightEventHandler()
     // Otherwise, blink the LED ON for a very short time.
     if (mFunction != kFunction_FactoryReset)
     {
-        if ((gIdentifyptr != nullptr) && (gIdentifyptr->mActive))
-        {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-            sStatusLED.Blink(250, 250);
-#endif // ENABLE_WSTK_LEDS
-        }
-        else if (sIdentifyEffect != Clusters::Identify::EffectIdentifierEnum::kStopEffect)
-        {
-            if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kBlink)
-            {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-                sStatusLED.Blink(50, 50);
-#endif // ENABLE_WSTK_LEDS
-            }
-            if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kBreathe)
-            {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-                sStatusLED.Blink(1000, 1000);
-#endif // ENABLE_WSTK_LEDS
-            }
-            if (sIdentifyEffect == Clusters::Identify::EffectIdentifierEnum::kOkay)
-            {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-                sStatusLED.Blink(300, 700);
-#endif // ENABLE_WSTK_LEDS
-            }
-        }
-#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
-        else if (sIsProvisioned && sIsEnabled)
-        {
-            if (sIsAttached)
-            {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-                sStatusLED.Set(true);
-#endif // ENABLE_WSTK_LEDS
-            }
-            else
-            {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-                sStatusLED.Blink(950, 50);
-#endif
-            }
-        }
-        else if (sHaveBLEConnections)
-        {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-            sStatusLED.Blink(100, 100);
-#endif // ENABLE_WSTK_LEDS
-        }
-        else
-        {
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
-            sStatusLED.Blink(50, 950);
-#endif // ENABLE_WSTK_LEDS
-        }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+        ActivateStatusLedPatterns();
     }
 
-#if defined(ENABLE_WSTK_LEDS) && defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)
     sStatusLED.Animate();
-#endif // ENABLE_WSTK_LEDS
+#endif // ENABLE_WSTK_LEDS && SL_CATALOG_SIMPLE_LED_LED1_PRESENT
 }
 
 void BaseApplication::ButtonHandler(AppEvent * aEvent)
@@ -516,6 +542,75 @@ void BaseApplication::StopStatusLEDTimer()
         appError(APP_ERROR_START_TIMER_FAILED);
     }
 }
+
+#ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
+void BaseApplication::OnIdentifyStart(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStart");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    StartStatusLEDTimer();
+#endif
+}
+
+void BaseApplication::OnIdentifyStop(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStop");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    StopStatusLEDTimer();
+#endif
+}
+
+void BaseApplication::OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
+{
+    ChipLogProgress(Zcl, "Trigger Identify Complete");
+    sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    StopStatusLEDTimer();
+#endif
+}
+
+void BaseApplication::OnTriggerIdentifyEffect(Identify * identify)
+{
+    sIdentifyEffect = identify->mCurrentEffectIdentifier;
+
+    if (identify->mEffectVariant != Clusters::Identify::EffectVariantEnum::kDefault)
+    {
+        ChipLogDetail(AppServer, "Identify Effect Variant unsupported. Using default");
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    StartStatusLEDTimer();
+#endif
+
+    switch (sIdentifyEffect)
+    {
+    case Clusters::Identify::EffectIdentifierEnum::kBlink:
+    case Clusters::Identify::EffectIdentifierEnum::kOkay:
+        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerIdentifyEffectCompleted,
+                                                           identify);
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kBreathe:
+    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
+        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(10), OnTriggerIdentifyEffectCompleted,
+                                                           identify);
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kFinishEffect:
+        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
+        (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(1), OnTriggerIdentifyEffectCompleted,
+                                                           identify);
+        break;
+    case Clusters::Identify::EffectIdentifierEnum::kStopEffect:
+        (void) chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerIdentifyEffectCompleted, identify);
+        break;
+    default:
+        sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
+        ChipLogProgress(Zcl, "No identifier effect");
+    }
+}
+#endif // EMBER_AF_PLUGIN_IDENTIFY_SERVER
 
 void BaseApplication::LightTimerEventHandler(TimerHandle_t xTimer)
 {

--- a/examples/platform/silabs/efr32/BaseApplication.h
+++ b/examples/platform/silabs/efr32/BaseApplication.h
@@ -29,11 +29,15 @@
 #include "AppEvent.h"
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
+#include <app/util/config.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <platform/CHIPDeviceLayer.h>
+
+#ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
+#include <app/clusters/identify-server/identify-server.h>
+#endif
 
 #ifdef DISPLAY_ENABLED
 #include "demo-ui.h"
@@ -103,6 +107,14 @@ public:
      */
     static void StopStatusLEDTimer(void);
 
+#ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
+    // Idenfiy server command callbacks.
+    static void OnIdentifyStart(Identify * identify);
+    static void OnIdentifyStop(Identify * identify);
+    static void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState);
+    static void OnTriggerIdentifyEffect(Identify * identify);
+#endif
+
     enum Function_t
     {
         kFunction_NoneSelected   = 0,
@@ -114,7 +126,7 @@ public:
     } Function;
 
 protected:
-    CHIP_ERROR Init(Identify * identifyObj);
+    CHIP_ERROR Init();
 
     /**
      * @brief Function called to start the function timer
@@ -172,6 +184,16 @@ protected:
      * @brief Updates device LEDs
      */
     static void LightEventHandler();
+
+    /**
+     * @brief Activate a set of Led patterns of the Status led
+     *        Identify patterns and Trigger effects have priority
+     *        If no identification patterns are in progress, we provide
+     *        commissioning status feedback.
+     *
+     * @return True if a Led pattern was set, otherwise, returns false.
+     */
+    static bool ActivateStatusLedPatterns();
 
     /**
      * @brief Start the factory Reset process

--- a/examples/thermostat/silabs/include/AppTask.h
+++ b/examples/thermostat/silabs/include/AppTask.h
@@ -36,7 +36,6 @@
 #include "SensorManager.h"
 #include "TemperatureManager.h"
 #include "timers.h" // provides FreeRTOS timer support
-#include <app/clusters/identify-server/identify-server.h>
 #include <ble/BLEEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -88,20 +87,6 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is received
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStart(Identify * identify);
-
-    /**
-     * @brief Callback called by the identify-server when an identify command is stopped or finished
-     *
-     * @param identify identify structure the command applies on
-     */
-    static void OnIdentifyStop(Identify * identify);
 
 private:
     static AppTask sAppTask;

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -40,13 +40,9 @@ void OnTriggerEffect(Identify * identify)
 {
     Clusters::Identify::EffectIdentifierEnum sIdentifyEffect = identify->mCurrentEffectIdentifier;
 
-    ChipLogProgress(Zcl, "IDENTFY  OnTriggerEffect");
-
-    if (identify->mCurrentEffectIdentifier == Clusters::Identify::EffectIdentifierEnum::kChannelChange)
+    if (identify->mEffectVariant != Clusters::Identify::EffectVariantEnum::kDefault)
     {
-        ChipLogProgress(Zcl, "IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE - Not supported, use effect varriant %d",
-                        to_underlying(identify->mEffectVariant));
-        sIdentifyEffect = static_cast<Clusters::Identify::EffectIdentifierEnum>(identify->mEffectVariant);
+        ChipLogDetail(AppServer, "Identify Effect Variant unsupported. Using default");
     }
 
     switch (sIdentifyEffect)
@@ -54,6 +50,7 @@ void OnTriggerEffect(Identify * identify)
     case Clusters::Identify::EffectIdentifierEnum::kBlink:
     case Clusters::Identify::EffectIdentifierEnum::kBreathe:
     case Clusters::Identify::EffectIdentifierEnum::kOkay:
+    case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
         WindowApp::Instance().PostEvent(WindowApp::EventId::WinkOn);
         (void) chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(5), OnTriggerEffectCompleted, identify);
         break;


### PR DESCRIPTION
fixes #26797 -> Invalid cast removed, support the `EffectIdentifierEnum::kChannelChange`. For the Effect Variant, currently, only `EffectVariantEnum::kDefault` exist; Add a condition and a print in case new `EffectVariantEnum` values are eventually added

Other changes:
- Bringing all the duplicated identify implementation in each Silabs app to be handled by the common baseApplication.cpp.
- Clean up the led patterns implementation
- Add a few ifdef in case identify cluster is not enabled or in case the Silabs board used doesn't have a status led.

_* I removed the Invalid cast for the qpg platform also._

Can be reviewed by commit
- Commit 1 is the base of the changes and fixes.
- Commit 2 Cleans up the same duplication for other Silabs apps
- Commit 3 remove invalid cast for qpg