### PR TITLE
Disabled CC26x2x7 builds in CI

### DIFF
--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -36,6 +36,9 @@ jobs:
             BUILD_TYPE: gn_cc26x2x7
 
         runs-on: ubuntu-latest
+        # This CI is disabled because running out of flash and a solution was not found in time, see https://github.com/project-chip/connectedhomeip/pull/26186
+        # An issue was opened at https://github.com/project-chip/connectedhomeip/issues/26957
+        # TODO : Enable this once we have a way to run without out of flash failure or remove platform if it cannot support the SDK
         if: github.actor != 'restyled-io[bot]' && false
 
         container:

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -36,7 +36,7 @@ jobs:
             BUILD_TYPE: gn_cc26x2x7
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]' && false
 
         container:
             image: connectedhomeip/chip-build-ti:0.7.14


### PR DESCRIPTION
Disabled the Build example - TI CC26X2X7 yaml build due to failure for this [PR](https://github.com/project-chip/connectedhomeip/pull/26186).

Disabling as the problem is a lack of Flash on a specific device for a specific app.

