### PR TITLE
Cleanup of SceneTable in scenes-server.cpp

### DIFF
--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -110,7 +110,7 @@ CHIP_ERROR ScenesServer::Init()
     VerifyOrReturnError(registerAttributeAccessOverride(this), CHIP_ERROR_INCORRECT_STATE);
     mGroupProvider = Credentials::GetGroupDataProvider();
 
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable = scenes::GetSceneTableImpl();
+    SceneTable * sceneTable = scenes::GetSceneTableImpl();
     ReturnErrorOnFailure(sceneTable->Init(&chip::Server::GetInstance().GetPersistentStorage()));
 
     for (auto endpoint : EnabledEndpointsWithServerCluster(Id))
@@ -143,7 +143,7 @@ void ScenesServer::Shutdown()
 {
     chip::app::InteractionModelEngine::GetInstance()->UnregisterCommandHandler(this);
 
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable = scenes::GetSceneTableImpl();
+    SceneTable * sceneTable = scenes::GetSceneTableImpl();
     sceneTable->Finish();
     mGroupProvider = nullptr;
     mIsInitialized = false;
@@ -159,8 +159,7 @@ void AddSceneParse(CommandHandlerInterface::HandlerContext & ctx, const CommandD
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupID = req.groupID;
@@ -270,8 +269,7 @@ void ViewSceneParse(HandlerContext & ctx, const CommandData & req, GroupDataProv
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupID = req.groupID;
@@ -347,7 +345,7 @@ CHIP_ERROR StoreSceneParse(const FabricIndex & fabricIdx, const EndpointId & end
         StatusIB(ToInteractionModelStatus(Attributes::SceneTableSize::Get(endpointID, &endpointTableSize))).ToChipError());
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable = scenes::GetSceneTableImpl(endpointID, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(endpointID, endpointTableSize);
 
     // Verify Endpoint in group
     VerifyOrReturnError(nullptr != groupProvider, CHIP_ERROR_INTERNAL);
@@ -400,7 +398,7 @@ CHIP_ERROR RecallSceneParse(const FabricIndex & fabricIdx, const EndpointId & en
         StatusIB(ToInteractionModelStatus(Attributes::SceneTableSize::Get(endpointID, &endpointTableSize))).ToChipError());
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable = scenes::GetSceneTableImpl(endpointID, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(endpointID, endpointTableSize);
 
     // Verify Endpoint in group
     VerifyOrReturnError(nullptr != groupProvider, CHIP_ERROR_INTERNAL);
@@ -491,7 +489,7 @@ CHIP_ERROR ScenesServer::Read(const ConcreteReadAttributePath & aPath, Attribute
         StatusIB(ToInteractionModelStatus(Attributes::SceneTableSize::Get(aPath.mEndpointId, &endpointTableSize))).ToChipError());
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable;
+    SceneTable * sceneTable;
 
     switch (aPath.mAttributeId)
     {
@@ -511,7 +509,7 @@ CHIP_ERROR ScenesServer::Read(const ConcreteReadAttributePath & aPath, Attribute
 void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId)
 {
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable = scenes::GetSceneTableImpl(aEndpointId);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(aEndpointId);
     VerifyOrReturn(nullptr != sceneTable);
 
     MakeSceneInvalid(aEndpointId);
@@ -568,8 +566,7 @@ void ScenesServer::HandleRemoveScene(HandlerContext & ctx, const Commands::Remov
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupID = req.groupID;
@@ -616,8 +613,7 @@ void ScenesServer::HandleRemoveAllScenes(HandlerContext & ctx, const Commands::R
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupID = req.groupID;
@@ -706,8 +702,7 @@ void ScenesServer::HandleGetSceneMembership(HandlerContext & ctx, const Commands
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupID = req.groupID;
@@ -762,8 +757,7 @@ void ScenesServer::HandleCopyScene(HandlerContext & ctx, const Commands::CopySce
         AddResponseOnError(ctx, response, Attributes::SceneTableSize::Get(ctx.mRequestPath.mEndpointId, &endpointTableSize)));
 
     // Get Scene Table Instance
-    scenes::SceneTable<scenes::ExtensionFieldSetsImpl> * sceneTable =
-        scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(ctx.mRequestPath.mEndpointId, endpointTableSize);
 
     // Response data
     response.groupIdentifierFrom = req.groupIdentifierFrom;


### PR DESCRIPTION
Replaced scenes::SceneTable<scenes::ExtensionFieldSetsImpl> with SceneTable in scenes-server.cpp

