### PR TITLE
Remove format/test from efr32 because efr32-brd4161a-unit-test runs out of flash

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,7 +59,6 @@ if (chip_build_tests) {
       "${chip_root}/src/lib/address_resolve/tests",
       "${chip_root}/src/lib/asn1/tests",
       "${chip_root}/src/lib/core/tests",
-      "${chip_root}/src/lib/format/tests",
       "${chip_root}/src/messaging/tests",
       "${chip_root}/src/protocols/bdx/tests",
       "${chip_root}/src/protocols/user_directed_commissioning/tests",
@@ -93,6 +92,7 @@ if (chip_build_tests) {
         # TODO(#10447): App test has HF on EFR32.
         "${chip_root}/src/app/tests",
         "${chip_root}/src/credentials/tests",
+        "${chip_root}/src/lib/format/tests",
         "${chip_root}/src/lib/support/tests",
         "${chip_root}/src/protocols/secure_channel/tests",
         "${chip_root}/src/system/tests",


### PR DESCRIPTION
Fixing build error for efr32 (out of flash):

```
....
Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    [1641/1650] ld ./matter-silabs-device_tests.out
28448   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    FAILED: matter-silabs-device_tests.out matter-silabs-device_tests.out.map
28449   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    arm-none-eabi-g++ -T../../src/test_driver/efr32/third_party/connectedhomeip/examples/platform/silabs/efr32/ldscripts/efr32mg12.ld -Wl,--no-warn-rwx-segment -march=armv7e-m -mcpu=cortex-m4 -mabi=aapcs -mfpu=fpv4-sp-d1
        │ 6 -mfloat-abi=softfp -mthumb -Og --specs=nosys.specs --specs=nano.specs -Werror -Wl,--fatal-warnings -fdiagnostics-color -Wl,--gc-sections -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=realloc -Wl,--wrap=calloc -Wl,--wrap=MemoryAlloc -Wl,--wrap=_malloc_r -Wl,--wra
        │ p=_realloc_r -Wl,--wrap=_free_r -Wl,--wrap=_calloc_r -Wl,-Map,./matter-silabs-device_tests.out.map @./matter-silabs-device_tests.out.rsp -o ./matter-silabs-device_tests.out
28450   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    /pwenv/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: ./matter-silabs-device_tests.out section `.text' will not fit in region `FLASH'
28451   │ Step #4 - "EFR32":     main(auto_envvar_prefix='CHIP')
28452   │ Step #4 - "EFR32":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
28453   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    /pwenv/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: FLASH memory overflowed !
28454   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    /pwenv/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: FLASH memory overlapped with NVM section.
28455   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    /pwenv/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 122500 bytes
28456   │ Step #4 - "EFR32": 2023-07-07 18:02:57 INFO    collect2: error: ld returned 1 exit status
```