### PR TITLE
[Silabs] Update Silicon Labs container

### DIFF
--- a/integrations/docker/images/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/chip-build-efr32/Dockerfile
@@ -8,7 +8,8 @@ RUN set -x \
     gcc-arm-none-eabi=15:9-2019-q4-0ubuntu1 \
     binutils-arm-none-eabi=2.34-4ubuntu1+13ubuntu1 \
     git-lfs \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
+    python3-sphinx \
     ccache=3.7.7-1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
@@ -29,9 +30,10 @@ RUN wget https://www.silabs.com/documents/login/software/slc_cli_linux.zip && \
 
 ENV PATH="${PATH}:/slc_cli/"
 
-#  TODO Fix me
-# RUN slc configuration  --sdk="$GSDK_ROOT" && \
-#     slc signature trust --sdk "$GSDK_ROOT"
+# Install Python Packages
 
-
+# SLC required Python Packages
 RUN pip3 install lark jinja2 stringcase
+
+# Sphinx required Python Packages
+RUN pip3 install myst_parser sphinx_rtd_theme sphinx_tabs linkify-it-py

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.21 Version bump reason: [Ameba] ota portinglayer api
+0.7.22 Version bump reason: Update Silicon Labs docker


### PR DESCRIPTION
As the title described.

Add Sphinx, and Java 17 since slc-cli (Silicon Labs specific platform generation tools) required its.


SLC CLI doesn't have the option to fetch a specific version. This is why we removed the calls from the Dockerfile. These steps, which are really quick to execute, will be made directly inside the EFR32 CI step to prevent DOcker container  breakage should the SLC CLI version changes. This is far from ideal but it's the best way to do dommage control IMO.

