### PR TITLE
[ESP32] Fix the incoming IM messages not being shown when debug logs are enabled

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -85,6 +85,10 @@ chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                ${is_debug})
 
+if (CONFIG_CHIP_CONFIG_IM_PRETTY_PRINT)
+    chip_gn_arg_bool("enable_im_pretty_print" "true")
+endif()
+
 # Config the chip log level by IDF menuconfig
 if (CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 1)
     chip_gn_arg_bool  ("chip_error_logging" "true")


### PR DESCRIPTION
#### Problem
Earlier incoming IM messages were shown on ESP32 console, but sometime back they were not visible.

#### Change Overview
Setting the gn argument `enable_im_pretty_print` to `true` fixes the issue.

#### Tests
Built lighting-app/esp32 with Debug log level and able to see the IM prints:
<details>
  <summary>Sample Output</summary>

```
I (67264) chip[EM]: >>> [E:13551r S:38134 M:54945565] (S) Msg RX from 1:000000000001B669 [D849] --- Type 0001:08 (IM:InvokeCommandRequest)
D (67274) chip[EM]: Handling via exchange: 13551r, Delegate: 0x3fc9c0dc
D (67274) chip[DMG]: InvokeRequestMessage =
D (67274) chip[DMG]: {
D (67284) chip[DMG]:    suppressResponse = false,
D (67294) chip[DMG]:    timedRequest = false,
D (67294) chip[DMG]:    InvokeRequests =
D (67304) chip[DMG]:    [
D (67304) chip[DMG]:            CommandDataIB =
D (67304) chip[DMG]:            {
D (67304) chip[DMG]:                    CommandPathIB =
D (67314) chip[DMG]:                    {
D (67314) chip[DMG]:                            EndpointId = 0x0,
D (67314) chip[DMG]:                            ClusterId = 0x30,
D (67324) chip[DMG]:                            CommandId = 0x4,
D (67324) chip[DMG]:                    },
D (67324) chip[DMG]:
D (67324) chip[DMG]:                    CommandFields =
D (67334) chip[DMG]:                    {
D (67334) chip[DMG]:                    },
D (67334) chip[DMG]:            },
D (67344) chip[DMG]:
D (67344) chip[DMG]:    ],
D (67354) chip[DMG]:
D (67354) chip[DMG]:    InteractionModelRevision = 1
D (67354) chip[DMG]: },
D (67364) chip[DMG]: Received command for Endpoint=0 Cluster=0x0000_0030 Command=0x0000_0004
I (67364) chip[FS]: GeneralCommissioning: Received CommissioningComplete
```

</details>