### PR TITLE
[ESP32] Fix Ethernet Commissioning on esp-idf v5.0.2

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/ota-image.cmake)
 
-set(CHIP_REQUIRE_COMPONENTS freertos lwip bt mbedtls fatfs app_update console openthread nvs_flash spi_flash)
+set(CHIP_REQUIRE_COMPONENTS esp_eth freertos lwip bt mbedtls fatfs app_update console openthread nvs_flash spi_flash)
 
 if(NOT "${IDF_TARGET}" STREQUAL "esp32h2")
     list(APPEND CHIP_REQUIRE_COMPONENTS mdns)

--- a/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
@@ -30,6 +30,7 @@
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 #include <platform/internal/BLEManager.h>
 
+#include "esp_eth_com.h"
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_wifi.h"

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -14,6 +14,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "esp_eth.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 
 using namespace ::chip;
@@ -31,14 +34,15 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp_netif_t * eth_netif = esp_netif_new(&cfg);
 
     // Init MAC and PHY configs to default
-    eth_mac_config_t mac_config  = ETH_MAC_DEFAULT_CONFIG();
-    eth_phy_config_t phy_config  = ETH_PHY_DEFAULT_CONFIG();
-    phy_config.phy_addr          = CONFIG_ETH_PHY_ADDR;
-    phy_config.reset_gpio_num    = CONFIG_ETH_PHY_RST_GPIO;
-    mac_config.smi_mdc_gpio_num  = CONFIG_ETH_MDC_GPIO;
-    mac_config.smi_mdio_gpio_num = CONFIG_ETH_MDIO_GPIO;
-    esp_eth_mac_t * mac          = esp_eth_mac_new_esp32(&mac_config);
-    esp_eth_phy_t * phy          = esp_eth_phy_new_ip101(&phy_config);
+    eth_mac_config_t mac_config               = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config               = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.phy_addr                       = CONFIG_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num                 = CONFIG_ETH_PHY_RST_GPIO;
+    eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+    esp32_emac_config.smi_mdc_gpio_num        = CONFIG_ETH_MDC_GPIO;
+    esp32_emac_config.smi_mdio_gpio_num       = CONFIG_ETH_MDIO_GPIO;
+    esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+    esp_eth_phy_t * phy                       = esp_eth_phy_new_ip101(&phy_config);
 
     esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);
     esp_eth_handle_t eth_handle = NULL;


### PR DESCRIPTION
###PROBLEM
- Currently, the ethernet commissioning is failing on idf v5.0.2
- This is due to the reason that during migrating to v5.0 from v4, the components which were public before are changed to private 
- So the esp_eth component and Its required header files are added to the code 

###TESTING
- Tested Ethernet commissioning and control