### PR TITLE
Refactor network commissioning setup in Linux example apps.

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -24,7 +24,6 @@
 #include <app/CommandHandler.h>
 #include <app/att-storage.h>
 #include <app/clusters/identify-server/identify-server.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <lib/support/CHIPMem.h>
@@ -35,17 +34,6 @@
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
 #include <transport/raw/PeerAddress.h>
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#include <platform/Darwin/NetworkCommissioningDriver.h>
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#include <platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#include <platform/Linux/NetworkCommissioningDriver.h>
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 
 #include <Options.h>
 
@@ -105,42 +93,7 @@ static Identify gIdentify1 = {
     OnTriggerEffect,
 };
 
-// Network commissioning
 namespace {
-// This file is being used by platforms other than Linux, so we need this check to disable related features since we only
-// implemented them on linux.
-constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
-constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-NetworkCommissioning::LinuxThreadDriver sThreadDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-NetworkCommissioning::LinuxWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-NetworkCommissioning::LinuxEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sThreadDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointSecondary, &sWiFiDriver);
-#endif
-
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sEthernetDriver);
 
 class ExampleDeviceInstanceInfoProvider : public DeviceInstanceInfoProvider
 {
@@ -200,58 +153,6 @@ ExampleDeviceInstanceInfoProvider gExampleDeviceInstanceInfoProvider;
 
 void ApplicationInit()
 {
-    (void) kNetworkCommissioningEndpointMain;
-    // Enable secondary endpoint only when we need it, this should be applied to all platforms.
-    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
-
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-        // Only enable secondary endpoint for network commissioning cluster when both WiFi and Thread are enabled.
-        emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, true);
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        // If we only enable WiFi on this device, "move" WiFi instance to main NetworkCommissioning cluster endpoint.
-        sWiFiNetworkCommissioningInstance.~Instance();
-        new (&sWiFiNetworkCommissioningInstance)
-            Clusters::NetworkCommissioning::Instance(kNetworkCommissioningEndpointMain, &sWiFiDriver);
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-    }
-    else
-    {
-        sEthernetNetworkCommissioningInstance.Init();
-    }
-
     std::string path = kChipEventFifoPathPrefix + std::to_string(getpid());
 
     if (sChipNamedPipeCommands.Start(path, &sAllClustersCommandDelegate) != CHIP_NO_ERROR)

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -28,7 +28,8 @@ constexpr chip::EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), &kNetworkCommissioningEndpointSecondary) == 0);
+    VerifyOrDie(
+        ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), chip::MakeOptional(kNetworkCommissioningEndpointSecondary)) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
     LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -21,9 +21,14 @@
 #include "binding-handler.h"
 #include "main-common.h"
 
+// Network commissioning
+namespace {
+constexpr chip::EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+} // anonymous namespace
+
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions()) == 0);
+    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), &kNetworkCommissioningEndpointSecondary) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
     LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();

--- a/examples/all-clusters-minimal-app/linux/main-common.cpp
+++ b/examples/all-clusters-minimal-app/linux/main-common.cpp
@@ -21,12 +21,10 @@
 #include <app/CommandHandler.h>
 #include <app/att-storage.h>
 #include <app/clusters/identify-server/identify-server.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <lib/support/CHIPMem.h>
 #include <new>
-#include <platform/Linux/NetworkCommissioningDriver.h>
 #include <platform/PlatformManager.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
@@ -84,94 +82,7 @@ static Identify gIdentify1 = {
     OnTriggerEffect,
 };
 
