### PR TITLE
Cancel incomplete BLE connection when CloseAllBleConnections() is called

### DIFF
--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -308,6 +308,13 @@ void BleLayer::Shutdown()
 
 void BleLayer::CloseAllBleConnections()
 {
+    // Cancel any ongoing attempt to establish new BLE connection
+    CHIP_ERROR err = CancelBleIncompleteConnection();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Ble, "CancelBleIncompleteConnection() failed, err = %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
     // Close and free all BLE end points.
     for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
     {


### PR DESCRIPTION
When CloseAllBleConnections() is called, any ongoing attempt to establish new BLE connection should be cancelled because it is no longer needed for a new BLE connection to establish. CancelConnection() of the connection delegate should be called to cancel any ongoing new BLE connection so that platform- specific BLEManager can do cleanup. This is needed because we are encountering a problem that BLEManager not doing clean up when establishing PASE session times out, causing problem in the BT layer. Since BLEManager is platform-specific, it doesn't have knowledge of when PASE times out. But BLEManager needs to do clean up whenever CloseAllBleConnections() is called.

