### PR TITLE
Followup for #27314 to change the type int of the return value of Get…

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/types.py
+++ b/scripts/py_matter_idl/matter_idl/generators/types.py
@@ -427,7 +427,7 @@ def IsSignedDataType(data_type: DataType) -> bool:
     return sized_type.is_signed
 
 
-def GetDataTypeSizeInBits(data_type: DataType) -> int:
+def GetDataTypeSizeInBits(data_type: DataType) -> Optional[int]:
     """
     Returns the size in bits for a given data type or None if the data type can not be found.
     """


### PR DESCRIPTION
…DataTypeSizeInBits from int to Optional[int]

#### Problem

This PR changes the type annotation of. `GetDataSizeInBits` from `int` to `Optional[int]` as noticed in https://github.com/project-chip/connectedhomeip/commit/84e38eec2dbaf42f47f1c1ec47177445fd0b517e#r118966671
