### PR TITLE
Make bootstrap.sh more friendly to other shells.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -80,7 +80,7 @@ exclude:
     - "zzz_generated/**/*" # already clang-formatted by our zap tooling
     - "src/controller/java/generated/java/**/*" # not formatted: generated files
     - "src/controller/java/zap-generated/**/*" # not formatted: generated files
-    - "scripts/bootstrap.sh" # tries to quote loop variable
+    - "scripts/setup/bootstrap.sh" # tries to quote loop variable
 
 
 changed_paths:

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -80,6 +80,7 @@ exclude:
     - "zzz_generated/**/*" # already clang-formatted by our zap tooling
     - "src/controller/java/generated/java/**/*" # not formatted: generated files
     - "src/controller/java/zap-generated/**/*" # not formatted: generated files
+    - "scripts/bootstrap.sh" # tries to quote loop variable
 
 
 changed_paths:

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -36,7 +36,7 @@ _install_additional_pip_requirements() {
         _OLD_IFS=$IFS
         IFS=","
         if [ -n "$ZSH_VERSION" ]; then
-            setopt local_options sh_word_split
+            setopt local_options shwordsplit
         fi
 
         for platform in ${_SETUP_PLATFORM}; do

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -21,7 +21,7 @@ _install_additional_pip_requirements() {
     # figure out additional pip install items
     while [ $# -gt 0 ]; do
         case $1 in
-            -p|--platform)
+            -p | --platform)
                 _SETUP_PLATFORM=$2
                 shift # argument
                 shift # value
@@ -36,10 +36,10 @@ _install_additional_pip_requirements() {
         _OLD_IFS=$IFS
         IFS=","
         if [ -n "$ZSH_VERSION" ]; then
-          setopt sh_word_split
+            setopt sh_word_split
         fi
 
-        for platform in ${_SETUP_PLATFORM}; do
+        for platform in "$_SETUP_PLATFORM"; do
             # Allow none as an alias of nothing extra installed (like -p none)
             if [ "$platform" != "none" ]; then
                 echo "Installing pip requirements for $platform..."

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -39,7 +39,7 @@ _install_additional_pip_requirements() {
             setopt sh_word_split
         fi
 
-        for platform in "$_SETUP_PLATFORM"; do
+        for platform in ${_SETUP_PLATFORM}; do
             # Allow none as an alias of nothing extra installed (like -p none)
             if [ "$platform" != "none" ]; then
                 echo "Installing pip requirements for $platform..."

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -19,9 +19,9 @@ _install_additional_pip_requirements() {
     shift
 
     # figure out additional pip install items
-    while [[ $# -gt 0 ]]; do
+    while [ $# -gt 0 ]; do
         case $1 in
-            -p | --platform)
+            -p|--platform)
                 _SETUP_PLATFORM=$2
                 shift # argument
                 shift # value
@@ -32,13 +32,14 @@ _install_additional_pip_requirements() {
         esac
     done
 
-    if ! [ -z "$_SETUP_PLATFORM" ]; then
+    if [ -n "$_SETUP_PLATFORM" ]; then
+        _OLD_IFS=$IFS
+        IFS=","
         if [ -n "$ZSH_VERSION" ]; then
-            IFS="," read -r -A _PLATFORMS <<<"$_SETUP_PLATFORM"
-        else
-            IFS="," read -r -a _PLATFORMS <<<"$_SETUP_PLATFORM"
+          setopt sh_word_split
         fi
-        for platform in "${_PLATFORMS[@]}"; do
+
+        for platform in ${_SETUP_PLATFORM}; do
             # Allow none as an alias of nothing extra installed (like -p none)
             if [ "$platform" != "none" ]; then
                 echo "Installing pip requirements for $platform..."
@@ -47,6 +48,8 @@ _install_additional_pip_requirements() {
                     -c "$_CHIP_ROOT/scripts/setup/constraints.txt"
             fi
         done
+        IFS=$_OLD_IFS
+        unset _OLD_IFS
         unset _PLATFORMS
     fi
 

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -36,7 +36,7 @@ _install_additional_pip_requirements() {
         _OLD_IFS=$IFS
         IFS=","
         if [ -n "$ZSH_VERSION" ]; then
-            setopt sh_word_split
+            setopt local_options sh_word_split
         fi
 
         for platform in ${_SETUP_PLATFORM}; do


### PR DESCRIPTION
I found some CI systems trying to use dash, and that does not seem to work at all due to it not understanding `<<<` or `[[`.

Dash is still not ok because overall because arguments to `. scripts/activate.sh` do not get passed along, however it would work as a default invocation.

Changes:
  - loop using IFS (and set sh_word_split for ZSH)
  - replaced `[[` tests with `[`
  - removed restyler for this file, because it tries quoting `for platform in ${_SETUP_PLATFORM};` and that breaks the script. I found no way to tell shellharden to not try to fix that. Still checking...
