### PR TITLE
[QPG] Replace qpg6105 with qpg_target_ic and qpg_target_board.

### DIFF
--- a/third_party/qpg_sdk/BUILD.gn
+++ b/third_party/qpg_sdk/BUILD.gn
@@ -150,7 +150,7 @@ qpg_make_build("qpg_bootloader") {
     "WORKDIR=" + rebase_path(target_gen_dir, root_build_dir) +
         "/${qpg_sdk_lib_dir}/Bootloader_${qpg_target_ic}_compr_secure",
     "UMB_WORKDIR=" + rebase_path(target_gen_dir, root_build_dir) +
-        "/${qpg_sdk_lib_dir}/UMB_QPG6105DK_B01_nrt_flash_compr_secure",
+        "/${qpg_sdk_lib_dir}/UMB_${qpg_target_board}_nrt_flash_compr_secure",
   ]
 }
 config("qpg_retain_bootloader") {
@@ -169,7 +169,7 @@ static_library("qpg_bootloader_lib") {
 
 qpg_make_build("qpg_openthread_glue") {
   make_sources = [ "${qpg_sdk_root}/Components/Qorvo/Matter" ]
-  make_output = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_qpg6105_ftd/libOpenThreadQorvoGlue_${qpg_target_ic}_ftd.a" ]
+  make_output = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_${qpg_target_ic}_ftd/libOpenThreadQorvoGlue_${qpg_target_ic}_ftd.a" ]
   make_args = [
     "-f",
     rebase_path(qpg_sdk_root, root_build_dir) + "/Libraries/Qorvo/OpenThreadQorvoGlue/Makefile.OpenThreadQorvoGlue_${qpg_target_ic}_ftd",
@@ -183,7 +183,7 @@ qpg_make_build("qpg_openthread_glue") {
 }
 static_library("qpg_openthread_glue_lib") {
   deps = [ "${chip_root}/third_party/qpg_sdk:qpg_openthread_glue" ]
-  libs = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_qpg6105_ftd/libOpenThreadQorvoGlue_${qpg_target_ic}_ftd.a" ]
+  libs = [ "${target_gen_dir}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_${qpg_target_ic}_ftd/libOpenThreadQorvoGlue_${qpg_target_ic}_ftd.a" ]
 }
 
 qpg_make_build("qpg_light_factorydata") {

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -27,6 +27,9 @@ declare_args() {
   # Target IC for QPG SDK
   qpg_target_ic = "qpg6105"
 
+  # Target board for QPG SDK
+  qpg_target_board = "QPG6105DK_B01"
+
   # an option to disable referencing qorvo object archive files (*.a)
   qpg_sdk_include_platform_libs = true
 


### PR DESCRIPTION
Removing absolute references with build arguments for re-use with other targets.