### PR TITLE
[Typos] Update the max specifier of some attributes of the door lock cluster …

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -69,8 +69,8 @@ limitations under the License.
             cluster itself. Those attributes/commands are marked with a special comment. -->
 
         <!-- Attributes -->
-        <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="2" isNullable="true" reportable="true" writable="false">LockState</attribute>
-        <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="10" writable="false">LockType</attribute>
+        <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="3" isNullable="true" reportable="true" writable="false">LockState</attribute>
+        <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="11" writable="false">LockType</attribute>
         <attribute side="server" code="2" define="ACTUATOR_ENABLED" type="boolean" writable="false">ActuatorEnabled</attribute>
         <!-- Conformance feature DPS - for now optional -->
         <attribute side="server" code="3" define="DOOR_STATE" type="DoorStateEnum" min="0" max="5" isNullable="true" reportable="true" optional="true">DoorState</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -26,7 +26,7 @@ limitations under the License.
     <description>This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.</description>
 
     <globalAttribute side="server" code="0xFFFC" value="0" />
-    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE"                     type="PlaybackStateEnum" min="0x00" max="0x02" default="0x00" writable="false"                    optional="false">CurrentState</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE"                     type="PlaybackStateEnum" min="0x00" max="0x03" default="0x00" writable="false"                    optional="false">CurrentState</attribute>
     <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME"                type="EPOCH_US"          min="0x00"            default="0x00" writable="false" isNullable="true"  optional="true">StartTime</attribute>
     <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION"                  type="INT64U"            min="0x00"            default="0"    writable="false" isNullable="true"  optional="true">Duration</attribute>
     <attribute side="server" code="0x0003" define="MEDIA_PLAYBACK_PLAYBACK_POSITION"         type="PlaybackPositionStruct"                                 writable="false" isNullable="true"  optional="true">SampledPosition</attribute>


### PR DESCRIPTION
…and media playback cluster to match the possible values for their enum types

#### Problem

Reading some cluster specifications I found out that some `max` specifier were inaccurate. That is not something that is really used in your code generation since it affects only "read-only" attributes but that is distracting.

