### PR TITLE
Enable TAPI_VERIFY_MODE=Pedantic.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#import <Matter/MTRDefines.h>
 
 #import "MTRAttributeTLVValueDecoder_Internal.h"
 #import "MTRBaseDevice_Internal.h"
@@ -86,6 +87,7 @@ NSString * const MTREventTimestampDateKey = @"eventTimestampDate";
 
 class MTRDataValueDictionaryCallbackBridge;
 
+MTR_HIDDEN
 @interface MTRReadClientContainer : NSObject
 @property (nonatomic, readwrite) app::ReadClient * readClientPtr;
 @property (nonatomic, readwrite) app::AttributePathParams * pathParams;

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.h
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.h
@@ -16,11 +16,13 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MTRCommissionableBrowserDelegate;
 
+MTR_HIDDEN
 @interface MTRCommissionableBrowser : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowserResult_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowserResult_Internal.h
@@ -16,6 +16,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 
 #import "MTRCommissionableBrowserResult.h"
 
@@ -23,6 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_HIDDEN
 @interface MTRCommissionableBrowserResultInterfaces : NSObject
 
 @property (nonatomic, readwrite) chip::Optional<chip::Dnssd::CommonResolutionData> resolutionData;

--- a/src/darwin/Framework/CHIP/MTRControllerAccessControl.h
+++ b/src/darwin/Framework/CHIP/MTRControllerAccessControl.h
@@ -16,9 +16,11 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_HIDDEN
 @interface MTRControllerAccessControl : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDefines.h
+++ b/src/darwin/Framework/CHIP/MTRDefines.h
@@ -21,6 +21,8 @@
 
 #define MTR_EXPORT __attribute__((visibility("default")))
 
+#define MTR_HIDDEN __attribute__((visibility("hidden")))
+
 #ifdef __cplusplus
 #define MTR_EXTERN extern "C" MTR_EXPORT
 #else

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDefines.h>
 #import <os/lock.h>
 
 #import "MTRAsyncCallbackWorkQueue_Internal.h"
@@ -44,6 +45,7 @@ typedef void (^MTRDeviceAttributeReportHandler)(NSArray * _Nonnull);
 // Consider moving utility classes to their own file
 #pragma mark - Utility Classes
 // This class is for storing weak references in a container
+MTR_HIDDEN
 @interface MTRWeakReference<ObjectType> : NSObject
 + (instancetype)weakReferenceWithObject:(ObjectType)object;
 - (instancetype)initWithObject:(ObjectType)object;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -14,6 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#import <Matter/MTRDefines.h>
+
 #import "MTRDeviceController_Internal.h"
 
 #import "MTRBaseDevice_Internal.h"
@@ -1021,6 +1023,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
  * Shim to allow us to treat an MTRDevicePairingDelegate as an
  * MTRDeviceControllerDelegate.
  */
+MTR_HIDDEN
 @interface MTRDevicePairingDelegateShim : NSObject <MTRDeviceControllerDelegate>
 @property (nonatomic, readonly) id<MTRDevicePairingDelegate> delegate;
 - (instancetype)initWithDelegate:(id<MTRDevicePairingDelegate>)delegate;
@@ -1078,6 +1081,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
  * Shim to allow us to treat an MTRNOCChainIssuer as an
  * MTROperationalCertificateIssuer.
  */
+MTR_HIDDEN
 @interface MTROperationalCertificateChainIssuerShim : NSObject <MTROperationalCertificateIssuer>
 @property (nonatomic, readonly) id<MTRNOCChainIssuer> nocChainIssuer;
 @property (nonatomic, readonly) BOOL shouldSkipAttestationCertificateValidation;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -23,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSXPCConnection * _Nonnull (^MTRXPCConnectBlock)(void);
 
+MTR_HIDDEN
 @interface MTRDeviceControllerOverXPC : MTRDeviceController
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -18,6 +18,7 @@
 
 #import "MTRDeviceControllerStartupParams.h"
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/DataModelTypes.h>
@@ -42,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithParams:(MTRDeviceControllerStartupParams *)params;
 @end
 
