### PR TITLE
[matter_yamltests] Add saveDataVersionAs supports

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -105,6 +105,7 @@ class YamlLoader:
             'minInterval': int,
             'maxInterval': int,
             'timedInteractionTimeoutMs': int,
+            'dataVersion': (list, int, str),  # Can be a variable
             'busyWaitMs': int,
             'wait': str,
         }
@@ -166,7 +167,8 @@ class YamlLoader:
             'error': str,
             'clusterError': int,
             'constraints': dict,
-            'saveAs': str
+            'saveAs': str,
+            'saveDataVersionAs': str,
         }
 
         if allow_name_key:


### PR DESCRIPTION
#### Problem

This PR make it possible to save the data version from a request and use the saved value into an other test.

