### PR TITLE
[ESP32] Add API to create user defined size of endpoint array

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -40,6 +40,7 @@
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <examples/platform/esp32/mode-support/static-supported-modes-manager.h>
 #include <platform/ESP32/ESP32Utils.h>
 
 #if CONFIG_HAVE_DISPLAY
@@ -112,6 +113,9 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 static void InitServer(intptr_t context)
 {
     Esp32AppServer::Init(&sCallbacks); // Init ZCL Data Model and CHIP App Server AND Initialize device attestation config
+
+    app::Clusters::ModeSelect::StaticSupportedModesManager instance;
+    instance.InitEndpointArray(FIXED_ENDPOINT_COUNT);
 
 #if !(CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_THREAD)
     // We only have network commissioning on endpoint 0.

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -114,9 +114,6 @@ static void InitServer(intptr_t context)
 {
     Esp32AppServer::Init(&sCallbacks); // Init ZCL Data Model and CHIP App Server AND Initialize device attestation config
 
-    app::Clusters::ModeSelect::StaticSupportedModesManager instance;
-    instance.InitEndpointArray(FIXED_ENDPOINT_COUNT);
-
 #if !(CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_THREAD)
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
@@ -131,6 +128,12 @@ static void InitServer(intptr_t context)
 #if CONFIG_DEVICE_TYPE_M5STACK
     SetupPretendDevices();
 #endif
+    err = app::Clusters::ModeSelect::StaticSupportedModesManager::getStaticSupportedModesManagerInstance().InitEndpointArray(
+        FIXED_ENDPOINT_COUNT);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to initialize endpoint array for supported-modes, err:%" CHIP_ERROR_FORMAT, err.Format());
+    }
 }
 
 extern "C" void app_main()

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -35,14 +35,27 @@ SupportedModesManager::ModeOptionsProvider * StaticSupportedModesManager::epMode
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
-void StaticSupportedModesManager::InitEndpointArray(int size)
+int StaticSupportedModesManager::mSize = 0;
+
+CHIP_ERROR StaticSupportedModesManager::InitEndpointArray(int size)
 {
+    if (epModeOptionsProviderList != nullptr)
+    {
+        ChipLogError(Zcl, "Cannot allocate epModeOptionsProviderList");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
     mSize                     = size;
     epModeOptionsProviderList = new SupportedModesManager::ModeOptionsProvider[mSize];
+    if (epModeOptionsProviderList == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to allocate memory to epModeOptionsProviderList");
+        return CHIP_ERROR_NO_MEMORY;
+    }
     for (int i = 0; i < mSize; i++)
     {
         epModeOptionsProviderList[i] = ModeOptionsProvider();
     }
+    return CHIP_NO_ERROR;
 }
 
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
@@ -183,7 +196,7 @@ Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointI
 
 const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
 {
-    return &StaticSupportedModesManager::instance;
+    return &StaticSupportedModesManager::getStaticSupportedModesManagerInstance();
 }
 
 void StaticSupportedModesManager::FreeSupportedModes(EndpointId endpointId) const

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -31,13 +31,13 @@ using SemanticTag          = Structs::SemanticTagStruct::Type;
 template <typename T>
 using List = app::DataModel::List<T>;
 
-SupportedModesManager::ModeOptionsProvider *StaticSupportedModesManager::epModeOptionsProviderList = nullptr;
+SupportedModesManager::ModeOptionsProvider * StaticSupportedModesManager::epModeOptionsProviderList = nullptr;
 
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
 void StaticSupportedModesManager::InitEndpointArray(int size)
 {
-    mSize = size;
+    mSize                     = size;
     epModeOptionsProviderList = new SupportedModesManager::ModeOptionsProvider[mSize];
     for (int i = 0; i < mSize; i++)
     {

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -31,13 +31,15 @@ using SemanticTag          = Structs::SemanticTagStruct::Type;
 template <typename T>
 using List = app::DataModel::List<T>;
 
+SupportedModesManager::ModeOptionsProvider *StaticSupportedModesManager::epModeOptionsProviderList = nullptr;
+
 const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
 
-SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::epModeOptionsProviderList[FIXED_ENDPOINT_COUNT];
-
-void StaticSupportedModesManager::InitEndpointArray()
+void StaticSupportedModesManager::InitEndpointArray(int size)
 {
-    for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
+    mSize = size;
+    epModeOptionsProviderList = new SupportedModesManager::ModeOptionsProvider[mSize];
+    for (int i = 0; i < mSize; i++)
     {
         epModeOptionsProviderList[i] = ModeOptionsProvider();
     }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -41,7 +41,7 @@ private:
 
 public:
     // InitEndpointArray should be called only once in the application. Memory allocated to the
-    // epModeOptionsProviderList will be needed till the lifetime of the program.
+    // epModeOptionsProviderList will be needed for the lifetime of the program, so it's never deallocated.
     static CHIP_ERROR InitEndpointArray(int size);
 
     // DeInitEndpointArray should be called only when application need to reallocate memory of

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -33,7 +33,7 @@ private:
     using SemanticTag          = Structs::SemanticTagStruct::Type;
     int mSize;
 
-    static ModeOptionsProvider *epModeOptionsProviderList;
+    static ModeOptionsProvider * epModeOptionsProviderList;
 
     void FreeSupportedModes(EndpointId endpointId) const;
 

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -31,16 +31,27 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
 private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using SemanticTag          = Structs::SemanticTagStruct::Type;
-    int mSize;
+    static int mSize;
 
     static ModeOptionsProvider * epModeOptionsProviderList;
 
     void FreeSupportedModes(EndpointId endpointId) const;
 
-public:
-    void InitEndpointArray(int size);
-
     static const StaticSupportedModesManager instance;
+
+public:
+    // InitEndpointArray should be called only once in the application. Memory allocated to the
+    // epModeOptionsProviderList will be needed till the lifetime of the program.
+    static CHIP_ERROR InitEndpointArray(int size);
+
+    // DeInitEndpointArray should be called only when application need to reallocate memory of
+    // epModeOptionsProviderList ( Eg. Bridges ).
+    static void DeInitEndpointArray()
+    {
+        delete[] epModeOptionsProviderList;
+        epModeOptionsProviderList = nullptr;
+        mSize                     = 0;
+    }
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -31,14 +31,15 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
 private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using SemanticTag          = Structs::SemanticTagStruct::Type;
+    int mSize;
 
-    static ModeOptionsProvider epModeOptionsProviderList[FIXED_ENDPOINT_COUNT];
-
-    void InitEndpointArray();
+    static ModeOptionsProvider *epModeOptionsProviderList;
 
     void FreeSupportedModes(EndpointId endpointId) const;
 
 public:
+    void InitEndpointArray(int size);
+
     static const StaticSupportedModesManager instance;
 
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
@@ -48,11 +49,11 @@ public:
 
     void CleanUp(EndpointId endpointId) const;
 
-    StaticSupportedModesManager() { InitEndpointArray(); }
+    StaticSupportedModesManager() {}
 
     ~StaticSupportedModesManager()
     {
-        for (int i = 0; i < FIXED_ENDPOINT_COUNT; i++)
+        for (int i = 0; i < mSize; i++)
         {
             FreeSupportedModes(i);
         }


### PR DESCRIPTION
- Problem 

> endpoint array size was fixed.

- Changes

> Add API to create user defined size of endpoint array.
> Moved static DRAM data to Heap

- Testing 

>  Tested commissioning and cluster control on esp32.