### PR TITLE
CheckWriteRead should fail if payloadBase38Representation fails to parse the QRCode

### DIFF
--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -141,7 +141,11 @@ inline bool CheckWriteRead(SetupPayload & inPayload, bool allowInvalidPayload = 
     memset(optionalInfo, 0xFF, sizeof(optionalInfo));
     auto generator = QRCodeSetupPayloadGenerator(inPayload);
     generator.SetAllowInvalidPayload(allowInvalidPayload);
-    generator.payloadBase38Representation(result, optionalInfo, sizeof(optionalInfo));
+    CHIP_ERROR err = generator.payloadBase38Representation(result, optionalInfo, sizeof(optionalInfo));
+
+    if (err != CHIP_NO_ERROR) {
+        return false;
+    }
 
     outPayload = {};
     QRCodeSetupPayloadParser(result).populatePayload(outPayload);

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -143,7 +143,8 @@ inline bool CheckWriteRead(SetupPayload & inPayload, bool allowInvalidPayload = 
     generator.SetAllowInvalidPayload(allowInvalidPayload);
     CHIP_ERROR err = generator.payloadBase38Representation(result, optionalInfo, sizeof(optionalInfo));
 
-    if (err != CHIP_NO_ERROR) {
+    if (err != CHIP_NO_ERROR)
+    {
         return false;
     }
 


### PR DESCRIPTION
Currently, we ignore the return result of payloadBase38Representation with in CheckWriteRead 

CheckWriteRead should fail if payloadBase38Representation fails to parse the QRCode
