### PR TITLE
Remove unused ZCL message-manipulation bits.

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -241,24 +241,6 @@ uint16_t emberAfFixedEndpointCount(void);
  */
 bool emberAfIsTypeSigned(EmberAfAttributeType dataType);
 
-/**
- * @brief Function that extracts a 16-bit integer from the message buffer
- */
-uint16_t emberAfGetInt16u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
-
-/**
- * @brief Macro for consistency, that extracts single byte out of the message
- */
-#define emberAfGetInt8u(message, currentIndex, msgLen) message[currentIndex]
-
-/**
- * @brief Macro for consistency that copies a uint8_t from variable into buffer.
- */
-#define emberAfCopyInt8u(data, index, x) (data[index] = (x))
-/**
- * @brief function that copies a uint16_t value into a buffer
- */
-void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x);
 /*
  * @brief Function that copies a ZCL string type into a buffer.  The size
  * parameter should indicate the maximum number of characters to copy to the

--- a/src/app/util/common.h
+++ b/src/app/util/common.h
@@ -22,7 +22,3 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/attribute-table.h>
 #include <app/util/util.h>
-
-// the variables used to setup and send responses to cluster messages
-extern uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
-extern uint16_t appResponseLength;

--- a/src/app/util/config.h
+++ b/src/app/util/config.h
@@ -43,10 +43,6 @@
 #define EMBER_BINDING_TABLE_SIZE 10
 #endif // EMBER_BINDING_TABLE_SIZE
 
-// Legacy definition that we can remove once Scenes is no longer using the
-// Zigbee message-writing bits.
-#define EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH 1024
-
 /**
  * @brief CHIP uses millisecond ticks
  */

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -16,107 +16,10 @@
  */
 
 #include <app/util/af.h>
-#include <app/util/config.h>
 #include <app/util/util.h>
-#include <lib/support/TypeTraits.h>
+#include <lib/core/CHIPEncoding.h>
 
 using namespace chip;
