### PR TITLE
[chiptool.py] Carry over the data version for attribute reads returne…

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/SafeInt.h>
 #include <lib/support/jsontlv/TlvJson.h>
 
+constexpr const char * kDataVersionKey    = "dataVersion";
 constexpr const char * kClusterIdKey      = "clusterId";
 constexpr const char * kEndpointIdKey     = "endpointId";
 constexpr const char * kAttributeIdKey    = "attributeId";
@@ -69,6 +70,10 @@ CHIP_ERROR LogAttributeAsJSON(const chip::app::ConcreteDataAttributePath & path,
     value[kClusterIdKey]   = path.mClusterId;
     value[kEndpointIdKey]  = path.mEndpointId;
     value[kAttributeIdKey] = path.mAttributeId;
+    if (path.mDataVersion.HasValue())
+    {
+        value[kDataVersionKey] = path.mDataVersion.Value();
+    }
 
     chip::TLV::TLVReader reader;
     reader.Init(*data);

--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -34,6 +34,7 @@ _EVENT = 'event'
 _ERROR = 'error'
 _CLUSTER_ERROR = 'clusterError'
 _VALUE = 'value'
+_DATA_VERSION = 'dataVersion'
 
 # FabricIndex is a special case where the field is added as a struct field by the SDK
 # if needed but is not part of the XML definition of the struct.
@@ -88,7 +89,7 @@ class Decoder:
                 elif key == _EVENT_ID:
                     key = _EVENT
                     value = specs.get_event_name(payload[_CLUSTER_ID], value)
-                elif key == _VALUE or key == _ERROR or key == _CLUSTER_ERROR:
+                elif key == _VALUE or key == _ERROR or key == _CLUSTER_ERROR or key == _DATA_VERSION:
                     pass
                 else:
                     # Raise an error since the other fields probably needs to be translated too.


### PR DESCRIPTION
…d by chip-tool

#### Problem

The IDM tests targeting attribute reads makes uses of the `dataVersion` field. This PR reports it over WebSocket for a latter use by the `matter_yamltests` framework.
