### PR TITLE
Stop running old-style YAML tests on Darwin tsan jobs.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -381,6 +381,7 @@ jobs:
                      "
             - name: Run Tests
               timeout-minutes: 80
+              if: matrix.build_variant != 'no-ble-tsan-clang'
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \


### PR DESCRIPTION
These jobs are very slow, and we are already running the python-driver tests here, as well as running the old-style tests on Darwin asan and Linux tsan.
