### PR TITLE
Fix chip-tool remove-keyset command.

### DIFF
--- a/examples/chip-tool/commands/group/Commands.h
+++ b/examples/chip-tool/commands/group/Commands.h
@@ -332,10 +332,7 @@ public:
         }
         iter->Release();
 
-        if (err == CHIP_NO_ERROR)
-        {
-            return err;
-        }
+        ReturnErrorOnFailure(err);
         ReturnErrorOnFailure(groupDataProvider->RemoveKeySet(fabricIndex, keysetId));
 
         SetCommandExitStatus(CHIP_NO_ERROR);


### PR DESCRIPTION
We were returning without calling SetCommandExitStatus if removing group keys _succeeded_, which is backwards.

Fixes https://github.com/project-chip/connectedhomeip/issues/27600
