### PR TITLE
ESP32: Add option to enable controller building

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -158,6 +158,10 @@ if (CONFIG_ENABLE_CHIP_SHELL)
     chip_gn_arg_append("chip_build_libshell"                "true")
 endif()
 
+if (CONFIG_ENABLE_CHIP_CONTROLLER_BUILD)
+    chip_gn_arg_append("chip_build_controller"              "true")
+endif()
+
 if (CONFIG_ENABLE_WIFI_STATION OR CONFIG_ENABLE_WIFI_AP)
     chip_gn_arg_append("chip_enable_wifi"                       "true")
 else()

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -96,6 +96,12 @@ menu "CHIP Core"
             help
                 Link the application against CHIP interactive shell.
 
+        config ENABLE_CHIP_CONTROLLER_BUILD
+            bool "Enable chip-controller build"
+            default n
+            help
+                This option enables chip-controller building.
+
         config DISABLE_IPV4
             bool "Disable IPv4 functionality in the CHIP stack"
             default "n"


### PR DESCRIPTION
Add option to enable chip-controller building for ESP32 platform.