-// Network commissioning
-namespace {
-// This file is being used by platforms other than Linux, so we need this check to disable related features since we only
-// implemented them on linux.
-constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
-constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-NetworkCommissioning::LinuxThreadDriver sLinuxThreadDriver;
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(kNetworkCommissioningEndpointMain,
-                                                                             &sLinuxThreadDriver);
-#endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointSecondary,
-                                                                           &sLinuxWiFiDriver);
-#endif
-NetworkCommissioning::LinuxEthernetDriver sLinuxEthernetDriver;
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain,
-                                                                               &sLinuxEthernetDriver);
-#else  // CHIP_DEVICE_LAYER_TARGET_LINUX
-Clusters::NetworkCommissioning::NullNetworkDriver sNullNetworkDriver;
-Clusters::NetworkCommissioning::Instance sNullNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sNullNetworkDriver);
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-} // namespace
-
-void ApplicationInit()
-{
-    (void) kNetworkCommissioningEndpointMain;
-    // Enable secondary endpoint only when we need it, this should be applied to all platforms.
-    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-        // Only enable secondary endpoint for network commissioning cluster when both WiFi and Thread are enabled.
-        emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, true);
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        // If we only enable WiFi on this device, "move" WiFi instance to main NetworkCommissioning cluster endpoint.
-        sWiFiNetworkCommissioningInstance.~Instance();
-        new (&sWiFiNetworkCommissioningInstance)
-            Clusters::NetworkCommissioning::Instance(kNetworkCommissioningEndpointMain, &sLinuxWiFiDriver);
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-    }
-    else
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-    {
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-        sEthernetNetworkCommissioningInstance.Init();
-#else
-        // Use NullNetworkCommissioningInstance to disable the network commissioning functions.
-        sNullNetworkCommissioningInstance.Init();
-#endif
-    }
-}
+void ApplicationInit() {}
 
 void emberAfLowPowerClusterInitCallback(EndpointId endpoint)
 {

--- a/examples/all-clusters-minimal-app/linux/main.cpp
+++ b/examples/all-clusters-minimal-app/linux/main.cpp
@@ -20,9 +20,14 @@
 #include "AppOptions.h"
 #include "binding-handler.h"
 
+// Network commissioning
+namespace {
+constexpr chip::EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+} // anonymous namespace
+
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions()) == 0);
+    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), &kNetworkCommissioningEndpointSecondary) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
     LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();

--- a/examples/all-clusters-minimal-app/linux/main.cpp
+++ b/examples/all-clusters-minimal-app/linux/main.cpp
@@ -27,7 +27,8 @@ constexpr chip::EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), &kNetworkCommissioningEndpointSecondary) == 0);
+    VerifyOrDie(
+        ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), chip::MakeOptional(kNetworkCommissioningEndpointSecondary)) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
     LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -24,7 +24,6 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/EventLogging.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/reporting/reporting.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
@@ -38,17 +37,6 @@
 #include <platform/CommissionableDataProvider.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#include <platform/Darwin/NetworkCommissioningDriver.h>
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#include <platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#include <platform/Linux/NetworkCommissioningDriver.h>
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 
 #include <pthread.h>
 #include <sys/ioctl.h>
