### PR TITLE
Fix printing of port in Darwin OnResolve callback.

### DIFF
--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -250,7 +250,7 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
                       void * context)
 {
     ChipLogProgress(Discovery, "Mdns: %s flags: %d, interface: %u, fullname: %s, hostname: %s, port: %u", __func__, flags,
-                    (unsigned) interfaceId, StringOrNullMarker(fullname), StringOrNullMarker(hostname), port);
+                    (unsigned) interfaceId, StringOrNullMarker(fullname), StringOrNullMarker(hostname), ntohs(port));
     auto sdCtx = reinterpret_cast<ResolveContext *>(context);
     ReturnOnFailure(MdnsContexts::GetInstance().Has(sdCtx));
     LogOnFailure(__func__, err);


### PR DESCRIPTION
The port here is in network byte order.
