### PR TITLE
Fix TestExchangeMgr assertion about exchange ids.

### DIFF
--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -107,7 +107,6 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * ec1 = ctx.NewExchangeToBob(&mockAppDelegate);
     NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, ec1 != nullptr);
     NL_TEST_ASSERT(inSuite, ec1->IsInitiator() == true);
-    NL_TEST_ASSERT(inSuite, ec1->GetExchangeId() != 0);
     NL_TEST_ASSERT(inSuite, ec1->GetSessionHandle() == ctx.GetSessionAliceToBob());
     NL_TEST_ASSERT(inSuite, ec1->GetDelegate() == &mockAppDelegate);
 


### PR DESCRIPTION
0 is a perfectly valid exchange id, and can happen.

Fixes https://github.com/project-chip/connectedhomeip/issues/27667


