### PR TITLE
Add countryCode to MTRCommissioningParameters.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -88,6 +88,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL skipCommissioningComplete MTR_NEWLY_AVAILABLE;
 
+/**
+ * The country code to provide to the device during commissioning.
+ *
+ * If not nil, this must be a 2-character ISO 3166-1 country code, which the
+ * device can use to decide on things like radio communications bands.
+ */
+@property (nonatomic, copy, nullable) NSString * countryCode MTR_NEWLY_AVAILABLE;
+
 @end
 
 @interface MTRCommissioningParameters (Deprecated)

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -31,6 +31,7 @@
 #import "MTRPersistentStorageDelegateBridge.h"
 #import "MTRSetupPayload.h"
 #import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 #import <setup_payload/ManualSetupPayloadGenerator.h>
 #import <setup_payload/SetupPayload.h>
 #import <zap-generated/MTRBaseClusters.h>
@@ -491,6 +492,9 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
             self->_deviceAttestationDelegateBridge = new MTRDeviceAttestationDelegateBridge(
                 self, commissioningParams.deviceAttestationDelegate, timeoutSecs, shouldWaitAfterDeviceAttestation);
             params.SetDeviceAttestationDelegate(self->_deviceAttestationDelegateBridge);
+        }
+        if (commissioningParams.countryCode != nil) {
+            params.SetCountryCode(AsCharSpan(commissioningParams.countryCode));
         }
 
         chip::NodeId deviceId = [nodeID unsignedLongLongValue];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -96,10 +96,11 @@ static MTRBaseDevice * GetConnectedDevice(void)
 {
     XCTAssertEqual(error.code, 0);
 
+    __auto_type * params = [[MTRCommissioningParameters alloc] init];
+    params.countryCode = @("au");
+
     NSError * commissionError = nil;
-    [sController commissionNodeWithID:@(kDeviceId)
-                  commissioningParams:[[MTRCommissioningParameters alloc] init]
-                                error:&commissionError];
+    [sController commissionNodeWithID:@(kDeviceId) commissioningParams:params error:&commissionError];
     XCTAssertNil(commissionError);
 
     // Keep waiting for controller:commissioningComplete:
@@ -2348,6 +2349,25 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Wait till establishment
     [self waitForExpectations:@[ startupEventExpectation, expectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test026_LocationAttribute
+{
+    __auto_type * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read Basic Information Location attribute"];
+
+    __auto_type * cluster = [[MTRBaseClusterBasicInformation alloc] initWithDevice:device endpointID:@(0) queue:queue];
+    [cluster readAttributeLocationWithCompletion:^(NSString * _Nullable value, NSError * _Nullable error) {
+        XCTAssertNil(error);
+
+        // Matches what we passed in during commissioning.
+        XCTAssertEqualObjects(value, @"au");
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
 }
 
 - (void)test900_SubscribeAllAttributes


### PR DESCRIPTION
This lets commissioners control what the Location of a device is set to at commissioning time.
