### PR TITLE
Fixing the .zap files for contradicting device type data

### DIFF
--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.zap
@@ -5439,8 +5439,8 @@
     },
     {
       "name": "MA-extendedcolorlight",
-      "deviceTypeName": "MA-dimmablelight",
-      "deviceTypeCode": 257,
+      "deviceTypeName": "MA-extendedcolorlight",
+      "deviceTypeCode": 269,
       "deviceTypeProfileId": 259,
       "clusters": [
         {

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
@@ -5439,8 +5439,8 @@
     },
     {
       "name": "MA-extendedcolorlight",
-      "deviceTypeName": "MA-dimmablelight",
-      "deviceTypeCode": 257,
+      "deviceTypeName": "MA-extendedcolorlight",
+      "deviceTypeCode": 269,
       "deviceTypeProfileId": 259,
       "clusters": [
         {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -6439,7 +6439,7 @@ server cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type anonymousEndpointType = 65280, version 1;
+  device type rootdevice = 22, version 1;
   binding cluster GeneralCommissioning;
   binding cluster ThreadNetworkDiagnostics;
   binding cluster Switch;

--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -33,10 +33,10 @@
   ],
   "endpointTypes": [
     {
-      "name": "Anonymous Endpoint Type",
-      "deviceTypeName": null,
-      "deviceTypeCode": null,
-      "deviceTypeProfileId": null,
+      "name": "MA-rootdevice",
+      "deviceTypeName": "MA-rootdevice",
+      "deviceTypeCode": 22,
+      "deviceTypeProfileId": 259,
       "clusters": [
         {
           "name": "Descriptor",

--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -14559,7 +14559,7 @@
       "endpointId": 0,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 65280
+      "deviceIdentifier": 22
     },
     {
       "endpointTypeName": "Anonymous Endpoint Type",

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -6398,7 +6398,7 @@ server cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type anonymousEndpointType = 65280, version 1;
+  device type rootdevice = 22, version 1;
   binding cluster GeneralCommissioning;
   binding cluster ThreadNetworkDiagnostics;
   binding cluster Switch;

--- a/examples/placeholder/linux/apps/app2/config.zap
+++ b/examples/placeholder/linux/apps/app2/config.zap
@@ -33,10 +33,10 @@
   ],
   "endpointTypes": [
     {
-      "name": "Anonymous Endpoint Type",
-      "deviceTypeName": null,
-      "deviceTypeCode": null,
-      "deviceTypeProfileId": null,
+      "name": "MA-rootdevice",
+      "deviceTypeName": "MA-rootdevice",
+      "deviceTypeCode": 22,
+      "deviceTypeProfileId": 259,
       "clusters": [
         {
           "name": "Descriptor",

--- a/examples/placeholder/linux/apps/app2/config.zap
+++ b/examples/placeholder/linux/apps/app2/config.zap
@@ -14585,7 +14585,7 @@
       "endpointId": 0,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 65280
+      "deviceIdentifier": 22
     },
     {
       "endpointTypeName": "Anonymous Endpoint Type",


### PR DESCRIPTION
Github: ZAP#862

Fixing the .zap files for contradicting device type data in some of the .zap files. This came out from the changes being made in https://github.com/project-chip/zap/pull/1040

