### PR TITLE
[Silabs] [EFR32] Fixed Lock app build error for the RS9116 BLE 

### DIFF
--- a/examples/lock-app/silabs/BUILD.gn
+++ b/examples/lock-app/silabs/BUILD.gn
@@ -95,7 +95,6 @@ if (wifi_soc) {
     if (chip_enable_ble_rs911x) {
       # TODO efr32_sdk should not need a header from this location
       include_dirs += [
-        "${src_plat_dir}/rs911x",
         "${examples_plat_dir}/rs911x",
         "${examples_plat_dir}/rs911x/hal",
       ]


### PR DESCRIPTION
Problem
Build failure on RS9116 BLE because of one wrong path.

Fixes added
Removed the path that's not needed for RS9116 BLE.

Testing
I tested with all combinations of RS9116.