### PR TITLE
[Darwin] MTRDevice should coalesce reads and avoid duplicates

### DIFF
--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -42,8 +42,8 @@ typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 // after the one that was dropped.
 typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
 
-// The duplicate check handler is called by the work queue when the client wishes to verify if a work item is a duplicate of an
-// existing one, so that the client can decide to not enqueue the new duplicate. The work queue will
+// The duplicate check handler is called by the work queue when the client wishes to check whether a work item is a duplicate of an
+// existing one, so that the client can decide to not enqueue the new duplicate.
 typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * isDuplicate);
 
 // MTRAsyncCallbackQueue high level description

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -23,6 +23,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 
+// The batching handler is called by the work queue when a work item is batchable. The handler will be passed the opaque data from
+// the current and the next work item, and should the next item's data be fully merged into the first, the fullyMerged BOOL should
+// be set to YES, so that the work queue can remove the "next item" from the queue. And when fullyMerged is set to YES, this handler
+// will be called again, if the following item is also batchable with the same ID.
+typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
+
+// The duplicate check handler is called by the work queue when the client wishes to verify if a work item is a duplicate of an
+// existing one, so that the client can decide to not enqueue the new duplicate. The work queue will
+typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * isDuplicate);
+
 // MTRAsyncCallbackQueue high level description
 //   The MTRAsyncCallbackQueue was made to call one readyHandler
 //   block at a time asynchronously, and the readyHandler is
@@ -42,6 +52,23 @@ typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 //   - Set the readyHandler block on the WorkItem object
 //   - Call enqueueWorkItem on a MTRAsyncCallbackQueue
 
+// Optional feature: Work Item Batching
+//   When a work item is dequeued to run, if it is of a type that can be combined with similar work items in a batch, this facility
+//   gives the client of this API an opportunity to coalesce and merge work items.
+//      - The "batching ID" is used for grouping mergeable work items with unique merging strategies. The ID value is opaque to this
+//        API, and the API client is responsible for assinging them.
+//      - Each work item will only be asked to batch before it's first dequeued to run readyHandler.
+// See the MTRAsyncCallbackBatchingHandler definition above and the WorkItem's -setBatchingID:data:handler: method description for
+// more details.
+
+// Optional feature: Duplicate Filtering
+//   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
+//   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
+//      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
+//        to this API, and the API client is responsible for assinging them.
+// See the MTRAsyncCallbackDuplicateCheckHandler definition above and the WorkItem's -setDuplicateTypeID:handler: method description
+// for more details.
+
 // A serial one-at-a-time queue for performing work items
 @interface MTRAsyncCallbackWorkQueue : NSObject
 - (instancetype)init NS_UNAVAILABLE;
@@ -57,7 +84,12 @@ typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 // Note: Once a work item is enqueued, its handlers cannot be modified
 - (void)enqueueWorkItem:(MTRAsyncCallbackQueueWorkItem *)item;
 
-// TODO: Add a "set concurrency width" method to allow for more than 1 work item at a time
+// Before creating a work item, a client may call this method to check with existing work items that the new potential work item
+// data is not a duplicate request. The work queue will then look for all work items matching the duplicate type ID, and call their
+// duplicateCheckHandler.
+//
+// Returns YES if any item's duplicateCheckHandler returns a match.
+- (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData;
 @end
 
 // An item in the work queue
@@ -69,6 +101,18 @@ typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 @property (nonatomic, strong) MTRAsyncCallbackReadyHandler readyHandler;
 @property (nonatomic, strong) dispatch_block_t cancelHandler;
+
+// For work items that can be merged into a batch, set this handler with an identifier and an object that represents the mergeable
+// data. When the work queue processes a batchable item, if the next item is also batchable with the same batching identifier, the
+// work queue will call the batchingHandler to give the work item an opportunity to merge the data before readyHandler is called.
+// Should the two items be completely merged into one batch, the batchingHandler can signal that through the out argument
+// "fullyMerged", and the work queue will remove the second item.
+- (void)setBatchingID:(NSUInteger)opaqueBatchingID
+                 data:(id)opaqueBatchableData
+              handler:(MTRAsyncCallbackBatchingHandler)batchingHandler;
+
+// For work items that may have duplicates, set this handler with an identifier and a handler
+- (void)setDuplicateTypeID:(NSUInteger)opaqueDuplicateTypeID handler:(MTRAsyncCallbackDuplicateCheckHandler)duplicateCheckHandler;
 
 // Called by the creater of the work item when async work is done and should
 // be removed from the queue. The work queue will run the next work item.

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -23,29 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^MTRAsyncCallbackReadyHandler)(id context, NSUInteger retryCount);
 
