### PR TITLE
[ESP32] Config Option to enable/disable log filtering APIs

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -121,7 +121,6 @@ menu "CHIP Core"
             default n
             help
                 Option to enable/disable CHIP log level filtering APIs.
-                By default these APIs are enabled.
 
     endmenu # "General Options"
 

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -112,11 +112,16 @@ menu "CHIP Core"
             int  "Set threshold in ms"
             default 700
             help
-                 Time threshold for warning that dispatched took too long. You can
-		 set this default set to 0 to to disable event dispatching time
-		 measurement and suppress the logs "Long dispatch time:...".
+                Time threshold for warning that dispatched took too long. You can
+                set this default set to 0 to to disable event dispatching time
+                measurement and suppress the logs "Long dispatch time:...".
 
-        # TODO: add log level selection
+        config CHIP_LOG_FILTERING
+            bool "CHIP log level filtering APIs"
+            default n
+            help
+                Option to enable/disable CHIP log level filtering APIs.
+                By default these APIs are enabled.
 
     endmenu # "General Options"
 

--- a/src/platform/ESP32/CHIPPlatformConfig.h
+++ b/src/platform/ESP32/CHIPPlatformConfig.h
@@ -41,7 +41,11 @@
 // The ESP NVS implementation limits key names to 15 characters.
 #define CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH 15
 
+#ifndef CONFIG_CHIP_LOG_FILTERING
 #define CHIP_LOG_FILTERING 0
+#else
+#define CHIP_LOG_FILTERING CONFIG_CHIP_LOG_FILTERING
+#endif
 
 #define CHIP_CONFIG_ABORT() abort()
 


### PR DESCRIPTION
Also,
- Removed the stale TODO

Exposing an option to use the log filtering APIs.

#### Tests
- Enabled the above option
- compiled the firmware with log level info
- called `SetLogFilter(kLogCategory_Error)` in `examples/lighting-app/esp32/main/main.cpp`
- verified that the only error logs are printed on the console.