### PR TITLE
[door-lock] extend the OnFabricRemoved delegate with custom callback

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1350,12 +1350,13 @@ bool DoorLockServer::OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIn
     ChipLogProgress(Zcl, "[OnFabricRemoved] Handling a fabric removal from the door lock server [endpointId=%d,fabricIndex=%d]",
                     endpointId, fabricIndex);
 
+    bool status{ true };
     // Iterate over all the users and clean up the deleted fabric
     if (!clearFabricFromUsers(endpointId, fabricIndex))
     {
         ChipLogError(Zcl, "[OnFabricRemoved] Unable to cleanup fabric from users - internal error [endpointId=%d,fabricIndex=%d]",
                      endpointId, fabricIndex);
-        return false;
+        status = false;
     }
 
     // Iterate over all the credentials and clean up the fabrics
@@ -1364,10 +1365,15 @@ bool DoorLockServer::OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIn
         ChipLogError(Zcl,
                      "[OnFabricRemoved] Unable to cleanup fabric from credentials - internal error [endpointId=%d,fabricIndex=%d]",
                      endpointId, fabricIndex);
-        return false;
+        status = false;
     }
 
-    return true;
+    if (mOnFabricRemovedCustomCallback)
+    {
+        mOnFabricRemovedCustomCallback(endpointId, fabricIndex);
+    }
+
+    return status;
 }
 
 /**********************************************************

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -83,7 +83,8 @@ class DoorLockServer
 public:
     static DoorLockServer & Instance();
 
-    using Feature = chip::app::Clusters::DoorLock::Feature;
+    using Feature                       = chip::app::Clusters::DoorLock::Feature;
+    using OnFabricRemovedCustomCallback = void (*)(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
 
     void InitServer(chip::EndpointId endpointId);
 
@@ -187,6 +188,18 @@ public:
     }
 
     inline bool SupportsUnbolt(chip::EndpointId endpointId) { return GetFeatures(endpointId).Has(Feature::kUnbolt); }
+
+    /**
+     * @brief Allows the application to register a custom callback which will be called after the default DoorLock
+     *        OnFabricRemoved implementation. At that point the door lock cluster has done any
+     *        spec-required clearing of state for fabric removal.
+     *
+     * @param callback callback to be registered
+     */
+    inline void SetOnFabricRemovedCustomCallback(OnFabricRemovedCustomCallback callback)
+    {
+        mOnFabricRemovedCustomCallback = callback;
+    }
 
     bool OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
 
@@ -565,6 +578,8 @@ private:
     static_assert(kDoorLockClusterServerMaxEndpointCount <= kEmberInvalidEndpointIndex, "DoorLock Endpoint count error");
 
     std::array<EmberAfDoorLockEndpointContext, kDoorLockClusterServerMaxEndpointCount> mEndpointCtx;
+
+    OnFabricRemovedCustomCallback mOnFabricRemovedCustomCallback{ nullptr };
 
     static DoorLockServer instance;
 };


### PR DESCRIPTION
This extension allows to inject the custom user callback which will be called
before running default door-lock OnFabricRemove delegate.

For instance, in some use cases an application might want to clear its internal
credentials database

Exemplary usage:
```
DoorLockServer::Instance().SetOnFabricRemovedCustomCallback([](EndpointId endpointId, FabricIndex fabricIndex) {
    ChipLogProgress(Zcl, "OnRemoveFabric extension callback");
    if (ClearAllCredentialsFromFabric(fabricIndex)) {
	ChipLogError(Zcl, "Cannot clear door lock credentials for fabric %d", fabricIndex);
    }
});
```
