### PR TITLE
SEDs should stay in active mode while a fail-safe is armed.

### DIFF
--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -21,6 +21,8 @@
  */
 
 #include <lib/support/SafeInt.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <platform/ConnectivityManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include "FailSafeContext.h"
@@ -48,6 +50,19 @@ void FailSafeContext::HandleDisarmFailSafe(intptr_t arg)
     failSafeContext->DisarmFailSafe();
 }
 
+void FailSafeContext::SetFailSafeArmed(bool armed)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    if (IsFailSafeArmed() != armed)
+    {
+        // Per spec, we should be staying in active mode while a fail-safe is
+        // armed.
+        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(armed);
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+    mFailSafeArmed = armed;
+}
+
 void FailSafeContext::FailSafeTimerExpired()
 {
     if (!IsFailSafeArmed())
@@ -66,8 +81,9 @@ void FailSafeContext::ScheduleFailSafeCleanup(FabricIndex fabricIndex, bool addN
     // Not armed, but busy so cannot rearm (via General Commissioning cluster) until the flushing
     // via `HandleDisarmFailSafe` path is complete.
     // TODO: This is hacky and we need to remove all this event pushing business, to keep all fail-safe logic-only.
-    mFailSafeBusy  = true;
-    mFailSafeArmed = false;
+    mFailSafeBusy = true;
+
+    SetFailSafeArmed(false);
 
     ChipDeviceEvent event;
     event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
@@ -90,7 +106,7 @@ CHIP_ERROR FailSafeContext::ArmFailSafe(FabricIndex accessingFabricIndex, System
 
     CHIP_ERROR err           = CHIP_NO_ERROR;
     bool cancelTimersIfError = false;
-    if (!mFailSafeArmed)
+    if (!IsFailSafeArmed())
     {
         System::Clock::Timeout maxCumulativeTimeout = System::Clock::Seconds32(CHIP_DEVICE_CONFIG_MAX_CUMULATIVE_FAILSAFE_SEC);
         SuccessOrExit(err = DeviceLayer::SystemLayer().StartTimer(maxCumulativeTimeout, HandleMaxCumulativeFailSafeTimer, this));
@@ -100,8 +116,8 @@ CHIP_ERROR FailSafeContext::ArmFailSafe(FabricIndex accessingFabricIndex, System
     SuccessOrExit(
         err = DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds16(expiryLengthSeconds), HandleArmFailSafeTimer, this));
 
-    mFailSafeArmed = true;
-    mFabricIndex   = accessingFabricIndex;
+    SetFailSafeArmed(true);
+    mFabricIndex = accessingFabricIndex;
 
 exit:
 

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -66,7 +66,7 @@ public:
 
     bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {
-        return mFailSafeArmed && MatchesFabricIndex(accessingFabricIndex);
+        return IsFailSafeArmed() && MatchesFabricIndex(accessingFabricIndex);
     }
 
     // Returns true if the fail-safe is in a state where commands that require an armed
@@ -82,7 +82,7 @@ public:
 
     bool MatchesFabricIndex(FabricIndex accessingFabricIndex) const
     {
-        VerifyOrDie(mFailSafeArmed);
+        VerifyOrDie(IsFailSafeArmed());
         return (accessingFabricIndex == mFabricIndex);
     }
 
@@ -94,7 +94,7 @@ public:
 
     FabricIndex GetFabricIndex() const
     {
-        VerifyOrDie(mFailSafeArmed);
+        VerifyOrDie(IsFailSafeArmed());
         return mFabricIndex;
     }
 
@@ -131,12 +131,15 @@ private:
      */
     static void HandleDisarmFailSafe(intptr_t arg);
 
+    void SetFailSafeArmed(bool armed);
+
     /**
      * @brief Reset to unarmed basic state
      */
     void ResetState()
     {
-        mFailSafeArmed                    = false;
+        SetFailSafeArmed(false);
+
         mAddNocCommandHasBeenInvoked      = false;
         mUpdateNocCommandHasBeenInvoked   = false;
         mAddTrustedRootCertHasBeenInvoked = false;


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24047

Implements spec fix https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/5683
