### PR TITLE
[EFR32] Update support for TestEventTrigger

### DIFF
--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.cpp
@@ -27,4 +27,10 @@ bool SilabsTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableK
     return !mEnableKey.empty() && mEnableKey.data_equal(enableKey);
 }
 
+CHIP_ERROR SilabsTestEventTriggerDelegate::HandleEventTrigger(uint64_t eventTrigger)
+{
+    bool success = emberAfHandleEventTrigger(eventTrigger);
+    return success ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
+}
+
 } // namespace chip

--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.h
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.h
@@ -37,7 +37,7 @@ public:
     /**
      * @brief User handler for handling the test event trigger based on `eventTrigger` provided.
      * @param eventTrigger Event trigger to handle.
-     * @return CHIP_NO_ERROR on success or another CHIP_ERROR on failure.
+     * @return CHIP_NO_ERROR on success or CHIP_ERROR_INVALID_ARGUMENT on failure.
      */
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override;
 
@@ -46,3 +46,15 @@ private:
 };
 
 } // namespace chip
+
+/**
+ * @brief User handler for handling the test event trigger
+ *
+ * @note If TestEventTrigger is enabled, it needs to be implemented in the app
+ *
+ * @param eventTrigger Event trigger to handle
+ *
+ * @retval true on success
+ * @retval false if error happened
+ */
+bool emberAfHandleEventTrigger(uint64_t eventTrigger);

--- a/examples/platform/silabs/efr32/matter_config.cpp
+++ b/examples/platform/silabs/efr32/matter_config.cpp
@@ -56,7 +56,7 @@ static chip::DeviceLayer::Internal::Efr32PsaOperationalKeystore gOperationalKeys
 #include "SilabsDeviceDataProvider.h"
 #include "SilabsTestEventTriggerDelegate.h"
 #include <app/InteractionModelEngine.h>
-#include <string.h>
+#include <lib/support/BytesToHex.h>
 
 #ifdef CHIP_CONFIG_USE_ICD_SUBSCRIPTION_CALLBACKS
 ICDSubscriptionCallback SilabsMatterConfig::mICDSubscriptionHandler;
@@ -139,45 +139,6 @@ void SilabsMatterConfig::ConnectivityEventCallback(const ChipDeviceEvent * event
 static uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                                                                           0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                                                                           0xcc, 0xdd, 0xee, 0xff };
-
-static int hex_digit_to_int(char hex)
-{
-    if ('A' <= hex && hex <= 'F')
-    {
-        return 10 + hex - 'A';
-    }
-    if ('a' <= hex && hex <= 'f')
-    {
-        return 10 + hex - 'a';
-    }
-    if ('0' <= hex && hex <= '9')
-    {
-        return hex - '0';
-    }
-    return -1;
-}
-
-static size_t hex_string_to_binary(const char * hex_string, uint8_t * buf, size_t buf_size)
-{
-    size_t num_char = strlen(hex_string);
-    if (num_char != buf_size * 2)
-    {
-        return 0;
-    }
-    for (size_t i = 0; i < num_char; i += 2)
-    {
-        int digit0 = hex_digit_to_int(hex_string[i]);
-        int digit1 = hex_digit_to_int(hex_string[i + 1]);
-
-        if (digit0 < 0 || digit1 < 0)
-        {
-            return 0;
-        }
-        buf[i / 2] = (digit0 << 4) + digit1;
-    }
-
-    return buf_size;
-}
 #endif // SILABS_TEST_EVENT_TRIGGER_ENABLED
 
 CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
@@ -222,8 +183,9 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     static chip::CommonCaseDeviceServerInitParams initParams;
 
 #if SILABS_TEST_EVENT_TRIGGER_ENABLED
-    if (hex_string_to_binary(SILABS_TEST_EVENT_TRIGGER_ENABLE_KEY, sTestEventTriggerEnableKey,
-                             sizeof(sTestEventTriggerEnableKey)) == 0)
+    if (Encoding::HexToBytes(SILABS_TEST_EVENT_TRIGGER_ENABLE_KEY, strlen(SILABS_TEST_EVENT_TRIGGER_ENABLE_KEY),
+                             sTestEventTriggerEnableKey,
+                             TestEventTriggerDelegate::kEnableKeyLength) != TestEventTriggerDelegate::kEnableKeyLength)
     {
         SILABS_LOG("Failed to convert the EnableKey string to octstr type value");
         memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));


### PR DESCRIPTION
1. Replace the `hex_string_to_binary` function with the SDK's existing `HexToBytes` function.
2. Add `emberAfHandleEventTrigger` function for manufacturer testing.