### PR TITLE
Fix spelling error carried over from spec

### DIFF
--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -6915,7 +6915,7 @@ PICS:
       id: DGTHREAD.S.A0033
 
     - label:
-          "Does the DUT(server) support the RxErrInvalidScrAddrCount attribute?"
+          "Does the DUT(server) support the RxErrInvalidSrcAddrCount attribute?"
       id: DGTHREAD.S.A0034
 
     - label: "Does the DUT(server) support the RxErrSecCount attribute?"
@@ -7255,7 +7255,7 @@ PICS:
 
     - label:
           "Does the DUT(client) have access privileges for the
-          RxErrInvalidScrAddrCount attribute implemented on the server?"
+          RxErrInvalidSrcAddrCount attribute implemented on the server?"
       id: DGTHREAD.C.A0034
 
     - label:


### PR DESCRIPTION
Fixes:#25974

This is the last instance of this I can find in the SDK

