### PR TITLE
Increase timeout for cloudbuild smoke test.

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -108,8 +108,6 @@ steps:
               --target linux-arm64-python-bindings-clang
               --target linux-arm64-shell-ipv6only-clang
               --target linux-arm64-thermostat-ipv6only-clang
-              --target linux-arm64-tv-app-ipv6only-clang
-              --target linux-arm64-tv-casting-app-ipv6only-clang
               --target linux-x64-address-resolve-tool
               --target linux-x64-all-clusters-nodeps
               --target linux-x64-all-clusters-coverage
@@ -124,15 +122,12 @@ steps:
               --target linux-x64-light-rpc-ipv6only-minmdns-verbose
               --target linux-x64-lock-ipv6only
               --target linux-x64-minmdns-ipv6only
-              --target linux-x64-minmdns-ipv6only-minmdns-verbose
               --target linux-x64-ota-provider-ipv6only
               --target linux-x64-ota-requestor-ipv6only
               --target linux-x64-python-bindings
               --target linux-x64-rpc-console
               --target linux-x64-shell-ipv6only
               --target linux-x64-thermostat-ipv6only
-              --target linux-x64-tv-app-ipv6only
-              --target linux-x64-tv-casting-app-ipv6only
               build
               --create-archives /workspace/artifacts/
       waitFor:
@@ -164,7 +159,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 9000s
+timeout: 14400s
 queueTtl: 21600s
 
 artifacts:


### PR DESCRIPTION
Also remove some of the linux targets since building linux takes almost 1h now.

Generally we are almost at 2:30 build time, so we increase the timeout to 4h as well.

Hotfix because this is a cloudbuild change that cannot be verified by CI on github.
