### PR TITLE
[Ameba] [wifi] fix ssid and password length after getting from nvs

### DIFF
--- a/src/platform/Ameba/AmebaUtils.cpp
+++ b/src/platform/Ameba/AmebaUtils.cpp
@@ -108,8 +108,8 @@ CHIP_ERROR AmebaUtils::GetWiFiConfig(rtw_wifi_config_t * config)
                                                    &credentialsLen);
     SuccessOrExit(err);
 
-    config->ssid_len     = ssidLen;
-    config->password_len = credentialsLen;
+    config->ssid_len     = strlen((const char*) config->ssid);
+    config->password_len = strlen((const char*) config->password);
 
 exit:
     return err;

--- a/src/platform/Ameba/AmebaUtils.cpp
+++ b/src/platform/Ameba/AmebaUtils.cpp
@@ -108,8 +108,8 @@ CHIP_ERROR AmebaUtils::GetWiFiConfig(rtw_wifi_config_t * config)
                                                    &credentialsLen);
     SuccessOrExit(err);
 
-    config->ssid_len     = strlen((const char*) config->ssid);
-    config->password_len = strlen((const char*) config->password);
+    config->ssid_len     = strlen((const char *) config->ssid);
+    config->password_len = strlen((const char *) config->password);
 
 exit:
     return err;


### PR DESCRIPTION
- wifi ssid and password lengths are wrong
- use strlen instead to get the correct ssid and password length

