### PR TITLE
Make MinMDNS only report commissiabe nodes for active browse.

### DIFF
--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -55,16 +55,46 @@ void ActiveResolveAttempts::Complete(const PeerId & peerId)
 #endif
 }
 
-void ActiveResolveAttempts::Complete(const chip::Dnssd::DiscoveredNodeData & data)
+void ActiveResolveAttempts::CompleteCommissioner(const chip::Dnssd::DiscoveredNodeData & data)
 {
     for (auto & item : mRetryQueue)
     {
-        if (item.attempt.Matches(data))
+        if (item.attempt.Matches(data, chip::Dnssd::DiscoveryType::kCommissionerNode))
         {
             item.attempt.Clear();
             return;
         }
     }
+}
+
+void ActiveResolveAttempts::CompleteCommissionable(const chip::Dnssd::DiscoveredNodeData & data)
+{
+    for (auto & item : mRetryQueue)
+    {
+        if (item.attempt.Matches(data, chip::Dnssd::DiscoveryType::kCommissionableNode))
+        {
+            item.attempt.Clear();
+            return;
+        }
+    }
+}
+
+bool ActiveResolveAttempts::HasBrowseFor(chip::Dnssd::DiscoveryType type) const
+{
+    for (auto & item : mRetryQueue)
+    {
+        if (!item.attempt.IsBrowse())
+        {
+            continue;
+        }
+
+        if (item.attempt.BrowseData().type == type)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void ActiveResolveAttempts::CompleteIpResolution(SerializedQNameIterator targetHostName)

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -140,7 +140,7 @@ public:
         {
             return resolveData.Is<Resolve>() && (resolveData.Get<Resolve>().peerId == peer);
         }
-        bool Matches(const chip::Dnssd::DiscoveredNodeData & data) const
+        bool Matches(const chip::Dnssd::DiscoveredNodeData & data, chip::Dnssd::DiscoveryType type) const
         {
             if (!resolveData.Is<Browse>())
             {
@@ -149,13 +149,11 @@ public:
 
             auto & browse = resolveData.Get<Browse>();
 
-            // TODO: we should mark returned node data based on the query
-            if (browse.type != chip::Dnssd::DiscoveryType::kCommissionableNode)
+            if (browse.type != type)
             {
-                // We don't currently have markers in the returned DiscoveredNodeData to differentiate these, so assume all returned
-                // packets match
-                return true;
+                return false;
             }
+
             switch (browse.filter.type)
             {
             case chip::Dnssd::DiscoveryFilterType::kNone:
@@ -251,7 +249,8 @@ public:
 
     /// Mark a resolution as a success, removing it from the internal list
     void Complete(const chip::PeerId & peerId);
-    void Complete(const chip::Dnssd::DiscoveredNodeData & data);
+    void CompleteCommissioner(const chip::Dnssd::DiscoveredNodeData & data);
+    void CompleteCommissionable(const chip::Dnssd::DiscoveredNodeData & data);
     void CompleteIpResolution(SerializedQNameIterator targetHostName);
 
     /// Mark all browse-type scheduled attemptes as a success, removing them
@@ -288,6 +287,9 @@ public:
     /// Check if any of the pending queries are for the given host name for
     /// IP resolution.
     bool IsWaitingForIpResolutionFor(SerializedQNameIterator hostName) const;
+
+    /// Check if a browse operation is active for the given discovery type
+    bool HasBrowseFor(chip::Dnssd::DiscoveryType type) const;
 
 private:
     struct RetryEntry

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -84,7 +84,16 @@ public:
     };
     using RequiredInformationFlags = BitFlags<RequiredInformationBitFlags>;
 
-    IncrementalResolver() {}
+    // Type of service name that is contained in this resolver
+    enum class ServiceNameType
+    {
+        kInvalid, // not a matter service name
+        kOperational,
+        kCommissioner,
+        kCommissionable,
+    };
+
+    IncrementalResolver() = default;
 
     /// Checks if object has been initialized using the `InitializeParsing`
     /// method.
@@ -92,6 +101,8 @@ public:
 
     bool IsActiveCommissionParse() const { return mSpecificResolutionData.Is<CommissionNodeData>(); }
     bool IsActiveOperationalParse() const { return mSpecificResolutionData.Is<OperationalNodeData>(); }
+
+    ServiceNameType GetCurrentType() const { return mServiceNameType; }
 
     /// Start parsing a new record. SRV records are the records we are mainly
     /// interested on, after which TXT and A/AAAA are looked for.
@@ -171,6 +182,7 @@ private:
 
     StoredServerName mRecordName;     // Record name for what is parsed (SRV/PTR/TXT)
     StoredServerName mTargetHostName; // `Target` for the SRV record
+    ServiceNameType  mServiceNameType = ServiceNameType::kInvalid;
     CommonResolutionData mCommonResolutionData;
     ParsedRecordSpecificData mSpecificResolutionData;
 };

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -182,7 +182,7 @@ private:
 
     StoredServerName mRecordName;     // Record name for what is parsed (SRV/PTR/TXT)
     StoredServerName mTargetHostName; // `Target` for the SRV record
-    ServiceNameType  mServiceNameType = ServiceNameType::kInvalid;
+    ServiceNameType mServiceNameType = ServiceNameType::kInvalid;
     CommonResolutionData mCommonResolutionData;
     ParsedRecordSpecificData mSpecificResolutionData;
 };

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -127,7 +127,7 @@ void TestSingleBrowseAddRemove(nlTestSuite * inSuite, void * inContext)
     // once complete, nothing to schedule
     Dnssd::DiscoveredNodeData data;
     data.commissionData.longDiscriminator = 1234;
-    attempts.Complete(data);
+    attempts.CompleteCommissionable(data);
     NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduled().HasValue());
 }
@@ -376,7 +376,7 @@ void TestCombination(nlTestSuite * inSuite, void * inContext)
     attempts.Complete(MakePeerId(1));
     Dnssd::DiscoveredNodeData data;
     data.commissionData.longDiscriminator = 1234;
-    attempts.Complete(data);
+    attempts.CompleteCommissionable(data);
 
     NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduled().HasValue());


### PR DESCRIPTION
MinMDNS had no way to differentiate what type of active commissionable browse operations existed so would report any commissioner or commissionable node the same to devices.

This would make commissioner devices like chip-tool be able to detect themselves as 'commissionable' resulting in failed processing.