-// The batching handler is called by the work queue when all of the following are true:
-//
-// 1) A work item that is batchable is about to be dequeued and executed for the first time.
-// 2) The next work item in the queue is also batchable.
-// 3) The two work items have matching batching ids.
-//
-// The handler will be passed the opaque data of the two work items: opaqueDataCurrent is the data of the
-// item about to be executed and opaqueDataNext is the data for the next item.
-//
-// The handler is expected to mutate the data as needed to achieve batching.
-//
-// If after the data mutations opaqueDataNext no longer requires any work, the handler
-// should set *fullyMerged to YES to indicate that the next item can be dropped from the queue.
-//  Otherwise the handler should set *fullyMerged to NO.
-//
-// If *fullyMerged is set to YES, this handler may be called again to possibly also batch the work item
-// after the one that was dropped.
-typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
-
-// The duplicate check handler is called by the work queue when the client wishes to check whether a work item is a duplicate of an
-// existing one, so that the client can decide to not enqueue the new duplicate.
-typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * isDuplicate);
-
 // MTRAsyncCallbackQueue high level description
 //   The MTRAsyncCallbackQueue was made to call one readyHandler
 //   block at a time asynchronously, and the readyHandler is
@@ -65,23 +42,6 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 //   - Set the readyHandler block on the WorkItem object
 //   - Call enqueueWorkItem on a MTRAsyncCallbackQueue
 
-// Optional feature: Work Item Batching
-//   When a work item is dequeued to run, if it is of a type that can be combined with similar work items in a batch, this facility
-//   gives the client of this API an opportunity to coalesce and merge work items.
-//      - The "batching ID" is used for grouping mergeable work items with unique merging strategies. The ID value is opaque to this
-//        API, and the API client is responsible for assigning them.
-//      - Each work item will only be asked to batch before it's first dequeued to run readyHandler.
-// See the MTRAsyncCallbackBatchingHandler definition above and the WorkItem's -setBatchingID:data:handler: method description for
-// more details.
-
-// Optional feature: Duplicate Filtering
-//   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
-//   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
-//      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
-//        to this API, and the API client is responsible for assigning them.
-// See the MTRAsyncCallbackDuplicateCheckHandler definition above and the WorkItem's -setDuplicateTypeID:handler: method description
-// for more details.
-
 // A serial one-at-a-time queue for performing work items
 @interface MTRAsyncCallbackWorkQueue : NSObject
 - (instancetype)init NS_UNAVAILABLE;
@@ -96,13 +56,6 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 // Work items may be enqueued from any queue or thread
 // Note: Once a work item is enqueued, its handlers cannot be modified
 - (void)enqueueWorkItem:(MTRAsyncCallbackQueueWorkItem *)item;
