### PR TITLE
[Silabs]Update efr32 dockerfile to pull gsdk 4.2.3

### DIFF
--- a/integrations/docker/images/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/chip-build-efr32/Dockerfile
@@ -16,8 +16,8 @@ RUN set -x \
     && : # last line
 
 
-#Clone Gecko SDK 4.2.0 (d4854d2)
-RUN git clone --depth=1 --branch=v4.2.0 https://github.com/SiliconLabs/gecko_sdk.git
+#Clone Gecko SDK 4.2.0 (ef05eb6)
+RUN git clone --depth=1 --branch=v4.2.3 https://github.com/SiliconLabs/gecko_sdk.git
 
 ENV GSDK_ROOT=/gecko_sdk/
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.7.24 Version bump reason: [Telink] Update Docker image (Zephyr update)
+0.7.25 Version bump reason: Update silabs GSDK version


### PR DESCRIPTION
Update the docker file in a standalone PR
#27618 will need this to pass CI
