### PR TITLE
Allow json tracing to go to files instead of just logs

### DIFF
--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -47,7 +47,7 @@ source_set("commandline") {
   deps = [
     "${chip_root}/src/lib/support",
     "${chip_root}/src/tracing",
-    "${chip_root}/src/tracing/log_json",
+    "${chip_root}/src/tracing/json",
   ]
 
   public_deps = [ ":tracing_features" ]

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -59,19 +59,18 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
 
     while (splitter.Next(value))
     {
-        if (value.data_equal(CharSpan::fromCharString("json")))
-        {
-            // Will default to log as no file is open
-            chip::Tracing::Register(mJsonBackend);
-        }
-        else if (StartsWith(value, "json:"))
+        if (StartsWith(value, "json:"))
         {
             std::string fileName(value.data() + 5, value.size() - 5);
 
+            if (fileName != "log") {
             CHIP_ERROR err = mJsonBackend.Open(fileName.c_str());
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Failed to open json trace output: %" CHIP_ERROR_FORMAT, err.Format());
+            }
+            } else {
+                mJsonBackend.Close(); // just in case, ensure no file output
             }
             chip::Tracing::Register(mJsonBackend);
         }

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -59,8 +59,20 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
 
     while (splitter.Next(value))
     {
-        if (value.data_equal(CharSpan::fromCharString("log")))
+        if (value.data_equal(CharSpan::fromCharString("json")))
         {
+            // Will default to log as no file is open
+            chip::Tracing::Register(mJsonBackend);
+        }
+        else if (StartsWith(value, "json:"))
+        {
+            std::string fileName(value.data() + 5, value.size() - 5);
+
+            CHIP_ERROR err = mJsonBackend.Open(fileName.c_str());
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer, "Failed to open json trace output: %" CHIP_ERROR_FORMAT, err.Format());
+            }
             chip::Tracing::Register(mJsonBackend);
         }
 #if ENABLE_PERFETTO_TRACING

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -34,7 +34,6 @@ namespace chip {
 namespace CommandLineApp {
 
 namespace {
-#if ENABLE_PERFETTO_TRACING
 
 bool StartsWith(CharSpan argument, const char * prefix)
 {
@@ -47,8 +46,6 @@ bool StartsWith(CharSpan argument, const char * prefix)
     argument.reduce_size(prefix_len);
     return argument.data_equal(CharSpan(prefix, prefix_len));
 }
-
-#endif
 
 } // namespace
 

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -19,7 +19,7 @@
 
 #include <lib/support/StringSplitter.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <tracing/log_json/log_json_tracing.h>
+#include <tracing/json/json_tracing.h>
 #include <tracing/registry.h>
 
 #if ENABLE_PERFETTO_TRACING
@@ -61,7 +61,7 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
     {
         if (value.data_equal(CharSpan::fromCharString("log")))
         {
-            chip::Tracing::Register(mLogJsonBackend);
+            chip::Tracing::Register(mJsonBackend);
         }
 #if ENABLE_PERFETTO_TRACING
         else if (value.data_equal(CharSpan::fromCharString("perfetto")))
@@ -101,7 +101,7 @@ void TracingSetup::StopTracing()
 
 #endif
 
-    chip::Tracing::Unregister(mLogJsonBackend);
+    chip::Tracing::Unregister(mJsonBackend);
 }
 
 } // namespace CommandLineApp

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -65,7 +65,7 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
 
             if (fileName != "log")
             {
-                CHIP_ERROR err = mJsonBackend.Open(fileName.c_str());
+                CHIP_ERROR err = mJsonBackend.OpenFile(fileName.c_str());
                 if (err != CHIP_NO_ERROR)
                 {
                     ChipLogError(AppServer, "Failed to open json trace output: %" CHIP_ERROR_FORMAT, err.Format());
@@ -73,7 +73,7 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
             }
             else
             {
-                mJsonBackend.Close(); // just in case, ensure no file output
+                mJsonBackend.CloseFile(); // just in case, ensure no file output
             }
             chip::Tracing::Register(mJsonBackend);
         }

--- a/examples/common/tracing/TracingCommandLineArgument.cpp
+++ b/examples/common/tracing/TracingCommandLineArgument.cpp
@@ -63,13 +63,16 @@ void TracingSetup::EnableTracingFor(const char * cliArg)
         {
             std::string fileName(value.data() + 5, value.size() - 5);
 
-            if (fileName != "log") {
-            CHIP_ERROR err = mJsonBackend.Open(fileName.c_str());
-            if (err != CHIP_NO_ERROR)
+            if (fileName != "log")
             {
-                ChipLogError(AppServer, "Failed to open json trace output: %" CHIP_ERROR_FORMAT, err.Format());
+                CHIP_ERROR err = mJsonBackend.Open(fileName.c_str());
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(AppServer, "Failed to open json trace output: %" CHIP_ERROR_FORMAT, err.Format());
+                }
             }
-            } else {
+            else
+            {
                 mJsonBackend.Close(); // just in case, ensure no file output
             }
             chip::Tracing::Register(mJsonBackend);

--- a/examples/common/tracing/TracingCommandLineArgument.h
+++ b/examples/common/tracing/TracingCommandLineArgument.h
@@ -19,7 +19,7 @@
 
 #include "tracing/enabled_features.h"
 
-#include <tracing/log_json/log_json_tracing.h>
+#include <tracing/json/json_tracing.h>
 
 #if ENABLE_PERFETTO_TRACING
 #include <tracing/perfetto/file_output.h>      // nogncheck
@@ -57,7 +57,7 @@ public:
     void StopTracing();
 
 private:
-    ::chip::Tracing::LogJson::LogJsonBackend mLogJsonBackend;
+    ::chip::Tracing::Json::JsonBackend mJsonBackend;
 
 #if ENABLE_PERFETTO_TRACING
     chip::Tracing::Perfetto::FileTraceOutput mPerfettoFileOutput;

--- a/examples/common/tracing/TracingCommandLineArgument.h
+++ b/examples/common/tracing/TracingCommandLineArgument.h
@@ -29,9 +29,9 @@
 /// A string with supported command line tracing targets
 /// to be pretty-printed in help strings if needed
 #if ENABLE_PERFETTO_TRACING
-#define SUPPORTED_COMMAND_LINE_TRACING_TARGETS "log, perfetto, perfetto:<path>"
+#define SUPPORTED_COMMAND_LINE_TRACING_TARGETS "json:log, json:<path> perfetto, perfetto:<path>"
 #else
-#define SUPPORTED_COMMAND_LINE_TRACING_TARGETS "log"
+#define SUPPORTED_COMMAND_LINE_TRACING_TARGETS "json:log, json:<path>"
 #endif
 
 namespace chip {
@@ -44,7 +44,7 @@ public:
     ~TracingSetup() { StopTracing(); }
 
     /// Enable tracing based on the given command line argument
-    /// like "log" or "log,perfetto" or similar
+    /// like "json:log" or "json:/tmp/foo.txt,perfetto" or similar
     ///
     /// Single arguments as well as comma separated ones are accepted.
     ///

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -90,7 +90,7 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/tracing",
-    "${chip_root}/src/tracing/log_json",
+    "${chip_root}/src/tracing/json",
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -156,5 +156,6 @@ ALLOW: Dict[str, Set[str]] = {
     'src/controller/ExamplePersistentStorage.cpp': {'fstream'},
 
     # Library meant for non-embedded
-    'src/tracing/log_json/log_json_tracing.cpp': {'string', 'sstream'}
+    'src/tracing/json/json_tracing.cpp': {'string', 'sstream'},
+    'src/tracing/json/json_tracing.h': {'fstream'}
 }

--- a/src/tracing/json/BUILD.gn
+++ b/src/tracing/json/BUILD.gn
@@ -17,10 +17,10 @@ import("//build_overrides/chip.gni")
 
 # As this uses std::string, this library is NOT for use
 # for embedded devices.
-static_library("log_json") {
+static_library("json") {
   sources = [
-    "log_json_tracing.cpp",
-    "log_json_tracing.h",
+    "json_tracing.cpp",
+    "json_tracing.h",
   ]
 
   public_deps = [

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -253,7 +253,7 @@ void JsonBackend::Close()
         return;
     }
 
-    mOutputFile <<"]\n";
+    mOutputFile << "]\n";
 
     mOutputFile.close();
 }
@@ -268,7 +268,7 @@ CHIP_ERROR JsonBackend::Open(const char * path)
         return CHIP_ERROR_POSIX(errno);
     }
 
-    mOutputFile <<"[\n";
+    mOutputFile << "[\n";
     mFirstRecord = true;
 
     return CHIP_NO_ERROR;
@@ -281,9 +281,12 @@ void JsonBackend::OutputValue(::Json::Value & value)
 
     if (mOutputFile.is_open())
     {
-        if (!mFirstRecord) {
-            mOutputFile <<",\n";
-        } else {
+        if (!mFirstRecord)
+        {
+            mOutputFile << ",\n";
+        }
+        else
+        {
             mFirstRecord = false;
         }
         value["time_ms"] = chip::System::SystemClock().GetMonotonicTimestamp().count();

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -99,7 +99,7 @@ void DecodePayloadData(::Json::Value & value, chip::ByteSpan payload)
 
 JsonBackend::~JsonBackend()
 {
-    Close();
+    CloseFile();
 }
 
 void JsonBackend::TraceBegin(const char * label, const char * group)
@@ -246,7 +246,7 @@ void JsonBackend::LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo & info)
     OutputValue(value);
 }
 
-void JsonBackend::Close()
+void JsonBackend::CloseFile()
 {
     if (!mOutputFile.is_open())
     {
@@ -258,9 +258,9 @@ void JsonBackend::Close()
     mOutputFile.close();
 }
 
-CHIP_ERROR JsonBackend::Open(const char * path)
+CHIP_ERROR JsonBackend::OpenFile(const char * path)
 {
-    Close();
+    CloseFile();
     mOutputFile.open(path, std::ios_base::out);
 
     if (!mOutputFile)

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-#include <tracing/log_json/log_json_tracing.h>
+#include <tracing/json/json_tracing.h>
 
 #include <lib/address_resolve/TracingStructs.h>
 #include <lib/support/ErrorStr.h>
@@ -30,18 +30,18 @@
 
 namespace chip {
 namespace Tracing {
-namespace LogJson {
+namespace Json {
 
 namespace {
 
 using chip::StringBuilder;
 
 /// Writes the given value to chip log
-void LogJsonValue(Json::Value const & value)
+void LogJsonValue(::Json::Value const & value)
 {
-    Json::StreamWriterBuilder builder;
+    ::Json::StreamWriterBuilder builder;
 
-    std::unique_ptr<Json::StreamWriter> writer(builder.newStreamWriter());
+    std::unique_ptr<::Json::StreamWriter> writer(builder.newStreamWriter());
     std::stringstream output;
 
     writer->write(value, &output);
@@ -49,7 +49,7 @@ void LogJsonValue(Json::Value const & value)
     ChipLogProgress(Automation, "%s", output.str().c_str());
 }
 
-void DecodePayloadHeader(Json::Value & value, const PayloadHeader * payloadHeader)
+void DecodePayloadHeader(::Json::Value & value, const PayloadHeader * payloadHeader)
 {
 
     value["exchangeFlags"] = payloadHeader->GetExchangeFlags();
@@ -66,7 +66,7 @@ void DecodePayloadHeader(Json::Value & value, const PayloadHeader * payloadHeade
     }
 }
 
-void DecodePacketHeader(Json::Value & value, const PacketHeader * packetHeader)
+void DecodePacketHeader(::Json::Value & value, const PacketHeader * packetHeader)
 {
     value["msgCounter"]    = packetHeader->GetMessageCounter();
     value["sessionId"]     = packetHeader->GetSessionId();
@@ -98,9 +98,9 @@ void DecodePacketHeader(Json::Value & value, const PacketHeader * packetHeader)
     }
 }
 
-void DecodePayloadData(Json::Value & value, chip::ByteSpan payload)
+void DecodePayloadData(::Json::Value & value, chip::ByteSpan payload)
 {
-    value["payloadSize"] = static_cast<Json::Value::UInt>(payload.size());
+    value["payloadSize"] = static_cast<::Json::Value::UInt>(payload.size());
 
     // TODO: a decode would be useful however it likely requires more decode
     //       metadata
@@ -108,36 +108,36 @@ void DecodePayloadData(Json::Value & value, chip::ByteSpan payload)
 
 } // namespace
 
-void LogJsonBackend::TraceBegin(const char * label, const char * group)
+void JsonBackend::TraceBegin(const char * label, const char * group)
 {
-    Json::Value value;
+    ::Json::Value value;
     value["event"] = "TraceBegin";
     value["label"] = label;
     value["group"] = group;
     LogJsonValue(value);
 }
 
-void LogJsonBackend::TraceEnd(const char * label, const char * group)
+void JsonBackend::TraceEnd(const char * label, const char * group)
 {
-    Json::Value value;
+    ::Json::Value value;
     value["event"] = "TraceEnd";
     value["label"] = label;
     value["group"] = group;
     LogJsonValue(value);
 }
 
-void LogJsonBackend::TraceInstant(const char * label, const char * group)
+void JsonBackend::TraceInstant(const char * label, const char * group)
 {
-    Json::Value value;
+    ::Json::Value value;
     value["event"] = "TraceInstant";
     value["label"] = label;
     value["group"] = group;
     LogJsonValue(value);
 }
 
-void LogJsonBackend::LogMessageSend(MessageSendInfo & info)
+void JsonBackend::LogMessageSend(MessageSendInfo & info)
 {
-    Json::Value value;
+    ::Json::Value value;
     value["event"] = "MessageSend";
 
     switch (info.messageType)
@@ -160,9 +160,9 @@ void LogJsonBackend::LogMessageSend(MessageSendInfo & info)
     LogJsonValue(value);
 }
 
-void LogJsonBackend::LogMessageReceived(MessageReceivedInfo & info)
+void JsonBackend::LogMessageReceived(MessageReceivedInfo & info)
 {
-    Json::Value value;
+    ::Json::Value value;
 
     value["event"] = "MessageReceived";
 
@@ -186,9 +186,9 @@ void LogJsonBackend::LogMessageReceived(MessageReceivedInfo & info)
     LogJsonValue(value);
 }
 
-void LogJsonBackend::LogNodeLookup(NodeLookupInfo & info)
+void JsonBackend::LogNodeLookup(NodeLookupInfo & info)
 {
-    Json::Value value;
+    ::Json::Value value;
 
     value["event"]                = "LogNodeLookup";
     value["node_id"]              = info.request->GetPeerId().GetNodeId();
@@ -199,9 +199,9 @@ void LogJsonBackend::LogNodeLookup(NodeLookupInfo & info)
     LogJsonValue(value);
 }
 
-void LogJsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
+void JsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
 {
-    Json::Value value;
+    ::Json::Value value;
     value["event"] = "LogNodeDiscovered";
 
     value["node_id"]              = info.peerId->GetNodeId();
@@ -221,7 +221,7 @@ void LogJsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
     }
 
     {
-        Json::Value result;
+        ::Json::Value result;
 
         char address_buff[chip::Transport::PeerAddress::kMaxToStringSize];
 
@@ -239,9 +239,9 @@ void LogJsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
     LogJsonValue(value);
 }
 
-void LogJsonBackend::LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo & info)
+void JsonBackend::LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo & info)
 {
-    Json::Value value;
+    ::Json::Value value;
 
     value["event"]                = "LogNodeDiscoveryFailed";
     value["node_id"]              = info.peerId->GetNodeId();
@@ -251,6 +251,6 @@ void LogJsonBackend::LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo & info)
     LogJsonValue(value);
 }
 
-} // namespace LogJson
+} // namespace Json
 } // namespace Tracing
 } // namespace chip

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -21,7 +21,7 @@
 
 namespace chip {
 namespace Tracing {
-namespace LogJson {
+namespace Json {
 
 /// A Backend that outputs data to chip logging.
 ///
@@ -30,10 +30,10 @@ namespace LogJson {
 /// THREAD SAFETY:
 ///    class assumes that ChipLog* is thread_safe (generally
 ///    we ChipLog* everywhere, so that condition seems to be met).
-class LogJsonBackend : public ::chip::Tracing::Backend
+class JsonBackend : public ::chip::Tracing::Backend
 {
 public:
-    LogJsonBackend() = default;
+    JsonBackend() = default;
 
     void TraceBegin(const char * label, const char * group) override;
     void TraceEnd(const char * label, const char * group) override;
@@ -45,6 +45,6 @@ public:
     void LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo &) override;
 };
 
-} // namespace LogJson
+} // namespace Json
 } // namespace Tracing
 } // namespace chip

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -55,6 +55,7 @@ public:
     void LogNodeDiscovered(NodeDiscoveredInfo &) override;
     void LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo &) override;
     void Close() override { CloseFile(); }
+
 private:
     /// Does the actual write of the value
     void OutputValue(::Json::Value & value);

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -18,10 +18,11 @@
 #pragma once
 
 #include <tracing/backend.h>
-
-#include <json/json.h>
-
 #include <fstream>
+
+namespace Json {
+class Value;
+}
 
 namespace chip {
 namespace Tracing {

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -19,6 +19,10 @@
 
 #include <tracing/backend.h>
 
+#include <json/json.h>
+
+#include <fstream>
+
 namespace chip {
 namespace Tracing {
 namespace Json {
@@ -34,6 +38,10 @@ class JsonBackend : public ::chip::Tracing::Backend
 {
 public:
     JsonBackend() = default;
+    ~JsonBackend();
+
+    // Start tracing output to the given file
+    CHIP_ERROR Open(const char * path);
 
     void TraceBegin(const char * label, const char * group) override;
     void TraceEnd(const char * label, const char * group) override;
@@ -43,6 +51,14 @@ public:
     void LogNodeLookup(NodeLookupInfo &) override;
     void LogNodeDiscovered(NodeDiscoveredInfo &) override;
     void LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo &) override;
+
+private:
+    /// Does the actual write of the value
+    void OutputValue(::Json::Value & value);
+
+    // Output file if writing to a file. If closed, writing
+    // to ChipLog*
+    std::fstream mOutputFile;
 };
 
 } // namespace Json

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -17,8 +17,8 @@
  */
 #pragma once
 
-#include <tracing/backend.h>
 #include <fstream>
+#include <tracing/backend.h>
 
 namespace Json {
 class Value;

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -41,10 +41,10 @@ public:
     ~JsonBackend();
 
     // Start tracing output to the given file
-    CHIP_ERROR Open(const char * path);
+    CHIP_ERROR OpenFile(const char * path);
 
     // Close if an output file is open
-    void Close();
+    void CloseFile();
 
     void TraceBegin(const char * label, const char * group) override;
     void TraceEnd(const char * label, const char * group) override;
@@ -54,7 +54,7 @@ public:
     void LogNodeLookup(NodeLookupInfo &) override;
     void LogNodeDiscovered(NodeDiscoveredInfo &) override;
     void LogNodeDiscoveryFailed(NodeDiscoveryFailedInfo &) override;
-
+    void Close() override { CloseFile(); }
 private:
     /// Does the actual write of the value
     void OutputValue(::Json::Value & value);

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -43,6 +43,9 @@ public:
     // Start tracing output to the given file
     CHIP_ERROR Open(const char * path);
 
+    // Close if an output file is open
+    void Close();
+
     void TraceBegin(const char * label, const char * group) override;
     void TraceEnd(const char * label, const char * group) override;
     void TraceInstant(const char * label, const char * group) override;
@@ -59,6 +62,7 @@ private:
     // Output file if writing to a file. If closed, writing
     // to ChipLog*
     std::fstream mOutputFile;
+    bool mFirstRecord = true;
 };
 
 } // namespace Json


### PR DESCRIPTION
Outputting tracing data into logs is noisy. Generally one wants formatted data in dedicated files, so provide the option to write logs into files.

This changes a `--trace-to log` to be replaced with `--trace-to json:log` however more generally we now support `--trace-to json:$HOME/mylog.json` and which can be processed using `jq` or similar.

Changes:
  - renames `log_json` to just `json` in tracing
  - add option to output to files and process command line arguments allowing output to files
 
Tested:

```sh
./out/linux-x64-chip-tool/chip-tool pairing onnetwork 1 20202021 --trace-to json:$HOME/tmp/tool.json

jq ".[] | [.time_ms, .event] " ~/tmp/tool.json
```