### PR TITLE
[matter_yamltests] Add SpecDefinitions.get_cluster_names to get all t…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/definitions.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/definitions.py
@@ -87,6 +87,9 @@ class SpecDefinitions:
                     self.__responses_by_id[code][struct.code] = struct
                     self.__responses_by_name[name][struct.name] = struct.code
 
+    def get_cluster_names(self) -> List[str]:
+        return [name for name, _ in self.__clusters_by_name.items()]
+
     def get_cluster_name(self, cluster_id: int) -> str:
         cluster = self.__clusters_by_id.get(cluster_id)
         return cluster.name if cluster else None


### PR DESCRIPTION
…he cluster names

#### Problem

This just add a method to retrieve all the cluster names. Not a big deal but useful when the definitions code is used in some other contexts.
