### PR TITLE
Make build_python.sh automatically install run_python_test.py requirements

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -183,8 +183,6 @@ jobs:
             - name: Build Apps
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv --include_yamltests'
-                  scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.build.txt'
-                  scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.yaml_tests.txt'
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
@@ -424,8 +422,6 @@ jobs:
             - name: Build Python REPL and example apps
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv --extra_packages "mobly"'
-                  scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.build.txt'
-                  scripts/run_in_python_env.sh out/venv 'pip install colorama pyasn1 pyasn1_modules'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test \
@@ -499,8 +495,6 @@ jobs:
             - name: Build Python REPL and example apps
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
-                  scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.build.txt'
-                  scripts/run_in_python_env.sh out/venv 'pip install colorama'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target darwin-x64-all-clusters-${BUILD_VARIANT}-test \

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -198,7 +198,7 @@ if [ -n "$install_virtual_env" ]; then
 
     if [ "$install_pytest_requirements" = "yes" ]; then
         echo_blue "Installing python test dependencies ..."
-        "$ENVIRONMENT_ROOT"/bin/pip install -r "${CHIP_ROOT}/scripts/setup/requirements.python_tests.txt"
+        "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/setup/requirements.python_tests.txt"
     fi
 
     echo ""

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -43,6 +43,7 @@ declare chip_mdns
 declare case_retry_delta
 declare install_virtual_env
 declare clean_virtual_env=yes
+declare install_pytest_requirements=yes
 
 help() {
 
@@ -62,6 +63,8 @@ Input Options:
   -i, --install_virtual_env <path>                          Create a virtual environment with the wheels installed
                                                             <path> represents where the virtual environment is to be created.
   -c, --clean_virtual_env  <yes|no>                         When installing a virtual environment, create/clean it first.
+                                                            Defaults to yes.
+  --include_pytest_deps  <yes|no>                           Install requirements.python_tests.txt.
                                                             Defaults to yes.
   --extra_packages PACKAGES                                 Install extra Python packages from PyPI
   --include_yamltests                                       Whether to install the matter_yamltests wheel.
@@ -99,6 +102,10 @@ while (($#)); do
             ;;
         --clean_virtual_env | -c)
             clean_virtual_env=$2
+            shift
+            ;;
+        --include_pytest_deps)
+            install_pytest_requirements=$2
             shift
             ;;
         --extra_packages)
@@ -178,12 +185,21 @@ if [ -n "$install_virtual_env" ]; then
 
     if [ "$clean_virtual_env" = "yes" ]; then
         # Create a virtual environment that has access to the built python tools
+        echo_blue "Creating a clear VirtualEnv in '$ENVIRONMENT_ROOT' ..."
         virtualenv --clear "$ENVIRONMENT_ROOT"
+    elif [ ! -f "$ENVIRONMENT_ROOT"/bin/activate ]; then
+        echo_blue "Creating a new VirtualEnv in '$ENVIRONMENT_ROOT' ..."
+        virtualenv "$ENVIRONMENT_ROOT"
     fi
 
     source "$ENVIRONMENT_ROOT"/bin/activate
     "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade pip
     "$ENVIRONMENT_ROOT"/bin/pip install --upgrade "${WHEEL[@]}"
+
+    if [ "$install_pytest_requirements" = "yes" ]; then
+        echo_blue "Installing python test dependencies ..."
+        "$ENVIRONMENT_ROOT"/bin/pip install -r "${CHIP_ROOT}/scripts/setup/requirements.python_tests.txt"
+    fi
 
     echo ""
     echo_green "Compilation completed and WHL package installed in: "

--- a/scripts/setup/requirements.python_tests.txt
+++ b/scripts/setup/requirements.python_tests.txt
@@ -1,11 +1,10 @@
 # scripts/tests
 click
 colorama
+diskcache
+websockets
 
 # src/python_testing
 mobly
 pyasn1
 pyasn1_modules
-
-# scripts/tests/yaml/paths_finder.py
-diskcache

--- a/scripts/setup/requirements.python_tests.txt
+++ b/scripts/setup/requirements.python_tests.txt
@@ -4,6 +4,11 @@ colorama
 diskcache
 websockets
 
+# scripts/py_matter_idl
+# TODO: these should be wheel dependencies
+lark
+jinja2
+
 # src/python_testing
 mobly
 pyasn1

--- a/scripts/setup/requirements.python_tests.txt
+++ b/scripts/setup/requirements.python_tests.txt
@@ -6,3 +6,6 @@ colorama
 mobly
 pyasn1
 pyasn1_modules
+
+# scripts/tests/yaml/paths_finder.py
+diskcache

--- a/scripts/setup/requirements.python_tests.txt
+++ b/scripts/setup/requirements.python_tests.txt
@@ -1,0 +1,8 @@
+# scripts/tests
+click
+colorama
+
+# src/python_testing
+mobly
+pyasn1
+pyasn1_modules

--- a/scripts/setup/requirements.python_tests.txt
+++ b/scripts/setup/requirements.python_tests.txt
@@ -8,6 +8,7 @@ websockets
 # TODO: these should be wheel dependencies
 lark
 jinja2
+stringcase
 
 # src/python_testing
 mobly


### PR DESCRIPTION
Makes for e better developer flow: we generally want these in.

Updated unit tests in CI to validate that this option works by default.