### PR TITLE
[matter_yamltests] Allow response field to be configured from the con…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/errors.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/errors.py
@@ -176,3 +176,14 @@ class TestStepWaitResponseError(TestStepError):
 
         self.tag_key_with_error(content, 'wait')
         self.tag_key_with_error(content, 'response')
+
+
+class TestStepResponseVariableError(TestStepError):
+    """Raise when a test step response use a variable but this variable does not exist in the config section.
+    """
+
+    def __init__(self, content):
+        message = 'The variable does not exist in the config section.'
+        super().__init__(message)
+
+        self.tag_key_with_error(content, 'response')

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -16,8 +16,8 @@
 from typing import Tuple, Union
 
 from .errors import (TestStepError, TestStepGroupResponseError, TestStepInvalidTypeError, TestStepKeyError,
-                     TestStepNodeIdAndGroupIdError, TestStepValueAndValuesError, TestStepVerificationStandaloneError,
-                     TestStepWaitResponseError)
+                     TestStepNodeIdAndGroupIdError, TestStepResponseVariableError, TestStepValueAndValuesError,
+                     TestStepVerificationStandaloneError, TestStepWaitResponseError)
 from .fixes import add_yaml_support_for_scientific_notation_without_dot
 
 try:
@@ -78,12 +78,13 @@ class YamlLoader:
         tests = content.get('tests', [])
         for step_index, step in enumerate(tests):
             try:
-                self.__check_test_step(step)
+                config = content.get('config', {})
+                self.__check_test_step(config, step)
             except TestStepError as e:
                 e.update_context(step, step_index)
                 raise
 
-    def __check_test_step(self, content):
+    def __check_test_step(self, config: dict, content):
         schema = {
             'label': str,
             'identity': str,
@@ -101,7 +102,7 @@ class YamlLoader:
             'verification': str,
             'PICS': str,
             'arguments': dict,
-            'response': (dict, list),
+            'response': (dict, list, str),  # Can be a variable
             'minInterval': int,
             'maxInterval': int,
             'timedInteractionTimeoutMs': int,
@@ -115,6 +116,7 @@ class YamlLoader:
         self.__rule_step_with_verification_should_be_disabled_or_interactive(
             content)
         self.__rule_wait_should_not_expect_a_response(content)
+        self.__rule_response_variable_should_exist_in_config(config, content)
 
         if 'arguments' in content:
             arguments = content.get('arguments')
@@ -122,6 +124,13 @@ class YamlLoader:
 
         if 'response' in content:
             response = content.get('response')
+
+            # If the response is a variable, update the response value with the content of the variable such
+            # such that the error message looks nice if needed.
+            if isinstance(response, str):
+                response = config.get(response)
+                content['response'] = response
+
             if isinstance(response, list):
                 [self.__check_test_step_response(x) for x in response]
             else:
@@ -239,3 +248,9 @@ class YamlLoader:
     def __rule_wait_should_not_expect_a_response(self, content):
         if 'wait' in content and 'response' in content:
             raise TestStepWaitResponseError(content)
+
+    def __rule_response_variable_should_exist_in_config(self, config, content):
+        if 'response' in content:
+            response = content.get('response')
+            if isinstance(response, str) and response not in config:
+                raise TestStepResponseVariableError(content)

--- a/scripts/py_matter_yamltests/test_yaml_loader.py
+++ b/scripts/py_matter_yamltests/test_yaml_loader.py
@@ -301,7 +301,7 @@ class TestYamlLoader(unittest.TestCase):
         _, _, _, _, tests = load(content.format(value=value))
         self.assertEqual(tests, [{'response': [{'value': True}]}])
 
-        wrong_values = self._get_wrong_values([dict, list], spaces=6)
+        wrong_values = self._get_wrong_values([dict, list, str], spaces=6)
         for value in wrong_values:
             x = content.format(value=value)
             self.assertRaises(TestStepInvalidTypeError, load, x)


### PR DESCRIPTION
…fig section

#### Problem

In order to automate the IDM tests, it will be necessary to be able to configure the responses from the config section. This PR introduce such ability.

