### PR TITLE
Increase android build timeout

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
     full_android:
         name: Run
-        timeout-minutes: 75
+        timeout-minutes: 120
 
         env:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/


### PR DESCRIPTION
I see failures of timing out at 75 minutes, with chip tool builds taking around 30 minutes and since we have 2 of them, this easily times out at 75 mintes.

Timeout example: https://github.com/project-chip/connectedhomeip/actions/runs/5133277352/jobs/9235652439

Pass before that: https://github.com/project-chip/connectedhomeip/actions/runs/5133185740/jobs/9238673762 in 58 minutes. Apparently 15 minutes fuzzyness is insufficient (do not understand why) ... so increasing timeout.