### PR TITLE
Bugfix/scene save efs dynamical array

### DIFF
--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -741,8 +741,7 @@ CHIP_ERROR DefaultSceneTableImpl::SceneSaveEFS(SceneTableEntry & scene)
         // over-allocation
         uint8_t clusterCount = GetClusterCountFromEndpoint();
         chip::Platform::ScopedMemoryBuffer<clusterId> cBuffer;
-        cBuffer.Alloc(clusterCount);
-        VerifyOrReturnError(nullptr != cBuffer.Get(), CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(cBuffer.Calloc(clusterCount), CHIP_ERROR_NO_MEMORY);
         clusterCount = GetClustersFromEndpoint(cBuffer.Get(), clusterCount);
 
         Span<clusterId> cSpan(cBuffer.Get(), clusterCount);

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -737,7 +737,7 @@ CHIP_ERROR DefaultSceneTableImpl::SceneSaveEFS(SceneTableEntry & scene)
 {
     if (!HandlerListEmpty())
     {
-        uint8_t clusterCount = emberAfGetClusterCountForEndpoint(mEndpointId);
+        uint8_t clusterCount = GetClusterCountFromEndpoint();
         clusterId * cBuffer  = static_cast<clusterId *>(chip::Platform::MemoryCalloc(sizeof(clusterId), clusterCount));
         VerifyOrReturnError(nullptr != cBuffer, CHIP_ERROR_NO_MEMORY);
 
@@ -851,6 +851,14 @@ CHIP_ERROR DefaultSceneTableImpl::RemoveFabric(FabricIndex fabric_index)
 uint8_t DefaultSceneTableImpl::GetClustersFromEndpoint(ClusterId * clusterList, uint8_t listLen)
 {
     return emberAfGetClustersFromEndpoint(mEndpointId, clusterList, listLen, true);
+}
+
+/// @brief wrapper function around emberAfGetClusterCountForEndpoint to allow testing enforcing a specific count, shimmed in test
+/// configuration because emberAfGetClusterCountForEndpoint relies on <app/util/attribute-storage.h>, which relies on zap generated
+/// files
+uint8_t DefaultSceneTableImpl::GetClusterCountFromEndpoint()
+{
+    return emberAfGetClusterCountForEndpoint(mEndpointId);
 }
 
 void DefaultSceneTableImpl::SetEndpoint(EndpointId endpoint)

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -743,6 +743,8 @@ CHIP_ERROR DefaultSceneTableImpl::SceneSaveEFS(SceneTableEntry & scene)
 
         clusterCount = GetClustersFromEndpoint(cBuffer, clusterCount);
         chip::Platform::MemoryRealloc(cBuffer, clusterCount);
+
+        // If there were no supported clusters on the endpoint, returns no error
         VerifyOrReturnError(nullptr != cBuffer, CHIP_NO_ERROR);
 
         Span<clusterId> cSpan(cBuffer, clusterCount);

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -204,6 +204,9 @@ protected:
     // wrapper function around emberAfGetClustersFromEndpoint to allow override when testing
     virtual uint8_t GetClustersFromEndpoint(ClusterId * clusterList, uint8_t listLen);
 
+    // wrapper function around emberAfGetClusterCountForEndpoint to allow override when testing
+    virtual uint8_t GetClusterCountFromEndpoint();
+
     class SceneEntryIteratorImpl : public SceneEntryIterator
     {
     public:

--- a/src/app/tests/TestSceneTable.cpp
+++ b/src/app/tests/TestSceneTable.cpp
@@ -405,6 +405,8 @@ protected:
 
         return 0;
     }
+
+    uint8_t GetClusterCountFromEndpoint() override { return 3; }
 };
 
 // Storage

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -62,7 +62,7 @@ EndpointId endpoints[]    = { kMockEndpoint1, kMockEndpoint2, kMockEndpoint3 };
 uint16_t clusterIndex[]   = { 0, 2, 5 };
 uint8_t clusterCount[]    = { 2, 3, 4 };
 ClusterId clusters[]      = { MockClusterId(1), MockClusterId(2), MockClusterId(1), MockClusterId(2), MockClusterId(3),
-                         MockClusterId(1), MockClusterId(2), MockClusterId(3), MockClusterId(4) };
+                              MockClusterId(1), MockClusterId(2), MockClusterId(3), MockClusterId(4) };
 uint16_t attributeIndex[] = { 0, 2, 5, 7, 11, 16, 19, 25, 27 };
 uint16_t attributeCount[] = { 2, 3, 2, 4, 5, 3, 6, 2, 2 };
 AttributeId attributes[]  = {
@@ -116,7 +116,7 @@ uint16_t emberAfIndexFromEndpoint(chip::EndpointId endpoint)
     return UINT16_MAX;
 }
 
-uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server)
+uint8_t emberAfGetClusterCountForEndpoint(chip::EndpointId endpoint)
 {
     for (size_t i = 0; i < ArraySize(endpoints); i++)
     {
@@ -126,6 +126,11 @@ uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server)
         }
     }
     return 0;
+}
+
+uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server)
+{
+    return emberAfGetClusterCountForEndpoint(endpoint);
 }
 
 uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster)

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -62,7 +62,7 @@ EndpointId endpoints[]    = { kMockEndpoint1, kMockEndpoint2, kMockEndpoint3 };
 uint16_t clusterIndex[]   = { 0, 2, 5 };
 uint8_t clusterCount[]    = { 2, 3, 4 };
 ClusterId clusters[]      = { MockClusterId(1), MockClusterId(2), MockClusterId(1), MockClusterId(2), MockClusterId(3),
-                              MockClusterId(1), MockClusterId(2), MockClusterId(3), MockClusterId(4) };
+                         MockClusterId(1), MockClusterId(2), MockClusterId(3), MockClusterId(4) };
 uint16_t attributeIndex[] = { 0, 2, 5, 7, 11, 16, 19, 25, 27 };
 uint16_t attributeCount[] = { 2, 3, 2, 4, 5, 3, 6, 2, 2 };
 AttributeId attributes[]  = {


### PR DESCRIPTION
The intitial cluster buffer needs to be big enough for all the clusters on the endpoint, otherwise this will fail. InsertFieldSet will return an out of memory error if the user tries to add more field sets that supported.
