### PR TITLE
MinMds - remove duplicate broadcasts at startup time (remove IP address looping)

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -508,5 +508,28 @@ IPAddress IPAddress::MakeIPv4Broadcast()
     return ipAddr;
 }
 
+IPAddress IPAddress::Loopback(IPAddressType type)
+{
+    IPAddress address;
+#if INET_CONFIG_ENABLE_IPV4
+    if (type == IPAddressType::kIPv4)
+    {
+        address.Addr[0] = 0;
+        address.Addr[1] = 0;
+        address.Addr[2] = htonl(0xFFFF);
+        address.Addr[3] = htonl(0x7F000001);
+    }
+    else
+#endif
+    {
+        address.Addr[0] = 0;
+        address.Addr[1] = 0;
+        address.Addr[2] = 0;
+        address.Addr[3] = htonl(1);
+    }
+
+    return address;
+}
+
 } // namespace Inet
 } // namespace chip

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -698,6 +698,14 @@ public:
      *  not be modified by users of the CHIP Inet Layer.
      */
     static IPAddress Any;
+
+    /**
+     * Creates a loopback of the specified type. Type MUST be IPv6/v4.
+     *
+     * If type is anything else (or IPv4 is not available) an IPv6
+     * loopback will be created.
+     */
+    static IPAddress Loopback(IPAddressType type);
 };
 
 static_assert(std::is_trivial<IPAddress>::value, "IPAddress is not trivial");

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -880,7 +880,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         // since we use "BROADCAST" (unicast is false), we do not actually care about
         // the source IP address value, just that it has the right "type"
         //
-        // NOTE: cannot use Boradcast address as the source as they have the type kAny.
+        // NOTE: cannot use Broadcast address as the source as they have the type kAny.
         //
         // TODO: ideally we may want to have a destination that is explicit as "unicast/destIp"
         //       vs "multicast/addressType". Such a change requires larger code updates.

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -885,17 +885,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         // TODO: ideally we may want to have a destination that is explicit as "unicast/destIp"
         //       vs "multicast/addressType". Such a change requires larger code updates.
         packetInfo.SrcAddress = chip::Inet::IPAddress::Loopback(addressType);
-
-#if INET_CONFIG_ENABLE_IPV4
-        if (addressType == chip::Inet::IPAddressType::kIPv4)
-        {
-            BroadcastIpAddresses::GetIpv4Into(packetInfo.DestAddress);
-        }
-        else
-#endif
-        {
-            BroadcastIpAddresses::GetIpv6Into(packetInfo.DestAddress);
-        }
+        packetInfo.DestAddress = BroadcastIpAddresses::Get(addressType);
         packetInfo.SrcPort   = kMdnsPort;
         packetInfo.DestPort  = kMdnsPort;
         packetInfo.Interface = interfaceId;

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -884,11 +884,11 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         //
         // TODO: ideally we may want to have a destination that is explicit as "unicast/destIp"
         //       vs "multicast/addressType". Such a change requires larger code updates.
-        packetInfo.SrcAddress = chip::Inet::IPAddress::Loopback(addressType);
+        packetInfo.SrcAddress  = chip::Inet::IPAddress::Loopback(addressType);
         packetInfo.DestAddress = BroadcastIpAddresses::Get(addressType);
-        packetInfo.SrcPort   = kMdnsPort;
-        packetInfo.DestPort  = kMdnsPort;
-        packetInfo.Interface = interfaceId;
+        packetInfo.SrcPort     = kMdnsPort;
+        packetInfo.DestPort    = kMdnsPort;
+        packetInfo.Interface   = interfaceId;
 
         // Advertise all records
         //

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -206,10 +206,6 @@ private:
     /// removes all records by advertising a 0 TTL)
     void AdvertiseRecords(BroadcastAdvertiseType type);
 
-    /// Determine if advertisement on the specified interface/address is ok given the
-    /// interfaces on which the mDNS server is listening
-    bool ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr);
-
     FullQName GetCommissioningTxtEntries(const CommissionAdvertisingParameters & params);
     FullQName GetOperationalTxtEntries(OperationalQueryAllocator::Allocator * allocator,
                                        const OperationalAdvertisingParameters & params);
@@ -856,35 +852,6 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
 }
 
-bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)
-{
-    auto & server = GlobalMinimalMdnsServer::Server();
-
-    bool result = false;
-
-    server.ForEachEndPoints([&](auto * info) {
-        if (info->mListenUdp == nullptr)
-        {
-            return chip::Loop::Continue;
-        }
-
-        if (info->mInterfaceId != id)
-        {
-            return chip::Loop::Continue;
-        }
-
-        if (info->mAddressType != addr.Type())
-        {
-            return chip::Loop::Continue;
-        }
-
-        result = true;
-        return chip::Loop::Break;
-    });
-
-    return result;
-}
-
 void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
 {
     ResponseConfiguration responseConfiguration;
@@ -905,60 +872,65 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         UniquePtr<IpAddressIterator> allIps = GetAddressPolicy()->GetIpAddressesForEndpoint(interfaceId, addressType);
         VerifyOrDieWithMsg(allIps != nullptr, Discovery, "Failed to allocate memory for ip addresses.");
 
-        Inet::IPAddress ipAddress;
-        while (allIps->Next(ipAddress))
+        chip::Inet::IPPacketInfo packetInfo;
+
+        packetInfo.Clear();
+
+        // advertising on every interface requires a valid IP address
+        // since we use "BROADCAST" (unicast is false), we do not actually care about
+        // the source IP address value, just that it has the right "type"
+        //
+        // NOTE: cannot use Boradcast address as the source as they have the type kAny.
+        //
+        // TODO: ideally we may want to have a destination that is explicit as "unicast/destIp"
+        //       vs "multicast/addressType". Such a change requires larger code updates.
+#if INET_CONFIG_ENABLE_IPV4
+        if (addressType == chip::Inet::IPAddressType::kIPv4)
         {
-            if (!ShouldAdvertiseOn(interfaceId, ipAddress))
-            {
-                continue;
-            }
+            VerifyOrDie(chip::Inet::IPAddress::FromString("127.0.0.1", packetInfo.SrcAddress));
+            VerifyOrDie(packetInfo.SrcAddress.Type() == chip::Inet::IPAddressType::kIPv4);
+            BroadcastIpAddresses::GetIpv4Into(packetInfo.DestAddress);
+        }
+        else
+#endif
+        {
+            VerifyOrDie(chip::Inet::IPAddress::FromString("::1", packetInfo.SrcAddress));
+            VerifyOrDie(packetInfo.SrcAddress.Type() == chip::Inet::IPAddressType::kIPv6);
+            BroadcastIpAddresses::GetIpv6Into(packetInfo.DestAddress);
+        }
+        packetInfo.SrcPort   = kMdnsPort;
+        packetInfo.DestPort  = kMdnsPort;
+        packetInfo.Interface = interfaceId;
 
-            chip::Inet::IPPacketInfo packetInfo;
+        // Advertise all records
+        //
+        // TODO: Consider advertising delta changes.
+        //
+        // Current advertisement does not have a concept of "delta" to only
+        // advertise changes. Current implementation is to always
+        //    1. advertise TTL=0 (clear all caches)
+        //    2. advertise available records (with longer TTL)
+        //
+        // It would be nice if we could selectively advertise what changes, like
+        // send TTL=0 for anything removed/about to be removed (and only those),
+        // then only advertise new items added.
+        //
+        // This optimization likely will take more logic and state storage, so
+        // for now it is not done.
+        QueryData queryData(QType::PTR, QClass::IN, false /* unicast */);
+        queryData.SetIsInternalBroadcast(true);
 
-            packetInfo.Clear();
-            packetInfo.SrcAddress = ipAddress;
-            if (ipAddress.IsIPv4())
-            {
-                BroadcastIpAddresses::GetIpv4Into(packetInfo.DestAddress);
-            }
-            else
-            {
-                BroadcastIpAddresses::GetIpv6Into(packetInfo.DestAddress);
-            }
-            packetInfo.SrcPort   = kMdnsPort;
-            packetInfo.DestPort  = kMdnsPort;
-            packetInfo.Interface = interfaceId;
+        for (auto & it : mOperationalResponders)
+        {
+            it.GetAllocator()->GetQueryResponder()->ClearBroadcastThrottle();
+        }
+        mQueryResponderAllocatorCommissionable.GetQueryResponder()->ClearBroadcastThrottle();
+        mQueryResponderAllocatorCommissioner.GetQueryResponder()->ClearBroadcastThrottle();
 
-            // Advertise all records
-            //
-            // TODO: Consider advertising delta changes.
-            //
-            // Current advertisement does not have a concept of "delta" to only
-            // advertise changes. Current implementation is to always
-            //    1. advertise TTL=0 (clear all caches)
-            //    2. advertise available records (with longer TTL)
-            //
-            // It would be nice if we could selectively advertise what changes, like
-            // send TTL=0 for anything removed/about to be removed (and only those),
-            // then only advertise new items added.
-            //
-            // This optimization likely will take more logic and state storage, so
-            // for now it is not done.
-            QueryData queryData(QType::PTR, QClass::IN, false /* unicast */);
-            queryData.SetIsInternalBroadcast(true);
-
-            for (auto & it : mOperationalResponders)
-            {
-                it.GetAllocator()->GetQueryResponder()->ClearBroadcastThrottle();
-            }
-            mQueryResponderAllocatorCommissionable.GetQueryResponder()->ClearBroadcastThrottle();
-            mQueryResponderAllocatorCommissioner.GetQueryResponder()->ClearBroadcastThrottle();
-
-            CHIP_ERROR err = mResponseSender.Respond(0, queryData, &packetInfo, responseConfiguration);
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Discovery, "Failed to advertise records: %" CHIP_ERROR_FORMAT, err.Format());
-            }
+        CHIP_ERROR err = mResponseSender.Respond(0, queryData, &packetInfo, responseConfiguration);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Discovery, "Failed to advertise records: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -884,18 +884,16 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         //
         // TODO: ideally we may want to have a destination that is explicit as "unicast/destIp"
         //       vs "multicast/addressType". Such a change requires larger code updates.
