### PR TITLE
[wifi] combine ipv4 and ipv6 event

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.h
+++ b/src/platform/Ameba/ConnectivityManagerImpl.h
@@ -141,9 +141,8 @@ private:
     static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState);
 
     void UpdateInternetConnectivityState(void);
-    void OnStationIPv4AddressAvailable(void);
-    void OnStationIPv4AddressLost(void);
-    void OnIPv6AddressAvailable(void);
+    void OnStationIPv4v6AddressAvailable(void);
+    void OnStationIPv4v6AddressLost(void);
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 


### PR DESCRIPTION
- we got ipv4 first before ipv6
- sending ipv4 event separately will start dnssd server and we might not get ipv6 yet
- combine the ipv4 and ipv6 event, will block until both ipv4 and ipv6 is obtained, then trigger start dnssd

