### PR TITLE
Allow setting up an auto-resubscribe ReadClient with just a peer id.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -940,6 +940,19 @@ CHIP_ERROR ReadClient::SendAutoResubscribeRequest(ReadPrepareParams && aReadPrep
     return err;
 }
 
+CHIP_ERROR ReadClient::SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams)
+{
+    mPeer              = aPublisherId;
+    mReadPrepareParams = std::move(aReadPrepareParams);
+    CHIP_ERROR err     = EstablishSessionToPeer();
+    if (err != CHIP_NO_ERROR)
+    {
+        // Make sure we call our callback's OnDeallocatePaths.
+        StopResubscription();
+    }
+    return err;
+}
+
 CHIP_ERROR ReadClient::SendSubscribeRequest(const ReadPrepareParams & aReadPrepareParams)
 {
     VerifyOrReturnError(aReadPrepareParams.mMinIntervalFloorSeconds <= aReadPrepareParams.mMaxIntervalCeilingSeconds,
@@ -1118,12 +1131,8 @@ void ReadClient::OnResubscribeTimerCallback(System::Layer * /* If this starts be
     {
         // We don't have an active CASE session.  We need to go ahead and set
         // one up, if we can.
-        ChipLogProgress(DataManagement, "Trying to establish a CASE session");
-        auto * caseSessionManager = InteractionModelEngine::GetInstance()->GetCASESessionManager();
-        if (caseSessionManager)
+        if (_this->EstablishSessionToPeer() == CHIP_NO_ERROR)
         {
-            caseSessionManager->FindOrEstablishSession(_this->mPeer, &_this->mOnConnectedCallback,
-                                                       &_this->mOnConnectionFailureCallback);
             return;
         }
 
@@ -1207,6 +1216,15 @@ Optional<System::Clock::Timeout> ReadClient::GetSubscriptionTimeout()
     }
 
     return MakeOptional(timeout);
+}
+
+CHIP_ERROR ReadClient::EstablishSessionToPeer()
+{
+    ChipLogProgress(DataManagement, "Trying to establish a CASE session for subscription");
+    auto * caseSessionManager = InteractionModelEngine::GetInstance()->GetCASESessionManager();
+    VerifyOrReturnError(caseSessionManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    caseSessionManager->FindOrEstablishSession(mPeer, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace app

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -363,9 +363,8 @@ public:
      * available in the ReadPrepareParams.  When this is used, the ReadClient is
      * responsible for setting up the CASE session itself.
      *
-     * When using this version of SendAutoResubscribeRequest, the
-     * ReadPrepareParams should have a reference to a session, and if it does
-     * have one that session will be ignored.
+     * When using this version of SendAutoResubscribeRequest, any session to
+     * which ReadPrepareParams has a reference will be ignored.
      */
     CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -352,11 +352,22 @@ public:
      *  OnDeallocatePaths. Note: At a given time in the system, you can either have a single subscription with re-sub enabled that
      *  has mKeepSubscriptions = false, OR, multiple subs with re-sub enabled with mKeepSubscriptions = true. You shall not
      *  have a mix of both simultaneously. If SendAutoResubscribeRequest is called at all, it guarantees that it will call
-     *  OnDeallocatePaths when OnDone is called. SendAutoResubscribeRequest is the only case that calls OnDeallocatePaths, since
-     *  that's the only case when the consumer moved a ReadParams into the client.
+     *  OnDeallocatePaths (either befor returning error, or when OnDone is called). SendAutoResubscribeRequest is the only case
+     *  that calls OnDeallocatePaths, since that's the only case when the consumer moved a ReadParams into the client.
      *
      */
     CHIP_ERROR SendAutoResubscribeRequest(ReadPrepareParams && aReadPrepareParams);
+
+    /**
+     * Like SendAutoResubscribeRequest above, but without a session being
+     * available in the ReadPrepareParams.  When this is used, the ReadClient is
+     * responsible for setting up the CASE session itself.
+     *
+     * When using this version of SendAutoResubscribeRequest, the
+     * ReadPrepareParams should have a reference to a session, and if it does
+     * have one that session will be ignored.
+     */
+    CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
 
     /**
      *   This provides a standard re-subscription policy implementation that given a termination cause, does the following:
@@ -537,6 +548,13 @@ private:
     static void HandleDeviceConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
     CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
+
+    /**
+     * Start setting up a CASE session to our peer, if we can locate a
+     * CASESessionManager.  Returns error if we did not even manage to kick off
+     * a CASE attempt.
+     */
+    CHIP_ERROR EstablishSessionToPeer();
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeHolder mExchange;


### PR DESCRIPTION
This delegates all the work of setting up the CASE session, and the attendant retries, to the ReadClient.

Fixes https://github.com/project-chip/connectedhomeip/issues/23983

Testing: I did manual testing using a hacked-up version of chip-tool that ensured we had no existing session before calling the new API, and made sure that CASE got established and that if the server was not available at that point we did the normal auto-resubscribe retries of CASE until it did become available.