### PR TITLE
Delete last remnant of emberAfFindClusterServerEndpointIndex

### DIFF
--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -32,8 +32,9 @@ static constexpr size_t kLevelManagerTableSize = EMBER_AF_LEVEL_CONTROL_CLUSTER_
 namespace {
 
 LevelManager * gLevelManagerTable[kLevelManagerTableSize] = { nullptr };
+static_assert(kLevelManagerTableSize <= kEmberInvalidEndpointIndex, "gLevelManagerTable table size error");
 
-}
+} // namespace
 
 void emberAfLevelControlClusterInitCallback(EndpointId endpoint)
 {
@@ -44,8 +45,9 @@ void emberAfLevelControlClusterInitCallback(EndpointId endpoint)
 void LevelManager::NewManager(jint endpoint, jobject manager)
 {
     ChipLogProgress(Zcl, "TV Android App: LevelManager::NewManager");
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(static_cast<chip::EndpointId>(endpoint), app::Clusters::LevelControl::Id);
-    VerifyOrReturn(ep != kEmberInvalidEndpointIndex && ep < kLevelManagerTableSize,
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(static_cast<chip::EndpointId>(endpoint), app::Clusters::LevelControl::Id,
+                                                       EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT);
+    VerifyOrReturn(ep < kLevelManagerTableSize,
                    ChipLogError(Zcl, "TV Android App::Level::NewManager: endpoint %d not found", endpoint));
 
     VerifyOrReturn(gLevelManagerTable[ep] == nullptr,
@@ -65,8 +67,9 @@ void LevelManager::NewManager(jint endpoint, jobject manager)
 
 LevelManager * GetLevelManager(EndpointId endpoint)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, app::Clusters::LevelControl::Id);
-    return ((ep == kEmberInvalidEndpointIndex || ep >= kLevelManagerTableSize) ? nullptr : gLevelManagerTable[ep]);
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, app::Clusters::LevelControl::Id,
+                                                       EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT);
+    return (ep >= kLevelManagerTableSize) ? nullptr : gLevelManagerTable[ep]);
 }
 
 void LevelManager::PostLevelChanged(chip::EndpointId endpoint, uint8_t value)

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -69,7 +69,7 @@ LevelManager * GetLevelManager(EndpointId endpoint)
 {
     uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, app::Clusters::LevelControl::Id,
                                                        EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT);
-    return (ep >= kLevelManagerTableSize) ? nullptr : gLevelManagerTable[ep]);
+    return ((ep >= kLevelManagerTableSize) ? nullptr : gLevelManagerTable[ep]);
 }
 
 void LevelManager::PostLevelChanged(chip::EndpointId endpoint, uint8_t value)

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -69,9 +69,7 @@ OnOffManager * GetOnOffManager(EndpointId endpoint)
 {
     uint16_t ep =
         emberAfGetClusterServerEndpointIndex(endpoint, app::Clusters::OnOff::Id, EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT);
-    return (ep >= kOnffManagerTableSize)
-                ? nullptr
-                : gOnOffManagerTable[ep]);
+    return (ep >= kOnffManagerTableSize ? nullptr : gOnOffManagerTable[ep]);
 }
 
 void OnOffManager::PostOnOffChanged(chip::EndpointId endpoint, bool value)

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -32,8 +32,9 @@ static constexpr size_t kOnffManagerTableSize = EMBER_AF_ON_OFF_CLUSTER_SERVER_E
 namespace {
 
 OnOffManager * gOnOffManagerTable[kOnffManagerTableSize] = { nullptr };
+static_assert(kOnffManagerTableSize <= kEmberInvalidEndpointIndex, "gOnOffManagerTable table size error");
 
-}
+} // namespace
 
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
@@ -44,8 +45,9 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 void OnOffManager::NewManager(jint endpoint, jobject manager)
 {
     ChipLogProgress(Zcl, "TV Android App: OnOffManager::NewManager");
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(static_cast<chip::EndpointId>(endpoint), app::Clusters::OnOff::Id);
-    VerifyOrReturn(ep != kEmberInvalidEndpointIndex && ep < EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT,
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(static_cast<chip::EndpointId>(endpoint), app::Clusters::OnOff::Id,
+                                                       EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT);
+    VerifyOrReturn(ep < kOnffManagerTableSize,
                    ChipLogError(Zcl, "TV Android App::OnOff::NewManager: endpoint %d not found", endpoint));
 
     VerifyOrReturn(gOnOffManagerTable[ep] == nullptr,
@@ -65,8 +67,9 @@ void OnOffManager::NewManager(jint endpoint, jobject manager)
 
 OnOffManager * GetOnOffManager(EndpointId endpoint)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, app::Clusters::OnOff::Id);
-    return ((ep == kEmberInvalidEndpointIndex || ep >= EMBER_AF_MEDIA_PLAYBACK_CLUSTER_SERVER_ENDPOINT_COUNT)
+    uint16_t ep =
+        emberAfGetClusterServerEndpointIndex(endpoint, app::Clusters::OnOff::Id, EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT);
+    return (ep >= kOnffManagerTableSize)
                 ? nullptr
                 : gOnOffManagerTable[ep]);
 }

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -47,6 +47,7 @@ using Protocols::InteractionModel::Status;
 
 static constexpr size_t kOtaProviderDelegateTableSize =
     EMBER_AF_OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
+static_assert(kOtaProviderDelegateTableSize <= kEmberInvalidEndpointIndex, "OtaProvider Delegate table size error");
 
 namespace {
 constexpr size_t kLocationLen          = 2;   // The expected length of the location parameter in QueryImage
@@ -58,8 +59,9 @@ OTAProviderDelegate * gDelegateTable[kOtaProviderDelegateTableSize] = { nullptr 
 
 OTAProviderDelegate * GetDelegate(EndpointId endpoint)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id);
-    return (ep == 0xFFFF ? nullptr : gDelegateTable[ep]);
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id,
+                                                       EMBER_AF_OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT);
+    return (ep >= kOtaProviderDelegateTableSize ? nullptr : gDelegateTable[ep]);
 }
 
 bool SendStatusIfDelegateNull(app::CommandHandler * commandObj, const app::ConcreteCommandPath & path)
