### PR TITLE
Workaround Fan PercentSetting floating point precision error after "ceil()"

### DIFF
--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -347,8 +347,8 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
                            ChipLogError(Zcl, "Failed to get SpeedSetting with error: 0x%02x", status));
 
             uint16_t percent = percentSetting.Value();
-            // Plus 99 then devide by 100 instead of multiplying 0.01 to workaround floating point precision error
-            uint8_t speedSetting = static_cast<uint8_t>(ceil((speedMax * percent + 99) / 100));
+            // Plus 99 then integer divide by 100 instead of multiplying 0.01 to avoid floating point precision error
+            uint8_t speedSetting = static_cast<uint8_t>((speedMax * percent + 99) / 100);
 
             if (currentSpeedSetting.IsNull() || speedSetting != currentSpeedSetting.Value())
             {

--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -346,7 +346,7 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
             VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
                            ChipLogError(Zcl, "Failed to get SpeedSetting with error: 0x%02x", status));
 
-            float percent        = percentSetting.Value();
+            float percent = percentSetting.Value();
             // Minus insignificant number 0.00000001 before ceil() to avoid floating point precision error
             uint8_t speedSetting = static_cast<uint8_t>(ceil(speedMax * (percent * 0.01) - 0.00000001));
 

--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -346,9 +346,9 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
             VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
                            ChipLogError(Zcl, "Failed to get SpeedSetting with error: 0x%02x", status));
 
-            float percent = percentSetting.Value();
-            // Minus insignificant number 0.00000001 before ceil() to avoid floating point precision error
-            uint8_t speedSetting = static_cast<uint8_t>(ceil(speedMax * (percent * 0.01) - 0.00000001));
+            uint16_t percent = percentSetting.Value();
+            // Plus 99 then devide by 100 instead of multiplying 0.01 to workaround floating point precision error
+            uint8_t speedSetting = static_cast<uint8_t>(ceil((speedMax * percent + 99) / 100));
 
             if (currentSpeedSetting.IsNull() || speedSetting != currentSpeedSetting.Value())
             {

--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -347,7 +347,8 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
                            ChipLogError(Zcl, "Failed to get SpeedSetting with error: 0x%02x", status));
 
             float percent        = percentSetting.Value();
-            uint8_t speedSetting = static_cast<uint8_t>(ceil(speedMax * (percent * 0.01)));
+            // Minus insignificant number 0.00000001 before ceil() to avoid floating point precision error
+            uint8_t speedSetting = static_cast<uint8_t>(ceil(speedMax * (percent * 0.01) - 0.00000001));
 
             if (currentSpeedSetting.IsNull() || speedSetting != currentSpeedSetting.Value())
             {


### PR DESCRIPTION
Workaround floating point precision error which will cause result after `ceil()`

For example, the current value:
   speedMax: 10
   percent: 70
   speedMax * (percent * 0.01) = `7.000000000000001` (floating point
precision error)
   ceil(speedMax * (percent * 0.01)) = 8 => The error propagate to ceil
and cause the final result error.

Here's the debugging log from Linux:

```
...
ERR  [1689154261.810899][659359:659359] CHIP:ZCL:  SpeedMax: 10 ]
ERR  [1689154261.810925][659359:659359] CHIP:ZCL:  percent: 70.000000, percent*0.01: 0.700000000000000 
ERR  [1689154261.810945][659359:659359] CHIP:ZCL:  speedMax*(percent*0.01): 7.000000000000001 
ERR  [1689154261.810955][659359:659359] CHIP:ZCL:  ceil(speedMax*(percentage*0.01)) 8.000, speedSetting: 8 
...
```

Thus, the error propagate during calculation and causes incorrect result:
```
speed = ceil( SpeedMax * (percent * 0.01) )
      = ceil ( 10 * (70 * 0.01) )
      = ceil ( 10 * 0.70000000000 )
      = ceil ( 7.000000000000001 )
      = 8

```
then we get 80% when setting 70% to `PercentSetting`