### PR TITLE
Bootstrap log upload wasn't working

### DIFF
--- a/.github/actions/checkout-submodules-and-bootstrap/action.yaml
+++ b/.github/actions/checkout-submodules-and-bootstrap/action.yaml
@@ -27,4 +27,4 @@ runs:
     - name: Upload Bootstrap Logs
       uses: ./.github/actions/upload-bootstrap-logs
       with:
-        platform: ${{ inputs.bootstrap-log-name }}
+        bootstrap-log-name: ${{ inputs.bootstrap-log-name }}


### PR DESCRIPTION
Noticed this typo due to a warning here: https://github.com/project-chip/connectedhomeip/actions/runs/5402668462?pr=26082