### PR TITLE
[cherry-pick][esp32] Fix compilation error for esp32 based ble-controller

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -24,6 +24,7 @@
  */
 
 #pragma once
+#include <string>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 


### PR DESCRIPTION
This PR fixes compilation error for ble-controller application over esp32
Error received was: 
>  error: field 'mAddress' has incomplete type 'std::string' {aka 'std::__cxx11::basic_string<char>'}
