### PR TITLE
[Python] Modify rotatingId to a hexadecimal string

### DIFF
--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -141,8 +141,7 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         }
         if (dnsSdInfo->commissionData.rotatingIdLen > 0)
         {
-            jsonVal["rotatingId"] = std::string(reinterpret_cast<const char *>(dnsSdInfo->commissionData.rotatingId),
-                                                dnsSdInfo->commissionData.rotatingIdLen);
+            jsonVal["rotatingId"] = rotatingId;
         }
 
         {


### PR DESCRIPTION
Modify `rotatingId` to a hexadecimal string, the current content cannot be read by humans