@@ -81,36 +69,6 @@ EndpointId gFirstDynamicEndpointId;
 Device * gDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT];
 std::vector<Room *> gRooms;
 std::vector<Action *> gActions;
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-DeviceLayer::NetworkCommissioning::LinuxThreadDriver sThreadDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::LinuxEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sWiFiDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(0, &sThreadDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(0, &sEthernetDriver);
 
 const int16_t minMeasuredValue     = -27315;
 const int16_t maxMeasuredValue     = 32766;
@@ -769,48 +727,7 @@ bool emberAfActionsClusterInstantActionCallback(app::CommandHandler * commandObj
     return true;
 }
 
-void ApplicationInit()
-{
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-        // Just use the Thread one.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-    }
-    else
-    {
-        sEthernetNetworkCommissioningInstance.Init();
-    }
-}
+void ApplicationInit() {}
 
 const EmberAfDeviceType gBridgedOnOffDeviceTypes[] = { { DEVICE_TYPE_LO_ON_OFF_LIGHT, DEVICE_VERSION_DEFAULT },
                                                        { DEVICE_TYPE_BRIDGED_NODE, DEVICE_VERSION_DEFAULT } };

--- a/examples/chef/linux/main.cpp
+++ b/examples/chef/linux/main.cpp
@@ -20,9 +20,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/Linux/NetworkCommissioningDriver.h>
 
 #include <lib/shell/Engine.h>
 
@@ -32,19 +30,7 @@ using namespace chip;
 using namespace chip::Shell;
 using namespace chip::app;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-namespace {
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
-} // namespace
-#endif
-
-void ApplicationInit()
-{
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    sWiFiNetworkCommissioningInstance.Init();
-#endif
-}
+void ApplicationInit() {}
 
 int main(int argc, char * argv[])
 {

--- a/examples/contact-sensor-app/linux/main.cpp
+++ b/examples/contact-sensor-app/linux/main.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <AppMain.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/util/af.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 
@@ -28,95 +27,11 @@
 #include <imgui_ui/windows/qrcode.h>
 #endif
 
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#include <platform/Darwin/NetworkCommissioningDriver.h>
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#include <platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#include <platform/Linux/NetworkCommissioningDriver.h>
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 
-namespace {
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-DeviceLayer::NetworkCommissioning::LinuxThreadDriver sThreadDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::LinuxEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sWiFiDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(0, &sThreadDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(0, &sEthernetDriver);
-} // namespace
-
-void ApplicationInit()
-{
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-        // Just use the Thread one.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-    }
-    else
-    {
-        sEthernetNetworkCommissioningInstance.Init();
-    }
-}
+void ApplicationInit() {}
 
 int main(int argc, char * argv[])
 {

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -22,20 +22,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <lib/support/logging/CHIPLogging.h>
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#include <platform/Darwin/NetworkCommissioningDriver.h>
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#include <platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.h>
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#include <platform/Linux/NetworkCommissioningDriver.h>
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 
 #if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
 #include <imgui_ui/ui.h>
@@ -48,40 +36,6 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
-
-namespace {
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-DeviceLayer::NetworkCommissioning::LinuxThreadDriver sThreadDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::LinuxEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-DeviceLayer::NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-DeviceLayer::NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sWiFiDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(0, &sThreadDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(0, &sEthernetDriver);
-
-} // namespace
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
@@ -112,48 +66,7 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
     // TODO: implement any additional Cluster Server init actions
 }
 
-void ApplicationInit()
-{
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-        // Just use the Thread one.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-        sWiFiNetworkCommissioningInstance.Init();
-#endif
-    }
-    else
-    {
-        sEthernetNetworkCommissioningInstance.Init();
-    }
-}
+void ApplicationInit() {}
 
 int main(int argc, char * argv[])
 {

--- a/examples/lock-app/linux/main.cpp
+++ b/examples/lock-app/linux/main.cpp
@@ -18,8 +18,6 @@
 
 #include "AppMain.h"
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/Linux/NetworkCommissioningDriver.h>
 
 #include "LockAppCommandDelegate.h"
 #include "LockManager.h"
@@ -28,33 +26,6 @@ using namespace chip;
 using namespace chip::app;
 
 namespace {
-// We support either thread or wi-fi commissioning, not both.  Prefer thread if
-// both are available.
-#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
-DeviceLayer::NetworkCommissioning::LinuxThreadDriver sNetworkCommissioningDriver;
-Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0, &sNetworkCommissioningDriver);
-
-void InitNetworkCommissioning()
-{
-    sNetworkCommissioningInstance.Init();
-}
-
-#elif CHIP_DEVICE_CONFIG_ENABLE_WPA
-
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sNetworkCommissioningDriver;
-Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0, &sNetworkCommissioningDriver);
-
-void InitNetworkCommissioning()
-{
-    sNetworkCommissioningInstance.Init();
-}
-
-#else // !CHIP_DEVICE_CONFIG_ENABLE_WPA && !(CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD)
-
-void InitNetworkCommissioning() {}
-
-#endif // (CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD) || CHIP_DEVICE_CONFIG_ENABLE_WPA
-
 // Variables for handling named pipe commands
 constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_lock_app_fifo-";
 NamedPipeCommands sChipNamedPipeCommands;
@@ -64,8 +35,6 @@ LockAppCommandDelegate sLockAppCommandDelegate;
 
 void ApplicationInit()
 {
-    InitNetworkCommissioning();
-
     auto path = kChipEventFifoPathPrefix + std::to_string(getpid());
     if (sChipNamedPipeCommands.Start(path, &sLockAppCommandDelegate) != CHIP_NO_ERROR)
     {

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -257,7 +257,7 @@ void ApplicationInit()
 
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, &cmdLineOptions, &kNetworkCommissioningEndpointSecondary) == 0);
+    VerifyOrDie(ChipLinuxAppInit(argc, argv, &cmdLineOptions, MakeOptional(kNetworkCommissioningEndpointSecondary)) == 0);
     ChipLinuxAppMainLoop();
 
     // If the event loop had been stopped due to an update being applied, boot into the new image

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "AppMain.h"
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
@@ -130,29 +129,7 @@ OptionSet * allOptions[] = { &cmdLineOptions, nullptr };
 
 // Network commissioning
 namespace {
-constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
-
-// This file is being used by platforms other than Linux, so we need this check to disable related features since we only
-// implemented them on linux.
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-NetworkCommissioning::LinuxThreadDriver sLinuxThreadDriver;
-Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(kNetworkCommissioningEndpointMain,
-                                                                             &sLinuxThreadDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointSecondary,
-                                                                           &sLinuxWiFiDriver);
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-NetworkCommissioning::LinuxEthernetDriver sLinuxEthernetDriver;
-Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain,
-                                                                               &sLinuxEthernetDriver);
-#else  // CHIP_DEVICE_LAYER_TARGET_LINUX
-Clusters::NetworkCommissioning::NullNetworkDriver sNullNetworkDriver;
-Clusters::NetworkCommissioning::Instance sNullNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sNullNetworkDriver);
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 } // namespace
 
 bool CustomOTARequestorDriver::CanConsent()
@@ -204,68 +181,6 @@ static void InitOTARequestor(void)
     {
         gUserConsentProvider.SetUserConsentState(gUserConsentState);
         gRequestorUser.SetUserConsentDelegate(&gUserConsentProvider);
-    }
-}
-
-static void InitNetworkCommissioning(void)
-{
-    (void) kNetworkCommissioningEndpointMain;
-    // Enable secondary endpoint only when we need it, this should be applied to all platforms.
-    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
-
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-    const bool kThreadEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    };
-
-    const bool kWiFiEnabled = {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-    };
-
-    if (kThreadEnabled && kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        sWiFiNetworkCommissioningInstance.Init();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-       // Only enable secondary endpoint for network commissioning cluster when both WiFi and Thread are enabled.
-        emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, true);
-    }
-    else if (kThreadEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        sThreadNetworkCommissioningInstance.Init();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    }
-    else if (kWiFiEnabled)
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-        // If we only enable WiFi on this device, "move" WiFi instance to main NetworkCommissioning cluster endpoint.
-        sWiFiNetworkCommissioningInstance.~Instance();
-        new (&sWiFiNetworkCommissioningInstance)
-            Clusters::NetworkCommissioning::Instance(kNetworkCommissioningEndpointMain, &sLinuxWiFiDriver);
-        sWiFiNetworkCommissioningInstance.Init();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-    }
-    else
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-    {
-#if CHIP_DEVICE_LAYER_TARGET_LINUX
-        sEthernetNetworkCommissioningInstance.Init();
-#else
-        // Use NullNetworkCommissioningInstance to disable the network commissioning functions.
-        sNullNetworkCommissioningInstance.Init();
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
     }
 }
 