-
-//------------------------------------------------------------------------------
-
-// these variables are for storing responses that are created by zcl-utils
-// in functions called from emberIncomingMsgHandler. The response is sent
-// from emberAfTick (meant to be called immediately after emberTick).
-// There is only space for one response as each call to emberTick will
-// only result in a single call to emberIncomingMsgHandler. If the device
-// receives multiple ZCL messages, the stack will queue these and hand
-// these to the application via emberIncomingMsgHandler one at a time.
-uint8_t appResponseData[EMBER_AF_RESPONSE_BUFFER_LEN];
-uint16_t appResponseLength;
-
-//------------------------------------------------------------------------------
-// Utilities for adding bytes to the response buffer: appResponseData. These
-// functions take care of incrementing appResponseLength.
-
-uint8_t * emberAfPutInt8uInResp(uint8_t value)
-{
-    // emberAfDebugPrint("try %x max %x\r\n", appResponseLength, EMBER_AF_RESPONSE_BUFFER_LEN);
-    if (appResponseLength < EMBER_AF_RESPONSE_BUFFER_LEN)
-    {
-        // emberAfDebugPrint("put %x at spot %x\r\n", value, appResponseLength);
-        appResponseData[appResponseLength] = value;
-        appResponseLength++;
-        return &appResponseData[appResponseLength - 1];
-    }
-
-    return nullptr;
-}
-
-uint16_t * emberAfPutInt16uInResp(uint16_t value)
-{
-    uint8_t * low  = emberAfPutInt8uInResp(EMBER_LOW_BYTE(value));
-    uint8_t * high = emberAfPutInt8uInResp(EMBER_HIGH_BYTE(value));
-
-    if (low && high)
-    {
-        return (uint16_t *) low;
-    }
-
-    return nullptr;
-}
-
-uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
-{
-    if ((appResponseLength + length) < EMBER_AF_RESPONSE_BUFFER_LEN)
-    {
-        memmove(appResponseData + appResponseLength, data, length);
-        appResponseLength = static_cast<uint16_t>(appResponseLength + length);
-        return &appResponseData[appResponseLength - length];
-    }
-
-    return nullptr;
-}
-
-uint8_t * emberAfPutStringInResp(const uint8_t * buffer)
-{
-    uint8_t length = emberAfStringLength(buffer);
-    return emberAfPutBlockInResp(buffer, static_cast<uint16_t>(length + 1));
-}
-
-void emberAfPutInt16sInResp(int16_t value)
-{
-    emberAfPutInt16uInResp(static_cast<uint16_t>(value));
-}
-
-// ------------------------------------
-// Utilities for reading from RAM buffers (reading from incoming message
-// buffer)
-// ------------------------------------
-
-// retrieves an uint64_t which contains between 1 and 8 bytes of relevant data
-// depending on number of bytes requested.
-uint64_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes)
-{
-    uint64_t result = 0;
-    uint8_t i       = bytes;
-    if ((currentIndex + bytes) > msgLen)
-    {
-        emberAfDebugPrintln("GetInt, %x bytes short", bytes);
-        emberAfDebugFlush();
-        return 0;
-    }
-    while (i > 0)
-    {
-        result = (result << 8) + message[(currentIndex + i) - 1];
-        i--;
-    }
-    return result;
-}
-
-uint16_t emberAfGetInt16u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen)
-{
-    return static_cast<uint16_t>(emberAfGetInt(message, currentIndex, msgLen, 2));
-}
 
 uint8_t emberAfStringLength(const uint8_t * buffer)
 {
@@ -129,6 +32,6 @@ uint16_t emberAfLongStringLength(const uint8_t * buffer)
 {
     // The first two bytes specify the length of the long string.  A length of
     // 0xFFFF means the string is invalid and there is no character data.
-    uint16_t length = emberAfGetInt16u(buffer, 0, 2);
+    uint16_t length = Encoding::LittleEndian::Get16(buffer);
     return (length == 0xFFFF ? 0 : length);
 }

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -167,12 +167,6 @@ uint16_t emberAfFindClusterNameIndex(ClusterId cluster)
     return 0xFFFF;
 }
 
