### PR TITLE
Switch minmdns to use a single listening socket

### DIFF
--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -253,7 +253,7 @@ private:
     std::vector<std::string> mStorage;
 };
 
-void BroadcastPacket(mdns::Minimal::ServerBase * server)
+void BroadcastPacket(mdns::Minimal::Server * server)
 {
     System::PacketBufferHandle buffer = System::PacketBufferHandle::New(kMdnsMaxPacketSize);
     VerifyOrDie(!buffer.IsNull());
@@ -295,7 +295,7 @@ void BroadcastPacket(mdns::Minimal::ServerBase * server)
     }
 }
 
-mdns::Minimal::Server<20> gMdnsServer;
+mdns::Minimal::Server gMdnsServer;
 
 } // namespace
 

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -178,7 +178,7 @@ private:
     uint16_t mMessageId                       = 0;
 };
 
-mdns::Minimal::Server<10 /* endpoints */> gMdnsServer;
+mdns::Minimal::Server gMdnsServer;
 
 void StopSignalHandler(int signal)
 {
@@ -217,11 +217,11 @@ int main(int argc, char ** args)
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
     mdns::Minimal::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
-                                                  Dnssd::kLocalDomain };
+                                                        Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart tcpServerServiceName[] = { gOptions.instanceName, Dnssd::kOperationalServiceName,
                                                         Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart udpServiceName[]       = { Dnssd::kCommissionableServiceName, Dnssd::kCommissionProtocol,
-                                                  Dnssd::kLocalDomain };
+                                                        Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart udpServerServiceName[] = { gOptions.instanceName, Dnssd::kCommissionableServiceName,
                                                         Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -217,11 +217,11 @@ int main(int argc, char ** args)
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
     mdns::Minimal::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
-                                                        Dnssd::kLocalDomain };
+                                                  Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart tcpServerServiceName[] = { gOptions.instanceName, Dnssd::kOperationalServiceName,
                                                         Dnssd::kOperationalProtocol, Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart udpServiceName[]       = { Dnssd::kCommissionableServiceName, Dnssd::kCommissionProtocol,
-                                                        Dnssd::kLocalDomain };
+                                                  Dnssd::kLocalDomain };
     mdns::Minimal::QNamePart udpServerServiceName[] = { gOptions.instanceName, Dnssd::kCommissionableServiceName,
                                                         Dnssd::kCommissionProtocol, Dnssd::kLocalDomain };
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -906,6 +906,15 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
 
         // Attempt to get a "Real" IP address since `Type()` on a broadcast address
         // always returns IPAddressType::kAny
+        //
+        // Generally the "source" of a packet is not relevant below because we
+        // set `unicast` to false, so we will broadcast a reply rather than
+        // trying to reply to a specific IP.
+        //
+        // The first IP address covers the need of getting an address of the
+        // right type on that interface. This seemed more sane than just using
+        // 127.0.0.1 or ::1. Multicast addresses specifically are kAny so they
+        // do not work as explained above.
         CHIP_ERROR err = GetFirstIpAddress(interfaceId, addressType, packetInfo.SrcAddress);
 
         if (err != CHIP_NO_ERROR)

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -910,8 +910,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
 
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Failed to find a suitable IP address to advertise: %" CHIP_ERROR_FORMAT,
-                         err.Format());
+            ChipLogError(Discovery, "Failed to find a suitable IP address to advertise: %" CHIP_ERROR_FORMAT, err.Format());
             continue;
         }
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -914,11 +914,13 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
             continue;
         }
 
-        if (addressType != chip::Inet::IPAddressType::kIPv6)
+#if INET_CONFIG_ENABLE_IPV4
+        if (addressType == chip::Inet::IPAddressType::kIPv4)
         {
             BroadcastIpAddresses::GetIpv4Into(packetInfo.DestAddress);
         }
         else
