### PR TITLE
[thread] add timeout for attach in GenericThreadStackManagerImpl_OpenThread

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -59,6 +59,7 @@ CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCa
 void GenericThreadDriver::Shutdown()
 {
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
+    ThreadStackMgrImpl().CancelOnGoingOperations();
 }
 
 CHIP_ERROR GenericThreadDriver::CommitConfiguration()

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCa
 void GenericThreadDriver::Shutdown()
 {
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    ThreadStackMgrImpl().CancelOnGoingOperations();
+    ThreadStackMgrImpl().CancelOngoingOperations();
 }
 
 CHIP_ERROR GenericThreadDriver::CommitConfiguration()

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -88,8 +88,8 @@ public:
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }
-    uint8_t GetScanNetworkTimeoutSeconds() override { return 10; }
-    uint8_t GetConnectNetworkTimeoutSeconds() override { return 20; }
+    uint8_t GetScanNetworkTimeoutSeconds() override { return ThreadStackMgrImpl().kScanNetworkTimeoutSeconds; }
+    uint8_t GetConnectNetworkTimeoutSeconds() override { return ThreadStackMgrImpl().kAttachNetworkTimeoutSeconds; }
 
     CHIP_ERROR CommitConfiguration() override;
     CHIP_ERROR RevertConfiguration() override;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -236,7 +236,7 @@ private:
     static constexpr size_t kTotalDnsServiceTxtValueSize = std::max(Dnssd::CommissionAdvertisingParameters::kTxtTotalValueSize,
                                                                     Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize);
     static constexpr size_t kTotalDnsServiceTxtKeySize   = std::max(Dnssd::CommissionAdvertisingParameters::kTxtTotalKeySize,
-                                                                    Dnssd::OperationalAdvertisingParameters::kTxtTotalKeySize);
+                                                                  Dnssd::OperationalAdvertisingParameters::kTxtTotalKeySize);
 #else
     // Thread only supports operational discovery.
     static constexpr uint8_t kMaxDnsServiceTxtEntriesNumber = Dnssd::OperationalAdvertisingParameters::kTxtMaxNumber;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -65,6 +65,8 @@ template <class ImplClass>
 class GenericThreadStackManagerImpl_OpenThread
 {
 public:
+    static constexpr uint16_t kAttachNetworkTimeoutSeconds = 20;
+
     // ===== Platform-specific methods directly callable by the application.
 
     otInstance * OTInstance() const;
@@ -229,7 +231,7 @@ private:
     static constexpr size_t kTotalDnsServiceTxtValueSize = std::max(Dnssd::CommissionAdvertisingParameters::kTxtTotalValueSize,
                                                                     Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize);
     static constexpr size_t kTotalDnsServiceTxtKeySize   = std::max(Dnssd::CommissionAdvertisingParameters::kTxtTotalKeySize,
-                                                                  Dnssd::OperationalAdvertisingParameters::kTxtTotalKeySize);
+                                                                    Dnssd::OperationalAdvertisingParameters::kTxtTotalKeySize);
 #else
     // Thread only supports operational discovery.
     static constexpr uint8_t kMaxDnsServiceTxtEntriesNumber = Dnssd::OperationalAdvertisingParameters::kTxtMaxNumber;
@@ -273,6 +275,10 @@ private:
                                                   otError error);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
+    static void OnConnectNetworkTimeout(System::Layer * systemLayer, void * appState);
+    void OnConnectNetworkTimeout(void);
+    void OnAttachEnd(NetworkCommissioning::Status status);
 
     static void OnJoinerComplete(otError aError, void * aContext);
     void OnJoinerComplete(otError aError);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -81,7 +81,7 @@ public:
     {
         mpStatusChangeCallback = statusChangeCallback;
     }
