### PR TITLE
Revert "Remove tracing of encrypted message data (prepared buffers). (#27276)"

### DIFF
--- a/examples/common/tracing/TraceHandlers.cpp
+++ b/examples/common/tracing/TraceHandlers.cpp
@@ -226,6 +226,22 @@ std::string PayloadHeaderToJson(const PayloadHeader * payloadHeader)
     return jsonBody;
 }
 
+std::string PreparedSecureMessageDataToJson(const TracePreparedSecureMessageData * data, const std::string & peerAddressKey)
+{
+    const System::PacketBuffer * packetBuffer = data->packetBuffer->operator->();
+    std::string jsonBody                      = "{";
+    jsonBody += AsFirstJsonKey(peerAddressKey, AsJsonString(data->peerAddress));
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_size", std::to_string(packetBuffer->DataLength()));
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_hex", AsJsonHexString(packetBuffer->Start(), packetBuffer->DataLength()));
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("buffer_ptr", std::to_string(reinterpret_cast<std::uintptr_t>(packetBuffer)));
+    jsonBody += "}";
+
+    return jsonBody;
+}
+
 void SecureMessageSentHandler(const TraceSecureMessageSentData * eventData)
 {
     if (!gTraceOutputs.HasStreamAvailable())
@@ -274,9 +290,41 @@ void SecureMessageReceivedHandler(const TraceSecureMessageReceivedData * eventDa
     // Note that `eventData->session` is currently ignored.
 }
 
+void PreparedMessageSentHandler(const TracePreparedSecureMessageData * eventData)
+{
+    if (!gTraceOutputs.HasStreamAvailable())
+    {
+        return;
+    }
+
+    gTraceOutputs.StartEvent(std::string{ kTraceMessageEvent } + "." + kTracePreparedMessageSentDataFormat);
+    gTraceOutputs.AddField("json", PreparedSecureMessageDataToJson(eventData, "destination"));
+    gTraceOutputs.FinishEvent();
+}
+
+void PreparedMessageReceivedHandler(const TracePreparedSecureMessageData * eventData)
+{
+    if (!gTraceOutputs.HasStreamAvailable())
+    {
+        return;
+    }
+
+    gTraceOutputs.StartEvent(std::string{ kTraceMessageEvent } + "." + kTracePreparedMessageReceivedDataFormat);
+    gTraceOutputs.AddField("json", PreparedSecureMessageDataToJson(eventData, "source"));
+    gTraceOutputs.FinishEvent();
+}
+
 void TraceHandler(const char * type, const void * data, size_t size)
 {
-    if ((std::string{ type } == kTraceMessageSentDataFormat) && (size == sizeof(TraceSecureMessageSentData)))
+    if ((std::string{ type } == kTracePreparedMessageReceivedDataFormat) && (size == sizeof(TracePreparedSecureMessageData)))
+    {
+        PreparedMessageReceivedHandler(reinterpret_cast<const TracePreparedSecureMessageData *>(data));
+    }
+    else if ((std::string{ type } == kTracePreparedMessageSentDataFormat) && (size == sizeof(TracePreparedSecureMessageData)))
+    {
+        PreparedMessageSentHandler(reinterpret_cast<const TracePreparedSecureMessageData *>(data));
+    }
+    else if ((std::string{ type } == kTraceMessageSentDataFormat) && (size == sizeof(TraceSecureMessageSentData)))
     {
         SecureMessageSentHandler(reinterpret_cast<const TraceSecureMessageSentData *>(data));
     }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -400,6 +400,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
                     destination = &(multicastAddress.SetInterface(interfaceId));
                     if (mTransportMgr != nullptr)
                     {
+                        CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, &tempBuf);
                         if (CHIP_NO_ERROR != mTransportMgr->SendMessage(*destination, std::move(tempBuf)))
                         {
                             ChipLogError(Inet, "Failed to send Multicast message on interface %s", name);
@@ -428,6 +429,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
 
     if (mTransportMgr != nullptr)
     {
+        CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, &msgBuf);
         return mTransportMgr->SendMessage(*destination, std::move(msgBuf));
     }
 
@@ -552,6 +554,7 @@ CHIP_ERROR SessionManager::InjectCaseSessionWithTestKey(SessionHolder & sessionH
 
 void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::PacketBufferHandle && msg)
 {
+    CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(&peerAddress, &msg);
     PacketHeader partialPacketHeader;
 
     CHIP_ERROR err = partialPacketHeader.DecodeFixed(msg);

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -57,6 +57,22 @@
                                      sizeof(_trace_data));                                                                         \
     } while (0)
 
+#define CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, packetBuffer)                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const ::chip::trace::TracePreparedSecureMessageData _trace_data{ destination, packetBuffer };                              \
+        _CHIP_TRACE_MESSAGE_INTERNAL(::chip::trace::kTracePreparedMessageSentDataFormat,                                           \
+                                     reinterpret_cast<const char *>(&_trace_data), sizeof(_trace_data));                           \
+    } while (0)
+
+#define CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(source, packetBuffer)                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const ::chip::trace::TracePreparedSecureMessageData _trace_data{ source, packetBuffer };                                   \
+        _CHIP_TRACE_MESSAGE_INTERNAL(::chip::trace::kTracePreparedMessageReceivedDataFormat,                                       \
+                                     reinterpret_cast<const char *>(&_trace_data), sizeof(_trace_data));                           \
+    } while (0)
+
 #else // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED || CHIP_CONFIG_TRANSPORT_PW_TRACE_ENABLED
 #define CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, data, dataLen)                                                        \
     do                                                                                                                             \
@@ -68,14 +84,25 @@
     {                                                                                                                              \
     } while (0)
 
+#define CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, packetBuffer)                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
+
+#define CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(source, packetBuffer)                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED || CHIP_CONFIG_TRANSPORT_PW_TRACE_ENABLED
 
 namespace chip {
 namespace trace {
 
-constexpr const char * kTraceMessageEvent              = "SecureMsg";
-constexpr const char * kTraceMessageSentDataFormat     = "SecMsgSent";
-constexpr const char * kTraceMessageReceivedDataFormat = "SecMsgReceived";
+constexpr const char * kTraceMessageEvent                      = "SecureMsg";
+constexpr const char * kTraceMessageSentDataFormat             = "SecMsgSent";
+constexpr const char * kTraceMessageReceivedDataFormat         = "SecMsgReceived";
+constexpr const char * kTracePreparedMessageSentDataFormat     = "PreparedMsgSent";
+constexpr const char * kTracePreparedMessageReceivedDataFormat = "PreparedMsgReceived";
 
 struct TraceSecureMessageSentData
 {
@@ -93,6 +120,12 @@ struct TraceSecureMessageReceivedData
     const Transport::PeerAddress * peerAddress;
     const uint8_t * packetPayload;
     size_t packetSize;
+};
+
+struct TracePreparedSecureMessageData
+{
+    const Transport::PeerAddress * peerAddress;
+    const System::PacketBufferHandle * packetBuffer;
 };
 
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED


### PR DESCRIPTION
This reverts commit 5ed31da5cc5086fcfe0c3271c046ecbc87c30970.

That commit completely disabled tracing of payloads of sent messages, but certification depends on seeing those.

Fixes https://github.com/project-chip/connectedhomeip/issues/27824