+        packetInfo.SrcAddress = chip::Inet::IPAddress::Loopback(addressType);
+
 #if INET_CONFIG_ENABLE_IPV4
         if (addressType == chip::Inet::IPAddressType::kIPv4)
         {
-            VerifyOrDie(chip::Inet::IPAddress::FromString("127.0.0.1", packetInfo.SrcAddress));
-            VerifyOrDie(packetInfo.SrcAddress.Type() == chip::Inet::IPAddressType::kIPv4);
             BroadcastIpAddresses::GetIpv4Into(packetInfo.DestAddress);
         }
         else
 #endif
         {
-            VerifyOrDie(chip::Inet::IPAddress::FromString("::1", packetInfo.SrcAddress));
-            VerifyOrDie(packetInfo.SrcAddress.Type() == chip::Inet::IPAddressType::kIPv6);
             BroadcastIpAddresses::GetIpv6Into(packetInfo.DestAddress);
         }
         packetInfo.SrcPort   = kMdnsPort;

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -127,24 +127,12 @@ chip::Inet::IPAddress Get(chip::Inet::IPAddressType addressType)
 #if INET_CONFIG_ENABLE_IPV4
     if (addressType == chip::Inet::IPAddressType::kIPv4)
     {
-        if (!chip::Inet::IPAddress::FromString("224.0.0.251", address))
-        {
-            ChipLogError(Discovery, "Failed to parse standard IPv4 broadcast address");
-
-            // not valid, however the parsing should never fail
-            return chip::Inet::IPAddress::Any;
-        }
+        VerifyOrDie(chip::Inet::IPAddress::FromString("224.0.0.251", address));
     }
     else
 #endif
     {
-        if (!chip::Inet::IPAddress::FromString("FF02::FB", address))
-        {
-            ChipLogError(Discovery, "Failed to parse standard IPv6 broadcast address");
-
-            // not valid, however the parsing should never fail
-            return chip::Inet::IPAddress::Any;
-        }
+        VerifyOrDie(chip::Inet::IPAddress::FromString("FF02::FB", address));
     }
     return address;
 }

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -32,9 +32,7 @@ namespace Minimal {
 namespace BroadcastIpAddresses {
 
 // Get standard mDNS Broadcast addresses
-
-void GetIpv6Into(chip::Inet::IPAddress & dest);
-void GetIpv4Into(chip::Inet::IPAddress & dest);
+chip::Inet::IPAddress Get(chip::Inet::IPAddressType addressType);
 
 } // namespace BroadcastIpAddresses
 
@@ -130,10 +128,9 @@ public:
 
     ServerBase(EndpointInfoPoolType & pool) : mEndpoints(pool)
     {
-        BroadcastIpAddresses::GetIpv6Into(mIpv6BroadcastAddress);
-
+        mIpv6BroadcastAddress = BroadcastIpAddresses::Get(chip::Inet::IPAddressType::kIPv6);
 #if INET_CONFIG_ENABLE_IPV4
-        BroadcastIpAddresses::GetIpv4Into(mIpv4BroadcastAddress);
+        mIpv4BroadcastAddress = BroadcastIpAddresses::Get(chip::Inet::IPAddressType::kIPv4);
 #endif
     }
     virtual ~ServerBase();

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -178,13 +178,6 @@ public:
         return *this;
     }
 
-    /// Iterator through all Endpoints
-    template <typename Function>
-    chip::Loop ForEachEndPoints(Function && function)
-    {
-        return mEndpoints.ForEachActiveObject(std::forward<Function>(function));
-    }
-
     /// A server is considered listening if any UDP endpoint is active.
     ///
     /// This is expected to return false after any Shutdown() and will


### PR DESCRIPTION
MinMDNS advertises once for every IP address, but this makes no sense as a multicast is per interface not per external IP.

Ensure we only broadcast once per interface.

This pulls the "only advertise once per IP address" from #27219 as that is an obvious useful improvement (that PR is a larger change and requires more testing ... however advertisement reduction seems to be generally applicable immediately).

