### PR TITLE
Make sure we don't use CHIP_CONFIG_MAX_FABRICS before it's defined.

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -668,28 +668,6 @@
 #endif // CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE
 
 /**
- * @def CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
- *
- * @brief Defines the size of the pool used for tracking the state of
- * secure sessions. This controls the maximum number of concurrent
- * established secure sessions across all supported transports.
- *
- * This is sized by default to cover the sum of the following:
- *  - At least 3 CASE sessions / fabric (Spec Ref: 4.13.2.8)
- *  - 1 reserved slot for CASEServer as a responder.
- *  - 1 reserved slot for PASE.
- *
- *  NOTE: On heap-based platforms, there is no pre-allocation of the pool.
- *  Due to the use of an LRU-scheme to manage sessions, the actual active
- *  size of the pool will grow up to the value of this define,
- *  after which, it will remain at or around this size indefinitely.
- *
- */
-#ifndef CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
-#define CHIP_CONFIG_SECURE_SESSION_POOL_SIZE (CHIP_CONFIG_MAX_FABRICS * 3 + 2)
-#endif // CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
-
-/**
  * @def CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING
  *
  * @brief This enables logging of changes to the underlying reference count of
@@ -711,6 +689,28 @@
 #ifndef CHIP_CONFIG_MAX_FABRICS
 #define CHIP_CONFIG_MAX_FABRICS 16
 #endif // CHIP_CONFIG_MAX_FABRICS
+
+/**
+ * @def CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
+ *
+ * @brief Defines the size of the pool used for tracking the state of
+ * secure sessions. This controls the maximum number of concurrent
+ * established secure sessions across all supported transports.
+ *
+ * This is sized by default to cover the sum of the following:
+ *  - At least 3 CASE sessions / fabric (Spec Ref: 4.13.2.8)
+ *  - 1 reserved slot for CASEServer as a responder.
+ *  - 1 reserved slot for PASE.
+ *
+ *  NOTE: On heap-based platforms, there is no pre-allocation of the pool.
+ *  Due to the use of an LRU-scheme to manage sessions, the actual active
+ *  size of the pool will grow up to the value of this define,
+ *  after which, it will remain at or around this size indefinitely.
+ *
+ */
+#ifndef CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
+#define CHIP_CONFIG_SECURE_SESSION_POOL_SIZE (CHIP_CONFIG_MAX_FABRICS * 3 + 2)
+#endif // CHIP_CONFIG_SECURE_SESSION_POOL_SIZE
 
 /**
  *  @def CHIP_CONFIG_MAX_GROUP_DATA_PEERS


### PR DESCRIPTION
The definition of CHIP_CONFIG_SECURE_SESSION_POOL_SIZE uses CHIP_CONFIG_MAX_FABRICS but came before we ensures CHIP_CONFIG_MAX_FABRICS is defined.  This change just moves it to right after the definition of CHIP_CONFIG_MAX_FABRICS.
