### PR TITLE
Correct log message in OnGroupRemoved()

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -397,7 +397,7 @@ private:
             const FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
             if (fabric == nullptr)
             {
-                ChipLogError(AppServer, "Group added to nonexistent fabric?");
+                ChipLogError(AppServer, "Group removed from nonexistent fabric?");
                 return;
             }
 


### PR DESCRIPTION
Log message is clearly copy and pasted and has not been adapted.

