### PR TITLE
[ICD]Post the MsgSentEvent on retransmits also

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -323,6 +323,16 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     if (err == CHIP_NO_ERROR)
     {
+#if CONFIG_DEVICE_LAYER && CHIP_CONFIG_ENABLE_ICD_SERVER
+        DeviceLayer::ChipDeviceEvent event;
+        event.Type                       = DeviceLayer::DeviceEventType::kChipMsgSentEvent;
+        event.MessageSent.ExpectResponse = false;
+        CHIP_ERROR status                = DeviceLayer::PlatformMgr().PostEvent(&event);
+        if (status != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Failed to post retransmit message sent event %" CHIP_ERROR_FORMAT, status.Format());
+        }
+#endif // CONFIG_DEVICE_LAYER
 #if CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
         const ExchangeManager * exchangeMgr = entry->ec->GetExchangeMgr();
         // TODO: investigate why in ReliableMessageMgr::CheckResendApplicationMessageWithPeerExchange unit test released exchange

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -325,6 +325,9 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
     {
 #if CONFIG_DEVICE_LAYER && CHIP_CONFIG_ENABLE_ICD_SERVER
         DeviceLayer::ChipDeviceEvent event;
+        // Here always set ExpectResponse to false.
+        // The Initial message sent from the Exchange Context will have set ExpectResponse to the correct value.
+        // If we are expecting a Response, the ICD will already be in a state waiting for the response (or timeout).
         event.Type                       = DeviceLayer::DeviceEventType::kChipMsgSentEvent;
         event.MessageSent.ExpectResponse = false;
         CHIP_ERROR status                = DeviceLayer::PlatformMgr().PostEvent(&event);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -2000,10 +2000,6 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetPollingInter
         ChipLogError(DeviceLayer, "Failed to set SED interval to %" PRId32 "ms. Defaulting to %" PRId32 "ms",
                      pollingInterval.count(), curIntervalMS);
     }
-    else
-    {
-        ChipLogProgress(DeviceLayer, "OpenThread SED interval is %" PRId32 "ms", curIntervalMS);
-    }
 
     return err;
 }


### PR DESCRIPTION
This will kick the ICD into Active mode or extend its active mode duration for retransmitting messages also.
Fixes #27864 

Also, remove a noisy trace (particularly when idle/active interval are shorts)