### PR TITLE
Fix random android build failure in CI

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -113,6 +113,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-server build"
+            - name: Clean out build output
+              run: rm -rf ./out                    
             - name: Build Android arm64-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
```
WARNING    > A failure occurred while executing com.android.build.gradle.internal.tasks.StripDebugSymbolsRunnable
1690WARNING       > /__w/connectedhomeip/connectedhomeip/out/android-arm64-chip-tool/intermediates/merged_native_libs/debug/out/lib/arm64-v8a/libCHIPController.so -> /__w/connectedhomeip/connectedhomeip/out/android-arm64-chip-tool/intermediates/stripped_native_libs/debug/out/lib/arm64-v8a/libCHIPController.so: No space left on device
1691WARNING    > A failure occurred while executing com.android.build.gradle.internal.tasks.StripDebugSymbolsRunnable
1692WARNING       > /__w/connectedhomeip/connectedhomeip/out/android-arm64-chip-tool/intermediates/merged_native_libs/debug/out/lib/armeabi-v7a/libCHIPController.so -> /__w/connectedhomeip/connectedhomeip/out/android-arm64-chip-tool/intermediates/stripped_native_libs/debug/out/lib/armeabi-v7a/libCHIPController.so: No space left on device
1693WARNING
```

