### PR TITLE
[ReadHandler] Rename and comment

### DIFF
--- a/examples/all-clusters-app/nxp/mw320/main.cpp
+++ b/examples/all-clusters-app/nxp/mw320/main.cpp
@@ -14,8 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-//#include "FreeRTOS.h"
-//#include "task.h"
+// #include "FreeRTOS.h"
+// #include "task.h"
 
 #include <lib/shell/Engine.h>
 
@@ -28,7 +28,7 @@
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CodeUtils.h>
 
-//#include <lib/support/RandUtils.h>   //==> rm from TE7.5
+// #include <lib/support/RandUtils.h>   //==> rm from TE7.5
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -59,9 +59,9 @@
 #include "app/clusters/ota-requestor/DefaultOTARequestor.h"
 #include "app/clusters/ota-requestor/DefaultOTARequestorDriver.h"
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
-//#include <app/clusters/ota-requestor/DefaultOTARequestorUserConsent.h>
+// #include <app/clusters/ota-requestor/DefaultOTARequestorUserConsent.h>
 #include "platform/nxp/mw320/OTAImageProcessorImpl.h"
-//#include "app/clusters/ota-requestor/OTARequestorDriver.h"
+// #include "app/clusters/ota-requestor/OTARequestorDriver.h"
 
 // for ota module test
 #include "mw320_ota.h"
