### PR TITLE
Docker version update

### DIFF
--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.17 Version bump reason: Enable ARM64 build
+0.7.18 Version bump reason: vscode ZEPHYR SDK env path update


### PR DESCRIPTION
#27317 updated docker file content without bumping version. This unfortunately means that the 0.7.17 version may be invalid/floating, however only for a single commit.

Bumping version of the dockerfile.