### PR TITLE
Fix flash_bundle build breakage in nrfconnect

### DIFF
--- a/config/nrfconnect/app/flashing.cmake
+++ b/config/nrfconnect/app/flashing.cmake
@@ -40,7 +40,7 @@ add_custom_command(OUTPUT "${FLASHBUNDLE_FLASHER_PLATFORM}"
     VERBATIM)
 
 if (merged_hex_to_flash)
-  set(flashbundle_hex_to_copy "${merged_hex_to_flash}")
+  set(flashbundle_hex_to_copy "zephyr/${merged_hex_to_flash}")
 else()
   set(flashbundle_hex_to_copy "zephyr/${KERNEL_HEX_NAME}")
 endif()


### PR DESCRIPTION
After #27010, it looks like merged_hex_to_flash is set and is still located under zephyr

Without this, I get:

```
ninja: error: 'merged.hex', needed by 'chip-nrfconnect-lock-example/chip-nrfconnect-lock-example.hex', missing and no known rule to make it
```

when trying 

```
./scripts/build/build_examples.py --enable-flashbundle --target nrf-nrf52840dk-lock build
```

