### PR TITLE
[K32W0] Update Docker image to accommodate SDK 2.6.11

### DIFF
--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -12,9 +12,9 @@ RUN set -x \
 WORKDIR /opt/sdk
 # Setup the K32W SDK
 RUN set -x \
-    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_10_K32W061DK6.zip \
-    && unzip SDK_2_6_10_K32W061DK6.zip \
-    && rm -rf SDK_2_6_10_K32W061DK6.zip \
+    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_11_K32W061DK6.zip \
+    && unzip SDK_2_6_11_K32W061DK6.zip \
+    && rm -rf SDK_2_6_11_K32W061DK6.zip \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.2 Version bump reason: [Telink] Update Telink Docker image (Zephyr update)
+0.7.3 Version bump reason: [K32W0] SDK 2.6.11 update


### PR DESCRIPTION
K32W0 docker image now points to latest SDK release: 2.6.11.