### PR TITLE
[ESP32] Set the country code in esp_phy layer

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -31,6 +31,7 @@
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
+#include "esp_phy_init.h"
 #include "esp_ota_ops.h"
 #include "esp_wifi.h"
 #include "nvs.h"
@@ -234,6 +235,17 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     location       = static_cast<uint8_t>(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationTypeEnum::kIndoor);
     return CHIP_NO_ERROR;
 #endif
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreCountryCode(const char * code, size_t codeLen)
+{
+    // As per spec, codeLen has to be 2
+    VerifyOrReturnError((code != nullptr) && (codeLen == 2), CHIP_ERROR_INVALID_ARGUMENT);
+    // Write CountryCode to esp_phy layer
+    ReturnErrorOnFailure(MapConfigError(esp_phy_update_country_info(code)));
+    // As we do not have API to read country code from esp_phy layer, we are writing to NVS and when client reads the
+    // CountryCode then we read from NVS
+    return GenericConfigurationManagerImpl<ESP32Config>::StoreCountryCode(code, codeLen);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -31,8 +31,8 @@
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
-#include "esp_phy_init.h"
 #include "esp_ota_ops.h"
+#include "esp_phy_init.h"
 #include "esp_wifi.h"
 #include "nvs.h"
 #include "nvs_flash.h"

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -58,6 +58,10 @@ public:
     CHIP_ERROR GetLocationCapability(uint8_t & location) override;
     static ConfigurationManagerImpl & GetDefaultInstance();
 
+    // Set the country code to esp_phy layer and also store it to NVS
+    // GenericConfigurationManagerImpl::GetCountryCode() API already reads from the NVS so its not implemented here
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override;
+
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 


### PR DESCRIPTION
#### Problem
We do not set the country code in phy layer, it just lays in NVS

#### Change Overview
Set the country code in phy layer

#### Tests
Set/Get the valid and valid country code