-
-// Before creating a work item, a client may call this method to check with existing work items that the new potential work item
-// data is not a duplicate request. The work queue will then look for all work items matching the duplicate type ID, and call their
-// duplicateCheckHandler with the provided opaqueWorkItemData.
-//
-// Returns YES if any item's duplicateCheckHandler returns a match.
-- (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData;
 @end
 
 // An item in the work queue
@@ -114,18 +67,6 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 @property (nonatomic, strong) MTRAsyncCallbackReadyHandler readyHandler;
 @property (nonatomic, strong) dispatch_block_t cancelHandler;
-
-// For work items that can be merged into a batch, set this handler with an identifier and an object that represents the mergeable
-// data. When the work queue processes a batchable item, if the next item is also batchable with the same batching identifier, the
-// work queue will call the batchingHandler to give the work item an opportunity to merge the data before readyHandler is called.
-// Should the two items be completely merged into one batch, the batchingHandler can signal that through the out argument
-// "fullyMerged", and the work queue will remove the second item.
-- (void)setBatchingID:(NSUInteger)opaqueBatchingID
-                 data:(id)opaqueBatchableData
-              handler:(MTRAsyncCallbackBatchingHandler)batchingHandler;
-
-// For work items that may have duplicates, set this handler with an identifier and a handler
-- (void)setDuplicateTypeID:(NSUInteger)opaqueDuplicateTypeID handler:(MTRAsyncCallbackDuplicateCheckHandler)duplicateCheckHandler;
 
 // Called by the creater of the work item when async work is done and should
 // be removed from the queue. The work queue will run the next work item.

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -65,7 +65,7 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 //   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
 //   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
 //      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
-//        to this API, and the API client is responsible for assinging them.
+//        to this API, and the API client is responsible for assigning them.
 // See the MTRAsyncCallbackDuplicateCheckHandler definition above and the WorkItem's -setDuplicateTypeID:handler: method description
 // for more details.
 

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -99,7 +99,7 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 
 // Before creating a work item, a client may call this method to check with existing work items that the new potential work item
 // data is not a duplicate request. The work queue will then look for all work items matching the duplicate type ID, and call their
-// duplicateCheckHandler.
+// duplicateCheckHandler with the provided opaqueWorkItemData.
 //
 // Returns YES if any item's duplicateCheckHandler returns a match.
 - (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData;

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.h
@@ -56,7 +56,7 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 //   When a work item is dequeued to run, if it is of a type that can be combined with similar work items in a batch, this facility
 //   gives the client of this API an opportunity to coalesce and merge work items.
 //      - The "batching ID" is used for grouping mergeable work items with unique merging strategies. The ID value is opaque to this
-//        API, and the API client is responsible for assinging them.
+//        API, and the API client is responsible for assigning them.
 //      - Each work item will only be asked to batch before it's first dequeued to run readyHandler.
 // See the MTRAsyncCallbackBatchingHandler definition above and the WorkItem's -setBatchingID:data:handler: method description for
 // more details.

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
@@ -181,8 +181,6 @@
 
                 BOOL fullyMerged = NO;
                 workItem.batchingHandler(workItem.batchableData, nextWorkItem.batchableData, &fullyMerged);
-                MTR_LOG_DEFAULT(
-                    "MTRAsyncCallbackWorkQueue: merged items for batching - fully merged %@", fullyMerged ? @"YES" : @"NO");
                 if (!fullyMerged) {
                     // if some parts of the next item is
                     break;

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
@@ -182,7 +182,7 @@
                 BOOL fullyMerged = NO;
                 workItem.batchingHandler(workItem.batchableData, nextWorkItem.batchableData, &fullyMerged);
                 if (!fullyMerged) {
-                    // if some parts of the next item is
+                    // We can't remove the next work item, so we can't merge anything else into this one.
                     break;
                 }
 

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue.mm
@@ -197,17 +197,18 @@
 - (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData
 {
     os_unfair_lock_lock(&_lock);
-    int i = 0;
-    for (MTRAsyncCallbackQueueWorkItem * item in self.items) {
+    // Start from the last item
+    for (NSUInteger i = self.items.count; i > 0; i--) {
+        MTRAsyncCallbackQueueWorkItem * item = self.items[i - 1];
         BOOL isDuplicate = NO;
+        BOOL stop = NO;
         if (item.supportsDuplicateCheck && (item.duplicateTypeID == opaqueDuplicateTypeID) && item.duplicateCheckHandler) {
-            item.duplicateCheckHandler(opaqueWorkItemData, &isDuplicate);
-            if (isDuplicate) {
+            item.duplicateCheckHandler(opaqueWorkItemData, &isDuplicate, &stop);
+            if (stop) {
                 os_unfair_lock_unlock(&_lock);
-                return YES;
+                return isDuplicate;
             }
         }
-        i++;
     }
     os_unfair_lock_unlock(&_lock);
     return NO;

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -23,9 +23,62 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MTRDevice;
 
+// Optional feature: Work Item Batching
+//   When a work item is dequeued to run, if it is of a type that can be combined with similar work items in a batch, this facility
+//   gives the client of this API an opportunity to coalesce and merge work items.
+//      - The "batching ID" is used for grouping mergeable work items with unique merging strategies. The ID value is opaque to this
+//        API, and the API client is responsible for assigning them.
+//      - Each work item will only be asked to batch before it's first dequeued to run readyHandler.
+// See the MTRAsyncCallbackBatchingHandler definition for more details.
+
+// Optional feature: Duplicate Filtering
+//   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
+//   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
+//      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
+//        to this API, and the API client is responsible for assigning them.
+// See the MTRAsyncCallbackDuplicateCheckHandler definition and the WorkQueue's -isDuplicateForTypeID:workItemData: and
+// removeDuplicateCheckHandlerForTypeID:workItemData: method descriptions for more details.
+
+// The batching handler is called by the work queue when all of the following are true:
+//
+// 1) A work item that is batchable is about to be dequeued and executed for the first time.
+// 2) The next work item in the queue is also batchable.
+// 3) The two work items have matching batching ids.
+//
+// The handler will be passed the opaque data of the two work items: opaqueDataCurrent is the data of the
+// item about to be executed and opaqueDataNext is the data for the next item.
+//
+// The handler is expected to mutate the data as needed to achieve batching.
+//
+// If after the data mutations opaqueDataNext no longer requires any work, the handler should set *fullyMerged to YES to indicate
+// that the next item can be dropped from the queue. Otherwise the handler should set *fullyMerged to NO.
+//
+// If *fullyMerged is set to YES, this handler may be called again to possibly also batch the work item
+// after the one that was dropped.
+typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
+
+// The duplicate check handler is called by the work queue when the client wishes to check whether a work item is a duplicate of an
+// existing one, so that the client may decide to not enqueue a duplicate work item.
+//
+// The handler will be passed the opaque data of a potential duplicate work item.
+//
+// If the handler determins the data is indeed duplicate work, it should set *stop to YES, and set *isDuplicate to YES.
+//
+// If the handler determins the data is not duplicate work, it should set *stop to YES, and set *isDuplicate to NO.
+//
+// If the handler is unable to determins if the data is duplicate work, it should set *stop to NO.
+typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * isDuplicate, BOOL * stop);
+
 @interface MTRAsyncCallbackWorkQueue ()
 // The MTRDevice object is only held and passed back as a reference and is opaque to the queue
 - (instancetype)initWithContext:(id _Nullable)context queue:(dispatch_queue_t)queue;
+
+// Before creating a work item, a client may call this method to check with existing work items that the new potential work item
+// data is not a duplicate request.
+//    - This method will call the duplicate check handler for all work items matching the duplicate type ID, starting from the last
+//      item in the queue, and if a handler sets *stop to YES, this method will return the value the handler sets for *isDuplicate
+//    - If no duplicate check handlers sets *stop to YES, this method will return NO.
+- (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData;
 @end
 
 @interface MTRAsyncCallbackQueueWorkItem ()
@@ -34,11 +87,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSUInteger batchingID;
 @property (nonatomic, readonly) id batchableData;
 @property (nonatomic, readonly) MTRAsyncCallbackBatchingHandler batchingHandler;
+- (void)setBatchingID:(NSUInteger)opaqueBatchingID
+                 data:(id)opaqueBatchableData
+              handler:(MTRAsyncCallbackBatchingHandler)batchingHandler;
 
-// Duplicate filter
+// Duplicate check
 @property (nonatomic, readonly) BOOL supportsDuplicateCheck;
 @property (nonatomic, readonly) NSUInteger duplicateTypeID;
 @property (nonatomic, readonly) MTRAsyncCallbackDuplicateCheckHandler duplicateCheckHandler;
+- (void)setDuplicateTypeID:(NSUInteger)opaqueDuplicateTypeID handler:(MTRAsyncCallbackDuplicateCheckHandler)duplicateCheckHandler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -28,4 +28,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithContext:(id _Nullable)context queue:(dispatch_queue_t)queue;
 @end
 
+@interface MTRAsyncCallbackQueueWorkItem ()
+// Batching
+@property (nonatomic, readonly) BOOL batchable;
+@property (nonatomic, readonly) NSUInteger batchingID;
+@property (nonatomic, readonly) id batchableData;
+@property (nonatomic, readonly) MTRAsyncCallbackBatchingHandler batchingHandler;
+
+// Duplicate filter
+@property (nonatomic, readonly) BOOL supportsDuplicateCheck;
+@property (nonatomic, readonly) NSUInteger duplicateTypeID;
+@property (nonatomic, readonly) MTRAsyncCallbackDuplicateCheckHandler duplicateCheckHandler;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -66,7 +66,8 @@ typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueD
 //
 // If the handler determins the data is not duplicate work, it should set *stop to YES, and set *isDuplicate to NO.
 //
-// If the handler is unable to determins if the data is duplicate work, it should set *stop to NO.
+// If the handler is unable to determine if the data is duplicate work, it should set *stop to NO.
+// In this case, the value of *isDuplicate is not examined.
 typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * isDuplicate, BOOL * stop);
 
 @interface MTRAsyncCallbackWorkQueue ()

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -31,14 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 //      - Each work item will only be asked to batch before it's first dequeued to run readyHandler.
 // See the MTRAsyncCallbackBatchingHandler definition for more details.
 
-// Optional feature: Duplicate Filtering
-//   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
-//   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
-//      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
-//        to this API, and the API client is responsible for assigning them.
-// See the MTRAsyncCallbackDuplicateCheckHandler definition and the WorkQueue's -isDuplicateForTypeID:workItemData: and
-// removeDuplicateCheckHandlerForTypeID:workItemData: method descriptions for more details.
-
 // The batching handler is called by the work queue when all of the following are true:
 //
 // 1) A work item that is batchable is about to be dequeued and executed for the first time.
@@ -56,6 +48,14 @@ NS_ASSUME_NONNULL_BEGIN
 // If *fullyMerged is set to YES, this handler may be called again to possibly also batch the work item
 // after the one that was dropped.
 typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
+
+// Optional feature: Duplicate Filtering
+//   This is a facility that enables the API client to check if a potential work item has already been enqueued. By providing a
+//   handler that can answer if a work item's relevant data is a duplicate, it can avoid redundant queuing of requests.
+//      - The "duplicate type ID" is used for grouping different types of work items for duplicate checking. The ID value is opaque
+//        to this API, and the API client is responsible for assigning them.
+// See the MTRAsyncCallbackDuplicateCheckHandler definition and the WorkQueue's -isDuplicateForTypeID:workItemData: method
+// descriptions for more details.
 
 // The duplicate check handler is called by the work queue when the client wishes to check whether a work item is a duplicate of an
 // existing one, so that the client may decide to not enqueue a duplicate work item.

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -77,7 +77,7 @@ typedef void (^MTRAsyncCallbackDuplicateCheckHandler)(id opaqueItemData, BOOL * 
 // data is not a duplicate request.
 //    - This method will call the duplicate check handler for all work items matching the duplicate type ID, starting from the last
 //      item in the queue, and if a handler sets *stop to YES, this method will return the value the handler sets for *isDuplicate
-//    - If no duplicate check handlers sets *stop to YES, this method will return NO.
+//    - If no duplicate check handlers set *stop to YES, this method will return NO.
 - (BOOL)isDuplicateForTypeID:(NSUInteger)opaqueDuplicateTypeID workItemData:(id)opaqueWorkItemData;
 @end
 

--- a/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncCallbackWorkQueue_Internal.h
@@ -62,9 +62,9 @@ typedef void (^MTRAsyncCallbackBatchingHandler)(id opaqueDataCurrent, id opaqueD
 //
 // The handler will be passed the opaque data of a potential duplicate work item.
 //
-// If the handler determins the data is indeed duplicate work, it should set *stop to YES, and set *isDuplicate to YES.
+// If the handler determines the data is indeed duplicate work, it should set *stop to YES, and set *isDuplicate to YES.
 //
-// If the handler determins the data is not duplicate work, it should set *stop to YES, and set *isDuplicate to NO.
+// If the handler determines the data is not duplicate work, it should set *stop to YES, and set *isDuplicate to NO.
 //
 // If the handler is unable to determine if the data is duplicate work, it should set *stop to NO.
 // In this case, the value of *isDuplicate is not examined.

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -840,6 +840,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             }
 
             if (readRequestsNext.count == 0) {
+                MTR_LOG_DEFAULT("%@ batching - fully merged next item %@", logPrefix, fullyMerged ? @"YES" : @"NO");
                 *fullyMerged = YES;
             }
         };

--- a/src/darwin/Framework/CHIPTests/MTRAsyncCallbackQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncCallbackQueueTests.m
@@ -269,54 +269,53 @@
     MTRAsyncCallbackQueueWorkItem * workItem0 =
         [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
     MTRAsyncCallbackReadyHandler readyHandler0 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        // Give the following code a chance to enqueue and merge
-        sleep(1);
+        // While processing item 0, enqueue additional items to test batching
+        MTRAsyncCallbackQueueWorkItem * workItem1 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler1 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            [workItem1ReadyExpectation fulfill];
+            [workItem1 endWork];
+        };
+        workItem1.readyHandler = readyHandler1;
+        [workItem1 setBatchingID:1
+                            data:@(1)
+                         handler:^(id _Nonnull opaqueDataFirst, id _Nonnull opaqueDataSecond, BOOL * _Nonnull fullyMerged) {
+                             XCTAssertEqualObjects(opaqueDataFirst, @(1));
+                             XCTAssertEqualObjects(opaqueDataSecond, @(2));
+                             *fullyMerged = YES;
+                         }];
+        // No cancel handler on purpose.
+        [workQueue enqueueWorkItem:workItem1];
+
+        MTRAsyncCallbackQueueWorkItem * workItem2 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler2 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            workItem2ReadyCalled = YES;
+            [workItem2 endWork];
+        };
+        workItem2.readyHandler = readyHandler2;
+        [workItem2 setBatchingID:1
+                            data:@(2)
+                         handler:^(id _Nonnull opaqueDataFirst, id _Nonnull opaqueDataSecond, BOOL * _Nonnull fullyMerged) {
+                             workItem2BatchingCalled = YES;
+                         }];
+        // No cancel handler on purpose.
+        [workQueue enqueueWorkItem:workItem2];
+
+        MTRAsyncCallbackQueueWorkItem * workItem3 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler3 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            [workItem3ReadyExpectation fulfill];
+            [workItem3 endWork];
+        };
+        workItem3.readyHandler = readyHandler3;
+        [workQueue enqueueWorkItem:workItem3];
+
         [workItem0 endWork];
     };
     workItem0.readyHandler = readyHandler0;
     // No cancel handler on purpose.
     [workQueue enqueueWorkItem:workItem0];
-
-    MTRAsyncCallbackQueueWorkItem * workItem1 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler1 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        [workItem1ReadyExpectation fulfill];
-        [workItem1 endWork];
-    };
-    workItem1.readyHandler = readyHandler1;
-    [workItem1 setBatchingID:1
-                        data:@(1)
-                     handler:^(id _Nonnull opaqueDataFirst, id _Nonnull opaqueDataSecond, BOOL * _Nonnull fullyMerged) {
-                         XCTAssertEqualObjects(opaqueDataFirst, @(1));
-                         XCTAssertEqualObjects(opaqueDataSecond, @(2));
-                         *fullyMerged = YES;
-                     }];
-    // No cancel handler on purpose.
-    [workQueue enqueueWorkItem:workItem1];
-
-    MTRAsyncCallbackQueueWorkItem * workItem2 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler2 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        workItem2ReadyCalled = YES;
-        [workItem2 endWork];
-    };
-    workItem2.readyHandler = readyHandler2;
-    [workItem2 setBatchingID:1
-                        data:@(2)
-                     handler:^(id _Nonnull opaqueDataFirst, id _Nonnull opaqueDataSecond, BOOL * _Nonnull fullyMerged) {
-                         workItem2BatchingCalled = YES;
-                     }];
-    // No cancel handler on purpose.
-    [workQueue enqueueWorkItem:workItem2];
-
-    MTRAsyncCallbackQueueWorkItem * workItem3 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler3 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        [workItem3ReadyExpectation fulfill];
-        [workItem3 endWork];
-    };
-    workItem3.readyHandler = readyHandler3;
-    [workQueue enqueueWorkItem:workItem3];
 
     [self waitForExpectations:@[ workItem1ReadyExpectation, workItem3ReadyExpectation ] timeout:5];
 
