### PR TITLE
[Silabs] Enable Persistent Subs by default on all builds

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -43,9 +43,6 @@ declare_args() {
   chip_config_use_icd_subscription_callbacks = enable_sleepy_device
 }
 
-# Use persitent subscriptions for IC devices
-chip_persist_subscriptions = enable_sleepy_device
-
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
 import("${silabs_common_plat_dir}/args.gni")

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -103,7 +103,8 @@ declare_args() {
 
   # Enable Subscription persistence / resumption for CI and supported platforms
   if (chip_device_platform == "darwin" || chip_device_platform == "linux" ||
-      chip_device_platform == "esp32" || chip_device_platform == "fake") {
+      chip_device_platform == "esp32" || chip_device_platform == "fake" ||
+      chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
     chip_persist_subscriptions = true
   } else {
     chip_persist_subscriptions = false


### PR DESCRIPTION
#### Description
Enable persistent subs be default on all builds instead of just SED builds.

#### Tested
Manual tests

