### PR TITLE
Rollback() on data model builder should reset the error on the builder.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -559,7 +559,6 @@ CHIP_ERROR CommandHandler::RollbackResponse()
 {
     VerifyOrReturnError(mState == State::Preparing || mState == State::AddingCommand, CHIP_ERROR_INCORRECT_STATE);
     mInvokeResponseBuilder.Rollback(mBackupWriter);
-    mInvokeResponseBuilder.ResetError();
     // Note: We only support one command per request, so we reset the state to Idle here, need to review the states when adding
     // supports of having multiple requests in the same transaction.
     MoveToState(State::Idle);

--- a/src/app/MessageDef/Builder.h
+++ b/src/app/MessageDef/Builder.h
@@ -81,9 +81,13 @@ public:
     /**
      * Rollback the request state to the checkpointed TLVWriter
      *
-     * @param[in] aPoint A that captured the state via Checkpoint() at some point in the past
+     * @param[in] aPoint A writer that captured the state via Checkpoint() at some point in the past
      */
-    void Rollback(const chip::TLV::TLVWriter & aPoint) { *mpWriter = aPoint; }
+    void Rollback(const chip::TLV::TLVWriter & aPoint)
+    {
+        *mpWriter = aPoint;
+        ResetError();
+    }
 
     void EndOfContainer();
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -240,7 +240,6 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     {
         // If it failed with no memory, then we create a new chunk for it.
         mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
-        mWriteRequestBuilder.GetWriteRequests().ResetError();
         ReturnErrorOnFailure(StartNewMessage());
         err = TryPutSinglePreencodedAttributeWritePayload(attributePath, data);
         // Since we have created a new chunk for this element, the encode is expected to succeed.

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -297,7 +297,6 @@ private:
         {
             // If it failed with no memory, then we create a new chunk for it.
             mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
-            mWriteRequestBuilder.GetWriteRequests().ResetError();
             ReturnErrorOnFailure(StartNewMessage());
             ReturnErrorOnFailure(TryEncodeSingleAttributeDataIB(attributePath, value));
         }

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -330,7 +330,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         MatterPreAttributeWriteCallback(dataAttributePath);
         TLV::TLVWriter backup;
         DataVersion version = 0;
-        mWriteResponseBuilder.Checkpoint(backup);
+        mWriteResponseBuilder.GetWriteResponses().Checkpoint(backup);
         err = element.GetDataVersion(&version);
         if (CHIP_NO_ERROR == err)
         {
@@ -344,7 +344,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         err = WriteSingleClusterData(subjectDescriptor, dataAttributePath, dataReader, this);
         if (err != CHIP_NO_ERROR)
         {
-            mWriteResponseBuilder.Rollback(backup);
+            mWriteResponseBuilder.GetWriteResponses().Rollback(backup);
             err = AddStatus(dataAttributePath, StatusIB(err));
         }
         MatterPostAttributeWriteCallback(dataAttributePath);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -84,6 +84,11 @@ Engine::RetrieveClusterData(const SubjectDescriptor & aSubjectDescriptor, bool a
     return CHIP_NO_ERROR;
 }
 
+static bool IsOutOfWriterSpaceError(CHIP_ERROR err)
+{
+    return err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL;
+}
+
 CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Builder & aReportDataBuilder,
                                                            ReadHandler * apReadHandler, bool * apHasMoreChunks,
                                                            bool * apHasEncodedData)
@@ -185,13 +190,15 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
                              "Error retrieving data from clusterId: " ChipLogFormatMEI ", err = %" CHIP_ERROR_FORMAT,
                              ChipLogValueMEI(pathForRetrieval.mClusterId), err.Format());
 
-                // If error is not CHIP_ERROR_BUFFER_TOO_SMALL and is not CHIP_ERROR_NO_MEMORY, rollback and encode status.
+                // If error is not an "out of writer space" error, rollback and encode status.
                 // Otherwise, if partial data allowed, save the encode state.
                 // Otherwise roll back. If we have already encoded some chunks, we are done; otherwise encode status.
 
-                if (encodeState.AllowPartialData() && ((err == CHIP_ERROR_BUFFER_TOO_SMALL) || (err == CHIP_ERROR_NO_MEMORY)))
+                if (encodeState.AllowPartialData() && IsOutOfWriterSpaceError(err))
                 {
                     // Encoding is aborted but partial data is allowed, then we don't rollback and save the state for next chunk.
+                    // The expectation is that RetrieveClusterData has already reset attributeReportIBs to a good state (rolled
+                    // back any partial changes, etc).
                     apReadHandler->SetAttributeEncodeState(encodeState);
                 }
                 else
@@ -201,13 +208,14 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
                     attributeReportIBs.Rollback(attributeBackup);
                     apReadHandler->SetAttributeEncodeState(AttributeValueEncoder::AttributeEncodeState());
 
-                    if (err != CHIP_ERROR_NO_MEMORY && err != CHIP_ERROR_BUFFER_TOO_SMALL)
+                    if (!IsOutOfWriterSpaceError(err))
                     {
                         // Try to encode our error as a status response.
                         err = attributeReportIBs.EncodeAttributeStatus(pathForRetrieval, StatusIB(err));
                         if (err != CHIP_NO_ERROR)
                         {
-                            // OK, just roll back again and give up.
+                            // OK, just roll back again and give up; if we still ran out of space we
+                            // will send this status response in the next chunk.
                             attributeReportIBs.Rollback(attributeBackup);
                         }
                     }
@@ -241,15 +249,9 @@ exit:
     // These are are guaranteed to not fail since we've already reserved memory for the remaining 'close out' TLV operations in this
     // function and its callers.
     //
-    if ((err == CHIP_ERROR_BUFFER_TOO_SMALL) || (err == CHIP_ERROR_NO_MEMORY))
+    if (IsOutOfWriterSpaceError(err))
     {
         ChipLogDetail(DataManagement, "<RE:Run> We cannot put more chunks into this report. Enable chunking.");
-
-        //
-        // Reset the error tracked within the builder. Otherwise, any further attempts to write
-        // data through the builder will be blocked by that error.
-        //
-        attributeReportIBs.ResetError();
         err = CHIP_NO_ERROR;
     }
 
@@ -276,7 +278,6 @@ exit:
     if (!attributeDataWritten && err == CHIP_NO_ERROR)
     {
         aReportDataBuilder.Rollback(backup);
-        aReportDataBuilder.ResetError();
     }
 
     // hasMoreChunks + no data encoded is a flag that we have encountered some trouble when processing the attribute.
@@ -379,7 +380,7 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
             err           = CHIP_NO_ERROR;
             hasMoreChunks = false;
         }
