### PR TITLE
Treat MutableCharSpan and MutableByteSpan as "basic types".

### DIFF
--- a/src/app/data-model/BasicTypes.h
+++ b/src/app/data-model/BasicTypes.h
@@ -57,7 +57,19 @@ struct IsBasicType<ByteSpan>
 };
 
 template <>
+struct IsBasicType<MutableByteSpan>
+{
+    static constexpr bool value = true;
+};
+
+template <>
 struct IsBasicType<CharSpan>
+{
+    static constexpr bool value = true;
+};
+
+template <>
+struct IsBasicType<MutableCharSpan>
 {
     static constexpr bool value = true;
 };


### PR DESCRIPTION
In particular, they are known to not be fabric-scoped.  This should allow Encode() on these to work directly.


