### PR TITLE
Reduce number of replies on MinMds query processing.

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -470,7 +470,8 @@ void ServerBase::OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::S
         // Only consider queries that are received on the same interface we are listening on.
         // Without this, queries show up on all addresses on all interfaces, resulting
         // in more replies than one would expect.
-        if (endPoint->GetBoundInterface() == info->Interface) {
+        if (endPoint->GetBoundInterface() == info->Interface)
+        {
             srv->mDelegate->OnQuery(data, info);
         }
     }

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -467,7 +467,12 @@ void ServerBase::OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::S
 
     if (HeaderRef(const_cast<uint8_t *>(data.Start())).GetFlags().IsQuery())
     {
-        srv->mDelegate->OnQuery(data, info);
+        // Only consider queries that are received on the same interface we are listening on.
+        // Without this, queries show up on all addresses on all interfaces, resulting
+        // in more replies than one would expect.
+        if (endPoint->GetBoundInterface() == info->Interface) {
+            srv->mDelegate->OnQuery(data, info);
+        }
     }
     else
     {


### PR DESCRIPTION
UDP packets are received on every listening interface, resulting in single queries being multipled by the interface count and this causes more packets than expected being generated.

This change will only process queries that are originating from the same interface that the mdns endpoint is bound to.

