### PR TITLE
Update runner run function to be async.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -133,7 +133,7 @@ class TestRunner(TestRunnerBase):
     async def stop(self):
         return
 
-    def run(self, parser_builder_config: TestParserBuilderConfig, runner_config: TestRunnerConfig):
+    async def run(self, parser_builder_config: TestParserBuilderConfig, runner_config: TestRunnerConfig):
         if runner_config and runner_config.hooks:
             start = time.time()
             runner_config.hooks.start(len(parser_builder_config.tests))
@@ -143,9 +143,7 @@ class TestRunner(TestRunnerBase):
             if not parser or not runner_config:
                 continue
 
-            loop = asyncio.get_event_loop()
-            result = loop.run_until_complete(
-                self._run_with_timeout(parser, runner_config))
+            result = await self._run_with_timeout(parser, runner_config)
             if isinstance(result, Exception):
                 raise (result)
             elif not result:

--- a/scripts/tests/yaml/runner.py
+++ b/scripts/tests/yaml/runner.py
@@ -16,6 +16,7 @@
 
 import relative_importer  # isort: split # noqa: F401
 
+import asyncio
 import importlib
 import os
 import sys
@@ -269,7 +270,8 @@ def parse(parser_group: ParserGroup):
     runner_config = None
 
     runner = TestRunner()
-    return runner.run(parser_group.builder_config, runner_config)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 
 
 @runner_base.command()
@@ -279,7 +281,8 @@ def dry_run(parser_group: ParserGroup):
     runner_config = TestRunnerConfig(hooks=TestRunnerLogger())
 
     runner = TestRunner()
-    return runner.run(parser_group.builder_config, runner_config)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 
 
 @runner_base.command()
@@ -293,7 +296,8 @@ def run(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop_on_wa
     runner_config = TestRunnerConfig(adapter, parser_group.pseudo_clusters, runner_options, runner_hooks)
 
     runner = TestRunner()
-    return runner.run(parser_group.builder_config, runner_config)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 
 
 @runner_base.command()
@@ -316,7 +320,8 @@ def websocket(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop
         server_address, server_port, server_path, server_arguments, websocket_runner_hooks)
 
     runner = WebSocketRunner(websocket_runner_config)
-    return runner.run(parser_group.builder_config, runner_config)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 
 
 @runner_base.command()
@@ -331,7 +336,8 @@ def chip_repl(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop
     runner_config = TestRunnerConfig(adapter, parser_group.pseudo_clusters, runner_options, runner_hooks)
 
     runner = __import__(runner, fromlist=[None]).Runner(repl_storage_path, commission_on_network_dut)
-    return runner.run(parser_group.builder_config, runner_config)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 
 
 @runner_base.command()


### PR DESCRIPTION
Updating the runner.py run function to be async and moving the loop one level. This causes issues if the caller is already using an asynio loop, which test harness is doing. 

This is the error I see in Test Harness:

> Test Step Error: Error occurred during execution of test case TC-BINFO-1.1. this event loop is already running. Traceback (most recent call last): File "/app/./app/test_engine/models/test_case.py", line 207, in __execute_catch_errors await self.execute() File "/app/./app/chip_tool/test_case.py", line 317, in execute await super().execute() File "/app/./app/chip_tool/test_case.py", line 137, in execute await self.chip_tool.run_test(test_step_interface=self, test_id=test_name, test_type=self.test_type, test_parameters=self.test_parameters) File "/app/./app/chip_tool/chip_tool.py", line 519, in run_test return await self.run_websocket_test(test_step_interface, adapter, parser_builder_config) File "/app/./app/chip_tool/chip_tool.py", line 465, in run_websocket_test return await self.__test_harness_runner.run(parser_builder_config, runner_config) File "/usr/local/lib/python3.10/dist-packages/matter_yamltests/runner.py", line 147, in run result = loop.run_until_complete( File "uvloop/loop.pyx", line 1511, in uvloop.loop.Loop.run_until_complete File "uvloop/loop.pyx", line 1504, in uvloop.loop.Loop.run_until_complete File "uvloop/loop.pyx", line 1377, in uvloop.loop.Loop.run_forever File "uvloop/loop.pyx", line 518, in uvloop.loop.Loop._run RuntimeError: this event loop is already running.