### PR TITLE
[matter_yamltests] Add single/double constraint type supports

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -258,7 +258,8 @@ class FloatConverter(BaseConverter):
 
     def maybe_convert(self, typename, value):
         if typename == 'single':
-            value = float('%g' % value)
+            float_representation = float("%.16f" % value)
+            value = float('%g' % float_representation)
         return value
 
 

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -360,6 +360,10 @@ class _ConstraintType(BaseConstraint):
             success = value >= -36028797018963967 and value <= 36028797018963967
         elif self._type == 'nullable_int64s' and type(value) is int:
             success = value >= -9223372036854775807 and value <= 9223372036854775807
+        elif self._type == 'single' and type(value) is float:
+            success = self._is_single(value)
+        elif self._type == 'double' and type(value) is float:
+            success = self._is_double(value)
         else:
             success = self._type == value_type_name
         return success
@@ -502,6 +506,12 @@ class _ConstraintType(BaseConstraint):
             if value >= -9223372036854775807 and value <= 9223372036854775807:
                 types.append('nullable_int64s')
 
+            if self._is_single(value):
+                types.append('single')
+
+            if self._is_double(value):
+                types.append('double')
+
         types.sort(key=lambda input_type: [int(c) if c.isdigit(
         ) else c for c in re.split('([0-9]+)', input_type)])
 
@@ -509,10 +519,18 @@ class _ConstraintType(BaseConstraint):
             types.append(value_type_name)
 
         if len(types) == 1:
-            reason = f'The response type {types[0]}) does not match the constraint.'
+            reason = f'The response type ({types[0]}) does not match the constraint.'
         else:
             reason = f'The response value ({value}) is of one of those types: {types}.'
         return reason
+
+    def _is_single(self, value):
+        return (value >= -1.7976931348623157E+308 and value <= -2.2250738585072014E-308) or value == 0.0 or (
+            value >= 2.2250738585072014E-308 and value <= 1.7976931348623157E+308) or math.isnan(value) or math.isinf(value)
+
+    def _is_double(self, value):
+        return (value >= -1.7976931348623157E+308 and value <= -2.2250738585072014E-308) or value == 0.0 or (
+            value >= 2.2250738585072014E-308 and value <= 1.7976931348623157E+308) or math.isnan(value) or math.isinf(value)
 
 
 class _ConstraintMinLength(BaseConstraint):


### PR DESCRIPTION
#### Problem

With `matter_yamltests` there is no constraint for `single`/ `double`. This PR adds such constraint types.