### PR TITLE
Fix few format specifiers

### DIFF
--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -78,7 +78,7 @@ CHIP_ERROR CommandPathIB::Parser::PrettyPrint() const
             {
                 chip::CommandId commandId;
                 ReturnErrorOnFailure(reader.Get(commandId));
-                PRETTY_PRINT("\tCommandId = 0x%x,", commandId);
+                PRETTY_PRINT("\tCommandId = 0x%" PRIx32 ",", commandId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR EventPathIB::Parser::PrettyPrint() const
             {
                 EventId event;
                 reader.Get(event);
-                PRETTY_PRINT("\tEvent = 0x%x,", event);
+                PRETTY_PRINT("\tEvent = 0x%" PRIx32 ",", event);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;


### PR DESCRIPTION
#### Problem
Came across below format specifier errors when building ESP32 in debug mode
```
In file included from ../../../../../connectedhomeip/connectedhomeip/config/esp32/third_party/connectedhomeip/src/app/MessageDef/EventPathIB.cpp:21:
../../../../../connectedhomeip/connectedhomeip/config/esp32/third_party/connectedhomeip/src/app/MessageDef/EventPathIB.cpp: In member function 'CHIP_ERROR chip::app::EventPathIB::Parser::PrettyPrint() const':
../../../../../connectedhomeip/connectedhomeip/config/esp32/third_party/connectedhomeip/src/app/MessageDef/EventPathIB.cpp:92:30: error: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'chip::EventId' {aka 'long unsigned int'} [-Werror=format=]
   92 |                 PRETTY_PRINT("\tEvent = 0x%x,", event);
      |                              ^~~~~~~~~~~~~~~~~  ~~~~~
      |                                                 |
      |                                                 chip::EventId {aka long unsigned int}
../../../../../connectedhomeip/connectedhomeip/config/esp32/third_party/connectedhomeip/src/app/MessageDef/MessageDefHelper.h:58:29: note: in definition of macro 'PRETTY_PRINT'
   58 |         PrettyPrintIM(true, fmt, ##__VA_ARGS__);                                                                                   \
      |                             ^~~
../../../../../connectedhomeip/connectedhomeip/config/esp32/third_party/connectedhomeip/src/app/MessageDef/EventPathIB.cpp:92:44: note: format string is defined here
   92 |                 PRETTY_PRINT("\tEvent = 0x%x,", event);
      |                                           ~^
      |                                            |
      |                                            unsigned int
      |                                           %lx
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
```

#### Change Overview
Using PRIx32 macros rather than "%x"

#### Tests
Builds successfully.