### PR TITLE
Increase CI build timeouts.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -528,5 +528,5 @@ jobs:
                       .environment/pigweed-venv/*.log
 
             - name: Run Build Coverage
-              timeout-minutes: 20
+              timeout-minutes: 30
               run: ./scripts/build_coverage.sh

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -82,7 +82,7 @@ jobs:
                       .environment/pigweed-venv/*.log
 
             - name: Build QPG6105 example apps
-              timeout-minutes: 20
+              timeout-minutes: 30
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
Saw coverage hit timeout in https://github.com/project-chip/connectedhomeip/actions/runs/5123311349/jobs/9213629956?pr=26952

Saw QPG timeout in https://github.com/project-chip/connectedhomeip/actions/runs/5123311361/jobs/9213628661


Similar timeouts seen in other PRs, so bumping timeouts slightly.