### PR TITLE
[ESP32] Documentation guides for using secure cert with ECDSA peripheral

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -478,6 +478,7 @@ EEE
 eef
 ef
 EFR
+efuse
 eg
 EjQ
 elftools

--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -40,11 +40,11 @@ step.
     ```
 
 -   For ESP32C6 & ESP32H2, please use commit
-    [47852846d3](https://github.com/espressif/esp-idf/tree/47852846d3).
+    [ea5e0ff](https://github.com/espressif/esp-idf/tree/ea5e0ff).
 
     ```
     $ cd esp-idf
-    $ git checkout 47852846d3
+    $ git checkout ea5e0ff
     $ git submodule update --init
     $ ./install.sh
     ```


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/26655 added the support for using ECDSA peripheral on ESP32H2 and documentation is missing.

This adds the documentation for the same. Also, removed some redundant information.

Fixes https://github.com/project-chip/connectedhomeip/issues/26656