### PR TITLE
Fix Linux build break when thread is disabled

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -223,7 +223,7 @@ jobs:
                         build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug lock-app \
-                    out/linux-x64-lock/chip-lock-app \
+                    out/linux-x64-lock-no-thread/chip-lock-app \
                     /tmp/bloat_reports/
             - name: Build example contact sensor with UI
               run: |

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -219,7 +219,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target linux-x64-lock \
+                        --target linux-x64-lock-no-thread \
                         build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux debug lock-app \

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -24,6 +24,7 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/Linux/GlibTypeDeleter.h>
 
 #include "BluezObjectList.h"
 #include "Types.h"


### PR DESCRIPTION
### Problem

Building without thread support is broken on Linux.

### Changes

- added missing include
- added "no-thread" build variant to CI, so such configuration will be covered as well

### Testing

Tested locally with:
```sh
./scripts/build/build_examples.py --target linux-x64-light-no-thread build
```