+#endif // INET_CONFIG_ENABLE_IPV4
         {
             BroadcastIpAddresses::GetIpv6Into(packetInfo.DestAddress);
         }

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -36,14 +36,12 @@ public:
 class GlobalMinimalMdnsServer : public mdns::Minimal::ServerDelegate
 {
 public:
-    static constexpr size_t kMaxEndPoints = 30;
-
-    using ServerType = mdns::Minimal::Server<kMaxEndPoints>;
+    using ServerType = mdns::Minimal::Server;
 
     GlobalMinimalMdnsServer();
 
     static GlobalMinimalMdnsServer & Instance();
-    static mdns::Minimal::ServerBase & Server()
+    static mdns::Minimal::Server & Server()
     {
         if (Instance().mReplacementServer != nullptr)
         {
@@ -77,13 +75,13 @@ public:
         }
     }
 
-    void SetReplacementServer(mdns::Minimal::ServerBase * server) { mReplacementServer = server; }
+    void SetReplacementServer(mdns::Minimal::Server * server) { mReplacementServer = server; }
 
 private:
     ServerType mServer;
-    mdns::Minimal::ServerBase * mReplacementServer = nullptr;
-    MdnsPacketDelegate * mQueryDelegate            = nullptr;
-    MdnsPacketDelegate * mResponseDelegate         = nullptr;
+    mdns::Minimal::Server * mReplacementServer = nullptr;
+    MdnsPacketDelegate * mQueryDelegate        = nullptr;
+    MdnsPacketDelegate * mResponseDelegate     = nullptr;
 };
 
 } // namespace Dnssd

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -209,9 +209,13 @@ CHIP_ERROR ResponseSender::FlushReply()
             char interfaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
             mSendState.GetSourceInterfaceId().GetInterfaceName(interfaceName, sizeof(interfaceName));
 
-            const char * interfaceType = mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv4
+            const char * interfaceType =
+#if INET_CONFIG_ENABLE_IPV4
+                mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv4
                 ? "IPv4"
