### PR TITLE
Fix missing search & replace from #26941

### DIFF
--- a/examples/android/CHIPTool/app/build.gradle
+++ b/examples/android/CHIPTool/app/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'kotlin-parcelize'
 android {
     compileSdkVersion 31
 
+    ndkVersion "23.2.8568313"
+
     defaultConfig {
         applicationId "com.google.chip.chiptool"
         minSdkVersion 24

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -546,7 +546,7 @@ class AndroidBuilder(Builder):
                     "lib",
                     "jni",
                     self.board.AbiName(),
-                    "libSetupPayloadParser.so",
+                    "libOnboardingPayload.so",
                 ),
                 "jni/%s/libCHIPController.so"
                 % self.board.AbiName(): os.path.join(


### PR DESCRIPTION
Fixes a missing library name that makes android artifacts fail to copy when using something like `./scripts/build/build_examples.py --target android-arm64-chip-tool --enable-flashbundle build --copy-artifacts-to out/artifacts`

Adds a ndk version selection to chip-build to also be compatible with latest chip-build-android images.

This is to fix invalid file name after #26941 