@@ -226,8 +228,9 @@ namespace OTAProvider {
 
 void SetDelegate(EndpointId endpoint, OTAProviderDelegate * delegate)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id);
-    if (ep != 0xFFFF)
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id,
+                                                       EMBER_AF_OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT);
+    if (ep < kOtaProviderDelegateTableSize)
     {
         gDelegateTable[ep] = delegate;
     }

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -153,49 +153,17 @@ uint16_t emberAfIndexFromEndpoint(chip::EndpointId endpoint);
 uint16_t emberAfIndexFromEndpointIncludingDisabledEndpoints(chip::EndpointId endpoint);
 
 /**
- * Returns the index of the given endpoint in the list of all defined endpoints
- * (including disabled ones) that support the given cluster.
- *
- * Returns kEmberInvalidEndpointIndex if the given endpoint does not support the
- * given cluster.
- *
- * For fixed endpoints, the returned value never changes, but for dynamic
- * endpoints it can change if a dynamic endpoint is defined at a lower index
- * that also supports the given cluster.
- *
- * For example, if a device has 4 fixed endpoints (ids 0-3) and 2 dynamic
- * endpoints, and cluster X is supported on endpoints 1 and 3, then:
- *
- * 1) emberAfFindClusterServerEndpointIndex(0, X) returns kEmberInvalidEndpointIndex
- * 2) emberAfFindClusterServerEndpointIndex(1, X) returns 0
- * 3) emberAfFindClusterServerEndpointIndex(2, X) returns kEmberInvalidEndpointIndex
- * 4) emberAfFindClusterServerEndpointIndex(3, X) returns 1
- *
- * If the second dynamic endpoint is defined (via
- * emberAfSetDynamicEndpoint(1, 7, ...)) to
- * have endpoint id 7, and supports cluster X, but the first dynamic endpoint is
- * not defined, then emberAfFindClusterServerEndpointIndex(7, X) returns 2.
- *
- * If now the first dynamic endpoint is defined (via
- * emberAfSetDynamicEndpoint(0, 9, ...))
- * to have endpoint id 9, and supports cluster X, then
- * emberAfFindClusterServerEndpointIndex(7, X) starts returning 3 and
- * emberAfFindClusterServerEndpointIndex(9, X) returns 2.
- */
-uint16_t emberAfFindClusterServerEndpointIndex(chip::EndpointId endpoint, chip::ClusterId clusterId);
-
-/**
  *  @brief Returns the index of the given endpoint in the list of all endpoints that might support the given cluster server.
  *
  * Returns kEmberInvalidEndpointIndex if the given endpoint does not support the
  * given cluster or if the given endpoint is disabled.
  *
- * Unlike emberAfFindClusterServerEndpointIndex, this function always returns the same index
- * for a given endpointId instance, fixed or dynamic, if it does not return kEmberInvalidEndpointIndex.
+ * This function always returns the same index for a given endpointId instance, fixed or dynamic.
  *
- * The return index is identical to emberAfFindClusterServerEndpointIndex for fixed endpoints,
- * but for dynamic endpoints the indexing assumes that any dynamic endpoint could start supporting
- * the given server cluster.
+ * The return index for fixed endpoints will range from 0 to (fixedClusterServerEndpointCount - 1),
+ * For dynamic endpoints the indexing assumes that any dynamic endpoint could start supporting
+ * the given server cluster and their index will range from fixedClusterServerEndpointCount to
+ * (fixedClusterServerEndpointCount + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT - 1).
  *
  * For example, if a device has 4 fixed endpoints (ids 0-3) and 2 dynamic
  * endpoints, and cluster X is supported on endpoints 1 and 3, then

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -121,14 +121,6 @@ DataVersion fixedEndpointDataVersions[ZAP_FIXED_ENDPOINT_DATA_VERSION_COUNT];
 app::AttributeAccessInterface * gAttributeAccessOverrides = nullptr;
 } // anonymous namespace
 
-//------------------------------------------------------------------------------
-// Forward declarations
-
-// Returns endpoint index within a given cluster
-static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask);
-
-//------------------------------------------------------------------------------
-
 // Initial configuration
 void emberAfEndpointConfigure()
 {
@@ -823,34 +815,6 @@ const EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId e
         return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
     }
     return nullptr;
-}
-
-// Returns the endpoint index within a given cluster
-static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask)
-{
-    uint16_t i, epi = 0;
-
-    if (emberAfFindServerCluster(endpoint, clusterId) == nullptr)
-    {
-        return kEmberInvalidEndpointIndex;
-    }
-
-    for (i = 0; i < emberAfEndpointCount(); i++)
-    {
-        if (emAfEndpoints[i].endpoint == endpoint)
-        {
-            break;
-        }
-        if (emAfEndpoints[i].endpoint == kInvalidEndpointId)
-        {
-            // Not actually a configured endpoint.
-            continue;
-        }
-        epi = static_cast<uint16_t>(
-            epi + ((emberAfFindClusterIncludingDisabledEndpoints(emAfEndpoints[i].endpoint, clusterId, mask) != nullptr) ? 1 : 0));
-    }
-
-    return epi;
 }
 
 static uint16_t findIndexFromEndpoint(EndpointId endpoint, bool ignoreDisabledEndpoints)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -825,12 +825,6 @@ const EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId e
     return nullptr;
 }
 
-// Server wrapper for findClusterEndpointIndex
-uint16_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, ClusterId clusterId)
-{
-    return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_SERVER);
-}
-
 // Returns the endpoint index within a given cluster
 static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask)
 {

--- a/src/darwin/Framework/CHIP/MTRIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/MTRIMDispatch.mm
@@ -232,7 +232,7 @@ namespace app {
  */
 uint16_t emberAfGetClusterServerEndpointIndex(EndpointId endpoint, ClusterId cluster, uint16_t fixedClusterServerEndpointCount)
 {
-    if (endpoint == kSupportedEndpoint && clusterId == OtaSoftwareUpdateProvider::Id) {
+    if (endpoint == kSupportedEndpoint && cluster == OtaSoftwareUpdateProvider::Id) {
         return 0;
     }
 

--- a/src/darwin/Framework/CHIP/MTRIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/MTRIMDispatch.mm
@@ -230,7 +230,7 @@ namespace app {
  * Called by the OTA provider cluster server to determine an index
  * into its array.
  */
-uint16_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, ClusterId clusterId)
+uint16_t emberAfGetClusterServerEndpointIndex(EndpointId endpoint, ClusterId cluster, uint16_t fixedClusterServerEndpointCount)
 {
     if (endpoint == kSupportedEndpoint && clusterId == OtaSoftwareUpdateProvider::Id) {
         return 0;


### PR DESCRIPTION
There was a few `emberAfFindClusterServerEndpointIndex` calls left after #26922
this replaces the last of them and deletes the function altogether.

