### PR TITLE
[OIS] Settings cleanup

### DIFF
--- a/config/openiotsdk/chip-gn/args.gni
+++ b/config/openiotsdk/chip-gn/args.gni
@@ -30,6 +30,7 @@ chip_config_network_layer_ble = false
 chip_system_config_use_lwip = true
 lwip_platform = "external"
 chip_system_config_use_sockets = false
+chip_inet_config_enable_ipv4 = false
 
 chip_external_mbedtls = true
 

--- a/config/openiotsdk/cmake/sdk.cmake
+++ b/config/openiotsdk/cmake/sdk.cmake
@@ -69,7 +69,6 @@ set(IOTSDK_FETCH_LIST
     cmsis-freertos
     mbedtls
     lwip
-    cmsis-sockets-api
     trusted-firmware-m
 )
 
@@ -247,13 +246,6 @@ if("lwip" IN_LIST IOTSDK_FETCH_LIST)
         lwip-cmsis-sys
         lwip-cmsis-port-low-input-latency
         lwipopts
-    )
-endif()
-
-if("cmsis-sockets-api" IN_LIST IOTSDK_FETCH_LIST)
-    list(APPEND CONFIG_CHIP_EXTERNAL_TARGETS
-        cmsis-sockets-api
-        lwip-sockets
     )
 endif()
 

--- a/config/openiotsdk/lwip/user_lwipopts.h
+++ b/config/openiotsdk/lwip/user_lwipopts.h
@@ -50,6 +50,11 @@
 #define LWIP_RAW (1)
 
 /**
+ * Disable IPv4 support. Only IPv6 should be used in the Matter.
+ */
+#define LWIP_IPV4 0
+
+/**
  * Disable DHCP as the IP6 link local address can be used.
  */
 #define LWIP_DHCP 0


### PR DESCRIPTION
- Remove cmsis-sockets-api component.
- Disable IPv4 in LwIP and Matter build - only used IPv6 setting in Matter project.