### PR TITLE
[QPG] Added device timestamps in qpg logging

### DIFF
--- a/src/platform/qpg/Logging.cpp
+++ b/src/platform/qpg/Logging.cpp
@@ -8,6 +8,7 @@
 #include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 #include <platform/CHIPDeviceConfig.h>
+#include <system/SystemClock.h>
 
 #include <cstdio>
 #include <ctype.h>
@@ -45,37 +46,56 @@ namespace Logging {
 namespace Platform {
 
 /**
+ * @brief Add a timestamp in hh:mm:ss.ms format and the given prefix string to the given char buffer
+ * The time stamp is derived from the boot time
+ *
+ * @param logBuffer: pointer to the buffer where to add the information
+ *        prefix: A prefix to add to the trace e.g. The category
+ *        maxSize: Space availaible in the given buffer.
+ */
+static size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, size_t maxSize)
+{
+    // Derive the hours, minutes, seconds and milliseconds since boot time millisecond counter
+    uint64_t bootTime     = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+    uint16_t milliseconds = bootTime % 1000;
+    uint32_t totalSeconds = bootTime / 1000;
+    uint8_t seconds       = totalSeconds % 60;
+    totalSeconds /= 60;
+    uint8_t minutes = totalSeconds % 60;
+    uint32_t hours  = totalSeconds / 60;
+
+    return snprintf(logBuffer, maxSize, "[%02lu:%02u:%02u.%03u]%s", hours, minutes, seconds, milliseconds, prefix);
+}
+
+/**
  * CHIP log output function.
  */
 
 void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    size_t prefixLen;
-
-    prefixLen = 0;
+    size_t formattedMsgLen;
 
     // No build-time switches in Qorvo logging module.
     // Add small prefix to show logging category for now.
-    formattedMsg[prefixLen++] = '[';
     switch (category)
     {
     case kLogCategory_Error:
-        formattedMsg[prefixLen++] = 'E';
+        formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, "[E]", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         break;
     case kLogCategory_Detail:
-        formattedMsg[prefixLen++] = 'D';
+        formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, "[D]", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         break;
     case kLogCategory_Progress:
     default:
-        formattedMsg[prefixLen++] = 'P';
+        formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, "[P]", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
         break;
     }
-    snprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, "][%s] ", module);
+    snprintf(formattedMsg + formattedMsgLen, sizeof(formattedMsg) - formattedMsgLen, "[%s] ", module);
     formattedMsg[sizeof(formattedMsg) - 2] = 0; // -2 to allow at least one char for the vsnprintf
-    prefixLen                              = strlen(formattedMsg);
+    formattedMsgLen                        = strlen(formattedMsg);
 
-    vsnprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, msg, v);
+    vsnprintf(formattedMsg + formattedMsgLen, sizeof(formattedMsg) - formattedMsgLen, msg, v);
 
     qvCHIP_Printf(kPrintfModuleLogging, formattedMsg);
 


### PR DESCRIPTION
**Problem**
- Timestamps are not enabled in qpg logging layer.

**Change overview**
- Added timestamp as part of the logging string.

**Testing**
- Manual verification using serial terminal to capture the logs.