@@ -335,76 +334,74 @@
     MTRAsyncCallbackQueueWorkItem * workItem0 =
         [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
     MTRAsyncCallbackReadyHandler readyHandler0 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        // Give the following code a chance to enqueue and check for duplicates
-        sleep(1);
+        // While processing item 0, enqueue additional items to test duplicate checking
+        MTRAsyncCallbackQueueWorkItem * workItem1 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler1 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            [workItem1 endWork];
+        };
+        workItem1.readyHandler = readyHandler1;
+        [workItem1 setDuplicateTypeID:1
+                              handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
+                                  if ([opaqueItemData isEqual:@(1)]) {
+                                      *isDuplicate = YES;
+                                  } else {
+                                      *isDuplicate = NO;
+                                  }
+                              }];
+        // No cancel handler on purpose.
+        [workQueue enqueueWorkItem:workItem1];
+
+        MTRAsyncCallbackQueueWorkItem * workItem2 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler2 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            [workItem2 endWork];
+        };
+        workItem2.readyHandler = readyHandler2;
+        [workItem2 setDuplicateTypeID:1
+                              handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
+                                  if ([opaqueItemData isEqual:@(2)]) {
+                                      *isDuplicate = YES;
+                                  } else {
+                                      *isDuplicate = NO;
+                                  }
+                              }];
+        // No cancel handler on purpose.
+        [workQueue enqueueWorkItem:workItem2];
+
+        MTRAsyncCallbackQueueWorkItem * workItem3 =
+            [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+        MTRAsyncCallbackReadyHandler readyHandler3 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
+            [workItem3 endWork];
+        };
+        workItem3.readyHandler = readyHandler3;
+        [workItem3 setDuplicateTypeID:2
+                              handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
+                                  if ([opaqueItemData isEqual:@(1)]) {
+                                      *isDuplicate = YES;
+                                  } else {
+                                      *isDuplicate = NO;
+                                  }
+                              }];
+        [workQueue enqueueWorkItem:workItem3];
+
+        // At this point we should have duplicate type 1 with data @(1) and @(2), and type 2 with data @(1).
+        XCTAssertTrue([workQueue isDuplicateForTypeID:1 workItemData:@(1)]);
+        XCTAssertTrue([workQueue isDuplicateForTypeID:1 workItemData:@(2)]);
+        XCTAssertTrue([workQueue isDuplicateForTypeID:2 workItemData:@(1)]);
+
+        XCTAssertFalse([workQueue isDuplicateForTypeID:0 workItemData:@(1)]);
+        XCTAssertFalse([workQueue isDuplicateForTypeID:0 workItemData:@(2)]);
+        XCTAssertFalse([workQueue isDuplicateForTypeID:1 workItemData:@(0)]);
+        XCTAssertFalse([workQueue isDuplicateForTypeID:1 workItemData:@(3)]);
+        XCTAssertFalse([workQueue isDuplicateForTypeID:2 workItemData:@(2)]);
+
         [workItem0 endWork];
         [workItem0ReadyExpectation fulfill];
     };
     workItem0.readyHandler = readyHandler0;
     // No cancel handler on purpose.
     [workQueue enqueueWorkItem:workItem0];
