### PR TITLE
Restore imx builds and upgrade imx docker image

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -42,9 +42,7 @@ jobs:
                     - "-esp32"
                     - "-esp32-qemu"
                     - "-infineon"
-                    # NOTE: imx image requires too much space for GitHub-hosted runners. It fails with:
-                    # ApplyLayer exit status 1 stdout:  stderr: write /opt/fsl-imx-xwayland/5.15-kirkstone/sysroots/armv8a-poky-linux/opt/ltp/testcases/bin/fanotify15: no space left on device
-                    # - "-imx"
+                    - "-imx"
                     - "-k32w"
                     - "-mbed-os"
                     - "-nrf-platform"

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-imx:0.7.19.1
+            image: connectedhomeip/chip-build-imx:0.7.23
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Since the #27498 upgraded the imx SDK into the docker image, the disk space will be enough with this customized size SDK.
Restore the imx builds.