### PR TITLE
Fix py matter idl types

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/cpp/tlvmeta/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/tlvmeta/__init__.py
@@ -200,7 +200,8 @@ class ClusterTablesGenerator:
                         code="ConstantValueTag(0x%X)" % entry.code,
                         name=entry.name,
                         reference=None,
-                        real_type="%s::%s::%s" % (self.cluster.name, e.name, entry.name)
+                        real_type="%s::%s::%s" % (
+                            self.cluster.name, e.name, entry.name)
                     )
                     for entry in e.entries
                 ]
@@ -214,7 +215,8 @@ class ClusterTablesGenerator:
                         code="ConstantValueTag(0x%X)" % entry.code,
                         name=entry.name,
                         reference=None,
-                        real_type="%s::%s::%s" % (self.cluster.name, e.name, entry.name)
+                        real_type="%s::%s::%s" % (
+                            self.cluster.name, e.name, entry.name)
                     )
                     for entry in e.entries
                 ]

--- a/scripts/py_matter_idl/matter_idl/generators/cpp/tlvmeta/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/cpp/tlvmeta/__init__.py
@@ -245,7 +245,7 @@ def IndexInTable(name: Optional[str], table: List[Table]) -> str:
     for idx, t in enumerate(table):
         if t.full_name == name:
             # Index skipping hard-coded items
-            return idx + 2
+            return "%d" % (idx + 2)
 
     raise Exception("Name %r not found in table" % name)
 

--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -550,7 +550,7 @@ def GlobalEncodableValueFrom(typeName: str, context: TypeLookupContext) -> Encod
     """
     Filter to convert a global type name to an encodable value
     """
-    return EncodableValue(context, DataType(name=typeName), {})
+    return EncodableValue(context, DataType(name=typeName), set())
 
 
 def EncodableValueFrom(field: Field, context: TypeLookupContext) -> EncodableValue:

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/parsing.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from matter_idl.generators.types import GetDataTypeSizeInBits, IsSignedDataType
 from matter_idl.matter_idl_types import AccessPrivilege, Attribute, AttributeQuality, DataType, Field, FieldQuality
 
 
-def ParseInt(value: str, data_type: DataType = None) -> int:
+def ParseInt(value: str, data_type: Optional[DataType] = None) -> int:
     """
     Convert a string that is a known integer into an actual number.
 


### PR DESCRIPTION
Python strict type checker found some errors. Fix them.

Hotfix as this prevents python compilation with strict compilers.