### PR TITLE
ESP32: Fix the link issues for ieee802154 component and esp_eth component

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -371,9 +371,10 @@ endif()
 if(CONFIG_OPENTHREAD_ENABLED)
     idf_component_get_property(openthread_lib openthread COMPONENT_LIB)
     list(APPEND chip_libraries $<TARGET_FILE:${openthread_lib}>)
-
-    idf_component_get_property(ieee802154_lib ieee802154 COMPONENT_LIB)
-    list(APPEND chip_libraries $<TARGET_FILE:${ieee802154_lib}>)
+    if (CONFIG_IEEE802154_ENABLED)
+        idf_component_get_property(ieee802154_lib ieee802154 COMPONENT_LIB)
+        list(APPEND chip_libraries $<TARGET_FILE:${ieee802154_lib}>)
+    endif()
 endif()
 
 if((NOT CONFIG_USE_MINIMAL_MDNS) AND (CONFIG_ENABLE_WIFI_STATION OR CONFIG_ENABLE_WIFI_AP))
@@ -421,6 +422,11 @@ if (CONFIG_ESP32_WIFI_ENABLED)
 
     idf_component_get_property(wpa_supplicant_lib wpa_supplicant COMPONENT_LIB)
     list(APPEND chip_libraries $<TARGET_FILE:${wpa_supplicant_lib}>)
+endif()
+
+if (CONFIG_ETH_ENABLED)
+    idf_component_get_property(esp_eth_lib esp_eth COMPONENT_LIB)
+    list(APPEND chip_libraries $<TARGET_FILE:${esp_eth_lib}>)
 endif()
 
 idf_component_get_property(esp_netif_lib esp_netif COMPONENT_LIB)


### PR DESCRIPTION
### Changes
* Add the `esp_eth` component to the link libraries
* Add the check for linking ieee802154 component 
