### PR TITLE
Update syscalls_stubs.cpp

### DIFF
--- a/examples/platform/silabs/syscalls_stubs.cpp
+++ b/examples/platform/silabs/syscalls_stubs.cpp
@@ -174,7 +174,7 @@ int __attribute__((weak)) _read(int file, char * ptr, int len)
 {
     (void) file;
 #if SILABS_LOG_OUT_UART
-    return = uartConsoleRead(ptr, len);
+    return uartConsoleRead(ptr, len);
 #else
     (void) ptr;
     (void) len;


### PR DESCRIPTION
Fix the redundant assignment equals sign, which causes compilation to fail. 
The following command has been used for testing.
```
export SILABS_BOARD=BRD2601B

gn gen out --args='sl_uart_log_output=true'

ninja -C out
```

@jepenven-silabs Please help review this PR, thank you.

