### PR TITLE
If a AttributeReportIBs contains the same attribute path twice for an…

### DIFF
--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -169,10 +169,10 @@ CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aP
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ConcreteAttributePath & aPath, const StatusIB & aStatusIB,
+CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ConcreteDataAttributePath & aPath, const StatusIB & aStatusIB,
                                                       bool aEndOfReport)
 {
-    if (aPath == mBufferedPath)
+    if (aPath == mBufferedPath && aPath.IsListItemOperation())
     {
         //
         // If we encountered the same list again and it's not the last DataIB, then

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -56,7 +56,7 @@ private:
      *  2. The path provided in aPath is similar to what is buffered but we've hit the end of the report.
      *
      */
-    CHIP_ERROR DispatchBufferedData(const ConcreteAttributePath & aPath, const StatusIB & aStatus, bool aEndOfReport = false);
+    CHIP_ERROR DispatchBufferedData(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus, bool aEndOfReport = false);
 
     /*
      * Buffer up list data as they arrive.


### PR DESCRIPTION
… attribute that returns a list, the first one will be silently dropped by the BufferedReadCallback code

#### Problem

While toying with the IDM test I found that the following command does not work as expected:
```
$ ./out/debug/standalone/chip-tool operationalcredentials read-by-id 0,0 0x12344321 0
```

Basically reading multiple time the same attribute in a row fails if the underlying attribute type is a list.
This is because the code in `src/app/BufferedReadCallback.cpp` does compare the attribute path to determine if the data belongs to a list and needs to be appended. But if an other list with the "same" path is encountered then the previous content is cleared.

This PR avoid that still by checking if the path is the same but also if the attribute path is a list item operation.