### PR TITLE
Re-enable retry around checkout for minimal-build

### DIFF
--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -35,8 +35,14 @@ jobs:
             image: connectedhomeip/chip-build-minimal:0.7.3
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3.5.2
+            - uses: Wandalen/wretry.action@v1.3.0
+              name: Checkout
+              with:
+                  action: actions/checkout@v3.5.2
+                  with: |
+                      token: ${{ github.token }}
+                  attempt_limit: 3
+                  attempt_delay: 2000
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
             - name: Configure and build All Clusters App


### PR DESCRIPTION
This was disabled due to https://github.com/Wandalen/wretry.action/issues/83 and should be fixed in v1.3.0