@@ -338,13 +253,11 @@ void ApplicationInit()
 {
     // Initialize all OTA download components
     InitOTARequestor();
-    // Initialize Network Commissioning instances
-    InitNetworkCommissioning();
 }
 
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv, &cmdLineOptions) == 0);
+    VerifyOrDie(ChipLinuxAppInit(argc, argv, &cmdLineOptions, &kNetworkCommissioningEndpointSecondary) == 0);
     ChipLinuxAppMainLoop();
 
     // If the event loop had been stopped due to an update being applied, boot into the new image

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -347,7 +347,7 @@ private:
 };
 
 int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
-                     const EndpointId * secondaryNetworkCommissioningEndpoint)
+                     const Optional<EndpointId> secondaryNetworkCommissioningEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 #if CONFIG_NETWORK_LAYER_BLE
@@ -366,10 +366,7 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     err = ParseArguments(argc, argv, customOptions);
     SuccessOrExit(err);
 
-    if (secondaryNetworkCommissioningEndpoint != nullptr)
-    {
-        sSecondaryNetworkCommissioningEndpoint.Emplace(*secondaryNetworkCommissioningEndpoint);
-    }
+    sSecondaryNetworkCommissioningEndpoint = secondaryNetworkCommissioningEndpoint;
 
 #ifdef CHIP_CONFIG_KVS_PATH
     if (LinuxDeviceOptions::GetInstance().KVS == nullptr)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -19,11 +19,14 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
+#include "app/clusters/network-commissioning/network-commissioning.h"
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
+#include <app/util/endpoint-config-api.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/NodeId.h>
+#include <lib/core/Optional.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -79,6 +82,17 @@
 #include "AppMain.h"
 #include "CommissionableInit.h"
 
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+#include <platform/Darwin/NetworkCommissioningDriver.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#include <platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.h>
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
+
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
+#include <platform/Linux/NetworkCommissioningDriver.h>
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
+
 using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Credentials;
