### PR TITLE
Increase the timer slack TestRead allows to 100ms.

### DIFF
--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4645,14 +4645,14 @@ void TestReadInteraction::TestReadHandler_KeepSubscriptionTest(nlTestSuite * apS
 
 System::Clock::Timeout TestReadInteraction::ComputeSubscriptionTimeout(System::Clock::Seconds16 aMaxInterval)
 {
-    // Add 50ms of slack to our max interval to make sure we hit the
+    // Add 100ms of slack to our max interval to make sure we hit the
     // subscription liveness timer.
     const auto & ourMrpConfig = GetDefaultMRPConfig();
     auto publisherTransmissionTimeout =
         GetRetransmissionTimeout(ourMrpConfig.mActiveRetransTimeout, ourMrpConfig.mIdleRetransTimeout,
                                  System::SystemClock().GetMonotonicTimestamp(), Transport::kMinActiveTime);
 
-    return publisherTransmissionTimeout + aMaxInterval + System::Clock::Milliseconds32(50);
+    return publisherTransmissionTimeout + aMaxInterval + System::Clock::Milliseconds32(100);
 }
 
 // clang-format off


### PR DESCRIPTION
We're polling until a timer fires, but due to other threads losing the timeslice for a while we could decide it's not firing when it's just been blocked on the scheduler.  To reduce the risk of that, give it a bit more time to fire.

Fixes https://github.com/project-chip/connectedhomeip/issues/27438
