### PR TITLE
Enable tracing for all linux app builds

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -94,6 +94,8 @@ jobs:
                     linux debug all-clusters-app \
                     out/linux-x64-all-clusters/chip-all-clusters-app \
                     /tmp/bloat_reports/
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Build example Standalone All Clusters Minimal Server
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -134,6 +136,8 @@ jobs:
                     linux debug+rpc+ui lighting-app \
                     out/linux-x64-light-rpc-with-ui/chip-lighting-app \
                     /tmp/bloat_reports/
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Build example Standalone Bridge
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -164,6 +168,8 @@ jobs:
                     linux debug ota-requestor-app \
                     out/linux-x64-ota-requestor/chip-ota-requestor-app \
                     /tmp/bloat_reports/
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Build example Standalone Lock App
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/examples/all-clusters-app/linux/args.gni
+++ b/examples/all-clusters-app/linux/args.gni
@@ -23,3 +23,8 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/all-clusters-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
+matter_enable_tracing_support = true
+
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/all-clusters-minimal-app/linux/args.gni
+++ b/examples/all-clusters-minimal-app/linux/args.gni
@@ -23,3 +23,8 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/all-clusters-minimal-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
+matter_enable_tracing_support = true
+
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/bridge-app/linux/args.gni
+++ b/examples/bridge-app/linux/args.gni
@@ -23,3 +23,8 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/bridge-app/bridge-common/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
+matter_enable_tracing_support = true
+
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/contact-sensor-app/linux/args.gni
+++ b/examples/contact-sensor-app/linux/args.gni
@@ -26,5 +26,6 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/contact-sensor-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/contact-sensor-app/linux/args.gni
+++ b/examples/contact-sensor-app/linux/args.gni
@@ -25,3 +25,6 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/contact-sensor-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/lock-app/linux/args.gni
+++ b/examples/lock-app/linux/args.gni
@@ -24,5 +24,6 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/all-clusters-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/lock-app/linux/args.gni
+++ b/examples/lock-app/linux/args.gni
@@ -23,3 +23,6 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/all-clusters-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/log-source-app/linux/args.gni
+++ b/examples/log-source-app/linux/args.gni
@@ -17,5 +17,6 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/log-source-app/linux/args.gni
+++ b/examples/log-source-app/linux/args.gni
@@ -15,3 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/ota-provider-app/linux/args.gni
+++ b/examples/ota-provider-app/linux/args.gni
@@ -24,5 +24,6 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/ota-provider-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/ota-provider-app/linux/args.gni
+++ b/examples/ota-provider-app/linux/args.gni
@@ -23,3 +23,6 @@ chip_system_project_config_include = "<SystemProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/ota-provider-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -25,3 +25,7 @@ chip_project_config_include_dirs =
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_enable_ota_requestor = true
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"
+

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -26,6 +26,6 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_enable_ota_requestor = true
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"
-

--- a/examples/persistent-storage/linux/args.gni
+++ b/examples/persistent-storage/linux/args.gni
@@ -15,3 +15,6 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/persistent-storage/linux/args.gni
+++ b/examples/persistent-storage/linux/args.gni
@@ -16,5 +16,6 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/placeholder/linux/args.gni
+++ b/examples/placeholder/linux/args.gni
@@ -23,6 +23,6 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/placeholder/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"
-

--- a/examples/placeholder/linux/args.gni
+++ b/examples/placeholder/linux/args.gni
@@ -22,3 +22,7 @@ chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_project_config_include_dirs =
     [ "${chip_root}/examples/placeholder/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"
+

--- a/examples/thermostat/linux/args.gni
+++ b/examples/thermostat/linux/args.gni
@@ -15,3 +15,6 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/thermostat/linux/args.gni
+++ b/examples/thermostat/linux/args.gni
@@ -16,5 +16,6 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/tv-app/linux/args.gni
+++ b/examples/tv-app/linux/args.gni
@@ -29,3 +29,7 @@ chip_build_libshell = true
 chip_enable_additional_data_advertising = true
 
 chip_enable_rotating_device_id = true
+
+matter_enable_tracing_support = true
+# Perfetto requires C++17
+cpp_standard = "gnu++17"

--- a/examples/tv-app/linux/args.gni
+++ b/examples/tv-app/linux/args.gni
@@ -31,5 +31,6 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 matter_enable_tracing_support = true
+
 # Perfetto requires C++17
 cpp_standard = "gnu++17"

--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -31,3 +31,8 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_max_discovered_ip_addresses = 20
+
+matter_enable_tracing_support = true
+
+# Perfetto requires C++17
+cpp_standard = "gnu++17"


### PR DESCRIPTION
This enables perfetto & json tracing in all example apps for linux.

Has the sideffect of enabling C++17 (because perfetto requires it). We may need to update the default if we find that C++17 features are used and break other platform builds. The PR assumes that most people do not often try to use C++17 features and if they do, CI will complain (downside is basically a slow feedback cycle in that case).