### PR TITLE
Python tests: fix compare_time, add test

### DIFF
--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -21,8 +21,8 @@ from datetime import datetime, timedelta, timezone
 import chip.clusters as Clusters
 from chip.clusters.Types import Nullable, NullValue
 from chip.tlv import uint
-from matter_testing_support import (MatterBaseTest, async_test_body, default_matter_test_main, parse_pics, type_matches,
-                                    utc_time_in_matter_epoch, compare_time)
+from matter_testing_support import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main, parse_pics,
+                                    type_matches, utc_time_in_matter_epoch)
 from mobly import asserts, signals
 
 

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -22,8 +22,8 @@ import chip.clusters as Clusters
 from chip.clusters.Types import Nullable, NullValue
 from chip.tlv import uint
 from matter_testing_support import (MatterBaseTest, async_test_body, default_matter_test_main, parse_pics, type_matches,
-                                    utc_time_in_matter_epoch)
-from mobly import asserts
+                                    utc_time_in_matter_epoch, compare_time)
+from mobly import asserts, signals
 
 
 def get_raw_type_list():
@@ -156,6 +156,33 @@ class TestMatterTestingSupport(MatterBaseTest):
             asserts.assert_false(True, "PICS parser did not throw an error as expected")
         except ValueError:
             pass
+
+    def test_time_compare_function(self):
+        # only offset, exact match
+        compare_time(received=1000, offset=timedelta(microseconds=1000), utc=0, tolerance=timedelta())
+        # only utc, exact match
+        compare_time(received=1000, offset=timedelta(), utc=1000, tolerance=timedelta())
+        # both, exact match
+        compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta())
+        # both, negative offset
+        compare_time(received=0, offset=timedelta(microseconds=-1000), utc=1000, tolerance=timedelta())
+
+        # Exact match, within delta, both
+        compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta(seconds=5))
+
+        # Just inside tolerance
+        compare_time(received=1001, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
+
+        # Just outside tolerance
+        try:
+            compare_time(received=999, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
+            asserts.fail("Expected failure case for time just outside of the tolerance failed")
+        except signals.TestFailure:
+            pass
+
+        # everything in the seconds range
+        compare_time(received=timedelta(seconds=3600).total_seconds() * 1000000,
+                     offset=timedelta(seconds=3605), utc=0, tolerance=timedelta(seconds=5))
 
 
 if __name__ == "__main__":

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -188,10 +188,11 @@ def compare_time(received: int, offset: timedelta = timedelta(), utc: int = None
     if utc is None:
         utc = utc_time_in_matter_epoch()
 
-    expected = utc + offset.microseconds
+    # total seconds includes fractional for microseconds
+    expected = utc + offset.total_seconds()*1000000
     delta_us = abs(expected - received)
     delta = timedelta(microseconds=delta_us)
-    asserts.assert_less(delta, tolerance, "Received time is out of tolerance")
+    asserts.assert_less_equal(delta, tolerance, "Received time is out of tolerance")
 
 
 @dataclass


### PR DESCRIPTION
Compare time function is incorrect because "microseconds" ONLY includes the fractional seconds. total_seconds() is the right thing here - it's a float and includes the entire time, including fractional seconds, so it can be directly converted to microseconds.

Also add a test.
