### PR TITLE
examples/lock-app/esp32: synchronize buttons to matter

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -422,6 +422,11 @@ void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
 
         sLockLED.Set(false);
     }
+    if (sAppTask.mSyncClusterToButtonAction)
+    {
+        chip::DeviceLayer::SystemLayer().ScheduleWork(UpdateClusterState, nullptr);
+        sAppTask.mSyncClusterToButtonAction = false;
+    }
 }
 
 void AppTask::PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction)


### PR DESCRIPTION
Appears to have been badly copy/pasted from other examples perhaps. Without this update call, pushing the button locally will update the LEDs and print the messages, but will not update the matter cluster state.


