### PR TITLE
Increase our "waiting for subscription to time out" timer slack.

### DIFF
--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4645,14 +4645,15 @@ void TestReadInteraction::TestReadHandler_KeepSubscriptionTest(nlTestSuite * apS
 
 System::Clock::Timeout TestReadInteraction::ComputeSubscriptionTimeout(System::Clock::Seconds16 aMaxInterval)
 {
-    // Add 100ms of slack to our max interval to make sure we hit the
-    // subscription liveness timer.
+    // Add 1000ms of slack to our max interval to make sure we hit the
+    // subscription liveness timer.  100ms was tried in the past and is not
+    // sufficient: our process can easily lose the timeslice for 100ms.
     const auto & ourMrpConfig = GetDefaultMRPConfig();
     auto publisherTransmissionTimeout =
         GetRetransmissionTimeout(ourMrpConfig.mActiveRetransTimeout, ourMrpConfig.mIdleRetransTimeout,
                                  System::SystemClock().GetMonotonicTimestamp(), Transport::kMinActiveTime);
 
-    return publisherTransmissionTimeout + aMaxInterval + System::Clock::Milliseconds32(100);
+    return publisherTransmissionTimeout + aMaxInterval + System::Clock::Milliseconds32(1000);
 }
 
 // clang-format off


### PR DESCRIPTION
100ms is not enough: we have tests losing the timeslice for that long, and then we break out of our "waiting for timeout" loop before we process the firing of the timeout timer.

Fixes https://github.com/project-chip/connectedhomeip/issues/27829
