### PR TITLE
Allow device does not support any method for rendezvous

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
@@ -182,8 +182,8 @@ class OnboardingPayload(
       DiscoveryCapability.SOFT_AP
     )
 
-    // If discoveryCapabilities is empty or discoveryCapabilities contains values outside of allValid
-    if (discoveryCapabilities.isEmpty() || discoveryCapabilities.any { it !in allValid }) {
+    // If discoveryCapabilities is not empty and discoveryCapabilities contains values outside of allValid
+    if (!discoveryCapabilities.isEmpty() && discoveryCapabilities.any { it !in allValid }) {
       return false
     }
 

--- a/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
@@ -90,10 +90,6 @@ private fun generateBitSet(
   populateBits(bits, offset, payload.vendorId.toLong(), kVendorIDFieldLengthInBits, kTotalPayloadDataSizeInBits)
   populateBits(bits, offset, payload.productId.toLong(), kProductIDFieldLengthInBits, kTotalPayloadDataSizeInBits)
   populateBits(bits, offset, payload.commissioningFlow.toLong(), kCommissioningFlowFieldLengthInBits, kTotalPayloadDataSizeInBits)
-
-  if (payload.discoveryCapabilities.isEmpty())
-    throw OnboardingPayloadException("Invalid argument")
-
   populateBits(bits, offset, payload.getRendezvousInformation(), kRendezvousInfoFieldLengthInBits, kTotalPayloadDataSizeInBits)
   populateBits(bits, offset, payload.discriminator.toLong(), kPayloadDiscriminatorFieldLengthInBits, kTotalPayloadDataSizeInBits)  
   populateBits(bits, offset, payload.setupPinCode, kSetupPINCodeFieldLengthInBits, kTotalPayloadDataSizeInBits)  


### PR DESCRIPTION
Currently, kotlin OnboardingPayload require QRCode at least support one method for rendezvous to be valid, this is not align with native SetupPayload implementation which allow RendezvousInformationFlag::kNone   

/// The rendezvous type this device supports.
enum class RendezvousInformationFlag : uint8_t
{
    kNone      = 0,      ///< Device does not support any method for rendezvous
    kSoftAP    = 1 << 0, ///< Device supports Wi-Fi softAP
    kBLE       = 1 << 1, ///< Device supports BLE
    kOnNetwork = 1 << 2, ///< Device supports Setup on network
};

Update kotlin OnboardingPayload implementation to align with native implemenation