### PR TITLE
[Darwin] Add the ability to browse operational nodes with the device scanner

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -69,6 +69,7 @@ static_library("chip-tool-utils") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
+    "commands/discover/DiscoverOperationalsCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -22,6 +22,7 @@
 #include "commands/discover/DiscoverCommand.h"
 #include "commands/discover/DiscoverCommissionablesCommand.h"
 #include "commands/discover/DiscoverCommissionersCommand.h"
+#include "commands/discover/DiscoverOperationalsCommand.h"
 #include <lib/address_resolve/AddressResolve.h>
 
 class Resolve : public DiscoverCommand, public chip::AddressResolve::NodeListener
@@ -74,8 +75,9 @@ void registerCommandsDiscover(Commands & commands, CredentialIssuerCommands * cr
     commands_list clusterCommands = {
         make_unique<Resolve>(credsIssuerConfig),
         make_unique<DiscoverCommissionablesStartCommand>(credsIssuerConfig),
-        make_unique<DiscoverCommissionablesStopCommand>(credsIssuerConfig),
-        make_unique<DiscoverCommissionablesListCommand>(credsIssuerConfig),
+        make_unique<DiscoverOperationalsStartCommand>(credsIssuerConfig),
+        make_unique<DiscoverStopCommand>(credsIssuerConfig),
+        make_unique<DiscoverListCommand>(credsIssuerConfig),
         make_unique<DiscoverCommissionablesCommand>(credsIssuerConfig),
         make_unique<DiscoverCommissionableByShortDiscriminatorCommand>(credsIssuerConfig),
         make_unique<DiscoverCommissionableByLongDiscriminatorCommand>(credsIssuerConfig),

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -41,3 +41,27 @@ private:
     chip::NodeId mNodeId;
     uint64_t mFabricId;
 };
+
+class DiscoverStopCommand : public CHIPCommand
+{
+public:
+    DiscoverStopCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("stop", credIssuerCommands, "Stop browsing for commissionable/operational nodes over the network.")
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
+};
+
+class DiscoverListCommand : public CHIPCommand
+{
+public:
+    DiscoverListCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("list", credIssuerCommands, "List commissionable/operationals nodes discovered over the network.")
+    {}
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
+};

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -40,7 +40,7 @@ CHIP_ERROR DiscoverCommissionablesStartCommand::RunCommand()
 {
 #if CHIP_DEVICE_LAYER_TARGET_DARWIN
     VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(GetDeviceScanner().Start());
+    ReturnErrorOnFailure(GetDeviceScanner().StartCommissionableDiscovery());
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -49,32 +49,6 @@ CHIP_ERROR DiscoverCommissionablesStartCommand::RunCommand()
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 }
 
-CHIP_ERROR DiscoverCommissionablesStopCommand::RunCommand()
-{
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-    VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(GetDeviceScanner().Stop());
-
-    SetCommandExitStatus(CHIP_NO_ERROR);
-    return CHIP_NO_ERROR;
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-}
-
-CHIP_ERROR DiscoverCommissionablesListCommand::RunCommand()
-{
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-    VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
-    GetDeviceScanner().Log();
-
-    SetCommandExitStatus(CHIP_NO_ERROR);
-    return CHIP_NO_ERROR;
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-}
-
 CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()
 {
     mCommissioner = &CurrentCommissioner();

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -46,31 +46,14 @@ private:
 class DiscoverCommissionablesStartCommand : public CHIPCommand
 {
 public:
-    DiscoverCommissionablesStartCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("start", credIssuerCommands) {}
+    DiscoverCommissionablesStartCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("start-commissionables", credIssuerCommands,
+                    "Start browsing for commissionable nodes over the networks (mdns, BLE).")
+    {}
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
-};
-
-class DiscoverCommissionablesStopCommand : public CHIPCommand
-{
-public:
-    DiscoverCommissionablesStopCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("stop", credIssuerCommands) {}
-
-    /////////// CHIPCommand Interface /////////
-    CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
-};
-
-class DiscoverCommissionablesListCommand : public CHIPCommand
-{
-public:
-    DiscoverCommissionablesListCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("list", credIssuerCommands) {}
-
-    /////////// CHIPCommand Interface /////////
-    CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
 };
 
 class DiscoverCommissionablesCommand : public DiscoverCommissionablesCommandBase

--- a/examples/chip-tool/commands/discover/DiscoverOperationalsCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverOperationalsCommand.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2023 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,33 +16,25 @@
  *
  */
 
-#include "DiscoverCommand.h"
-
+#include "DiscoverOperationalsCommand.h"
 #include <commands/common/DeviceScanner.h>
+#include <commands/common/RemoteDataModelLogger.h>
+#include <lib/support/BytesToHex.h>
 
-CHIP_ERROR DiscoverCommand::RunCommand()
-{
-    return RunCommand(mNodeId, mFabricId);
-}
+using namespace ::chip;
 
-CHIP_ERROR DiscoverStopCommand::RunCommand()
-{
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-    VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(GetDeviceScanner().Stop());
-
-    SetCommandExitStatus(CHIP_NO_ERROR);
-    return CHIP_NO_ERROR;
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
-}
-
-CHIP_ERROR DiscoverListCommand::RunCommand()
+CHIP_ERROR DiscoverOperationalsStartCommand::RunCommand()
 {
 #if CHIP_DEVICE_LAYER_TARGET_DARWIN
+    auto compressedFabricId = MakeOptional(CurrentCommissioner().GetCompressedFabricId());
+
+    if (mShowAll.ValueOr(false))
+    {
+        compressedFabricId = NullOptional;
+    }
+
     VerifyOrReturnError(IsInteractive(), CHIP_ERROR_INCORRECT_STATE);
-    GetDeviceScanner().Log();
+    ReturnErrorOnFailure(GetDeviceScanner().StartOperationalDiscovery(compressedFabricId));
 
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/discover/DiscoverOperationalsCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverOperationalsCommand.h
@@ -1,0 +1,40 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+
+class DiscoverOperationalsStartCommand : public CHIPCommand
+{
+public:
+    DiscoverOperationalsStartCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("start-operationals", credIssuerCommands, "Start browsing for operational nodes over the network.")
+    {
+        AddArgument("show-all", 0, 1, &mShowAll,
+                    "Show all operational nodes found over the network. If false (the default), only nodes from the current "
+                    "commissioner will be retrieved (e.g nodes commissioned with the alpha fabric)");
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+
+private:
+    chip::Optional<bool> mShowAll;
+};

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -162,6 +162,10 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
         {
             requiredSize = snprintf(buffer, bufferLen, kCommissionerServiceName);
         }
+        else if (type == DiscoveryType::kOperational)
+        {
+            requiredSize = snprintf(buffer, bufferLen, kOperationalServiceName);
+        }
         else
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -82,6 +82,7 @@ struct DnssdService
     uint32_t mTtlSeconds = 120;
 
     void ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData);
+    CHIP_ERROR ToResolvedNodeData(const Span<Inet::IPAddress> & addresses, ResolvedNodeData & nodeData);
 };
 
 /**
@@ -277,7 +278,7 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
 
 #if CHIP_DEVICE_LAYER_TARGET_DARWIN
 /**
- * This function resolves the services published by mDNS
+ * This function resolves the commissionable services published by mDNS
  *
  * @param[in] browseResult  The service entry returned by @ref ChipDnssdBrowse
  * @param[in] interface     The interface to send queries.
@@ -290,6 +291,20 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
  */
 CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface,
                             CommissioningResolveDelegate * delegate);
+
+/**
+ * This function resolves the operational services published by mDNS
+ *
+ * @param[in] browseResult  The service entry returned by @ref ChipDnssdBrowse
+ * @param[in] interface     The interface to send queries.
+ * @param[in] delegate      The delegate to notify when a service is resolved.
+ *
+ * @retval CHIP_NO_ERROR                The resolve succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The name, type or delegate is nullptr.
+ * @retval Error code                   The resolve fails.
+ *
+ */
+CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface, OperationalResolveDelegate * delegate);
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 /**

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -299,8 +299,9 @@ static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_
     return Resolve(sdCtx, interfaceId, addressType, type, name);
 }
 
-static CHIP_ERROR Resolve(CommissioningResolveDelegate * delegate, uint32_t interfaceId, chip::Inet::IPAddressType addressType,
-                          const char * type, const char * name)
+template <typename T>
+static CHIP_ERROR Resolve(T * delegate, uint32_t interfaceId, chip::Inet::IPAddressType addressType, const char * type,
+                          const char * name)
 {
     auto counterHolder = GetCounterHolder(name);
     auto sdCtx         = chip::Platform::New<ResolveContext>(delegate, addressType, name, std::move(counterHolder));
@@ -448,6 +449,16 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
 }
 
 CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, CommissioningResolveDelegate * delegate)
+{
+    VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsSupportedProtocol(service->mProtocol), CHIP_ERROR_INVALID_ARGUMENT);
+
+    auto regtype     = GetFullType(service);
+    auto interfaceId = GetInterfaceId(interface);
+    return Resolve(delegate, interfaceId, service->mAddressType, regtype.c_str(), service->mName);
+}
+
+CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, OperationalResolveDelegate * delegate)
 {
     VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(IsSupportedProtocol(service->mProtocol), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -226,6 +226,7 @@ struct ResolveContext : public GenericContext
     DnssdResolveCallback callback;
     std::map<uint32_t, InterfaceInfo> interfaces;
     DNSServiceProtocol protocol;
+    DnssdServiceProtocol protocolType;
     std::string instanceName;
     std::shared_ptr<uint32_t> consumerCounter;
     BrowseContext * const browseThatCausedResolve; // Can be null
@@ -235,6 +236,8 @@ struct ResolveContext : public GenericContext
                    const char * instanceNameToResolve, BrowseContext * browseCausingResolve,
                    std::shared_ptr<uint32_t> && consumerCounterToUse);
     ResolveContext(CommissioningResolveDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
+                   const char * instanceNameToResolve, std::shared_ptr<uint32_t> && consumerCounterToUse);
+    ResolveContext(OperationalResolveDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
                    const char * instanceNameToResolve, std::shared_ptr<uint32_t> && consumerCounterToUse);
     virtual ~ResolveContext();
 


### PR DESCRIPTION
#### Problem

There is no underlying API for the `DnssdBrowseDelegate` to resolve operational nodes.
This PR add such supports for the `darwin` backend as well as a command in `chip-tool` for it.

This is an attempt to get #[26718](https://github.com/project-chip/connectedhomeip/pull/26718) to move forward to the `DnssdBrowseDelegate`. The benefit of it is that is allow to monitor nodes for long lived operations, such as addition and removals.
