### PR TITLE
Update Xcode project setting Text-Based InstallAPI Verification Mode

### DIFF
--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -1753,6 +1753,7 @@
 					CoreBluetooth,
 					"-lnetwork",
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -1767,10 +1768,12 @@
 					"-framework",
 					CoreData,
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
+				TAPI_VERIFY_MODE = ErrorsOnly;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
@@ -1905,6 +1908,7 @@
 					CoreBluetooth,
 					"-lnetwork",
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -1919,11 +1923,13 @@
 					"-framework",
 					CoreData,
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				STRIP_STYLE = "non-global";
+				TAPI_VERIFY_MODE = ErrorsOnly;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;


### PR DESCRIPTION
- Update Xcode settings TAPI_VERIFY_MODE to Errors Only.
- Xcode setting [reference](https://developer.apple.com/documentation/xcode/build-settings-reference#Text-Based-InstallAPI-Verification-Mode)