-
-    MTRAsyncCallbackQueueWorkItem * workItem1 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler1 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        [workItem1 endWork];
-    };
-    workItem1.readyHandler = readyHandler1;
-    [workItem1 setDuplicateTypeID:1
-                          handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
-                              if ([opaqueItemData isEqual:@(1)]) {
-                                  *isDuplicate = YES;
-                              } else {
-                                  *isDuplicate = NO;
-                              }
-                          }];
-    // No cancel handler on purpose.
-    [workQueue enqueueWorkItem:workItem1];
-
-    MTRAsyncCallbackQueueWorkItem * workItem2 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler2 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        [workItem2 endWork];
-    };
-    workItem2.readyHandler = readyHandler2;
-    [workItem2 setDuplicateTypeID:1
-                          handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
-                              if ([opaqueItemData isEqual:@(2)]) {
-                                  *isDuplicate = YES;
-                              } else {
-                                  *isDuplicate = NO;
-                              }
-                          }];
-    // No cancel handler on purpose.
-    [workQueue enqueueWorkItem:workItem2];
-
-    MTRAsyncCallbackQueueWorkItem * workItem3 =
-        [[MTRAsyncCallbackQueueWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
-    MTRAsyncCallbackReadyHandler readyHandler3 = ^(MTRDevice * _Nonnull device, NSUInteger retryCount) {
-        [workItem3 endWork];
-    };
-    workItem3.readyHandler = readyHandler3;
-    [workItem3 setDuplicateTypeID:2
-                          handler:^(id _Nonnull opaqueItemData, BOOL * _Nonnull isDuplicate) {
-                              if ([opaqueItemData isEqual:@(1)]) {
-                                  *isDuplicate = YES;
-                              } else {
-                                  *isDuplicate = NO;
-                              }
-                          }];
-    [workQueue enqueueWorkItem:workItem3];
-
-    // At this point we should have duplicate type 1 with data @(1) and @(2), and type 2 with data @(1).
-
-    XCTAssertTrue([workQueue isDuplicateForTypeID:1 workItemData:@(1)]);
-    XCTAssertTrue([workQueue isDuplicateForTypeID:1 workItemData:@(2)]);
-    XCTAssertTrue([workQueue isDuplicateForTypeID:2 workItemData:@(1)]);
-
-    XCTAssertFalse([workQueue isDuplicateForTypeID:0 workItemData:@(1)]);
-    XCTAssertFalse([workQueue isDuplicateForTypeID:0 workItemData:@(2)]);
-    XCTAssertFalse([workQueue isDuplicateForTypeID:1 workItemData:@(0)]);
-    XCTAssertFalse([workQueue isDuplicateForTypeID:1 workItemData:@(3)]);
-    XCTAssertFalse([workQueue isDuplicateForTypeID:2 workItemData:@(2)]);
 
     // double check that items 1~3 have not processed yet because of item 0's sleep()
     XCTAssertFalse(workItem0ReadyCalled);

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1454,6 +1454,32 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     [device setDelegate:delegate queue:queue];
 
+    // Test batching and duplicate check
+    //   - Read 13 different attributes in a row, expect that the 1st to go out by itself, the next 9 batch, and then the 3 after
+    //     are correctly queued in one batch
+    //   - Then read 3 duplicates and expect them to be filtered
+    //   - Note that these tests can only be verified via logs
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(0) params:nil];
+
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(1) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(2) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(3) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(4) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(5) params:nil];
+
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(6) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeScenesID) attributeID:@(7) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(0) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(1) params:nil];
+
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(2) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(3) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(4) params:nil];
+
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(4) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(4) params:nil];
+    [device readAttributeWithEndpointID:@(1) clusterID:@(MTRClusterIDTypeLevelControlID) attributeID:@(4) params:nil];
+
     [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
 
     XCTAssertNotEqual(attributeReportsReceived, 0);


### PR DESCRIPTION
This patch adds two facilities to `MTRAsyncCallbackWorkQueue` and `MTRAsyncCallbackQueueWorkItem` API:
1. A generic method to combine consecutive work items of the same type into smaller batches.
2. A generic method to scan the work queue for work items that is already enqueued to perform a particular task

And also amended MTRDevice to adopt these facilities to:
1. When there are consecutive read work items in the work queue, batch reads up to 9 attribute paths at a time.
2. Before creating a work item for a read, check the work queue for an existing request to read the same attribute path.

Testing: currently this is only passing unit tests for the `MTRAsyncCallbackWorkQueue` and `MTRAsyncCallbackQueueWorkItem` API changes. Further testing is needed to verify MTRDevice changes are working correctly.