-                : (mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv6 ? "IPv6" : "???");
+                :
+#endif // INET_CONFIG_ENABLE_IPV4
+                (mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv6 ? "IPv6" : "???");
 
             ChipLogDetail(Discovery, "Broadcasting mDns reply for query from %s to %s / %s", srcAddressString, interfaceName,
                           interfaceType);

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -206,7 +206,15 @@ CHIP_ERROR ResponseSender::FlushReply()
         else
         {
 #if CHIP_MINMDNS_HIGH_VERBOSITY
-            ChipLogDetail(Discovery, "Broadcasting mDns reply for query from %s", srcAddressString);
+            char interfaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
+            mSendState.GetSourceInterfaceId().GetInterfaceName(interfaceName, sizeof(interfaceName));
+
+            const char * interfaceType = mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv4
+                ? "IPv4"
+                : (mSendState.GetSourceAddress().Type() == chip::Inet::IPAddressType::kIPv6 ? "IPv6" : "???");
+
+            ChipLogDetail(Discovery, "Broadcasting mDns reply for query from %s to %s / %s", srcAddressString, interfaceName,
+                          interfaceType);
 #endif
             ReturnErrorOnFailure(mServer->BroadcastSend(mResponseBuilder.ReleasePacket(), kMdnsStandardPort,
                                                         mSendState.GetSourceInterfaceId(), mSendState.GetSourceAddress().Type()));

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.h
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.h
@@ -105,7 +105,7 @@ private:
 class ResponseSender : public ResponderDelegate
 {
 public:
-    ResponseSender(ServerBase * server) : mServer(server) {}
+    ResponseSender(Server * server) : mServer(server) {}
 
     CHIP_ERROR AddQueryResponder(QueryResponderBase * queryResponder);
     CHIP_ERROR RemoveQueryResponder(QueryResponderBase * queryResponder);
@@ -118,13 +118,13 @@ public:
     // Implementation of ResponderDelegate
     void AddResponse(const ResourceRecord & record) override;
 
-    void SetServer(ServerBase * server) { mServer = server; }
+    void SetServer(Server * server) { mServer = server; }
 
 private:
     CHIP_ERROR FlushReply();
     CHIP_ERROR PrepareNewReplyPacket();
 
-    ServerBase * mServer;
+    Server * mServer;
     QueryResponderPtrPool mResponders = {};
 
     /// Current send state

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -126,6 +126,7 @@ Server::~Server()
 void Server::Shutdown()
 {
     ShutdownEndpoints();
+    mBroadcastDestinationCount = 0;
     mIsInitialized = false;
 }
 

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -127,7 +127,7 @@ void Server::Shutdown()
 {
     ShutdownEndpoints();
     mBroadcastDestinationCount = 0;
-    mIsInitialized = false;
+    mIsInitialized             = false;
 }
 
 void Server::ShutdownEndpoints()

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -365,6 +365,7 @@ CHIP_ERROR Server::SingleBroadcastImpl(chip::System::PacketBufferHandle && data,
     }
 #endif
 
+    VerifyOrReturnError(mIpv6Endpoint != nullptr, CHIP_ERROR_NOT_CONNECTED);
     return mIpv6Endpoint->SendTo(mIpv6BroadcastAddress, port, std::move(data), interfaceId);
 }
 

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -257,7 +257,8 @@ CHIP_ERROR Server::BroadcastImpl(chip::System::PacketBufferHandle && data, uint1
         VerifyOrReturnError(mIpv4Endpoint != nullptr, CHIP_ERROR_NOT_CONNECTED);
         return mIpv4Endpoint->SendTo(mIpv4BroadcastAddress, port, std::move(data), interfaceId);
     }
-    else if (addressType == chip::Inet::IPAddressType::kAny && (mIpv4Endpoint != nullptr))
+
+    if (addressType == chip::Inet::IPAddressType::kAny && (mIpv4Endpoint != nullptr))
     {
         // For "Any" we consider IPV4 optional, so only report errors
         //

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -115,6 +115,9 @@ private:
                              chip::Inet::InterfaceId interfaceId   = chip::Inet::InterfaceId::Null(),
                              chip::Inet::IPAddressType addressType = chip::Inet::IPAddressType::kAny);
 
+    CHIP_ERROR SingleBroadcastImpl(chip::System::PacketBufferHandle && data, uint16_t port,
+                                   chip::Inet::InterfaceId, chip::Inet::IPAddressType);
+
     static void OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::System::PacketBufferHandle && buffer,
                                     const chip::Inet::IPPacketInfo * info);
 
@@ -131,6 +134,19 @@ private:
 #if INET_CONFIG_ENABLE_IPV4
     chip::Inet::IPAddress mIpv4BroadcastAddress;
 #endif
+
+    struct BroadcastDestination {
+        chip::Inet::InterfaceId interfaceId;
+        chip::Inet::IPAddressType addressType;
+
+        BroadcastDestination(chip::Inet::InterfaceId id, chip::Inet::IPAddressType type): interfaceId(id), addressType(type) {}
+        BroadcastDestination() : interfaceId(chip::Inet::InterfaceId::Null()),
+                                 addressType(chip::Inet::IPAddressType::kUnknown) {}
+
+    };
+    static constexpr size_t kMaxBroadcastDestinationCount = 20;
+    size_t mBroadcastDestinationCount = 0;
+    std::array<BroadcastDestination, kMaxBroadcastDestinationCount> mBroadcastDestination;
 
     bool mIsInitialized = false;
 };

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -115,8 +115,8 @@ private:
                              chip::Inet::InterfaceId interfaceId   = chip::Inet::InterfaceId::Null(),
                              chip::Inet::IPAddressType addressType = chip::Inet::IPAddressType::kAny);
 
-    CHIP_ERROR SingleBroadcastImpl(chip::System::PacketBufferHandle && data, uint16_t port,
-                                   chip::Inet::InterfaceId, chip::Inet::IPAddressType);
+    CHIP_ERROR SingleBroadcastImpl(chip::System::PacketBufferHandle && data, uint16_t port, chip::Inet::InterfaceId,
+                                   chip::Inet::IPAddressType);
 
     static void OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::System::PacketBufferHandle && buffer,
                                     const chip::Inet::IPPacketInfo * info);
