### PR TITLE
Do a `rm -rf out` after each mbed build, to save storage

### DIFF
--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -108,6 +108,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE lock-app \
                     examples/lock-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-lock-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build lighting-app example
               if: github.event_name == 'push' || steps.changed_paths.outputs.mbed == 'true'
@@ -118,6 +119,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE lighting-app \
                     examples/lighting-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-lighting-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build pigweed-app example
               if: github.event_name == 'push' || steps.changed_paths.outputs.pigweedapp == 'true'
@@ -128,6 +130,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE pigweed-app \
                     examples/pigweed-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-pigweed-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build all-clusters-app example
               if: github.event_name == 'push' || steps.changed_paths.outputs.mbed == 'true'
@@ -138,6 +141,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE all-clusters-app \
                     examples/all-clusters-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-all-clusters-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build all-clusters-minimal-app example
               if: github.event_name == 'push' || steps.changed_paths.outputs.mbed == 'true'
@@ -148,6 +152,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE all-clusters-minimal-app \
                     examples/all-clusters-minimal-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-all-clusters-minimal-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build shell example
               if: github.event_name == 'push' || steps.changed_paths.outputs.mbed == 'true'
@@ -158,6 +163,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE shell \
                     examples/shell/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-shell-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build ota-requestor-app example
               if: github.event_name == 'push' || steps.changed_paths.outputs.mbed == 'true'
@@ -168,6 +174,7 @@ jobs:
                     mbed $APP_TARGET+$APP_PROFILE shell \
                     examples/ota-requestor-app/mbed/build-CY8CPROTO_062_4343W/release/chip-mbed-ota-requestor-app-example.elf \
                     /tmp/bloat_reports/
+                  rm -rf ./out
 
             - name: Build unit tests
               # Temporarily disable build due to running out of flash space


### PR DESCRIPTION
MBedOS builds seem to run out of storage in master:

https://github.com/project-chip/connectedhomeip/actions/runs/5358500251/jobs/9720876322

each build seems to be large (e.g. OTARequestor is 1GB) so clean after each build
