### PR TITLE
Update Darwin availability annotations for MTRDeviceAttestationDeviceInfo.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -42,14 +42,15 @@ NS_ASSUME_NONNULL_BEGIN
  * for device attestation.  If attestation succeeds, this must match the vendor
  * ID from the certification declaration.
  */
-@property (nonatomic, readonly) NSNumber * basicInformationVendorID MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) NSNumber * basicInformationVendorID API_AVAILABLE(ios(16.6), macos(13.5), watchos(9.6), tvos(16.6));
 
 /**
  * The product ID value from the device's Basic Information cluster that was
  * used for device attestation.  If attestation succeeds, this must match one of
  * the product IDs from the certification declaration.
  */
-@property (nonatomic, readonly) NSNumber * basicInformationProductID MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) NSNumber * basicInformationProductID API_AVAILABLE(ios(16.6), macos(13.5), watchos(9.6), tvos(16.6))
+    ;
 
 @property (nonatomic, readonly) MTRCertificateDERBytes dacCertificate;
 @property (nonatomic, readonly) MTRCertificateDERBytes dacPAICertificate;


### PR DESCRIPTION
These properties are going into a known release.