@@ -135,17 +135,16 @@ private:
     chip::Inet::IPAddress mIpv4BroadcastAddress;
 #endif
 
-    struct BroadcastDestination {
+    struct BroadcastDestination
+    {
         chip::Inet::InterfaceId interfaceId;
         chip::Inet::IPAddressType addressType;
 
-        BroadcastDestination(chip::Inet::InterfaceId id, chip::Inet::IPAddressType type): interfaceId(id), addressType(type) {}
-        BroadcastDestination() : interfaceId(chip::Inet::InterfaceId::Null()),
-                                 addressType(chip::Inet::IPAddressType::kUnknown) {}
-
+        BroadcastDestination(chip::Inet::InterfaceId id, chip::Inet::IPAddressType type) : interfaceId(id), addressType(type) {}
+        BroadcastDestination() : interfaceId(chip::Inet::InterfaceId::Null()), addressType(chip::Inet::IPAddressType::kUnknown) {}
     };
     static constexpr size_t kMaxBroadcastDestinationCount = 20;
-    size_t mBroadcastDestinationCount = 0;
+    size_t mBroadcastDestinationCount                     = 0;
     std::array<BroadcastDestination, kMaxBroadcastDestinationCount> mBroadcastDestination;
 
     bool mIsInitialized = false;

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -71,18 +71,11 @@ void MakePrintableName(char (&location)[N], FullQName name)
 
 } // namespace
 
-class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, chip::ObjectPoolMem::kInline,
-                                               ServerBase::EndpointInfoPoolType::Interface>,
-                        public ServerBase,
-                        public ParserDelegate,
-                        public TxtRecordDelegate
+class CheckOnlyServer : public Server, public ParserDelegate, public TxtRecordDelegate
 {
 public:
-    CheckOnlyServer(nlTestSuite * inSuite) : ServerBase(*static_cast<ServerBase::EndpointInfoPoolType *>(this)), mInSuite(inSuite)
-    {
-        Reset();
-    }
-    CheckOnlyServer() : ServerBase(*static_cast<ServerBase::EndpointInfoPoolType *>(this)), mInSuite(nullptr) { Reset(); }
+    CheckOnlyServer(nlTestSuite * inSuite) : mInSuite(inSuite) { Reset(); }
+    CheckOnlyServer() : mInSuite(nullptr) { Reset(); }
     ~CheckOnlyServer() {}
 
     // Parser delegates
@@ -225,7 +218,7 @@ public:
         return true;
     }
 
-    // ServerBase overrides
+    // Server overrides
     CHIP_ERROR
     DirectSend(chip::System::PacketBufferHandle && data, const chip::Inet::IPAddress & addr, uint16_t port,
                chip::Inet::InterfaceId interface) override

--- a/src/platform/openiotsdk/CHIPPlatformConfig.h
+++ b/src/platform/openiotsdk/CHIPPlatformConfig.h
@@ -34,6 +34,9 @@
 #define CHIP_CONFIG_MAX_FABRICS 5
 #endif
 
+#define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
+#define CHIP_CONFIG_ERROR_SOURCE 1
+
 // ==================== Security Adaptations ====================
 
 // ==================== General Configuration Overrides ====================

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -193,7 +193,7 @@ void TestDnssdBrowse(nlTestSuite * inSuite, void * inContext)
 
     mdns::Minimal::SetDefaultAddressPolicy();
 
-    mdns::Minimal::Server<10> server;
+    mdns::Minimal::Server server;
     mdns::Minimal::QNamePart serverName[] = { "resolve-tester", "_mock", chip::Dnssd::kCommissionProtocol,
                                               chip::Dnssd::kLocalDomain };
     mdns::Minimal::ResponseSender responseSender(&server);


### PR DESCRIPTION
This means only a single query and reply should generally be seen (or 2 in the case of ipv4 support in parallel with IPv6), making minmdns dnssd implementation a lot less chatty.

Tested:
  - linux local tests, checked wireshark for both boot time advertisements and node discovery using minmdns tests, TC_RR_1_1 passes with minmdns
  - commissioned a M5stack