### PR TITLE
[Tizen] Change the platform version to 8.0 from 7.5

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -671,7 +671,7 @@ int BLEManagerImpl::StartBLEAdvertising()
 
     err = SystemInfo::GetPlatformVersion(version);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "GetPlatformVersion() failed. %s", ErrorStr(err)));
-    if (version.mMajor >= 7 && version.mMinor >= 5)
+    if (version.mMajor >= 8)
     {
         ret = bt_adapter_le_set_advertising_flags(
             mAdvertiser, BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC | BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP);


### PR DESCRIPTION
### Problem
bt_adapter_le_set_advertising_flags() is available since Tizen 8.0 not 7.5.

### Changes
* change the platform version check logic to 8.0.

### Testing
CI will test potential build failures. Functionality tested locally on Tizen device.