-        else if ((err == CHIP_ERROR_BUFFER_TOO_SMALL) || (err == CHIP_ERROR_NO_MEMORY))
+        else if (IsOutOfWriterSpaceError(err))
         {
             // when first cluster event is too big to fit in the packet, ignore that cluster event.
             // However, we may have encoded some attributes before, we don't skip it in that case.
@@ -423,11 +424,9 @@ exit:
     }
 
     // Maybe encoding the attributes has already used up all space.
-    if ((err == CHIP_NO_ERROR || err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL) &&
-        !(hasEncodedStatus || (eventCount != 0)))
+    if ((err == CHIP_NO_ERROR || IsOutOfWriterSpaceError(err)) && !(hasEncodedStatus || (eventCount != 0)))
     {
         aReportDataBuilder.Rollback(backup);
-        aReportDataBuilder.ResetError();
         err = CHIP_NO_ERROR;
     }
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -198,7 +198,9 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
                 {
                     // Encoding is aborted but partial data is allowed, then we don't rollback and save the state for next chunk.
                     // The expectation is that RetrieveClusterData has already reset attributeReportIBs to a good state (rolled
-                    // back any partial changes, etc).
+                    // back any partially-written AttributeReportIB instances, reset its error status).  Since AllowPartialData()
+                    // is true, we may not have encoded a complete attribute value, but we did, if we encoded anything, encode a
+                    // set of complete AttributeReportIB instances that represent part of the attribute value.
                     apReadHandler->SetAttributeEncodeState(encodeState);
                 }
                 else


### PR DESCRIPTION
Without this, it's too easy to forget to ResetError() when rolling back.  That's exactly what happened in ClusterStateCache:OnUpdateDataVersionFilterList, and that could lead to inability to ever re-subscribe after a subscription drop.

We had the following Rollback() calls not immediately followed by ResetError():

* In SendFailureStatus in ember-compatibility-functions.cpp. This is never reached when there is a failure on aAttributeReports, so doing the ResetError here is not a problem.
* AttributeValueEncoder::EncodeListItem. This was relying on the InteractionModelEngine to ResetError after the rollback.
* ClusterStateCache:OnUpdateDataVersionFilterList. When CreateDataVersionFilter() failed, this could leave the DataVersionFilterIBs::Builder in an error state, which would lead to the subscribe request (incorrectly) failing completely.
* WriteHandler::ProcessAttributeDataIBs. This codepath was apparently not getting hit in practice, since it would fail. It was also checkpointing/restoring on the wrong builder.
* Engine::BuildSingleReportDataAttributeReportIBs. This was buggy: If we hit an error other than "out of memory" while encoding the value, we could end up with the builder in an error state and then fail to encode our status response.
* ReadClient::SendReadRequest. This is never reached with an error on the builder.
* ReadClient::SendSubscribeRequestImpl. This is never reached with an error on the builder.
