### PR TITLE
Add Darwin API for starting multiple controllers on the same fabric.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -374,6 +374,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
         // bring-up.
         commissionerParams.removeFromFabricTableOnShutdown = false;
         commissionerParams.deviceAttestationVerifier = _factory.deviceAttestationVerifier;
+        commissionerParams.permitMultiControllerFabrics = startupParams.isAdditionalController;
 
         auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
@@ -150,6 +150,22 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
                                                               error:(NSError * __autoreleasing *)error;
 
 /**
+ * Create an additional MTRDeviceController on an existing fabric.  Returns nil on failure.
+ *
+ * The fabric is identified by the root public key and fabric id in
+ * the startupParams.
+ *
+ * This method will fail if there is no such fabric.
+ *
+ * This method will fail if the MTRDeviceControllerStartupParams don't follow
+ * the rules for creating a controller on a new fabric.  In particular, the
+ * vendor ID must not be nil.
+ */
+- (MTRDeviceController * _Nullable)createAdditionalControllerOnExistingFabric:(MTRDeviceControllerStartupParams *)startupParams
+                                                                        error:(NSError * __autoreleasing *)error
+    MTR_NEWLY_AVAILABLE;
+
+/**
  * Create a MTRDeviceController on a new fabric.  Returns nil on failure.
  *
  * This method will fail if the given fabric already exists.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -58,6 +58,8 @@ MTR_HIDDEN
 
 @property (nonatomic, assign, readonly) BOOL advertiseOperational;
 
+@property (nonatomic, assign, readonly) BOOL isAdditionalController;
+
 /**
  * Helper method that checks that our keypairs match our certificates.
  * Specifically:
@@ -73,21 +75,24 @@ MTR_HIDDEN
 - (BOOL)keypairsMatchCertificates;
 
 /**
- * Initialize for controller bringup on a new fabric.
+ * Initialize for controller bringup on a new fabric entry (which might be a new
+ * fabric or an additional controller on an existing fabric).
  */
-- (instancetype)initForNewFabric:(chip::FabricTable *)fabricTable
-                        keystore:(chip::Crypto::OperationalKeystore *)keystore
-            advertiseOperational:(BOOL)advertiseOperational
-                          params:(MTRDeviceControllerStartupParams *)params;
+- (instancetype)_initForNewFabricEntry:(chip::FabricTable *)fabricTable
+                              keystore:(chip::Crypto::OperationalKeystore *)keystore
+                  advertiseOperational:(BOOL)advertiseOperational
+                                params:(MTRDeviceControllerStartupParams *)params
+                isAdditionalController:(BOOL)isAdditionalController;
 
 /**
- * Initialize for controller bringup on an existing fabric.
+ * Initialize for controller bringup on an existing fabric entry, identified by
+ * the provided fabricIndex.
  */
-- (instancetype)initForExistingFabric:(chip::FabricTable *)fabricTable
-                          fabricIndex:(chip::FabricIndex)fabricIndex
-                             keystore:(chip::Crypto::OperationalKeystore *)keystore
-                 advertiseOperational:(BOOL)advertiseOperational
-                               params:(MTRDeviceControllerStartupParams *)params;
+- (instancetype)_initForExistingFabricEntry:(chip::FabricTable *)fabricTable
+                                fabricIndex:(chip::FabricIndex)fabricIndex
+                                   keystore:(chip::Crypto::OperationalKeystore *)keystore
+                       advertiseOperational:(BOOL)advertiseOperational
+                                     params:(MTRDeviceControllerStartupParams *)params;
 
 /**
  * Should use initForExistingFabric or initForNewFabric to initialize


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/27394

REVIEW NOTE: One thing I am not sure about is whether it's better to have this API or something like:
```
/**
 * Create an MTRDeviceController without doing any fabric checks.  Returns nil on failure.
 *
 * This method will fail if the MTRDeviceControllerStartupParams don't follow
 * the rules for creating a controller on a new fabric.  In particular, the
 * vendor ID must not be nil.
 */
- (MTRDeviceController * _Nullable)createControllerWithoutFabricChecks:(MTRDeviceControllerStartupParams *)startupParams
                                                                        error:(NSError * __autoreleasing *)error MTR_NEWLY_AVAILABLE;
```
