### PR TITLE
[Bouffalolab] Add build option to enable rotating device id

### DIFF
--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -2090,3 +2090,5 @@ endpoint 1 {
     ram      attribute clusterRevision default = 3;
   }
 }
+
+

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -2090,5 +2090,3 @@ endpoint 1 {
     ram      attribute clusterRevision default = 3;
   }
 }
-
-

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -603,6 +603,7 @@ def BuildBouffalolabTarget():
     target.AppendModifier('115200', baudrate=115200)
     target.AppendModifier('rpc', enable_rpcs=True)
     target.AppendModifier('cdc', enable_cdc=True)
+    target.AppendModifier('rotating_device_id', enable_rotating_device_id=True)
 
     return target
 

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -80,7 +80,8 @@ class BouffalolabBuilder(GnBuilder):
                  module_type: str = "BL706C-22",
                  baudrate=2000000,
                  enable_shell: bool = False,
-                 enable_cdc: bool = False
+                 enable_cdc: bool = False,
+                 enable_rotating_device_id: bool = False
                  ):
 
         if 'BL602' == module_type:
@@ -124,6 +125,10 @@ class BouffalolabBuilder(GnBuilder):
             self.argsOpt.append('import("//with_pw_rpc.gni")')
         elif enable_shell:
             self.argsOpt.append('chip_build_libshell=true')
+
+        if enable_rotating_device_id:
+            self.argsOpt.append('chip_enable_additional_data_advertising=true')
+            self.argsOpt.append('chip_enable_rotating_device_id=true')
 
         try:
             self.argsOpt.append('bouffalolab_sdk_root="%s"' % os.environ['BOUFFALOLAB_SDK_ROOT'])

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,7 +1,7 @@
 ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 asr-{asr582x,asr595x}-{all-clusters,all-clusters-minimal,lighting,light-switch,lock,bridge,temperature-measurement,thermostat,ota-requestor}[-ota][-shell][-no_logging][-factory][-rotating_id]
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller}[-no-debug]
-bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devkit,bl706-iot-dvk,bl706-night-light,bl704l-dvk}-light[-shell][-115200][-rpc][-cdc]
+bouffalolab-{bl602-iot-matter-v1,bl602-iot-dvk-3s,bl602-night-light,xt-zb6-devkit,bl706-iot-dvk,bl706-night-light,bl704l-dvk}-light[-shell][-115200][-rpc][-cdc][-rotating_device_id]
 cc32xx-lock
 ti-cc13x2x7_26x2x7-{lighting,lock,pump,pump-controller}[-mtd]
 ti-cc13x4_26x4-{all-clusters,lighting,lock,pump,pump-controller}[-mtd][-ftd]

--- a/src/platform/bouffalolab/BL602/args.gni
+++ b/src/platform/bouffalolab/BL602/args.gni
@@ -26,8 +26,6 @@ lwip_platform = "bl602"
 
 chip_inet_config_enable_ipv4 = true
 
-chip_enable_rotating_device_id = false
-
 chip_build_tests = false
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tun_endpoint = false

--- a/src/platform/bouffalolab/common/BLConfig.h
+++ b/src/platform/bouffalolab/common/BLConfig.h
@@ -72,8 +72,8 @@ public:
     static constexpr const char * kConfigKey_GroupKeyIndex               = ("group-key-index");
     static constexpr const char * kConfigKey_LifeTimeCounter             = ("life-time-counter");
 
-    static constexpr const char * kBLConfigKey_wifissid                  = ("blConfig_wifi-ssid");
-    static constexpr const char * kBLConfigKey_wifipassword              = ("blConfig_wifi-pwd");
+    static constexpr const char * kBLConfigKey_wifissid     = ("blConfig_wifi-ssid");
+    static constexpr const char * kBLConfigKey_wifipassword = ("blConfig_wifi-pwd");
 
     /** Counter Keys, diagnostic information  */
     static constexpr const char * kCounterKey_RebootCount           = ("reboot-count");

--- a/src/platform/bouffalolab/common/BLConfig.h
+++ b/src/platform/bouffalolab/common/BLConfig.h
@@ -70,6 +70,8 @@ public:
     static constexpr const char * kConfigKey_ActiveLocale                = ("active-locale");
     static constexpr const char * kConfigKey_Breadcrumb                  = ("breadcrumb");
     static constexpr const char * kConfigKey_GroupKeyIndex               = ("group-key-index");
+    static constexpr const char * kConfigKey_LifeTimeCounter             = ("life-time-counter");
+
     static constexpr const char * kBLConfigKey_wifissid                  = ("blConfig_wifi-ssid");
     static constexpr const char * kBLConfigKey_wifipassword              = ("blConfig_wifi-pwd");
 

--- a/src/platform/bouffalolab/common/BLEManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/BLEManagerImpl.cpp
@@ -26,6 +26,7 @@
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/internal/BLEManager.h>
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
 #include <setup_payload/AdditionalDataPayloadGenerator.h>

--- a/src/platform/bouffalolab/common/CHIPPlatformConfig.h
+++ b/src/platform/bouffalolab/common/CHIPPlatformConfig.h
@@ -26,7 +26,7 @@
 #define CHIP_CONFIG_PERSISTED_STORAGE_ENC_MSG_CNTR_ID 1
 #define CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH 2
 
-#define CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY 0x01
+#define CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY BLConfig::kConfigKey_LifeTimeCounter
 
 // ==================== Security Adaptations ====================
 //#define CHIP_CONFIG_SHA256_CONTEXT_SIZE sizeof(bl_sha_ctx_t)

--- a/src/platform/bouffalolab/common/FactoryDataProvider.cpp
+++ b/src/platform/bouffalolab/common/FactoryDataProvider.cpp
@@ -678,7 +678,10 @@ CHIP_ERROR FactoryDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & un
 #else
     constexpr uint8_t uniqueId[] = CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID;
 
-    uniqueIdSpan = MutableByteSpan((uint8_t *) uniqueId, sizeof(uniqueId));
+    VerifyOrReturnValue(uniqueIdSpan.size() >= sizeof(uniqueId), CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(uniqueIdSpan.data(), uniqueId, sizeof(uniqueId));
+    uniqueIdSpan.reduce_size(sizeof(uniqueId));
 
     return CHIP_NO_ERROR;
 #endif

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -542,7 +542,9 @@ template("bl_iot_sdk") {
       "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/platform_util.c",
       "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/sha256.c",
       "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/sha512.c",
+      "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/x509.c",
       "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/x509_create.c",
+      "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/x509_crt.c",
       "${bl_iot_sdk_root}/components/security/mbedtls_lts/mbedtls/library/x509write_csr.c",
     ]
 


### PR DESCRIPTION
Add build option to enable rotating device id in BLE additional data advertising for Amazon Frustration Free
Setup.