### PR TITLE
Remove dead-code init callbacks from some clusters.

### DIFF
--- a/src/app/clusters/basic-information/basic-information.cpp
+++ b/src/app/clusters/basic-information/basic-information.cpp
@@ -439,8 +439,6 @@ bool IsLocalConfigDisabled()
 } // namespace app
 } // namespace chip
 
-void emberAfBasicInformationClusterServerInitCallback(chip::EndpointId endpoint) {}
-
 void MatterBasicInformationPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -300,8 +300,6 @@ void MatterGroupKeyManagementPluginServerInitCallback()
 // Commands
 //
 
-void emberAfGroupKeyManagementClusterServerInitCallback(chip::EndpointId endpoint) {}
-
 bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::DecodableType & commandData)

--- a/src/app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.cpp
+++ b/src/app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.cpp
@@ -197,6 +197,4 @@ void RefrigeratorAlarmServer::SendNotifyEvent(EndpointId endpointId, BitMask<Ala
  * Callbacks Implementation
  *********************************************************/
 
-void emberAfRefrigeratorAlarmClusterServerInitCallback(EndpointId endpoint) {}
-
 void MatterRefrigeratorAlarmPluginServerInitCallback() {}

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -28,7 +28,6 @@ CommandHandlerInterfaceOnlyClusters:
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369
 ClustersWithInitFunctions:
-    - Basic
     - Color Control
     - Groups
     - Identify


### PR DESCRIPTION
Init callbacks are only called for clusters listed in ClustersWithInitFunctions.  "Basic" was not the right name for "Basic Information", so that one was effectively not listed, and neither "Refrigerator Alarm" nor "Group Key Management" were listed.
