### PR TITLE
Fix manual code processing in Python matter_testing_support

### DIFF
--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -574,14 +574,15 @@ def byte_string_from_hex(s: str) -> bytes:
     return unhexlify(s.replace(":", "").replace(" ", "").replace("0x", ""))
 
 
-def int_from_manual_code(s: str) -> int:
-    s = s.replace('-', '')
+def str_from_manual_code(s: str) -> str:
+    """Enforces legal format for manual codes and removes spaces/dashes."""
+    s = s.replace("-", "").replace(" ", "")
     regex = r"^([0-9]{11}|[0-9]{21})$"
     match = re.match(regex, s)
     if not match:
         raise ValueError("Invalid manual code format, does not match %s" % regex)
 
-    return int(s, 10)
+    return s
 
 
 def int_named_arg(s: str) -> Tuple[str, int]:
@@ -701,7 +702,7 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
     # TODO: this should also allow multiple once QR and manual codes are supported.
     config.qr_code_content = args.qr_code
     if args.manual_code:
-        config.manual_code = "%d" % args.manual_code
+        config.manual_code = args.manual_code
     else:
         config.manual_code = None
 
@@ -885,7 +886,7 @@ def parse_matter_test_args(argv: List[str]) -> MatterTestConfig:
 
     code_group.add_argument('-q', '--qr-code', type=str,
                             metavar="QR_CODE", help="QR setup code content (overrides passcode and discriminator)")
-    code_group.add_argument('--manual-code', type=int_from_manual_code,
+    code_group.add_argument('--manual-code', type=str_from_manual_code,
                             metavar="MANUAL_CODE", help="Manual setup code content (overrides passcode and discriminator)")
 
     fabric_group = parser.add_argument_group(


### PR DESCRIPTION
### Problem
- Leading zeroes in manual pairing code were lost due to a conversion bug, which prevented proper usage
- Found during plugfest

### This PR changes
- Avoids a round trip that removed leading zeroes and fixes the conversion to be lossless while retaining structural validation.
- Allows spaces in passcode.

### Testing done
- Executed TC_DeviceBasicComposition with a --manual-code having leading zeroes, against chip-lighting-app.
- Regression tests of TC_*.py
