### PR TITLE
CASE: Handle failure if unable to schedule handle/send sigma3c

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -77,9 +77,11 @@ CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const 
     {
         // We are in the middle of CASE handshake
 
-        // Check if we are stuck on background thread, if yes, unblock it, and continue
-        if (GetSession().InvokeBackgroundWorkWatchdog() == false)
+        // Invoke watchdog to fix any stuck handshakes
+        bool watchdogFired = GetSession().InvokeBackgroundWorkWatchdog();
+        if (!watchdogFired)
         {
+            // Handshake wasn't stuck, let it continue its work
             // TODO: Send Busy response, #27473
             ChipLogError(Inet, "CASE session is in establishing state, returning without responding");
             return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -89,6 +89,9 @@ private:
     //
     Optional<SessionHandle> mPinnedSecureSession;
 
+    // Track if we are in the middle of secure session handshake
+    bool mDoingCASEHandshake = false;
+
     CASESession mPairingSession;
     SessionManager * mSessionManager = nullptr;
 

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -89,9 +89,6 @@ private:
     //
     Optional<SessionHandle> mPinnedSecureSession;
 
-    // Track if we are in the middle of secure session handshake
-    bool mDoingCASEHandshake = false;
-
     CASESession mPairingSession;
     SessionManager * mSessionManager = nullptr;
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -2208,7 +2208,7 @@ System::Clock::Timeout CASESession::ComputeSigma2ResponseTimeout(const ReliableM
 
 bool CASESession::InvokeBackgroundWorkWatchdog()
 {
-    bool wasBlocked = false;
+    bool watchdogFired = false;
 
     if (mSendSigma3Helper && mSendSigma3Helper->UnableToScheduleAfterWorkCallback())
     {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -217,7 +217,7 @@ public:
         // If we are are being called, assert
         VerifyOrDie(SchedulingAfterWorkCallbackFailed());
 
-        if (auto *session = mSession.load())
+        if (auto * session = mSession.load())
         {
             return (session->*(mAfterWorkCallback))(mData, mStatus);
         }
@@ -291,7 +291,7 @@ private:
 
     // If background thread fails to schedule AfterWorkCallback then this flag is set to true
     // and CASEServer then can check this one and run the AfterWorkCallback for us.
-    std::atomic<bool> mScheduleAfterWorkFailed {false};
+    std::atomic<bool> mScheduleAfterWorkFailed{ false };
 
 public:
     // Data passed to `mWorkCallback` and `mAfterWorkCallback`.

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -2214,17 +2214,17 @@ bool CASESession::InvokeBackgroundWorkWatchdog()
     {
         ChipLogError(SecureChannel, "SendSigma3Helper was unable to schedule the AfterWorkCallback");
         mSendSigma3Helper->DoAfterWork();
-        wasBlocked = true;
+        watchdogFired = true;
     }
 
     if (mHandleSigma3Helper && mHandleSigma3Helper->UnableToScheduleAfterWorkCallback())
     {
         ChipLogError(SecureChannel, "HandleSigma3Helper was unable to schedule the AfterWorkCallback");
         mHandleSigma3Helper->DoAfterWork();
-        wasBlocked = true;
+        watchdogFired = true;
     }
 
-    return wasBlocked;
+    return watchdogFired;
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -242,9 +242,9 @@ private:
         {
             // We failed to schedule after work callback, so setting mScheduleAfterWorkFailed flag to true
             // This can be checked from foreground thread and after work callback can be retried
+            helper->mStatus = status;
             ChipLogError(SecureChannel, "Failed to Schedule the AfterWorkCallback on foreground thread");
             helper->mScheduleAfterWorkFailed.store(true);
-            helper->mStatus = status;
 
             // Release strong ptr since scheduling failed
             helper->mStrongPtr.reset();

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -191,6 +191,19 @@ public:
      **/
     void Clear();
 
+    // These APIs returns true if background thread fails to schedule the after work callback
+    // Then someone can run the after work callback in foreground thread
+    bool IsSendSigma3PermanentlyBlockedOnBackgroundWork();
+    bool IsHandleSigma3PermanentlyBlockedOnBackgroundWork();
+
+    // If work helper fails to schedule the after work callback then call these function to run the
+    // after work callback from foreground thread.
+    // Please make sure the check if the work is really blocked on background thread
+    // NOTE: These APIs will assert if not called from main matter thread and work is not blocked
+    //       in background thread.
+    CHIP_ERROR UnblockSendSigma3FromForegroundWork();
+    CHIP_ERROR UnblockHandleSigma3FromForegroundWork();
+
 private:
     friend class TestCASESession;
     enum class State : uint8_t

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -191,21 +191,6 @@ public:
      **/
     void Clear();
 
-    // These APIs returns true if background thread fails to schedule the after work callback
-    // Then someone can run the after work callback in foreground thread
-    bool IsSendSigma3PermanentlyBlockedOnBackgroundWork();
-    bool IsHandleSigma3PermanentlyBlockedOnBackgroundWork();
-
-    // If work helper fails to schedule the after work callback then call these function to run the
-    // after work callback from foreground thread.
-    // Please make sure the check if the work is really blocked on background thread
-    // NOTE: These APIs will assert if not called from main matter thread and work is not blocked
-    //       in background thread.
-    CHIP_ERROR UnblockSendSigma3FromForegroundWork();
-    CHIP_ERROR UnblockHandleSigma3FromForegroundWork();
-
-private:
-    friend class TestCASESession;
     enum class State : uint8_t
     {
         kInitialized         = 0,
@@ -219,6 +204,15 @@ private:
         kSendSigma3Pending   = 8,
         kHandleSigma3Pending = 9,
     };
+
+    State GetState() { return mState; }
+
+    // Check if any of the work helper is unable to schedule the after work callback
+    // If they are stuck run the after work callback from the foreground thread.
+    bool InvokeBackgroundWorkWatchdog();
+
+private:
+    friend class TestCASESession;
 
     /*
      * Initialize the object given a reference to the SessionManager, certificate validity policy and a delegate which will be

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -207,8 +207,8 @@ public:
 
     State GetState() { return mState; }
 
-    // Checks if any of the work helper is unable to schedule the after work callback
-    // If they are stuck, runs the after work callback from the foreground thread.
+    // Returns true if the CASE session handshake was stuck due to failing to schedule work on the Matter thread.
+    // If this function returns true, the CASE session has been reset and is ready for a new session establishment.
     bool InvokeBackgroundWorkWatchdog();
 
 private:

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -207,8 +207,8 @@ public:
 
     State GetState() { return mState; }
 
-    // Check if any of the work helper is unable to schedule the after work callback
-    // If they are stuck run the after work callback from the foreground thread.
+    // Checks if any of the work helper is unable to schedule the after work callback
+    // If they are stuck, runs the after work callback from the foreground thread.
     bool InvokeBackgroundWorkWatchdog();
 
 private:


### PR DESCRIPTION
#### Problem
Sending and Handling Sigma3 is an async process and divided into three parts, Sigma3a, Sigma3b, and Sigma3c.
Sigma3a schedules Sigma3b, and Sigma3b is suppose to schedule the Sigma3c.

If We fail to schedule Sigma3c then, we are in the state where the only option to recover is reboot. Problem is more described in https://github.com/project-chip/connectedhomeip/pull/25695#discussion_r1178391687 and logs in #26737 has hit this problem. 

Fixes #26737 and completes below item from #26280
> Improve handling if scheduling work fails.
https://github.com/project-chip/connectedhomeip/pull/25695#discussion_r1178391687

#### Change Overview
Implemented the suggestion provided by Marc here: https://github.com/project-chip/connectedhomeip/issues/26280#issuecomment-1595268002

- We are no longer unregistering the unsolicit message hander for sigma1. Based on handshake state and failure to schedule work, decide what to do:
    1. If in middle of handshake but it's zombie, tear down the handshake.
    2. If still in middle of handshake, return without responding.
    3. Otherwise, just do a new handshake.

- Added APIs in helper to check if it fails to schedule after work callback and to re run it from foreground thread.
- Added wrapper around the APIs for HandleSigma3 and SendSigma3 cases.

#### Tests
1. Built chip-tool and lighting-app/esp32, tested commissioning and onoff toggle.
2. Also to test specific scenario, I'have commented below line and verified that case server enables with this fix.
https://github.com/project-chip/connectedhomeip/blob/643f7aaeef020d00892ecb9631adc03e2504dacd/src/protocols/secure_channel/CASESession.cpp#L230

#### Follow ups to do
1. Send Busy response when we are in the middle of handshake and receives sigma1
2. Check if `RegisterUnsolicitedMessageHandlerForType()` can be moved out from `PrepareForSessionEstablishment()`, this gets called every time after case is established/failed.
3. Call `IsSendSigma3PermanentlyBlockedOnBackgroundWork()` and `UnblockSendSigma3FromForegroundWork()` from CASEClient.

https://github.com/project-chip/connectedhomeip/issues/27474 and https://github.com/project-chip/connectedhomeip/issues/27473