### PR TITLE
[Build Issue] fix build issue

### DIFF
--- a/src/lib/format/tests/TestDecoding.cpp
+++ b/src/lib/format/tests/TestDecoding.cpp
@@ -34,8 +34,7 @@ using namespace chip::TLV;
 using namespace chip::TLVMeta;
 using namespace chip::TestData;
 
-const Entry<ItemInfo> _empty_item[0]                 = {};
-const std::array<const Node<ItemInfo>, 1> empty_meta = { { { 0, _empty_item } } };
+const std::array<const Node<ItemInfo>, 1> empty_meta = { { { 0, {} } } };
 
 const Entry<ItemInfo> _FakeProtocolData[] = {
     { { AttributeTag(5), "proto5", ItemType::kDefault }, kInvalidNodeIndex },


### PR DESCRIPTION
When compiling on `Linux (x64 or arm64)`, the following errors are reported
```
[209/473] c++ obj/src/lib/format/tests/libFormatTests.TestDecoding.cpp.o
FAILED: obj/src/lib/format/tests/libFormatTests.TestDecoding.cpp.o
g++ -MMD -MF obj/src/lib/format/tests/libFormatTests.TestDecoding.cpp.o.d -Wconversion -O0 -g0 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-unused-parameter -Wno-cast-function-type -Wno-psabi -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../../= -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -Igen/src/controller/data_model -I../../../src/include -I../../../src -Igen/include -I../../../zzz_generated/app-common -I../../../config/standalone -I../../../third_party/nlassert/repo/include -I../../../third_party/nlio/repo/include -I../../../third_party/nlfaultinjection/repo/include -Igen/src/lib/format -I../../../third_party/nlunit-test/repo/src -c ../../../src/lib/format/tests/TestDecoding.cpp -o obj/src/lib/format/tests/libFormatTests.TestDecoding.cpp.o
../../../src/lib/format/tests/TestDecoding.cpp: In function ‘void __static_initialization_and_destruction_0(int, int)’:
../../../src/lib/format/tests/TestDecoding.cpp:37:23: error: statement has no effect [-Werror=unused-value]
   37 | const Entry<ItemInfo> _empty_item[0]                 = {};
      |                       ^~~~~~~~~~~
```
