### PR TITLE
Improve format in the README file by removing excessive indentation

### DIFF
--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -108,25 +108,25 @@ is simulated with the value/label pair `"room"`/`[light name]`.
 
 -   Install tool chain
 
-    ```
-    $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
+    ```sh
+    sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
     ```
 
 -   Build the example application:
 
-    ```
-    $ cd ~/connectedhomeip/examples/bridge-app/linux
-    $ git submodule update --init
-    $ source third_party/connectedhomeip/scripts/activate.sh
-    $ gn gen out/debug
-    $ ninja -C out/debug
+    ```sh
+    cd ~/connectedhomeip/examples/bridge-app/linux
+    git submodule update --init
+    source third_party/connectedhomeip/scripts/activate.sh
+    gn gen out/debug
+    ninja -C out/debug
     ```
 
 -   To delete generated executable, libraries and object files use:
 
-    ```
-    $ cd ~/connectedhomeip/examples/bridge-app/linux
-    $ rm -rf out/
+    ```sh
+    cd ~/connectedhomeip/examples/bridge-app/linux
+    rm -rf out/
     ```
 
 ## Running the Complete Example on Raspberry Pi 4
@@ -151,7 +151,7 @@ is simulated with the value/label pair `"room"`/`[light name]`.
             number after `hci` is the bluetooth device number, `1` in this
             example.
 
-            ```
+            ```sh
             $ hciconfig
             hci1:	Type: Primary  Bus: USB
                 BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
@@ -168,11 +168,11 @@ is simulated with the value/label pair `"room"`/`[light name]`.
 
         -   Run Linux Bridge Example App
 
-            ```
-            $ cd ~/connectedhomeip/examples/bridge-app/linux
-            $ sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
+            ```sh
+            cd ~/connectedhomeip/examples/bridge-app/linux
+            sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
             # In this example, the device we want to use is hci1
-            $ sudo out/debug/chip-bridge-app --ble-device 1
+            sudo out/debug/chip-bridge-app --ble-device 1
             ```
 
         -   Test the device using ChipDeviceController on your laptop /

--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -108,26 +108,26 @@ is simulated with the value/label pair `"room"`/`[light name]`.
 
 -   Install tool chain
 
-          ```
-          $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
-          ```
+    ```
+    $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
+    ```
 
 -   Build the example application:
 
-          ```
-          $ cd ~/connectedhomeip/examples/bridge-app/linux
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ gn gen out/debug
-          $ ninja -C out/debug
-          ```
+    ```
+    $ cd ~/connectedhomeip/examples/bridge-app/linux
+    $ git submodule update --init
+    $ source third_party/connectedhomeip/scripts/activate.sh
+    $ gn gen out/debug
+    $ ninja -C out/debug
+    ```
 
 -   To delete generated executable, libraries and object files use:
 
-          ```
-          $ cd ~/connectedhomeip/examples/bridge-app/linux
-          $ rm -rf out/
-          ```
+    ```
+    $ cd ~/connectedhomeip/examples/bridge-app/linux
+    $ rm -rf out/
+    ```
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -151,29 +151,29 @@ is simulated with the value/label pair `"room"`/`[light name]`.
             number after `hci` is the bluetooth device number, `1` in this
             example.
 
-                  ```
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+            ```
+            $ hciconfig
+            hci1:	Type: Primary  Bus: USB
+                BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
+                UP RUNNING PSCAN ISCAN
+                RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
+                TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
-                  ```
+            hci0:	Type: Primary  Bus: UART
+                BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+                UP RUNNING PSCAN ISCAN
+                RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
+                TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+            ```
 
         -   Run Linux Bridge Example App
 
-                  ```
-                  $ cd ~/connectedhomeip/examples/bridge-app/linux
-                  $ sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-bridge-app --ble-device 1
-                  ```
+            ```
+            $ cd ~/connectedhomeip/examples/bridge-app/linux
+            $ sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
+            # In this example, the device we want to use is hci1
+            $ sudo out/debug/chip-bridge-app --ble-device 1
+            ```
 
         -   Test the device using ChipDeviceController on your laptop /
             workstation etc.


### PR DESCRIPTION
This PR will improve the formatting in the README file by removing excessive indentation. Here is an example of how commands in the README look before and after the changes made by this PR:

before:

    ```
    $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
    ```
     
after:

  ```
  $ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev ninja-build python3-venv python3-dev unzip
  ```

