### PR TITLE
Fix prettier-yaml restyler error.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -190,6 +190,9 @@ restylers:
     - name: prettier-yaml
       image: restyled/restyler-prettier:v1.19.1-2
       enabled: true
+      command:
+          - prettier
+          - "--write"
       include:
           - "**/*.yml"
           - "**/*.yaml"


### PR DESCRIPTION
See
https://github.com/restyled-io/restyler/issues/208#issuecomment-1593198441 item 3: we are pinning a specific version of the prettier image, which means we have to use a command syntax that works with that version.