@@ -1528,7 +1528,7 @@ static void OnSwitchAttributeChangeCallback(EndpointId endpointId, AttributeId a
                 ReadHandler * phandler = pimEngine->ActiveHandlerAt(i);
                 if (phandler->IsType(chip::app::ReadHandler::InteractionType::Subscribe) &&
                         (phandler->IsGeneratingReports() || phandler->IsAwaitingReportResponse())) {
-                        phandler->UnblockUrgentEventDelivery();
+                        phandler->ForceDirtyState();
                         do_sendrpt = true;
                         break;
                 }

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -326,7 +326,7 @@ private:
     void GetSubscriptionId(SubscriptionId & aSubscriptionId) const { aSubscriptionId = mSubscriptionId; }
     AttributePathExpandIterator * GetAttributePathExpandIterator() { return &mAttributePathExpandIterator; }
 
-    /// @brief Notifies the read handler that a set of attribute paths has been marked dirty. This will scehdule an engine run if
+    /// @brief Notifies the read handler that a set of attribute paths has been marked dirty. This will schedule a reporting engine run if
     /// the change to the attribute path makes the ReadHandler reportable.
     /// @param aAttributeChanged Path to the attribute that was changed.
     void AttributePathIsDirty(const AttributePathParams & aAttributeChanged);
@@ -425,13 +425,13 @@ private:
 
     void PersistSubscription();
 
-    /// @brief Modifies a state flag in the read handler. If the flag went from a
-    /// non-reportable state to a reportable state, schedules an engine run.
+    /// @brief Modifies a state flag in the read handler. If the read handler went from a
+    /// non-reportable state to a reportable state, schedules a reporting engine run.
     /// @param aFlag Flag to set
     /// @param aValue Flag new value
     void SetStateFlag(ReadHandlerFlags aFlag, bool aValue = true);
 
-    /// @brief This function calls the SetStateFlag with the flag value set to false, thus possibly emitting a report
+    /// @brief This function call SetStateFlag with the flag value set to false, thus possibly emitting a report
     /// generation.
     /// @param aFlag Flag to clear
     void ClearStateFlag(ReadHandlerFlags aFlag);

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -291,10 +291,10 @@ private:
 
     bool IsIdle() const { return mState == HandlerState::Idle; }
 
-    /// @brief Returns whether the ReadHandler is in a state where it can send a report immediately. The main conditions for that
-    /// are that the handler is in a generating reports state and that the, meaning it has been subscribe to or is processing a read
-    /// request, that the min interval has elapsed and that either max interval has elapsed, forcing an empty report, or that the
-    /// handler is dirty. This function is used to determine whether a handler should be scheduled for a run.
+    /// @brief Returns whether the ReadHandler is in a state where it can immediately send a report. The main conditions for this
+    /// are that the handler is in a report generating state, meaning it is subscribed to or processing a read request, that the min
+    /// interval has expired and the max interval has expired, forcing an empty report, or that the handler is dirty. This function
+    /// is used to determine whether a report generation should be scheduled for the handler.
     /// @return
     bool IsReportableNow() const
     {

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -295,7 +295,7 @@ private:
     /// are that the handler is in a report generating state, meaning it is subscribed to or processing a read request, that the min
     /// interval has expired and the max interval has expired, forcing an empty report, or that the handler is dirty. This function
     /// is used to determine whether a report generation should be scheduled for the handler.
-    /// @return
+    /// @return Whether the ReadHandler is in a state where it can immediately send a report.
     bool IsReportableNow() const
     {
         // Important: Anything that changes the state IsReportableNow depends on in
@@ -331,7 +331,7 @@ private:
 
     /// @brief Update mDirtyGeneration to the latest DirtySetGeneration of the InteractionModelEngine. As this might make the
     /// readhandler dirty, this function checks if the readhandler is now reportable and schedules a run if it is the case.
-    /// @param aAttributeChanged
+    /// @param aAttributeChanged Path to the attribute that was changed.
     void UpdateDirtyGeneration(const AttributePathParams & aAttributeChanged);
     bool IsDirty() const
     {
@@ -435,7 +435,7 @@ private:
 
     /// @brief This function calls the SetStateFlagAndScheduleReport with the flag value to false, thus possibly emitting a report
     /// generation.
-    /// @param aFlag
+    /// @param aFlag Flag to clear
     void ClearStateFlagAndScheduleReport(ReadHandlerFlags aFlag);
 
     // Helpers for continuing the subscription resumption

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -326,8 +326,8 @@ private:
     void GetSubscriptionId(SubscriptionId & aSubscriptionId) const { aSubscriptionId = mSubscriptionId; }
     AttributePathExpandIterator * GetAttributePathExpandIterator() { return &mAttributePathExpandIterator; }
 
-    /// @brief Notifies the read handler that a set of attribute paths has been marked dirty. This will schedule a reporting engine run if
-    /// the change to the attribute path makes the ReadHandler reportable.
+    /// @brief Notifies the read handler that a set of attribute paths has been marked dirty. This will schedule a reporting engine
+    /// run if the change to the attribute path makes the ReadHandler reportable.
     /// @param aAttributeChanged Path to the attribute that was changed.
     void AttributePathIsDirty(const AttributePathParams & aAttributeChanged);
     bool IsDirty() const

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -356,7 +356,7 @@ private:
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
     /// @brief This allows the read handler to schedule a run as soon as the min interval has elapsed by setting the read handler to
-    /// a dirty state regardless of the attributes change, thus being reportable as soon as the min interval callback happends.
+    /// a dirty state regardless of the attributes change, thus being reportable as soon as the min interval callback happens.
     void ForceDirtyState();
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
@@ -404,7 +404,7 @@ private:
      */
     void Close(CloseOptions options = CloseOptions::kDropPersistedSubscription);
 
-    /// @brief This function is called when the min interval timer has expired, it restarts the timer on a timeout equalt to the
+    /// @brief This function is called when the min interval timer has expired, it restarts the timer on a timeout equal to the
     /// difference between the max interval and the min interval.
     static void MinIntervalExpiredCallback(System::Layer * apSystemLayer, void * apAppState);
     static void MaxIntervalExpiredCallback(System::Layer * apSystemLayer, void * apAppState);
@@ -427,7 +427,7 @@ private:
 
     void PersistSubscription();
 
-    /// @brief This function modifies at state Flag in the read handler and schedules an engine run if the read handler want from a
+    /// @brief This function modifies a state Flag in the read handler and schedules an engine run if the read handler want from a
     /// non reportable state to a reportable state, resulting in the emission of a report.
     /// @param aFlag Flag to set
     /// @param aValue Flag new value

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -214,13 +214,13 @@ private:
     {
         // mHoldMinInterval is used to prevent subscription data delivery while we are
         // waiting for the min reporting interval to elapse.
-        HoldMinInterval = (1 << 0),
+        WaitingUntilMinInterval = (1 << 0),
 
         // mHoldMaxInterval is used to prevent subscription empty report delivery while we
         // are waiting for the max reporting interval to elaps.  When mHoldMaxInterval
         // becomes false, we are allowed to send an empty report to keep the
         // subscription alive on the client.
-        HoldMaxInterval = (1 << 1),
+        WaitingUntilMaxInterval = (1 << 1),
 
         // The flag indicating we are in the middle of a series of chunked report messages, this flag will be cleared during
         // sending last chunked message.
@@ -355,8 +355,9 @@ private:
 
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
-    /// @brief This allows the read handler to schedule a run as soon as the min interval has elapsed by setting the read handler to
-    /// a dirty state regardless of the attributes change, thus being reportable as soon as the min interval callback happens.
+    /// @brief Forces the read handler into a dirty state, regardless of what's going on with attributes.
+    /// This can lead to scheduling of a reporting run immediately, if the min interval has been reached, 
+    /// or after the min interval is reached if it has not yet been reached.
     void ForceDirtyState();
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
@@ -427,13 +428,13 @@ private:
 
     void PersistSubscription();
 
-    /// @brief This function modifies a state Flag in the read handler and schedules an engine run if the read handler want from a
-    /// non reportable state to a reportable state, resulting in the emission of a report.
+    /// @brief Modifies a state flag in the read handler and schedules an engine run if the read handler want from a
+    /// non-reportable state to a reportable state.
     /// @param aFlag Flag to set
     /// @param aValue Flag new value
     void SetStateFlagAndScheduleReport(ReadHandlerFlags aFlag, bool aValue = true);
 
-    /// @brief This function calls the SetStateFlagAndScheduleReport with the flag value to false, thus possibly emitting a report
+    /// @brief This function calls the SetStateFlagAndScheduleReport with the flag value set to false, thus possibly emitting a report
     /// generation.
     /// @param aFlag Flag to clear
     void ClearStateFlagAndScheduleReport(ReadHandlerFlags aFlag);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -826,8 +826,8 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
     bool intersectsInterestPath = false;
     InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject(
         [&aAttributePath, &intersectsInterestPath](ReadHandler * handler) {
-            // We call UpdateDirtyGeneration for both read interactions and subscribe interactions, since we may send inconsistent
-            // attribute data between two chunks. UpdateDirtyGeneration will not schedule a new run for read handlers which are
+            // We call AttributePathIsDirty for both read interactions and subscribe interactions, since we may send inconsistent
+            // attribute data between two chunks. AttributePathIsDirty will not schedule a new run for read handlers which are
             // waiting for a response to the last message chunk for read interactions.
             if (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse())
             {
@@ -835,7 +835,7 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
                 {
                     if (object->mValue.Intersects(aAttributePath))
                     {
-                        handler->UpdateDirtyGeneration(aAttributePath);
+                        handler->AttributePathIsDirty(aAttributePath);
                         intersectsInterestPath = true;
                         break;
                     }

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -636,7 +636,7 @@ void Engine::Run()
         ReadHandler * readHandler = imEngine->ActiveHandlerAt(mCurReadHandlerIdx % (uint32_t) imEngine->mReadHandlers.Allocated());
         VerifyOrDie(readHandler != nullptr);
 
-        if (readHandler->IsReportable())
+        if (readHandler->IsReportableNow())
         {
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);
@@ -826,16 +826,16 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
     bool intersectsInterestPath = false;
     InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject(
         [&aAttributePath, &intersectsInterestPath](ReadHandler * handler) {
-            // We call SetDirty for both read interactions and subscribe interactions, since we may send inconsistent attribute data
-            // between two chunks. SetDirty will be ignored automatically by read handlers which are waiting for a response to the
-            // last message chunk for read interactions.
+            // We call UpdateDirtyGeneration for both read interactions and subscribe interactions, since we may send inconsistent
+            // attribute data between two chunks. UpdateDirtyGeneration will not schedule a new run for read handlers which are
+            // waiting for a response to the last message chunk for read interactions.
             if (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse())
             {
                 for (auto object = handler->GetAttributePathList(); object != nullptr; object = object->mpNext)
                 {
                     if (object->mValue.Intersects(aAttributePath))
                     {
-                        handler->SetDirty(aAttributePath);
+                        handler->UpdateDirtyGeneration(aAttributePath);
                         intersectsInterestPath = true;
                         break;
                     }
@@ -937,7 +937,7 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBy
             if (interestedPath->mValue.IsEventPathSupersetOf(aPath) && interestedPath->mValue.mIsUrgentEvent)
             {
                 isUrgentEvent = true;
-                handler->UnblockUrgentEventDelivery();
+                handler->ForceDirtyState();
                 break;
             }
         }
@@ -967,7 +967,7 @@ void Engine::ScheduleUrgentEventDeliverySync(Optional<FabricIndex> fabricIndex)
             return Loop::Continue;
         }
 
-        handler->UnblockUrgentEventDelivery();
+        handler->ForceDirtyState();
 
         return Loop::Continue;
     });

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1587,7 +1587,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         dirtyPath5.mAttributeId = 4;
 
         // Test report with 2 different path
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mGotEventResponse     = false;
         delegate.mNumAttributeResponse = 0;
@@ -1604,7 +1604,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 2 different path, and 1 same path
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1620,7 +1620,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 3 different path, and one path is overlapped with another
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1636,7 +1636,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 3 different path, all are not overlapped, one path is not interested for current subscription
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1652,8 +1652,8 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test empty report
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldSync, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
         NL_TEST_ASSERT(apSuite, engine->GetReportingEngine().IsRunScheduled());
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
@@ -1740,12 +1740,12 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         GenerateEvents(apSuite, apContext);
 
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsDirty());
         delegate.mGotEventResponse = false;
         delegate.mGotReport        = false;
 
-        NL_TEST_ASSERT(apSuite, nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
         nonUrgentDelegate.mGotEventResponse = false;
         nonUrgentDelegate.mGotReport        = false;
@@ -1781,13 +1781,13 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // Since we just sent a report for our urgent subscription, we should have our min interval timer
         // running again.
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsDirty());
         delegate.mGotEventResponse = false;
 
         // For our non-urgent subscription, we did not send anything, so we
         // should not have a min interval timer running there.
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
 
         // Wait for the min interval timer to fire.
@@ -1807,15 +1807,15 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // min-interval timer should have fired, and our handler should still
         // not be dirty or even reportable.
-        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsReportableNow());
 
         // And the non-urgent one should not have changed state either, since
         // it's waiting for the max-interval.
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldReport));
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportableNow());
 
         // There should be no reporting run scheduled.  This is very important;
         // otherwise we can get a false-positive pass below because the run was
@@ -1827,11 +1827,11 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // Urgent read handler should now be dirty, and reportable.
         NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsReportableNow());
 
         // Non-urgent read handler should not be reportable.
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportableNow());
 
         // Still no reporting should have happened.
         NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
@@ -1914,7 +1914,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
         // Set a concrete path dirty
         {
-            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -1935,7 +1935,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
         // Set a endpoint dirty
         {
-            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
             delegate.mNumArrayItems        = 0;
@@ -2027,7 +2027,7 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
 
         // Set a partial overlapped path dirty
         {
-            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -2104,7 +2104,7 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
 
         // Set a full overlapped path dirty and expect to receive one E2C3A1
         {
-            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -2225,8 +2225,8 @@ void TestReadInteraction::TestSubscribeInvalidAttributePathRoundtrip(nlTestSuite
         NL_TEST_ASSERT(apSuite, engine->ActiveHandlerAt(0) != nullptr);
         delegate.mpReadHandler = engine->ActiveHandlerAt(0);
 
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldSync, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
         NL_TEST_ASSERT(apSuite, engine->GetReportingEngine().IsRunScheduled());
 
         ctx.DrainAndServiceIO();
@@ -2401,7 +2401,7 @@ void TestReadInteraction::TestPostSubscribeRoundtripStatusReportTimeout(nlTestSu
         dirtyPath2.mAttributeId = 2;
 
         // Test report with 2 different path
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
 
@@ -2415,8 +2415,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripStatusReportTimeout(nlTestSu
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldSync, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         ctx.ExpireSessionBobToAlice();
@@ -2763,8 +2763,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkStatusReportTimeout(nlT
         dirtyPath1.mEndpointId  = Test::kMockEndpoint3;
         dirtyPath1.mAttributeId = Test::MockAttributeId(4);
 
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldSync, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
         err = engine->GetReportingEngine().SetDirty(dirtyPath1);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         delegate.mGotReport            = false;
@@ -2865,8 +2865,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReportTimeout(nlTestSui
         dirtyPath1.mEndpointId  = Test::kMockEndpoint3;
         dirtyPath1.mAttributeId = Test::MockAttributeId(4);
 
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
-        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldSync, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
         err = engine->GetReportingEngine().SetDirty(dirtyPath1);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         delegate.mGotReport            = false;
@@ -4246,7 +4246,7 @@ void TestReadInteraction::TestSubscriptionReportWithDefunctSession(nlTestSuite *
         NL_TEST_ASSERT(apSuite, SessionHandle(*readHandler->GetSession()) == ctx.GetSessionAliceToBob());
 
         // Test that we send reports as needed.
-        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        readHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         engine->GetReportingEngine().SetDirty(subscribePath);
@@ -4262,7 +4262,7 @@ void TestReadInteraction::TestSubscriptionReportWithDefunctSession(nlTestSuite *
         // Test that if the session is defunct we don't send reports and clean
         // up properly.
         readHandler->GetSession()->MarkAsDefunct();
-        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::HoldReport, false);
+        readHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         engine->GetReportingEngine().SetDirty(subscribePath);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1587,7 +1587,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         dirtyPath5.mAttributeId = 4;
 
         // Test report with 2 different path
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mGotEventResponse     = false;
         delegate.mNumAttributeResponse = 0;
@@ -1604,7 +1604,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 2 different path, and 1 same path
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1620,7 +1620,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 3 different path, and one path is overlapped with another
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1636,7 +1636,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test report with 3 different path, all are not overlapped, one path is not interested for current subscription
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         err                            = engine->GetReportingEngine().SetDirty(dirtyPath1);
@@ -1652,8 +1652,8 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
         // Test empty report
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMaxInterval, false);
         NL_TEST_ASSERT(apSuite, engine->GetReportingEngine().IsRunScheduled());
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
@@ -1740,12 +1740,13 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         GenerateEvents(apSuite, apContext);
 
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsDirty());
         delegate.mGotEventResponse = false;
         delegate.mGotReport        = false;
 
-        NL_TEST_ASSERT(apSuite, nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite,
+                       nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
         nonUrgentDelegate.mGotEventResponse = false;
         nonUrgentDelegate.mGotReport        = false;
@@ -1781,13 +1782,14 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // Since we just sent a report for our urgent subscription, we should have our min interval timer
         // running again.
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsDirty());
         delegate.mGotEventResponse = false;
 
         // For our non-urgent subscription, we did not send anything, so we
         // should not have a min interval timer running there.
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite,
+                       !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
 
         // Wait for the min interval timer to fire.
@@ -1807,13 +1809,14 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // min-interval timer should have fired, and our handler should still
         // not be dirty or even reportable.
-        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsDirty());
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsReportableNow());
 
         // And the non-urgent one should not have changed state either, since
         // it's waiting for the max-interval.
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::HoldMinInterval));
+        NL_TEST_ASSERT(apSuite,
+                       !nonUrgentDelegate.mpReadHandler->mFlags.Has(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval));
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportableNow());
 
@@ -1914,7 +1917,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
         // Set a concrete path dirty
         {
-            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -1935,7 +1938,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
         // Set a endpoint dirty
         {
-            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
             delegate.mNumArrayItems        = 0;
@@ -2027,7 +2030,7 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
 
         // Set a partial overlapped path dirty
         {
-            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -2104,7 +2107,7 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
 
         // Set a full overlapped path dirty and expect to receive one E2C3A1
         {
-            delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+            delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
             delegate.mGotReport            = false;
             delegate.mNumAttributeResponse = 0;
 
@@ -2225,8 +2228,8 @@ void TestReadInteraction::TestSubscribeInvalidAttributePathRoundtrip(nlTestSuite
         NL_TEST_ASSERT(apSuite, engine->ActiveHandlerAt(0) != nullptr);
         delegate.mpReadHandler = engine->ActiveHandlerAt(0);
 
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMaxInterval, false);
         NL_TEST_ASSERT(apSuite, engine->GetReportingEngine().IsRunScheduled());
 
         ctx.DrainAndServiceIO();
@@ -2401,7 +2404,7 @@ void TestReadInteraction::TestPostSubscribeRoundtripStatusReportTimeout(nlTestSu
         dirtyPath2.mAttributeId = 2;
 
         // Test report with 2 different path
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
 
@@ -2415,8 +2418,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripStatusReportTimeout(nlTestSu
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMaxInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         ctx.ExpireSessionBobToAlice();
@@ -2763,8 +2766,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkStatusReportTimeout(nlT
         dirtyPath1.mEndpointId  = Test::kMockEndpoint3;
         dirtyPath1.mAttributeId = Test::MockAttributeId(4);
 
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMaxInterval, false);
         err = engine->GetReportingEngine().SetDirty(dirtyPath1);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         delegate.mGotReport            = false;
@@ -2865,8 +2868,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReportTimeout(nlTestSui
         dirtyPath1.mEndpointId  = Test::kMockEndpoint3;
         dirtyPath1.mAttributeId = Test::MockAttributeId(4);
 
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
-        delegate.mpReadHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMaxInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
+        delegate.mpReadHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMaxInterval, false);
         err = engine->GetReportingEngine().SetDirty(dirtyPath1);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         delegate.mGotReport            = false;
@@ -4246,7 +4249,7 @@ void TestReadInteraction::TestSubscriptionReportWithDefunctSession(nlTestSuite *
         NL_TEST_ASSERT(apSuite, SessionHandle(*readHandler->GetSession()) == ctx.GetSessionAliceToBob());
 
         // Test that we send reports as needed.
-        readHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         engine->GetReportingEngine().SetDirty(subscribePath);
@@ -4262,7 +4265,7 @@ void TestReadInteraction::TestSubscriptionReportWithDefunctSession(nlTestSuite *
         // Test that if the session is defunct we don't send reports and clean
         // up properly.
         readHandler->GetSession()->MarkAsDefunct();
-        readHandler->SetStateFlagAndScheduleReport(ReadHandler::ReadHandlerFlags::HoldMinInterval, false);
+        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::WaitingUntilMinInterval, false);
         delegate.mGotReport            = false;
         delegate.mNumAttributeResponse = 0;
         engine->GetReportingEngine().SetDirty(subscribePath);


### PR DESCRIPTION
This PR renames and comments various methods and members of the ReadHandler to make its report scheduling mechanism more explicit.

