### PR TITLE
[vscode] Fix debugging with  arm-none-eabi-gdb

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
     docker.io \
     iputils-ping net-tools \
     libncurses5 \
+    libncursesw5 \
     libpython2.7 \
     && :
 


### PR DESCRIPTION
Add libncursesw5 to the vscode Docker image.
It's required by the current version of arm-none-eabi-gdb (12.2).

