### PR TITLE
[nrfconnect] Bump nRF Connect SDK version in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION=latest
 
 FROM connectedhomeip/chip-build:${VERSION} as build
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v2.3.0
+ARG NCS_REVISION=v2.4.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt/NordicSemiconductor/nRF5_tools
@@ -15,14 +15,14 @@ RUN set -x \
     | tar zxvf - \
     && tar xvf JLink_Linux_V780c_x86_64.tgz \
     && rm JLink_Linux_V780c_x86_64.* \
-    && curl --location https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64_minimal.tar.gz \
-    | tar zxvf - \
-    && zephyr-sdk-0.15.2/setup.sh -t arm-zephyr-eabi \
+    && curl --location https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64_minimal.tar.xz --output zephyr-sdk-0.16.0_linux-x86_64_minimal.tar.xz \
+    && tar xvf zephyr-sdk-0.16.0_linux-x86_64_minimal.tar.xz \
+    && zephyr-sdk-0.16.0/setup.sh -t arm-zephyr-eabi \
     && : # last line
 
 WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
-    && python3 -m pip install -U --no-cache-dir west==0.14.0 \
+    && python3 -m pip install -U --no-cache-dir west==1.0.0 \
     && west init -m https://github.com/nrfconnect/sdk-nrf --mr "$NCS_REVISION" \
     && west config update.narrow true \
     && west config update.fetch smart \
@@ -62,6 +62,6 @@ ENV LD_LIBRARY_PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V780c_x86_64:${LD_LIBRARY_PAT
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=${NRF5_TOOLS_ROOT}/zephyr-sdk-0.15.2
+ENV ZEPHYR_SDK_INSTALL_DIR=${NRF5_TOOLS_ROOT}/zephyr-sdk-0.16.0
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ENV ZEPHYR_TOOLCHAIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.15 Version bump reason: [Java] Set JAVA_PATH in chip-build-java and vscode
+0.7.16 Version bump reason: [nrfconnect] Update nRF Connect SDK version.

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -161,7 +161,7 @@ class NrfConnectBuilder(Builder):
                 zephyr_base = os.environ['ZEPHYR_BASE']
                 nrfconnect_sdk = os.path.dirname(zephyr_base)
                 zephyr_sdk_dir = os.environ.get('ZEPHYR_SDK_INSTALL_DIR') or os.path.join(
-                    os.environ['NRF5_TOOLS_ROOT'], 'zephyr-sdk-0.15.2')
+                    os.environ['NRF5_TOOLS_ROOT'], 'zephyr-sdk-0.16.0')
 
                 # NRF builds will both try to change .west/config in nrfconnect and
                 # overall perform a git fetch on that location

--- a/scripts/examples/nrfconnect_example.sh
+++ b/scripts/examples/nrfconnect_example.sh
@@ -44,7 +44,7 @@ source "../scripts/activate.sh"
 export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 
 if [[ -z "$ZEPHYR_SDK_INSTALL_DIR" && -n "$NRF5_TOOLS_ROOT" ]]; then
-    export ZEPHYR_SDK_INSTALL_DIR="$NRF5_TOOLS_ROOT"/zephyr-sdk-0.15.2
+    export ZEPHYR_SDK_INSTALL_DIR="$NRF5_TOOLS_ROOT"/zephyr-sdk-0.16.0
 fi
 
 # Set ccache base directory to improve the cache hit ratio


### PR DESCRIPTION
Regular update of nRF Connect SDK to 2.4.0 version

