### PR TITLE
[typos] Move the log related to the attribute reads for chip-tool a f…

### DIFF
--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -318,12 +318,12 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
                                                     std::vector<ClusterId> clusterIds, std::vector<AttributeId> attributeIds,
                                                     ReadClient::InteractionType interactionType)
 {
+    ChipLogProgress(chipTool,
+                    "Sending %sAttribute to:", interactionType == ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
+
     InteractionModelConfig::AttributePathsConfig pathsConfig;
     ReturnErrorOnFailure(
         InteractionModelConfig::GetAttributePaths(endpointIds, clusterIds, attributeIds, mDataVersions, pathsConfig));
-
-    ChipLogProgress(chipTool,
-                    "Sending %sAttribute to:", interactionType == ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
 
     ReadPrepareParams params(device->GetSecureSession().Value());
     params.mpEventPathParamsList        = nullptr;


### PR DESCRIPTION
…ew lines up otherwise the header appears before the list of attributes

#### Problem

This PR just fix a typo where the logs are misplaced. The header appears before the content that is generated `InteractionModelConfig::GetAttributePaths`...