### PR TITLE
Reclassify excessive logging in LevelControl and OnOffServer from Pro…

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -246,7 +246,7 @@ void emberAfLevelControlClusterServerTickCallback(EndpointId endpoint)
         return;
     }
 
-    ChipLogProgress(Zcl, "Event: move from %d", currentLevel.Value());
+    ChipLogDetail(Zcl, "Event: move from %d", currentLevel.Value());
 
     // adjust by the proper amount, either up or down
     if (state->transitionTimeMs == 0)
@@ -267,8 +267,8 @@ void emberAfLevelControlClusterServerTickCallback(EndpointId endpoint)
         currentLevel.SetNonNull(static_cast<uint8_t>(currentLevel.Value() - 1));
     }
 
-    ChipLogProgress(Zcl, " to %d ", currentLevel.Value());
-    ChipLogProgress(Zcl, "(diff %c1)", state->increasing ? '+' : '-');
+    ChipLogDetail(Zcl, " to %d ", currentLevel.Value());
+    ChipLogDetail(Zcl, "(diff %c1)", state->increasing ? '+' : '-');
 
     status = Attributes::CurrentLevel::Set(endpoint, currentLevel);
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -813,7 +813,7 @@ exit:
  */
 void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
 {
-    ChipLogProgress(Zcl, "Timer callback - Entering callbackc");
+    ChipLogDetail(Zcl, "Timer callback - Entering callback");
 
     bool isOn = false;
     OnOff::Attributes::OnOff::Get(endpoint, &isOn);
@@ -826,7 +826,7 @@ void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
         // Update onTime values
         uint16_t onTime = MIN_TIME_VALUE;
         OnOff::Attributes::OnTime::Get(endpoint, &onTime);
-        ChipLogProgress(Zcl, "Timer callback - On Time:  %d", onTime);
+        ChipLogDetail(Zcl, "Timer callback - On Time:  %d", onTime);
 
         if (onTime > 0)
         {
@@ -836,7 +836,7 @@ void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
 
         if (onTime == 0)
         {
-            ChipLogProgress(Zcl, "Timer callback - Turning off OnOff");
+            ChipLogDetail(Zcl, "Timer callback - Turning off OnOff");
 
             OnOff::Attributes::OffWaitTime::Set(endpoint, 0);
             setOnOffValue(endpoint, Commands::Off::Id, false);
@@ -854,7 +854,7 @@ void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
             OnOff::Attributes::OffWaitTime::Set(endpoint, offWaitTime);
         }
 
-        ChipLogProgress(Zcl, "Timer Callback - wait Off Time:  %d", offWaitTime);
+        ChipLogDetail(Zcl, "Timer Callback - wait Off Time:  %d", offWaitTime);
 
         // Validate if necessary to restart timer
         if (offWaitTime > 0)


### PR DESCRIPTION
Reclassify excessive logging in LevelControl and OnOffServer from Progress to Detail
Background:
https://github.com/project-chip/connectedhomeip/pull/27035
"We can iterate and convert things to LogDetail or guard logs with additional defines as a followup."