### PR TITLE
Make racy Darwin test less racy.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -1686,7 +1686,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     MTRClusterStateCacheContainer * clusterStateCacheContainer = [[MTRClusterStateCacheContainer alloc] init];
     NSLog(@"Setting up attribute cache subscription...");
-    __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(1) maxInterval:@(60)];
+    __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(0) maxInterval:@(60)];
     [device subscribeWithQueue:queue
         params:params
         clusterStateCacheContainer:clusterStateCacheContainer


### PR DESCRIPTION
We used a 1s min-interval and a 1s sleep to wait for reports.  Those could race very easily.  Better to use a sleep longer than the min-interval.

Fixes https://github.com/project-chip/connectedhomeip/issues/27507
