### PR TITLE
[ota-requestor] Added update cancelling in case of apply failure

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -192,7 +192,11 @@ void DefaultOTARequestorDriver::ApplyTimerHandler(System::Layer * systemLayer, v
     DefaultOTARequestorDriver * driver = ToDriver(appState);
 
     VerifyOrDie(driver->mImageProcessor != nullptr);
-    driver->mImageProcessor->Apply();
+
+    if (driver->mImageProcessor->Apply() != CHIP_NO_ERROR)
+    {
+        driver->mRequestor->CancelImageUpdate();
+    }
 }
 
 void DefaultOTARequestorDriver::UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay)


### PR DESCRIPTION
The Ota Requestor's Apply API returns CHIP_ERROR, however it is not handled by the DefaultOTARequestorDriver.

Added cancelling update in case of Apply failure to reset the OTA Requestor state and prevent stucking in kApplying state.

