### PR TITLE
[chip-tool] In interactive server mode when a response is sent over t…

### DIFF
--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -153,50 +153,56 @@ struct InteractiveServerResult
     {
         auto lock = ScopedLock(mMutex);
 
-        std::string resultsStr;
+        std::stringstream content;
+        content << "{";
+
+        content << "  \"results\": [";
         if (mResults.size())
         {
             for (const auto & result : mResults)
             {
-                resultsStr = resultsStr + result + ",";
+                content << result << ",";
             }
 
             // Remove last comma.
-            resultsStr.pop_back();
+            content.seekp(-1, std::ios_base::end);
         }
 
         if (mStatus != EXIT_SUCCESS)
         {
-            if (resultsStr.size())
+            if (mResults.size())
             {
-                resultsStr = resultsStr + ",";
+                content << ",";
             }
-            resultsStr = resultsStr + "{ \"error\": \"FAILURE\" }";
+            content << "{ \"error\": \"FAILURE\" }";
         }
+        content << "],";
 
-        std::string logsStr;
+        content << "\"logs\": [";
         if (mLogs.size())
         {
             for (const auto & log : mLogs)
             {
-                logsStr = logsStr + "{";
-                logsStr = logsStr + "  \"module\": \"" + log.module + "\",";
-                logsStr = logsStr + "  \"category\": \"" + log.messageType + "\",";
-                logsStr = logsStr + "  \"message\": \"" + log.message + "\"";
-                logsStr = logsStr + "},";
+                content << "{"
+                           "  \"module\": \"" +
+                        log.module +
+                        "\","
+                        "  \"category\": \"" +
+                        log.messageType +
+                        "\","
+                        "  \"message\": \"" +
+                        log.message +
+                        "\""
+                        "},";
             }
 
             // Remove last comma.
-            logsStr.pop_back();
+            content.seekp(-1, std::ios_base::end);
         }
+        content << "]";
 
-        std::string jsonLog;
-        jsonLog = jsonLog + "{";
-        jsonLog = jsonLog + "  \"results\": [" + resultsStr + "],";
-        jsonLog = jsonLog + "  \"logs\": [" + logsStr + "]";
-        jsonLog = jsonLog + "}";
-
-        return jsonLog;
+        content << "}";
+        return content.str();
     }
 };
 


### PR DESCRIPTION
…he wire it keeps creating new strings instead of concatening to the already existing strings

#### Problem

When building large strings of text that will be sent over WebSocket it takes a long time. This is because the string is built at the end and instead of "just" concatenating the code builds new strings all the time. I have observed some WebSocket timeout without this patch for strings that ends up taking megabytes. With this patch I can't tell there is a delay.