@@ -86,6 +100,123 @@ using namespace chip::DeviceLayer;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::app::Clusters;
+
+// Network comissioning implementation
+namespace {
+// If secondaryNetworkCommissioningEndpoint has a value and both Thread and WiFi
+// are enabled, we put the WiFi network commissioning cluster on
+// secondaryNetworkCommissioningEndpoint.
+Optional<EndpointId> sSecondaryNetworkCommissioningEndpoint;
+
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#define CHIP_APP_MAIN_HAS_THREAD_DRIVER 1
+DeviceLayer::NetworkCommissioning::LinuxThreadDriver sThreadDriver;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#define CHIP_APP_MAIN_HAS_WIFI_DRIVER 1
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sWiFiDriver;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+#define CHIP_APP_MAIN_HAS_ETHERNET_DRIVER 1
+DeviceLayer::NetworkCommissioning::LinuxEthernetDriver sEthernetDriver;
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
+
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#define CHIP_APP_MAIN_HAS_WIFI_DRIVER 1
+DeviceLayer::NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+#define CHIP_APP_MAIN_HAS_ETHERNET_DRIVER 1
+DeviceLayer::NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
+
+#if CHIP_APP_MAIN_HAS_THREAD_DRIVER
+app::Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(kRootEndpointId, &sThreadDriver);
+#endif // CHIP_APP_MAIN_HAS_THREAD_DRIVER
+
+#if CHIP_APP_MAIN_HAS_WIFI_DRIVER
+// The WiFi network commissioning instance cannot be constructed until we know
+// whether we have an sSecondaryNetworkCommissioningEndpoint.
+Optional<app::Clusters::NetworkCommissioning::Instance> sWiFiNetworkCommissioningInstance;
+#endif // CHIP_APP_MAIN_HAS_WIFI_DRIVER
+
+#if CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+app::Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kRootEndpointId, &sEthernetDriver);
+#endif // CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+
+void EnableThreadNetworkCommissioning()
+{
+#if CHIP_APP_MAIN_HAS_THREAD_DRIVER
+    sThreadNetworkCommissioningInstance.Init();
+#endif // CHIP_APP_MAIN_HAS_THREAD_DRIVER
+}
+
+void EnableWiFiNetworkCommissioning(EndpointId endpoint)
+{
+#if CHIP_APP_MAIN_HAS_WIFI_DRIVER
+    sWiFiNetworkCommissioningInstance.Emplace(endpoint, &sWiFiDriver);
+    sWiFiNetworkCommissioningInstance.Value().Init();
+#endif // CHIP_APP_MAIN_HAS_WIFI_DRIVER
+}
+
+void InitNetworkCommissioning()
+{
+    if (sSecondaryNetworkCommissioningEndpoint.HasValue())
+    {
+        // Enable secondary endpoint only when we need it, this should be applied to all platforms.
+        emberAfEndpointEnableDisable(sSecondaryNetworkCommissioningEndpoint.Value(), false);
+    }
+
+    const bool kThreadEnabled = {
+#if CHIP_APP_MAIN_HAS_THREAD_DRIVER
+        LinuxDeviceOptions::GetInstance().mThread
+#else
+        false
+#endif
+    };
+
+    const bool kWiFiEnabled = {
+#if CHIP_APP_MAIN_HAS_WIFI_DRIVER
+        LinuxDeviceOptions::GetInstance().mWiFi
+#else
+        false
+#endif
+    };
+
+    if (kThreadEnabled && kWiFiEnabled)
+    {
+        if (sSecondaryNetworkCommissioningEndpoint.HasValue())
+        {
+            EnableThreadNetworkCommissioning();
+            EnableWiFiNetworkCommissioning(sSecondaryNetworkCommissioningEndpoint.Value());
+            // Only enable secondary endpoint for network commissioning cluster when both WiFi and Thread are enabled.
+            emberAfEndpointEnableDisable(sSecondaryNetworkCommissioningEndpoint.Value(), true);
+        }
+        else
+        {
+            // Just use the Thread one.
+            EnableThreadNetworkCommissioning();
+        }
+    }
+    else if (kThreadEnabled)
+    {
+        EnableThreadNetworkCommissioning();
+    }
+    else if (kWiFiEnabled)
+    {
+        EnableWiFiNetworkCommissioning(kRootEndpointId);
+    }
+    else
+    {
+#if CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+        sEthernetNetworkCommissioningInstance.Init();
+#endif // CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+    }
+}
+} // anonymous namespace
 
 #if defined(ENABLE_CHIP_SHELL)
 using chip::Shell::Engine;
@@ -215,7 +346,8 @@ private:
     TestEventTriggerDelegate * mOtherDelegate = nullptr;
 };
 
