### PR TITLE
[Tizen] Fix memory leak when re-connecting BLE

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -97,6 +97,13 @@ static constexpr System::Clock::Timeout kNewConnectionScanTimeout = System::Cloc
 /* Tizen Default Connect Timeout */
 static constexpr System::Clock::Timeout kConnectTimeout = System::Clock::Seconds16(10);
 
+static void __BLEConnectionFree(BLEConnection * conn)
+{
+    VerifyOrReturn(conn != nullptr);
+    g_free(conn->peerAddr);
+    g_free(conn);
+}
+
 static void __AdapterStateChangedCb(int result, bt_adapter_state_e adapterState, void * userData)
 {
     ChipLogProgress(DeviceLayer, "Adapter State Changed: %s", adapterState == BT_ADAPTER_ENABLED ? "Enabled" : "Disabled");
@@ -140,7 +147,10 @@ CHIP_ERROR BLEManagerImpl::_BleInitialize(void * userData)
     ret = bt_gatt_set_connection_state_changed_cb(GattConnectionStateChangedCb, nullptr);
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed. ret: %d", ret));
 
-    sInstance.InitConnectionData();
+    // The hash table key is stored in the BLEConnection structure
+    // and is freed by the __BLEConnectionFree() function.
+    sInstance.mConnectionMap =
+        g_hash_table_new_full(g_str_hash, g_str_equal, nullptr, reinterpret_cast<GDestroyNotify>(__BLEConnectionFree));
 
     sInstance.mFlags.Set(Flags::kTizenBLELayerInitialized);
     ChipLogProgress(DeviceLayer, "BLE Initialized");
@@ -713,16 +723,6 @@ exit:
     return ret;
 }
 
-void BLEManagerImpl::InitConnectionData()
-{
-    /* Initialize Hashmap */
-    if (!mConnectionMap)
-    {
-        mConnectionMap = g_hash_table_new(g_str_hash, g_str_equal);
-        ChipLogProgress(DeviceLayer, "GATT Connection HashMap created");
-    }
-}
-
 static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle, void * data)
 {
     bt_gatt_type_e type;
@@ -803,14 +803,13 @@ void BLEManagerImpl::AddConnectionData(const char * remoteAddr)
             /* Local Device is BLE Central Role */
             if (IsDeviceChipPeripheral(conn))
             {
-                g_hash_table_insert(mConnectionMap, (gpointer) conn->peerAddr, conn);
+                g_hash_table_insert(mConnectionMap, conn->peerAddr, conn);
                 ChipLogProgress(DeviceLayer, "New Connection Added for [%s]", StringOrNullMarker(remoteAddr));
                 NotifyHandleNewConnection(conn);
             }
             else
             {
-                g_free(conn->peerAddr);
-                g_free(conn);
+                __BLEConnectionFree(conn);
             }
         }
         else
@@ -822,7 +821,7 @@ void BLEManagerImpl::AddConnectionData(const char * remoteAddr)
             conn->gattCharC1Handle = mGattCharC1Handle;
             conn->gattCharC2Handle = mGattCharC2Handle;
 
-            g_hash_table_insert(mConnectionMap, (gpointer) conn->peerAddr, conn);
+            g_hash_table_insert(mConnectionMap, conn->peerAddr, conn);
             ChipLogProgress(DeviceLayer, "New Connection Added for [%s]", StringOrNullMarker(remoteAddr));
         }
     }
@@ -839,13 +838,7 @@ void BLEManagerImpl::RemoveConnectionData(const char * remoteAddr)
     VerifyOrReturn(conn != nullptr,
                    ChipLogError(DeviceLayer, "Connection does not exist for [%s]", StringOrNullMarker(remoteAddr)));
 
-    g_hash_table_remove(mConnectionMap, conn->peerAddr);
-
-    g_free(conn->peerAddr);
-    g_free(conn);
-
-    if (!g_hash_table_size(mConnectionMap))
-        mConnectionMap = nullptr;
+    g_hash_table_remove(mConnectionMap, remoteAddr);
 
     ChipLogProgress(DeviceLayer, "Connection Removed");
 }

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -187,7 +187,6 @@ private:
     static void CharacteristicNotificationCb(bt_gatt_h characteristic, char * value, int len, void * userData);
 
     // ==== Connection.
-    void InitConnectionData();
     void AddConnectionData(const char * remoteAddr);
     void RemoveConnectionData(const char * remoteAddr);
 


### PR DESCRIPTION
### Problem

There is a mem leak when connecting and disconnecting BLE device more than once.

### Changes

- use GDestroyNotify for freeing BLEConnection structure instead of manually managing resources
- do not "free" `mConnectionMap` when it's size if zero

### Testing

Manually tested BLE commissioning on Tizen.