### PR TITLE
[ESP32] remove `src` prefix from include (use `app/` instead of `src/app/`)

### DIFF
--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
-#include <src/app/util/af.h>
+#include <app/util/af.h>
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
#### Problem

src should not be in #include <path>.

#### Changes

Removed src from #include <path>

#### Testing
Build all-clusters-app