### PR TITLE
Remove null terminator from  Base38 String in kotlin

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/Base38.kt
+++ b/src/controller/java/src/chip/onboardingpayload/Base38.kt
@@ -54,7 +54,7 @@ fun base38Encode(inBuf: ByteArray, outBuf: CharArray): Unit {
 
     val base38CharactersNeeded = kBase38CharactersNeededInNBytesChunk[bytesInChunk - 1].toByte()
 
-    if ((outIdx + base38CharactersNeeded) >= outBuf.size) {
+    if ((outIdx + base38CharactersNeeded) > outBuf.size) {
       throw OnboardingPayloadException("Buffer is too small")
     }
 
@@ -62,12 +62,6 @@ fun base38Encode(inBuf: ByteArray, outBuf: CharArray): Unit {
       outBuf[outIdx++] = kCodes[value % kRadix]
       value /= kRadix.toInt()
     }
-  }
-
-  if (outIdx < outBuf.size) {
-    outBuf[outIdx] = '\u0000'
-  } else {
-    throw OnboardingPayloadException("Buffer is too small")
   }
 }
 

--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayload.kt
@@ -143,6 +143,20 @@ class OnboardingPayload(
     setupPinCode
   )
 
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is OnboardingPayload) return false
+
+    return version == other.version &&
+            vendorId == other.vendorId &&
+            productId == other.productId &&
+            commissioningFlow == other.commissioningFlow &&
+            discoveryCapabilities == other.discoveryCapabilities &&
+            discriminator == other.discriminator &&
+            hasShortDiscriminator == other.hasShortDiscriminator &&
+            setupPinCode == other.setupPinCode
+  }
+
   fun addOptionalQRCodeInfo(info: OptionalQRCodeInfo) {
     optionalQRCodeInfo[info.tag] = info
   }

--- a/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
@@ -27,7 +27,7 @@ class QRCodeBasicOnboardingPayloadGenerator(private val payload: OnboardingPaylo
 
   /**
    * This function is called to encode the binary data of a payload to a
-   * base38 null-terminated string.
+   * base38 string.
    *
    * The resulting size of the outBuffer span will be the size of data written.
    *

--- a/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/chip/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
@@ -18,6 +18,7 @@
 package chip.onboardingpayload
 
 import java.lang.StringBuilder
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A minimal QR code setup payload generator that omits any optional data,
@@ -63,7 +64,9 @@ fun payloadBase38RepresentationWithTLV(
     throw OnboardingPayloadException("Buffer is too small")
   } else {
     val subBuffer = outBuffer.copyOfRange(prefixLen, outBuffer.size)
-    kQRCodePrefix.toCharArray(outBuffer, 0, prefixLen)
+    for (i in kQRCodePrefix.indices) {
+      outBuffer[i] = kQRCodePrefix[i]
+    }
 
     base38Encode(bits, subBuffer)
     
@@ -81,7 +84,7 @@ private fun generateBitSet(
   tlvDataStart: ByteArray?,
   tlvDataLengthInBytes: Int
 ) {
-  var offset = 0
+  var offset: AtomicInteger = AtomicInteger(0)
   val totalPayloadSizeInBits = kTotalPayloadDataSizeInBits + (tlvDataLengthInBytes * 8)
   if (bits.size * 8 < totalPayloadSizeInBits)
     throw OnboardingPayloadException("Buffer is too small")
@@ -100,18 +103,19 @@ private fun generateBitSet(
 // Populates numberOfBits starting from LSB of input into bits, which is assumed to be zero-initialized
 private fun populateBits(
   bits: ByteArray,
-  offset: Int,
+  offset: AtomicInteger,
   input: Long,
   numberOfBits: Int,
   totalPayloadDataSizeInBits: Int
 ) {
-  if (offset + numberOfBits > totalPayloadDataSizeInBits)
+  if (offset.get() + numberOfBits > totalPayloadDataSizeInBits)
     throw OnboardingPayloadException("Invalid argument")
 
   if (input >= (1L shl numberOfBits))
     throw OnboardingPayloadException("Invalid argument")
 
-  var index = offset
+  var index = offset.get()
+  offset.addAndGet(numberOfBits)
   var inputValue = input
   while (inputValue != 0L) {
     if (inputValue and 1L != 0L) {
@@ -125,7 +129,7 @@ private fun populateBits(
 
 private fun populateTLVBits(
   bits: ByteArray,
-  offset: Int,
+  offset: AtomicInteger,
   tlvBuf: ByteArray?,
   tlvBufSizeInBytes: Int,
   totalPayloadDataSizeInBits: Int

--- a/src/controller/java/src/chip/onboardingpayload/QRCodeOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/chip/onboardingpayload/QRCodeOnboardingPayloadGenerator.kt
@@ -111,12 +111,11 @@ class QRCodeOnboardingPayloadGenerator(private val onboardingPayload: Onboarding
     }
 
     var tlvDataLengthInBytes = generateTLVFromOptionalData(onboardingPayload, tlvDataStart, tlvDataStartSize)
-    
     val bits = ByteArray(kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes)
     val buffer = CharArray(base38EncodedLength(bits.size) + kQRCodePrefix.length)
     payloadBase38RepresentationWithTLV(onboardingPayload, buffer, bits, tlvDataStart, tlvDataLengthInBytes)
     
-    return buffer.toString()
+    return String(buffer)
   }
 
   private fun generateTLVFromOptionalData(


### PR DESCRIPTION
We don't need to account for null terminator in kotlin String, it has been taken care by the language itself. Remove null terminator from Base38 String CharArray from Base38 kotlin.

Override the equals method  from the Any class in OnboardingPayload

