### PR TITLE
Optimize compilation time

### DIFF
--- a/examples/all-clusters-minimal-app/asr/src/DeviceCallbacks.cpp
+++ b/examples/all-clusters-minimal-app/asr/src/DeviceCallbacks.cpp
@@ -25,6 +25,7 @@
 #include "DeviceCallbacks.h"
 
 #include "CHIPDeviceManager.h"
+#include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/server/Dnssd.h>

--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
@@ -18,6 +18,7 @@
 
 #include "SubDeviceManager.h"
 #include "SubDevice.h"
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>

--- a/examples/bridge-app/asr/subdevice/subdevice_test.cpp
+++ b/examples/bridge-app/asr/subdevice/subdevice_test.cpp
@@ -20,6 +20,7 @@
 #include "SubDeviceManager.h"
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app-common/zap-generated/ids/Commands.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/identify-server/identify-server.h>

--- a/examples/contact-sensor-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
+++ b/examples/contact-sensor-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
@@ -21,6 +21,7 @@
 #include "AppTask.h"
 #include "ContactSensorManager.h"
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -360,6 +360,7 @@ source_set("efr32-common") {
 
   public_deps += [
     "${chip_root}/examples/providers:device_info_provider",
+    "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
@@ -28,6 +28,8 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 class CallbackBaseJNI
 {
 public:

--- a/examples/tv-casting-app/tv-casting-common/include/ApplicationBasic.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ApplicationBasic.h
@@ -21,6 +21,8 @@
 
 #include <controller/CHIPCluster.h>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // SUBSCRIBER CLASSES
 class VendorNameSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo>
 {

--- a/examples/tv-casting-app/tv-casting-common/include/ApplicationLauncher.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ApplicationLauncher.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class LaunchAppCommand
     : public MediaCommandBase<chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type,

--- a/examples/tv-casting-app/tv-casting-common/include/Channel.h
+++ b/examples/tv-casting-app/tv-casting-common/include/Channel.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class ChangeChannelCommand : public MediaCommandBase<chip::app::Clusters::Channel::Commands::ChangeChannel::Type,
                                                      chip::app::Clusters::Channel::Commands::ChangeChannelResponse::DecodableType>

--- a/examples/tv-casting-app/tv-casting-common/include/ContentLauncher.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ContentLauncher.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class LaunchURLCommand : public MediaCommandBase<chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type,
                                                  chip::app::Clusters::ContentLauncher::Commands::LauncherResponse::DecodableType>

--- a/examples/tv-casting-app/tv-casting-common/include/KeypadInput.h
+++ b/examples/tv-casting-app/tv-casting-common/include/KeypadInput.h
@@ -21,6 +21,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 class SendKeyCommand : public MediaCommandBase<chip::app::Clusters::KeypadInput::Commands::SendKey::Type,
                                                chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType>
 {

--- a/examples/tv-casting-app/tv-casting-common/include/LevelControl.h
+++ b/examples/tv-casting-app/tv-casting-common/include/LevelControl.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class StepCommand
     : public MediaCommandBase<chip::app::Clusters::LevelControl::Commands::Step::Type, chip::app::DataModel::NullObjectType>

--- a/examples/tv-casting-app/tv-casting-common/include/MediaPlayback.h
+++ b/examples/tv-casting-app/tv-casting-common/include/MediaPlayback.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class PlayCommand : public MediaCommandBase<chip::app::Clusters::MediaPlayback::Commands::Play::Type,
                                             chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType>

--- a/examples/tv-casting-app/tv-casting-common/include/OnOff.h
+++ b/examples/tv-casting-app/tv-casting-common/include/OnOff.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class OnCommand : public MediaCommandBase<chip::app::Clusters::OnOff::Commands::On::Type, chip::app::DataModel::NullObjectType>
 {

--- a/examples/tv-casting-app/tv-casting-common/include/TargetNavigator.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetNavigator.h
@@ -22,6 +22,8 @@
 #include <controller/CHIPCluster.h>
 #include <functional>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 // COMMAND CLASSES
 class NavigateTargetCommand
     : public MediaCommandBase<chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type,

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -23,6 +23,8 @@
 #include <app/OperationalSessionSetup.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#include <app-common/zap-generated/cluster-objects.h>
+
 constexpr size_t kMaxNumberOfEndpoints = 5;
 
 class TargetVideoPlayerInfo;

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -75,11 +75,13 @@ function(chip_configure_data_model APP_TARGET)
 
     if (ARG_INCLUDE_SERVER)
         target_sources(${APP_TARGET} ${SCOPE}
-            ${CHIP_APP_BASE_DIR}/server/EchoHandler.cpp
+            ${CHIP_APP_BASE_DIR}/server/AclStorage.cpp
+            ${CHIP_APP_BASE_DIR}/server/DefaultAclStorage.cpp
+            ${CHIP_APP_BASE_DIR}/server/CommissioningWindowManager.cpp
             ${CHIP_APP_BASE_DIR}/server/Dnssd.cpp
+            ${CHIP_APP_BASE_DIR}/server/EchoHandler.cpp
             ${CHIP_APP_BASE_DIR}/server/OnboardingCodesUtil.cpp
             ${CHIP_APP_BASE_DIR}/server/Server.cpp
-            ${CHIP_APP_BASE_DIR}/server/CommissioningWindowManager.cpp
         )
 
         target_compile_options(${APP_TARGET} ${SCOPE}

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Nullable.h>
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningModeProvider.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <lib/core/ClusterEnums.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/dnssd/Advertiser.h>
 #include <messaging/ExchangeDelegate.h>

--- a/src/app/util/generic-callbacks.h
+++ b/src/app/util/generic-callbacks.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-metadata.h>
 #include <app/util/basic-types.h>

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -17,6 +17,7 @@
  */
 
 #pragma once
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/OperationalSessionSetup.h>
 #include <controller/CommissioneeDeviceProxy.h>
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -20,10 +20,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/basic-types.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/ClusterEnums.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CommonIterator.h>
 

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -31,7 +31,7 @@
 #include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
 #endif
 
-#include <app-common/zap-generated/cluster-objects.h>
+#include <lib/core/ClusterEnums.h>
 #include <lib/support/Span.h>
 #include <platform/PersistedStorage.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -31,7 +31,6 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/basic-types.h>
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/util/basic-types.h>
 #include <inet/IPAddress.h>

--- a/src/lib/BUILD.gn
+++ b/src/lib/BUILD.gn
@@ -19,7 +19,6 @@ static_library("lib") {
   public_deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/ble",
-    "${chip_root}/src/controller",
     "${chip_root}/src/crypto",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/asn1",
@@ -28,10 +27,16 @@ static_library("lib") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/platform",
+    "${chip_root}/src/protocols",
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/system",
     "${chip_root}/src/transport",
   ]
+
+  # See src/lib/lib.gni for declaration of this build arg.
+  if (chip_build_controller) {
+    public_deps += [ "${chip_root}/src/controller" ]
+  }
 
   # Only include the shell if it is being used. The shell is
   # a debug feature mostly useful for embedded examples.

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/lib/core/core.gni")
+
 declare_args() {
+  # Build controller library.
+  chip_build_controller = chip_target_style != "embedded"
+
   # Enable libshell support.
   chip_build_libshell = false
 

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -25,6 +25,8 @@
 #include <platform/PlatformManager.h>
 #include <platform/ThreadStackManager.h>
 
+#include <app-common/zap-generated/ids/Attributes.h>
+
 #include <nlbyteorder.hpp>
 #include <nlio-byteorder.hpp>
 #include <nlio.hpp>

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -25,6 +25,8 @@
 #include <platform/ThreadStackManager.h>
 #include <platform/webos/NetworkCommissioningDriver.h>
 
+#include <app-common/zap-generated/ids/Attributes.h>
+
 #include <nlbyteorder.hpp>
 #include <nlio-byteorder.hpp>
 #include <nlio.hpp>

--- a/src/protocols/secure_channel/CASEDestinationId.cpp
+++ b/src/protocols/secure_channel/CASEDestinationId.cpp
@@ -20,6 +20,7 @@
 #include <credentials/FabricTable.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/Span.h>
 
 #include "CASEDestinationId.h"


### PR DESCRIPTION
1. Do not to include `cluster-objects.h` if not needed as parsing such a large header significantly impacts the build time and in most cases it is enough to include `ClusterEnums.h`.
2. Do not build the controller library for embedded targets, by default. If needed, this can be overriden using the chip_build_controller argument from lib.gni.

It reduces the time of building `libCHIP.a` on my PC from almost 1 min 40s to about 1 minute for nRF Connect platform.

Overall, I think we would greatly speed up the compilation time if `cluster-objects.*` files were divided into _one file per cluster_ or at least into utility and application clusters.