### PR TITLE
Silicon Labs: Attestation credentials now remain upon factory reset.

### DIFF
--- a/examples/platform/silabs/SilabsDeviceAttestationCreds.h
+++ b/examples/platform/silabs/SilabsDeviceAttestationCreds.h
@@ -34,6 +34,8 @@ namespace Silabs {
  */
 DeviceAttestationCredentialsProvider * GetSilabsDacProvider();
 
+void SilabsDacProviderMigration(void);
+
 } // namespace Silabs
 } // namespace Credentials
 } // namespace chip

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -300,5 +300,14 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
 }
 
 } // namespace PersistedStorage
+
+namespace Silabs {
+
+void MigrateKvsMap(void)
+{
+    PersistedStorage::KeyValueStoreMgrImpl().KvsMapMigration();
+}
+
+} // namespace Silabs
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/silabs/KeyValueStoreManagerImpl.h
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.h
@@ -33,10 +33,6 @@ namespace PersistedStorage {
 
 class KeyValueStoreManagerImpl final : public KeyValueStoreManager
 {
-    // Allow the KeyValueStoreManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class KeyValueStoreManager;
-
 public:
     CHIP_ERROR Init(void);
     CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);

--- a/src/platform/silabs/MigrationManager.cpp
+++ b/src/platform/silabs/MigrationManager.cpp
@@ -17,7 +17,6 @@
 
 #include "MigrationManager.h"
 #include <platform/CHIPDeviceLayer.h>
-#include <platform/KeyValueStoreManager.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <stdio.h>
 
@@ -38,7 +37,10 @@ typedef struct
 
 #define COUNT_OF(A) (sizeof(A) / sizeof((A)[0]))
 static migrationData_t migrationTable[] = {
-    { .migrationGroup = 1, .migrationFunc = &KeyValueStoreMgrImpl().KvsMapMigration },
+    { .migrationGroup = 1, .migrationFunc = MigrateKvsMap },
+#ifdef SILABS_ATTESTATION_CREDENTIALS
+    { .migrationGroup = 2, .migrationFunc = MigrateDacProvider },
+#endif
     // add any additional migration neccesary. migrationGroup should stay equal if done in the same commit or increment by 1 for
     // each new entry.
 };

--- a/src/platform/silabs/MigrationManager.h
+++ b/src/platform/silabs/MigrationManager.h
@@ -24,8 +24,6 @@ namespace Silabs {
 
 class MigrationManager
 {
-    friend class KeyValueStoreManagerImpl;
-
 public:
     /**
      * The Silabs migration manager is implemented as a singleton
@@ -38,6 +36,13 @@ private:
     MigrationManager(){};
     ~MigrationManager(){};
 };
+
+/**
+ * Migration functions. These definitions allow the MigrationManager
+ * to be agnostic of the specifics of each individual migration.
+ */
+void MigrateKvsMap(void);
+void MigrateDacProvider(void);
 
 } // namespace Silabs
 } // namespace DeviceLayer

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -112,6 +112,14 @@ public:
     static constexpr Key kConfigKey_ProductURL            = SilabsConfigKey(kMatterFactory_KeyBase, 0x11);
     static constexpr Key kConfigKey_PartNumber            = SilabsConfigKey(kMatterFactory_KeyBase, 0x12);
     static constexpr Key kConfigKey_UniqueId              = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
+    static constexpr Key kConfigKey_Creds_KeyId           = SilabsConfigKey(kMatterFactory_KeyBase, 0x20);
+    static constexpr Key kConfigKey_Creds_Base_Addr       = SilabsConfigKey(kMatterFactory_KeyBase, 0x21);
+    static constexpr Key kConfigKey_Creds_DAC_Offset      = SilabsConfigKey(kMatterFactory_KeyBase, 0x22);
+    static constexpr Key kConfigKey_Creds_DAC_Size        = SilabsConfigKey(kMatterFactory_KeyBase, 0x23);
+    static constexpr Key kConfigKey_Creds_PAI_Offset      = SilabsConfigKey(kMatterFactory_KeyBase, 0x24);
+    static constexpr Key kConfigKey_Creds_PAI_Size        = SilabsConfigKey(kMatterFactory_KeyBase, 0x25);
+    static constexpr Key kConfigKey_Creds_CD_Offset       = SilabsConfigKey(kMatterFactory_KeyBase, 0x26);
+    static constexpr Key kConfigKey_Creds_CD_Size         = SilabsConfigKey(kMatterFactory_KeyBase, 0x27);
     // Matter Config Keys
     static constexpr Key kConfigKey_ServiceConfig      = SilabsConfigKey(kMatterConfig_KeyBase, 0x01);
     static constexpr Key kConfigKey_PairedAccountId    = SilabsConfigKey(kMatterConfig_KeyBase, 0x02);
@@ -135,14 +143,6 @@ public:
     static constexpr Key kConfigKey_YearDaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x16);
     static constexpr Key kConfigKey_HolidaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x17);
     static constexpr Key kConfigKey_OpKeyMap           = SilabsConfigKey(kMatterConfig_KeyBase, 0x20);
-    static constexpr Key kConfigKey_Creds_KeyId        = SilabsConfigKey(kMatterConfig_KeyBase, 0x21);
-    static constexpr Key kConfigKey_Creds_Base_Addr    = SilabsConfigKey(kMatterConfig_KeyBase, 0x22);
-    static constexpr Key kConfigKey_Creds_DAC_Offset   = SilabsConfigKey(kMatterConfig_KeyBase, 0x23);
-    static constexpr Key kConfigKey_Creds_DAC_Size     = SilabsConfigKey(kMatterConfig_KeyBase, 0x24);
-    static constexpr Key kConfigKey_Creds_PAI_Offset   = SilabsConfigKey(kMatterConfig_KeyBase, 0x25);
-    static constexpr Key kConfigKey_Creds_PAI_Size     = SilabsConfigKey(kMatterConfig_KeyBase, 0x26);
-    static constexpr Key kConfigKey_Creds_CD_Offset    = SilabsConfigKey(kMatterConfig_KeyBase, 0x27);
-    static constexpr Key kConfigKey_Creds_CD_Size      = SilabsConfigKey(kMatterConfig_KeyBase, 0x28);
 
     static constexpr Key kConfigKey_GroupKeyMax =
         SilabsConfigKey(kMatterConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
@@ -160,7 +160,7 @@ public:
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
+    static constexpr Key kMaxConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x2F);
     static constexpr Key kMinConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x00);
     static constexpr Key kMaxConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x20);
 


### PR DESCRIPTION
* Credentials now remain upon factory reset.
* Base address is now read from NVM, if configured.

Tested on MG12 and MG24
