### PR TITLE
[Python] unrestrict vendor id

### DIFF
--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -177,7 +177,8 @@ async def AddNOCForNewFabricFromExisting(commissionerDevCtrl, newFabricDevCtrl, 
                                                  opCreds.Commands.AddNOC(chainForAddNOC.nocBytes,
                                                                          chainForAddNOC.icacBytes,
                                                                          chainForAddNOC.ipkBytes,
-                                                                         newFabricDevCtrl.nodeId, 0xFFF1))
+                                                                         newFabricDevCtrl.nodeId,
+                                                                         newFabricDevCtrl.fabricAdmin.vendorId))
     if resp.statusCode is not opCreds.Enums.NodeOperationalCertStatusEnum.kOk:
         # Expiring the failsafe timer in an attempt to clean up.
         await commissionerDevCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))


### PR DESCRIPTION
In function: `AddNOCForNewFabricFromExisting`  hard-coded `vendorId=0xFFF1` when `AddNOC`, this is unreasonable