### PR TITLE
Set C++ standard to 17 for dynamic_bridge.

### DIFF
--- a/examples/dynamic-bridge-app/linux/args.gni
+++ b/examples/dynamic-bridge-app/linux/args.gni
@@ -23,3 +23,5 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/dynamic-bridge-app/bridge-common/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
+cpp_standard="c++17"


### PR DESCRIPTION
This uses std::from_chars which is a C++17 feature. Since this is linux, it is safe to say C++17 or higher.


