### PR TITLE
[matter_yamltests] Increase the maximum message size that can be rece…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
@@ -23,6 +23,7 @@ from .hooks import WebSocketRunnerHooks
 from .runner import TestRunner
 
 _KEEP_ALIVE_TIMEOUT_IN_SECONDS = 40
+_MAX_MESSAGE_SIZE_IN_BYTES = 10485760  # 10 MB
 
 
 @dataclass
@@ -67,7 +68,7 @@ class WebSocketRunner(TestRunner):
             start = time.time()
             try:
                 self._hooks.connecting(url)
-                connection = await websockets.connect(url, ping_timeout=_KEEP_ALIVE_TIMEOUT_IN_SECONDS)
+                connection = await websockets.connect(url, ping_timeout=_KEEP_ALIVE_TIMEOUT_IN_SECONDS, max_size=_MAX_MESSAGE_SIZE_IN_BYTES)
                 duration = round((time.time() - start) * 1000, 0)
                 self._hooks.success(duration)
                 return connection


### PR DESCRIPTION
…ived by the websocket

### Problem

When using YAML commands that returns a large amount of data, it may be bigger than the current allowed size for web socket messages.

This PR raise the allowed amount of data to be 10MB. This is 4 times bigger than the maximum amount of data I have observed but I don't want to have to increase this value all the time if I ever end up adding additional informations to what is reported by the web socket and in practice it does not hurt.

