### PR TITLE
Testing buildjet vs github actions cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -187,7 +187,7 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -349,7 +349,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -408,7 +408,7 @@ jobs:
                   mkdir -p ~/Library/Logs/DiagnosticReports || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -508,7 +508,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -50,7 +50,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -86,7 +86,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -122,7 +122,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform nrfconnect
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -66,7 +66,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               if: ${{ !env.ACT }}
               with:
@@ -88,7 +88,7 @@ jobs:
               id: cirque-bootstrap-cache-key
               run: echo "val=$(scripts/tests/cirque_tests.sh cachekeyhash)" >> $GITHUB_OUTPUT
             - name: Cirque Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               if: ${{ !env.ACT }}
               with:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -69,7 +69,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -52,7 +52,7 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -53,7 +53,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ameba
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -51,7 +51,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform asr
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -60,7 +60,7 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         timeout-minutes: 10
         with:
           key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -63,7 +63,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -61,7 +61,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -66,7 +66,7 @@ jobs:
         run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
       - name: Bootstrap cache
-        uses: actions/cache@v3
+        uses: buildjet/cache@v3
         timeout-minutes: 10
         with:
           key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -179,7 +179,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -62,7 +62,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -52,7 +52,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -76,7 +76,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -62,7 +62,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -75,7 +75,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -65,7 +65,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -62,7 +62,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -61,7 +61,7 @@ jobs:
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -55,7 +55,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -66,7 +66,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -57,7 +57,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -117,7 +117,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -60,7 +60,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -248,4 +248,3 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -222,4 +222,3 @@ jobs:
               if: always()
               run: |
                   git grep -n 'SuccessOrExit([^=)]*(' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
-

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -58,7 +58,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -122,7 +122,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform tizen
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -49,7 +49,7 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -104,7 +104,7 @@ jobs:
                   ref: "${{ github.event.inputs.releaseTag }}"
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -57,7 +57,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform android
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/smoketest-darwin.yaml
+++ b/.github/workflows/smoketest-darwin.yaml
@@ -52,7 +52,7 @@ jobs:
               run: brew install python@3.9
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -353,7 +353,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -476,7 +476,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
@@ -569,7 +569,7 @@ jobs:
                   mkdir objdir-clone || true
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -53,7 +53,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -54,7 +54,7 @@ jobs:
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
             - name: Bootstrap cache
-              uses: actions/cache@v3
+              uses: buildjet/cache@v3
               timeout-minutes: 10
               with:
                   key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}


### PR DESCRIPTION
Looking around this, we're still getting hit hard with actions/cache@3, surveying around I see people have had success with this: https://buildjet.com/for-github-actions/blog/launch-buildjet-cache