### PR TITLE
Update DFT prompt, add interactive flag and update rpath

### DIFF
--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -22,7 +22,7 @@
 
 #include <editline.h>
 
-constexpr const char * kInteractiveModePrompt = ">>> ";
+constexpr const char * kInteractiveModePrompt = "Stop and restart stack: [Ctrl+_] & [Ctrl+^] \nQuit Interactive: 'quit()'\n>>> ";
 constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/darwin_framework_tool_history";
 constexpr const char * kInteractiveModeStopCommand = "quit()";
 

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -1576,6 +1576,7 @@
 					CONFIG_BUILD_FOR_HOST_UNIT_TEST,
 					CONFIG_USE_LOCAL_STORAGE,
 					"CHIP_CONFIG_SKIP_APP_SPECIFIC_GENERATED_HEADER_INCLUDES=1",
+					"CONFIG_USE_INTERACTIVE_MODE=1",
 				);
 				"HEADER_SEARCH_PATHS[arch=*]" = (
 					"$(CHIP_ROOT)/examples/darwin-framework-tool",
@@ -1594,6 +1595,10 @@
 					"$(CHIP_ROOT)/examples/chip-tool",
 					"$(CHIP_ROOT)/examples/chip-tool/commands/clusters",
 					"$(CHIP_ROOT)/zzz_generated/chip-tool",
+				);
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				"LIBRARY_SEARCH_PATHS[arch=*]" = (
 					"$(CONFIGURATION_TEMP_DIR)/Matter.build/out/lib",
@@ -1625,6 +1630,7 @@
 					CONFIG_BUILD_FOR_HOST_UNIT_TEST,
 					CONFIG_USE_LOCAL_STORAGE,
 					"CHIP_CONFIG_SKIP_APP_SPECIFIC_GENERATED_HEADER_INCLUDES=1",
+					"CONFIG_USE_INTERACTIVE_MODE=1",
 				);
 				"HEADER_SEARCH_PATHS[arch=*]" = (
 					"$(CHIP_ROOT)/examples//darwin-framework-tool",
@@ -1644,6 +1650,10 @@
 					"$(CHIP_ROOT)/examples/chip-tool/commands/clusters",
 					"$(CHIP_ROOT)/examples/chip-tool",
 					"$(CHIP_ROOT)/zzz_generated/chip-tool",
+				);
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				"LIBRARY_SEARCH_PATHS[arch=*]" = (
 					"$(CONFIGURATION_TEMP_DIR)/Matter.build/out/lib",


### PR DESCRIPTION
Summary:
DFT does not have information on restarting the stack, stopping the stack, quitting in interactive mode, when compiling DFT in Xcode, interactive mode is not enabled, and when running the DFT using the Xcode build, if does not use the correct Matter.framework.

- Fixes #23984
- Adds CONFIG_USE_INTERACTIVE_MODE to debug and release
- Update rpath to search executable_path and BUILT_PRODUCTS_DIR