### PR TITLE
Bump the timeout on the build part of the darwin-tests job.

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -92,7 +92,7 @@ jobs:
               run: defaults delete com.apple.dt.xctest.tool
               continue-on-error: true
             - name: Build Apps
-              timeout-minutes: 75
+              timeout-minutes: 90
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
It's building 6 example apps plus darwin-framework-tool.  The example apps now take 8-10 minutes each in CI, and darwin-framework-tool takes 15-20, so 75 minutes is too short.