-void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
-{
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
-}
-
 void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)
 {
     if (src == nullptr)

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -19,6 +19,8 @@
 
 #include <inttypes.h>
 
+#include <app/util/af-types.h>
+
 // Cluster name structure
 typedef struct
 {
@@ -27,11 +29,6 @@ typedef struct
 } EmberAfClusterName;
 
 extern const EmberAfClusterName zclClusterNames[];
-
-#include <app/util/af.h>
-
-// EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH is defined in config.h
-#define EMBER_AF_RESPONSE_BUFFER_LEN EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH
 
 void emberAfInit();
 uint16_t emberAfFindClusterNameIndex(chip::ClusterId cluster);
@@ -44,25 +41,6 @@ uint16_t emberAfFindClusterNameIndex(chip::ClusterId cluster);
  * up to 4 bytes.
  */
 EmberAfDifferenceType emberAfGetDifference(uint8_t * pData, EmberAfDifferenceType value, uint8_t dataSize);
-
-/**
- * Retrieves an uint64_t from the given Zigbee payload. The integer retrieved
- * may be cast into an integer of the appropriate size depending on the
- * number of bytes requested from the message. In Zigbee, all integers are
- * passed over the air in LSB form. LSB to MSB conversion is
- * done within this function automatically before the integer is returned.
- *
- * Obviously (due to return value) this function can only handle
- * the retrieval of integers between 1 and 8 bytes in length.
- *
- */
-uint64_t emberAfGetInt(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen, uint8_t bytes);
-
-uint8_t * emberAfPutInt8uInResp(uint8_t value);
-uint16_t * emberAfPutInt16uInResp(uint16_t value);
-uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length);
-uint8_t * emberAfPutStringInResp(const uint8_t * buffer);
-void emberAfPutInt16sInResp(int16_t value);
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
 

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -13,6 +13,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/odd-sized-integers.h>
+#include <lib/core/CHIPEncoding.h>
 
 namespace chip {
 namespace app {
@@ -92,7 +93,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, {{zapTypeToEncodableClusterObjectTy
                   "value.size() might be too big");
     VerifyOrReturnError(value.size() <= {{maxLength}}, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[{{maxLength}} + {{>sizingBytes}}];
-    emberAfCopyInt{{#if (isShortString type)}}8{{else}}16{{/if}}u(zclString, 0, static_cast<{{>lengthType}}>(value.size()));
+    auto length = static_cast<{{>lengthType}}>(value.size());
+    {{#if (isShortString type)}}
+      Encoding::Put8(zclString, length);
+    {{else}}
+      Encoding::LittleEndian::Put16(zclString, length);
+    {{/if}}
     memcpy(&zclString[{{>sizingBytes}}], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, {{>clusterId}}, Id, zclString, ZCL_{{typeAsDelimitedMacro type}}_ATTRIBUTE_TYPE);
     {{else}}

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -30,6 +30,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/odd-sized-integers.h>
+#include <lib/core/CHIPEncoding.h>
 
 namespace chip {
 namespace app {
@@ -1576,7 +1577,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -1606,7 +1608,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -1636,7 +1639,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -2192,7 +2196,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(512 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 512, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[512 + 2];
-    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
     memcpy(&zclString[2], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::Actions::Id, Id, zclString, ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -2290,7 +2295,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BasicInformation::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -2702,7 +2708,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(35 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 35, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[35 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::LocalizationConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -3159,7 +3166,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(60 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 60, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[60 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -3755,7 +3763,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(60 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 60, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[60 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -3816,7 +3825,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(20 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 20, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[20 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -3846,7 +3856,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(20 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 20, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[20 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -4486,7 +4497,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::NetworkCommissioning::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
 }
@@ -5378,7 +5390,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5441,7 +5454,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5473,7 +5487,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5536,7 +5551,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(64 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[64 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5599,7 +5615,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(64 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[64 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5631,7 +5648,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5663,7 +5681,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5695,7 +5714,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(256 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 256, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[256 + 2];
-    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
     memcpy(&zclString[2], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5727,7 +5747,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(64 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[64 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5759,7 +5780,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -5822,7 +5844,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BridgedDeviceBasicInformation::Id, Id, zclString,
                                  ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
@@ -6948,7 +6971,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::ModeSelect::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -11279,7 +11303,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(3 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 3, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[3 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::DoorLock::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -17026,7 +17051,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(254 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[254 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::ColorControl::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -19053,7 +19079,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -19083,7 +19110,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(16 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[16 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -40880,7 +40908,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -41988,7 +42017,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -42049,7 +42079,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -42141,7 +42172,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(32 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[32 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -47118,7 +47150,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
     static_assert(10 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[10 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
 }
@@ -47148,7 +47181,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
     static_assert(1000 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 1000, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[1000 + 2];
-    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
     memcpy(&zclString[2], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE);
 }
@@ -47178,7 +47212,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(10 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[10 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -47208,7 +47243,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(1000 < NumericAttributeTraits<uint16_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 1000, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[1000 + 2];
-    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    auto length = static_cast<uint16_t>(value.size());
+    Encoding::LittleEndian::Put16(zclString, length);
     memcpy(&zclString[2], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE);
 }
@@ -48883,7 +48919,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
     static_assert(10 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[10 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
 }
@@ -48931,7 +48968,8 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
     static_assert(10 < NumericAttributeTraits<uint8_t>::kNullValue, "value.size() might be too big");
     VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
     uint8_t zclString[10 + 1];
-    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    auto length = static_cast<uint8_t>(value.size());
+    Encoding::Put8(zclString, length);
     memcpy(&zclString[1], value.data(), value.size());
     return emberAfWriteAttribute(endpoint, Clusters::UnitTesting::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
 }


### PR DESCRIPTION
These were being used by the old scenes implementation, which is now gone.
