### PR TITLE
Change endpointId type to int to align with other override functions

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/model/ChipEventPath.java
+++ b/src/controller/java/src/chip/devicecontroller/model/ChipEventPath.java
@@ -83,7 +83,7 @@ public class ChipEventPath {
   }
 
   /** Create a new {@link ChipEventPath} with only concrete ids. */
-  public static ChipEventPath newInstance(long endpointId, long clusterId, long eventId) {
+  public static ChipEventPath newInstance(int endpointId, long clusterId, long eventId) {
     return new ChipEventPath(
         ChipPathId.forId(endpointId),
         ChipPathId.forId(clusterId),


### PR DESCRIPTION
endpointId is defined as unsigned short in the native side, we should use int to handle the range constraints to ensure that the values stay within the range of a UShort (0 to 65,535).