-    void CancelOnGoingOperations(void);
+    void CancelOngoingOperations(void);
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -65,7 +65,11 @@ template <class ImplClass>
 class GenericThreadStackManagerImpl_OpenThread
 {
 public:
+    // OpenThread won't report attach failure since it will continously retry in the background. 20s is the duration of about 5
+    // attach attempts.
     static constexpr uint16_t kAttachNetworkTimeoutSeconds = 20;
+    // Scan usually takes 300ms / channel * 16 channels. Use 10s for any possible lags.
+    static constexpr uint16_t kScanNetworkTimeoutSeconds = 10;
 
     // ===== Platform-specific methods directly callable by the application.
 
@@ -77,6 +81,7 @@ public:
     {
         mpStatusChangeCallback = statusChangeCallback;
     }
+    void CancelOnGoingOperations(void);
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -370,12 +370,12 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AttachToThreadN
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::CancelOnGoingOperations(void)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::CancelOngoingOperations(void)
 {
     if (mpConnectCallback != nullptr)
     {
         Impl()->SetThreadEnabled(false);
-        OnAttachEnd(NetworkCommissioning::Status::kUnknown);
+        OnAttachEnd(NetworkCommissioning::Status::kOtherConnectionFailure);
     }
 }
 
@@ -383,14 +383,13 @@ template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnConnectNetworkTimeout(System::Layer * systemLayer, void * appState)
 {
     DeviceLayer::SystemLayer().ScheduleLambda(
-        []() { ThreadStackManagerImpl().OnAttachEnd(NetworkCommissioning::Status::kNetworkNotFound); });
+        []() { ThreadStackMgrImpl().OnAttachEnd(NetworkCommissioning::Status::kNetworkNotFound); });
 }
 
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnThreadAttachFinished()
 {
-    DeviceLayer::SystemLayer().ScheduleLambda(
-        []() { ThreadStackManagerImpl().OnAttachEnd(NetworkCommissioning::Status::kSuccess); });
+    DeviceLayer::SystemLayer().ScheduleLambda([]() { ThreadStackMgrImpl().OnAttachEnd(NetworkCommissioning::Status::kSuccess); });
 }
 
 template <class ImplClass>
@@ -400,8 +399,8 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnAttachEnd(NetworkCom
 
     // CancelOnGoingOperations will be called when the upper driver is invalidating the callback. So the reference to the callback
     // is expected to be valid here.
-    mpConnectCallback = nullptr;
     mpConnectCallback->OnResult(status, CharSpan(), 0);
+    mpConnectCallback = nullptr;
 }
 
 template <class ImplClass>


### PR DESCRIPTION
Fixes #26939 

OpenThread does not report failure of attaching to an existing network since it is a mesh network.

This PR adds a timer when calling `AttachToThreadNetwork` and will abort the process when it failed to attach to an existing network (timeout).

Testing: With this PR included, the command will return within timeout (20s):

```
2023-06-02 06:25:24 ubuntu chip.CTL[63073] INFO Received ArmFailSafe response errorCode=0     
2023-06-02 06:25:24 ubuntu chip.CTL[63073] INFO Successfully finished commissioning step 'FailsafeBeforeThreadEnable'                                                                                                
2023-06-02 06:25:24 ubuntu chip.CTL[63073] INFO Commissioning stage next step: 'FailsafeBeforeThreadEnable' -> 'ThreadNetworkEnable'
2023-06-02 06:25:24 ubuntu chip.CTL[63073] INFO Performing next commissioning step 'ThreadNetworkEnable'
2023-06-02 06:25:24 ubuntu chip.EM[63073] INFO <<< [E:49546i S:46852 M:188263796] (S) Msg TX to 0:FFFFFFFB00000000 [0000] --- Type 0001:08 (IM:InvokeCommandRequest)
2023-06-02 06:25:24 ubuntu chip.IN[63073] INFO (S) Sending msg 188263796 on secure session with LSID: 46852
2023-06-02 06:25:26 ubuntu chip.BLE[63073] ERROR BLE scan error: src/platform/Linux/bluez/ChipDeviceScanner.cpp:174: CHIP Error 0x00000032: Timeout
2023-06-02 06:25:44 ubuntu chip.EM[63073] INFO >>> [E:49546i S:46852 M:124049853] (S) Msg RX from 0:FFFFFFFB00000000 [0000] --- Type 0001:09 (IM:InvokeCommandResponse)
2023-06-02 06:25:44 ubuntu chip.DMG[63073] INFO Received Command Response Data, Endpoint=0 Cluster=0x0000_0031 Command=0x0000_0007
2023-06-02 06:25:44 ubuntu chip.CTL[63073] INFO Received ConnectNetwork response, networkingStatus=5        
```