### PR TITLE
Fix event logging test for platforms using system time

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR EventManagement::EnsureSpaceInCircularBuffer(size_t aRequiredSpace, P
 
     // Check that we have this much space in all our event buffers that might
     // hold the event. If we do not, that will prevent the event from being
-    // properly evicted into higher-priority bufers.  We want to discover
+    // properly evicted into higher-priority buffers. We want to discover
     // this early, so that testing surfaces the need to make those buffers
     // larger.
     for (auto * currentBuffer = mpEventBuffer; currentBuffer; currentBuffer = currentBuffer->GetNextCircularEventBuffer())

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -399,9 +399,9 @@ private:
         int mFieldsToRead = 0;
         /* PriorityLevel and DeltaTime are there if that is not first event when putting events in report*/
 #if CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
-        Timestamp mCurrentTime = Timestamp::System(System::Clock::kZero);
-#else  // CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
         Timestamp mCurrentTime = Timestamp::Epoch(System::Clock::kZero);
+#else  // CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
+        Timestamp mCurrentTime = Timestamp::System(System::Clock::kZero);
 #endif // CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
         PriorityLevel mPriority  = PriorityLevel::First;
         ClusterId mClusterId     = 0;

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -160,10 +160,9 @@ static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & 
     //      hard-coded logic of this unit test.
     //      The size of TLV-encoded event can vary depending on the UTC vs system time controlled by
     //      the CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS, because the relative system time
-    //      will be most likely encoded on 1 byte, while the UTC time will be encoded on 8 bytes.
+    //      will be most likely encoded in 1 byte, while the UTC time will be encoded in 8 bytes.
     NL_TEST_ASSERT(apSuite, sizeof(gDebugEventBuffer) >= eventTLVSize * 3 && sizeof(gDebugEventBuffer) < eventTLVSize * 4);
 
-    printf("length written : %u \n", static_cast<unsigned int>(writer.GetLengthWritten()));
     reader.Init(backingStore.Get(), writer.GetLengthWritten());
 
     err = chip::TLV::Utilities::Count(reader, totalNumElements, false);

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -55,9 +55,9 @@ static const chip::EndpointId kTestEndpointId1    = 2;
 static const chip::EndpointId kTestEndpointId2    = 3;
 static const chip::TLV::Tag kLivenessDeviceStatus = chip::TLV::ContextTag(1);
 
-static uint8_t gDebugEventBuffer[128];
-static uint8_t gInfoEventBuffer[128];
-static uint8_t gCritEventBuffer[128];
+static uint8_t gDebugEventBuffer[120];
+static uint8_t gInfoEventBuffer[120];
+static uint8_t gCritEventBuffer[120];
 static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 
 class TestContext : public chip::Test::AppContext
@@ -154,6 +154,16 @@ static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & 
     err = alogMgmt.FetchEventsSince(writer, clusterInfo, startingEventNumber, eventCount, chip::Access::SubjectDescriptor{});
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR || err == CHIP_END_OF_TLV);
 
+    auto eventTLVSize = writer.GetLengthWritten() / eventCount;
+    // XXX: Make sure that the sizes of our event storages are big enough to hold at least 3 events
+    //      but small enough not to hold 4 events. It is very important to check this because of the
+    //      hard-coded logic of this unit test.
+    //      The size of TLV-encoded event can vary depending on the UTC vs system time controlled by
+    //      the CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS, because the relative system time
+    //      will be most likely encoded on 1 byte, while the UTC time will be encoded on 8 bytes.
+    NL_TEST_ASSERT(apSuite, sizeof(gDebugEventBuffer) >= eventTLVSize * 3 && sizeof(gDebugEventBuffer) < eventTLVSize * 4);
+
+    printf("length written : %u \n", static_cast<unsigned int>(writer.GetLengthWritten()));
     reader.Init(backingStore.Get(), writer.GetLengthWritten());
 
     err = chip::TLV::Utilities::Count(reader, totalNumElements, false);
@@ -307,22 +317,19 @@ static void CheckLogEventWithDiscardLowEvent(nlTestSuite * apSuite, void * apCon
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
 }
-/**
- *   Test Suite. It lists all the test functions.
- */
 
-const nlTest sTests[] = { NL_TEST_DEF("CheckLogEventWithEvictToNextBuffer", CheckLogEventWithEvictToNextBuffer),
-                          NL_TEST_DEF("CheckLogEventWithDiscardLowEvent", CheckLogEventWithDiscardLowEvent), NL_TEST_SENTINEL() };
+const nlTest sTests[] = {
+    NL_TEST_DEF("CheckLogEventWithEvictToNextBuffer", CheckLogEventWithEvictToNextBuffer),
+    NL_TEST_DEF("CheckLogEventWithDiscardLowEvent", CheckLogEventWithDiscardLowEvent),
+    NL_TEST_SENTINEL(),
+};
 
-// clang-format off
-nlTestSuite sSuite =
-{
+nlTestSuite sSuite = {
     "EventLogging",
     &sTests[0],
     TestContext::Initialize,
-    TestContext::Finalize
+    TestContext::Finalize,
 };
-// clang-format on
 
 } // namespace
 


### PR DESCRIPTION
### Problem

Using UTC (epoch) vs system relative time in the event logging affects the size of TLV-encoded events. This has to be accounted for in the unit test otherwise the test might fail without apparent reasons (that was happening when the `CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS` was defined as `0`).

### Changes

- assert buffer size in comparison with TLV-encoded event size (+ verbose explanation for someone hunting for a bug in the future)
- fixed system vs epoch logic in the EventManagement class initializer

### Testing

Tested locally that the `TestEventLogging` test passes when CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS=0

- CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS=0 (TLV-encoded event size: 32 bytes)
  ```
  [1686089929.815877][838234:838234] CHIP:EVL: LogEvent event number: 0x0000000000000009 priority: 0, endpoint id:  0x2 cluster id: 0x0000_0022 event id: 0x1 Sys timestamp: 0x0000000000000004
  ```
- CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS=1 (TLV-encoded event size: 39 bytes)
  ```
  [1686089894.236697][836435:836435] CHIP:EVL: LogEvent event number: 0x0000000000000009 priority: 0, endpoint id:  0x2 cluster id: 0x0000_0022 event id: 0x1 Epoch timestamp: 0x0000018892CA095C
  ```