### PR TITLE
Update cloudbuild vscode version to be uniform 

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.7.3"
+    - name: "connectedhomeip/chip-build-vscode:0.7.16"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:


### PR DESCRIPTION
A previous update missed a line.
Without this, cloudbuild would download 2 docker images and that can be significantly slower as these images are large.