+MTR_HIDDEN
 @interface MTRDeviceControllerStartupParamsInternal : MTRDeviceControllerStartupParams
 
 // Fabric table we can use to do things like allocate operational keys.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDefines.h>
+
 #import "MTRDeviceController+XPC.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -27,6 +29,7 @@ typedef void (^MTRXPCReportHandler)(id _Nullable values, NSError * _Nullable err
  * Releasing the handle may cause invalidating the XPC connection. Hence, in order to retain the connection, the handle must not be
  * released.
  */
+MTR_HIDDEN
 @interface MTRDeviceControllerXPCProxyHandle : NSObject
 
 @property (nonatomic, readonly, getter=proxy) id<MTRDeviceControllerServerProtocol> proxy;
@@ -40,6 +43,7 @@ typedef void (^MTRGetProxyHandleHandler)(dispatch_queue_t queue, MTRDeviceContro
  *
  * This class is in charge of making a new XPC connection and disconnecting as needed by the clients and by the report handlers.
  */
+MTR_HIDDEN
 @interface MTRDeviceControllerXPCConnection<MTRDeviceControllerClientProtocol> : NSObject
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDefines.h>
+
 #import "MTRBaseDevice.h"
 #import "MTRCluster.h" // For MTRSubscriptionEstablishedHandler
 #import "MTRDeviceControllerXPCConnection.h"
@@ -23,6 +25,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_HIDDEN
 @interface MTRDeviceOverXPC : MTRBaseDevice
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDefines.h>
+
 #import "MTRError.h"
 #import "MTRError_Internal.h"
 
@@ -32,6 +34,7 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 
 // Class for holding on to a CHIP_ERROR that we can use as the value
 // in a dictionary.
+MTR_HIDDEN
 @interface MTRErrorHolder : NSObject
 @property (nonatomic, readonly) CHIP_ERROR error;
 

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -16,6 +16,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
 #import <Matter/MTRError.h>
 
 #include <app/MessageDef/StatusIB.h>
@@ -23,6 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_HIDDEN
 @interface MTRError : NSObject
 + (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
 + (NSError * _Nullable)errorForIMStatus:(const chip::app::StatusIB &)status;

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -492,9 +492,11 @@ private:
     uint64_t mTransferGeneration = 0;
 };
 
+namespace {
 BdxOTASender gOtaSender;
 
-static NSInteger const kOtaProviderEndpoint = 0;
+NSInteger const kOtaProviderEndpoint = 0;
+} // anonymous namespace
 
 MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate)
     : mDelegate(delegate)

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -1753,6 +1753,7 @@
 					CoreBluetooth,
 					"-lnetwork",
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -1767,11 +1768,14 @@
 					"-framework",
 					CoreData,
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
+				TAPI_VERIFY_MODE = Pedantic;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				VERSION_INFO_EXPORT_DECL = "__attribute__((visibility(\"hidden\")))";
 			};
 			name = Debug;
 		};
@@ -1905,6 +1909,7 @@
 					CoreBluetooth,
 					"-lnetwork",
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -1919,12 +1924,15 @@
 					"-framework",
 					CoreData,
 					"-Wl,-unexported_symbol,\"__Z*\"",
+					"-Wl,-hidden-lCHIP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				STRIP_STYLE = "non-global";
+				TAPI_VERIFY_MODE = Pedantic;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				VERSION_INFO_EXPORT_DECL = "__attribute__((visibility(\"hidden\")))";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This ensures that the symbols we export are all declared in our headers.

Some symbols we were exporting we should stop exporting, hence the MTR_HIDDEN.

For the darwin-framework-tool build we were ending up exporting a bunch of C symbols from libCHIP.a; Joshua Villasenor figured out that we should -Wl,-hidden-lCHIP to avoid that.

The existing -Wl,-unexported_symbol,\"__Z*\" cannot be removed, because we include Matter headers, which declare various symbols.  So we need either this, or changing our default visibility, but that (1) would need MTR_EXPORT on a bunch of stuff and (2) would affect testability.

The VERSION_INFO_EXPORT_DECL is to stop exporting MatterVersionNumber and MatterVersionString symbols.
