### PR TITLE
Dynamic Bridge Build Fail [BUG] #26208,with Assign function,it is pos…

### DIFF
--- a/src/lib/assign/ValueAssign.cpp
+++ b/src/lib/assign/ValueAssign.cpp
@@ -1,0 +1,19 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+namespace chip {
+namespace Value {} // namespace Value
+} // namespace chip


### PR DESCRIPTION
…sible to assign between all clusters in dynamic generated cluster

fix Dynamic Bridge Build Fail [BUG] #26208,
1、add a  ValueAssin.cpp in assign lib, without this cpp file, this assign lib will only contains one ValueAssign.h file, and can not be ar to a lib in mac(ubuntu seems does not have
 this issue).
2、provide a more cases adapted  templates and functions in ValueAssign.h,with a detail description doc in the comment at the beginning of the ValueAssign.h to support
all kinds of assign.

