### PR TITLE
Timesync tests: minor fixes

### DIFF
--- a/src/python_testing/TC_TIMESYNC_2_5.py
+++ b/src/python_testing/TC_TIMESYNC_2_5.py
@@ -67,7 +67,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         self.print_step(4, "Test setting unsorted list - expect error")
         if dst_max_size_dut > 1:
             th_utc = utc_time_in_matter_epoch()
-            dst = [dst_struct(offset=3600, validStarting=th_utc, valid_until=th_utc+1.577e+13),
+            dst = [dst_struct(offset=3600, validStarting=th_utc, validUntil=th_utc+1.577e+13),
                    dst_struct(offset=3600, validStarting=0, validUntil=th_utc)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
 
@@ -79,7 +79,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         self.print_step(6, "Test setting list with invalid second entry - expect error")
         if dst_max_size_dut > 1:
             th_utc = utc_time_in_matter_epoch()
-            dst = [dst_struct(offset=3600, validStarting=0, valid_until=th_utc+3e+8),
+            dst = [dst_struct(offset=3600, validStarting=0, validUntil=th_utc+3e+8),
                    dst_struct(offset=3600, validStarting=th_utc, validUntil=th_utc+1.577e+13)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
 
@@ -91,7 +91,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         self.print_step(8, "Test setting list with two null values - expect error")
         if dst_max_size_dut > 1:
             th_utc = utc_time_in_matter_epoch()
-            dst = [dst_struct(offset=3600, validStarting=0, valid_until=NullValue),
+            dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue),
                    dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=NullValue)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
 
@@ -103,7 +103,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         self.print_step(10, "Test setting list with null value not at end - expect error")
         if dst_max_size_dut > 1:
             th_utc = utc_time_in_matter_epoch()
-            dst = [dst_struct(offset=3600, validStarting=0, valid_until=NullValue),
+            dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue),
                    dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=th_utc+1.577e+13)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
 

--- a/src/python_testing/TC_TIMESYNC_2_6.py
+++ b/src/python_testing/TC_TIMESYNC_2_6.py
@@ -101,7 +101,7 @@ class TC_TIMESYNC_2_6(MatterBaseTest):
 
         self.print_step(14, "Set DefaultNTP to good IPv6")
         ntp = "fe80::1"
-        await self.send_set_default_ntp(ntp=ntp)
+        await self.send_set_default_ntp_cmd(ntp=ntp)
 
         self.print_step(15, "Read DefaultNTP")
         attr = await self.read_ts_attribute_expect_success(default_ntp_attr)

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -84,7 +84,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
         local = await self.read_ts_attribute_expect_success(local_attr)
         compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
 
-        self.print_step(6, "Send SetTimeZone command with 0 offset")
+        self.print_step(6, "Send SetTimeZone command with 3600 offset")
         tz = [tz_struct(offset=3600, validAt=0)]
         ret = await self.send_set_time_zone_cmd(tz)
         asserts.assert_true(ret.DSTOffsetRequired, "DSTOffsetRequired not set to true")


### PR DESCRIPTION
Fixing a couple of errors found when running these tests against the time sync cluster branch.