### PR TITLE
Disabling tests here so they only run in macOS builds, not iOS builds

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -26,7 +26,6 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
-
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 #define ENABLE_OTA_TESTS 0
 #else

--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -26,6 +26,13 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
+
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#define ENABLE_OTA_TESTS 0
+#else
+#define ENABLE_OTA_TESTS 1
+#endif
+
 // TODO: Disable test005_DoBDXTransferAllowUpdateRequest until PR #26040 is merged.
 // Currently the poll interval causes delays in the BDX transfer and
 // results in the test taking a long time.
@@ -347,6 +354,7 @@ static MTROTAProviderDelegateImpl * sOTAProviderDelegate;
     NSString * imageToolPath = [NSString
         pathWithComponents:@[ [pwd substringToIndex:(pwd.length - @"darwin/Framework".length)], @"app", @"ota_image_tool.py" ]];
 
+#if ENABLE_OTA_TESTS
     NSTask * task = [[NSTask alloc] init];
     [task setLaunchPath:imageToolPath];
     [task setArguments:@[
@@ -358,7 +366,8 @@ static MTROTAProviderDelegateImpl * sOTAProviderDelegate;
     XCTAssertNil(launchError);
     [task waitUntilExit];
     XCTAssertEqual([task terminationStatus], 0);
-
+#endif
+    
     NSData * updateToken = [sOTAProviderDelegate generateUpdateToken];
 
     __block NSFileHandle * readHandle;
@@ -591,6 +600,8 @@ static BOOL sNeedsStackShutdown = YES;
 
     [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
 }
+
+#if ENABLE_OTA_TESTS
 
 - (void)test000_SetUp
 {
@@ -889,5 +900,7 @@ static BOOL sNeedsStackShutdown = YES;
     ResetCommissionee(device, dispatch_get_main_queue(), self, kTimeoutInSeconds);
     [[self class] shutdownStack];
 }
+
+#endif
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -367,7 +367,7 @@ static MTROTAProviderDelegateImpl * sOTAProviderDelegate;
     [task waitUntilExit];
     XCTAssertEqual([task terminationStatus], 0);
 #endif
-    
+
     NSData * updateToken = [sOTAProviderDelegate generateUpdateToken];
 
     __block NSFileHandle * readHandle;


### PR DESCRIPTION
When locally running tests, these try to run under iOS, and fail. Disabling them.