### PR TITLE
[matter_yamltests] Add constraint type 'struct'

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -232,6 +232,8 @@ class _ConstraintType(BaseConstraint):
         success = False
         if self._type == 'boolean' and type(value) is bool:
             success = True
+        elif self._type == 'struct' and type(value) is dict:
+            success = True
         elif self._type == 'list' and type(value) is list:
             success = True
         elif self._type == 'char_string' and type(value) is str:
@@ -367,6 +369,8 @@ class _ConstraintType(BaseConstraint):
 
         if type(value) is bool:
             types.append('boolean')
+        elif type(value) is dict:
+            types.append('struct')
         elif type(value) is list:
             types.append('list')
         elif type(value) is str:


### PR DESCRIPTION
#### Problem

When using `matter_yamltests` there is no generic keyword to check if an attribute returned value is a `struct`. A generic struct constraint may be useful for automating the IDM test related to reading, notably for the case where it tries to check if reading a struct works.