-int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
+int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
+                     const EndpointId * secondaryNetworkCommissioningEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 #if CONFIG_NETWORK_LAYER_BLE
@@ -233,6 +365,11 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
 
     err = ParseArguments(argc, argv, customOptions);
     SuccessOrExit(err);
+
+    if (secondaryNetworkCommissioningEndpoint != nullptr)
+    {
+        sSecondaryNetworkCommissioningEndpoint.Emplace(*secondaryNetworkCommissioningEndpoint);
+    }
 
 #ifdef CHIP_CONFIG_KVS_PATH
     if (LinuxDeviceOptions::GetInstance().KVS == nullptr)
@@ -422,6 +559,8 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     Shell::RegisterControllerCommands();
 #endif // defined(ENABLE_CHIP_SHELL)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+
+    InitNetworkCommissioning();
 
     ApplicationInit();
 

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -22,13 +22,17 @@
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 #include <transport/TransportMgr.h>
 
 #include "Options.h"
 
-int ChipLinuxAppInit(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr);
+// Applications can optionally provide the endpoint id of a secondary network
+// commissioning endpoint, if one is supported.
+int ChipLinuxAppInit(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr,
+                     const chip::EndpointId * secondaryNetworkCommissioningEndpoit = nullptr);
 
 /**
  * A main loop implementation describes how an application main loop is to be

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -23,6 +23,7 @@
 #include <controller/CommissionerDiscoveryController.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/core/Optional.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 #include <transport/TransportMgr.h>
@@ -32,7 +33,7 @@
 // Applications can optionally provide the endpoint id of a secondary network
 // commissioning endpoint, if one is supported.
 int ChipLinuxAppInit(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr,
-                     const chip::EndpointId * secondaryNetworkCommissioningEndpoit = nullptr);
+                     const chip::Optional<chip::EndpointId> secondaryNetworkCommissioningEndpoit = chip::NullOptional);
 
 /**
  * A main loop implementation describes how an application main loop is to be

--- a/examples/thermostat/linux/main.cpp
+++ b/examples/thermostat/linux/main.cpp
@@ -21,20 +21,11 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/clusters/identify-server/identify-server.h>
-#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/util/af.h>
-#include <platform/Linux/NetworkCommissioningDriver.h>
 
 using namespace chip;
 using namespace chip::app;
 // using namespace chip::app::Clusters;
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-namespace {
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
-Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
-} // namespace
-#endif
 
 void OnIdentifyStart(Identify *)
 {
@@ -78,12 +69,7 @@ static Identify gIdentify1 = {
     OnTriggerEffect,
 };
 
-void ApplicationInit()
-{
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    sWiFiNetworkCommissioningInstance.Init();
-#endif
-}
+void ApplicationInit() {}
 
 int main(int argc, char * argv[])
 {

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -231,11 +231,6 @@ bool emberAfIsDeviceIdentifying(chip::EndpointId endpoint);
 /** @name Miscellaneous */
 // @{
 
-/**
- * @brief Enable/disable endpoints
- */
-bool emberAfEndpointEnableDisable(chip::EndpointId endpoint, bool enable);
-
 /** @brief Returns true if a given ZCL data type is a list type. */
 bool emberAfIsThisDataTypeAListType(EmberAfAttributeType dataType);
 

--- a/src/app/util/endpoint-config-api.h
+++ b/src/app/util/endpoint-config-api.h
@@ -33,6 +33,11 @@
 uint16_t emberAfEndpointCount(void);
 
 /**
+ * @brief Enable/disable endpoints
+ */
+bool emberAfEndpointEnableDisable(chip::EndpointId endpoint, bool enable);
+
+/**
  * Returns whether the endpoint at the specified index (which must be less than
  * emberAfEndpointCount() is enabled.  If an endpoint is disabled, it is not
  * guaranteed to have an EmberAfEndpointType.


### PR DESCRIPTION
Linux (and Mac) example apps were inconsistent in terms of how they handled network commissioning, with most of them being buggy in terms of not setting things up properly on Mac or not setting things up properly at all.

The changes here move the setup into AppMain, so it's handled consistently across all example apps.
