### PR TITLE
[silabs] WiFi -Fix for 917SoC Apps build failure

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -248,6 +248,7 @@ source_set("siwx917-common") {
 
   sources = [
     "${silabs_common_plat_dir}/LEDWidget.cpp",
+    "${silabs_common_plat_dir}/SoftwareFaultReports.cpp",
     "${silabs_common_plat_dir}/heap_4_silabs.c",
     "${silabs_common_plat_dir}/silabs_utils.cpp",
     "${silabs_common_plat_dir}/syscalls_stubs.cpp",

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -34,6 +34,10 @@
 #endif
 #endif // BRD4325A
 
+#ifdef BRD4325A // For SiWx917 Platform only
+#include "core_cm4.h"
+#endif
+
 // Technically FaultRecording is an octstr up to 1024 bytes.
 // We currently only report short strings. 100 char will more than enough for now.
 constexpr uint8_t kMaxFaultStringLen = 100;


### PR DESCRIPTION
Resolved 917SoC build issues caused by SoftwareFaultReports.cpp