### PR TITLE
[chip-tool] The error is not reported over websocket when a read/subs…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -74,7 +74,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
+            LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -83,7 +83,7 @@ public:
 
         if (data != nullptr)
         {
-            ReturnOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
+            LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
 
             error = DataModelLogger::LogCommand(path, data);
             if (CHIP_NO_ERROR != error)
@@ -97,7 +97,7 @@ public:
 
     virtual void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override
     {
-        ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
+        LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
 
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -37,7 +37,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
+            LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -51,7 +51,7 @@ public:
             return;
         }
 
-        ReturnOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
+        LogErrorOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
 
         error = DataModelLogger::LogAttribute(path, data);
         if (CHIP_NO_ERROR != error)
@@ -70,7 +70,7 @@ public:
             CHIP_ERROR error = status->ToChipError();
             if (CHIP_NO_ERROR != error)
             {
-                ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(eventHeader, *status));
+                LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(eventHeader, *status));
 
                 ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
                 mError = error;
@@ -85,7 +85,7 @@ public:
             return;
         }
 
-        ReturnOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
+        LogErrorOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
 
         CHIP_ERROR error = DataModelLogger::LogEvent(eventHeader, data);
         if (CHIP_NO_ERROR != error)
@@ -98,6 +98,8 @@ public:
 
     void OnError(CHIP_ERROR error) override
     {
+        LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
+
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;
     }

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -120,7 +120,7 @@ public:
         CHIP_ERROR error = status.ToChipError();
         if (CHIP_NO_ERROR != error)
         {
-            ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
+            LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
 
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
             mError = error;
@@ -129,7 +129,7 @@ public:
 
     void OnError(const chip::app::WriteClient * client, CHIP_ERROR error) override
     {
-        ReturnOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
+        LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(error));
 
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
         mError = error;


### PR DESCRIPTION
…cribe action has a global error

#### Problem

The IDM tests targeting attribute reads sometimes expects an `INVALID_ACTION`. This generic error is not carried over WebSocket.
