### PR TITLE
update time sync TC_TIMESYNC_2_7 and TC_TIMESYNC_2_8

### DIFF
--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -108,6 +108,8 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
         if tz_list_size > 1:
             th_utc = utc_time_in_matter_epoch()
             tz = [tz_struct(offset=3600, validAt=0), tz_struct(offset=7200, validAt=th_utc+1e+7)]
+            ret = await self.send_set_time_zone_cmd(tz)
+            asserts.assert_true(ret.DSTOffsetRequired, "DSTOffsetRequired not set to true")
 
         self.print_step(12, "Send SetDSTOffset command")
         if tz_list_size > 1:

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -106,10 +106,9 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(11, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
+        asserts.assert_equal(local, NullValue, "LocalTime cannot be calculated since DST is empty")
 
         self.print_step(12, "Send SetDSTOffset command")
-        th_utc = utc_time_in_matter_epoch()
         dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue)]
         await self.send_set_dst_cmd(dst)
 
@@ -164,11 +163,10 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         self.print_step(24, "Read LocalTime")
         if dst_list_size > 1:
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
+            asserts.assert_equal(local, NullValue, "LocalTime cannot be calculated since DST is empty")
 
         self.print_step(25, "Send SetDSTOffset command")
-        th_utc = utc_time_in_matter_epoch()
-        dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue)]
+        dst = [dst_struct(offset=-3600, validStarting=0, validUntil=NullValue)]
         await self.send_set_dst_cmd(dst)
 
         self.print_step(26, "Read LocalTime")
@@ -176,7 +174,6 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(27, "Send SetDSTOffset command")
-        th_utc = utc_time_in_matter_epoch()
         dst = [dst_struct(offset=0, validStarting=0, validUntil=NullValue)]
         await self.send_set_dst_cmd(dst)
 


### PR DESCRIPTION
- TC_TIMESYNC_2_7 : step 11 added missed set time zone
- TC_TIMESYNC_2_8 : expect null for LocalTime when DST expires in steps 11 and 24 (https://github.com/CHIP-Specifications/chip-test-plans/pull/2949) and correct offset in step 25  

Fixes: https://github.com/project-chip/connectedhomeip/issues/27805
Fixes: https://github.com/project-chip/connectedhomeip/issues/27806