### PR TITLE
[Tizen] Prevent the possible build error in ConfigurationManager

### DIFF
--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -32,7 +32,9 @@
 #include <platform/Tizen/PosixConfig.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #include "WiFiManager.h"
+#endif
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
Fix the build error with no wifi option.

./scripts/build/build_examples.py --target tizen-arm-light-no-ble-no-wifi-no-thread build

 INFO    In file included from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/platform/Tizen/ConfigurationManagerImpl.cpp:35:
 INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/platform/Tizen/WiFiManager.h:24:10: fatal error: wifi-manager.h: No such file or directory
 INFO       24 | #include <wifi-manager.h>
 INFO          |          ^~~~~~~~~~~~~~~~
 INFO    compilation terminated.