### PR TITLE
Update websocket_runner keep alive timeout

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/websocket_runner.py
@@ -22,7 +22,7 @@ import websockets
 from .hooks import WebSocketRunnerHooks
 from .runner import TestRunner
 
-_KEEP_ALIVE_TIMEOUT_IN_SECONDS = 40
+_KEEP_ALIVE_TIMEOUT_IN_SECONDS = 120
 _MAX_MESSAGE_SIZE_IN_BYTES = 10485760  # 10 MB
 
 


### PR DESCRIPTION
## The problem

**Context:** Using the runner in Test Harness (chip-certification-tool).

**Description:** The web socket connection to the runner was timing out when pairing/commissioning failed during a test suite setup.

**Steps to reproduce:**
- Run an automated test case (e.g.  `TC-ACE-1.1`) in Test Harness
- Don't run any DUT
- At the test suite setup TH will try to commission the DUT, but since none is running, the commissioning command will timeout
- Before the `chip-tool` pairing command times out, the runner web socket keep alive ping times out and closes the connection, causing a failure in TH
<img width="2160" alt="Screenshot 2023-07-07 at 11 50 16" src="https://github.com/project-chip/connectedhomeip/assets/116589288/43ceaed9-3b9d-40b0-a7af-418f129bd7d1">

**Expected behavior:**
- After the commissioning fails, the web socket connection was supposed to continue and then TH would ask the user if they want to retry the commissioning
<img width="2160" alt="Screenshot 2023-07-07 at 14 47 04" src="https://github.com/project-chip/connectedhomeip/assets/116589288/f944634a-ecdc-4624-80e0-4061c520527c">

- If a DUT is available during the retry, then the commissioning should succeed and the test case should execute normally
<img width="2160" alt="Screenshot 2023-07-07 at 13 27 30" src="https://github.com/project-chip/connectedhomeip/assets/116589288/c0fa4190-05fa-4eaa-ad87-edaf4a4cb51b">

## Solution

Increasing the keep alive ping timeout value solved the problem.

The new value was found through trial and error. The value 110 also worked, but I chose 120 just to be sure. Values <= 100 still caused the failure.