### PR TITLE
Change to prefer IPv6 link local address

### DIFF
--- a/src/lib/dnssd/IPAddressSorter.h
+++ b/src/lib/dnssd/IPAddressSorter.h
@@ -34,21 +34,13 @@ enum class IpScore : unsigned
     // "Other" IPv6 include:
     //   - invalid addresses (have seen router bugs during interop testing)
     //   - embedded IPv4 (::/80)
-    kOtherIpv6 = 1,
-    kIpv4      = 2, // Not Matter SPEC, so low priority
-#ifdef __APPLE__
+    kOtherIpv6                     = 1,
+    kIpv4                          = 2, // Not Matter SPEC, so low priority
     kUniqueLocal                   = 3, // ULA. Thread devices use this
     kGlobalUnicast                 = 4, // Maybe routable, not local subnet
     kUniqueLocalWithSharedPrefix   = 5, // Prefix seems to match a local interface
     kGlobalUnicastWithSharedPrefix = 6, // Prefix seems to match a local interface
     kLinkLocal                     = 7, // Valid only on an interface
-#else
-    kLinkLocal                     = 3, // Valid only on an interface
-    kUniqueLocal                   = 4, // ULA. Thread devices use this
-    kGlobalUnicast                 = 5, // Maybe routable, not local subnet
-    kUniqueLocalWithSharedPrefix   = 6, // Prefix seems to match a local interface
-    kGlobalUnicastWithSharedPrefix = 7, // Prefix seems to match a local interface
-#endif // __APPLE__
 };
 
 void Sort(Inet::IPAddress * addresses, size_t count, Inet::InterfaceId interfaceId);


### PR DESCRIPTION
The IPv6 LLA of the Commissioner is almost always valid. On the other hand, Commissioner's ULA updates sometimes don't work well, so it's very rare that there is no ULA.
At this time, the Commissioner mDNS resolves IPv6 addresses through Commissionable Node Discovery,

- If it selects ULA address, "Network is unreachable" error occurs.
- If it selects LLA address, it works well.

Through IPv6 source address selection,

- If IPv6 destination address is LLA, source address is selected as LLA.
- If IPv6 destination address is ULA, source address is selected as ULA.

The solution is simple. The Commissioner should prefer IPv6 LLA over ULA among mDNS resolved IPv6 addresses. The same problem occurred on android and darwin platforms, and it is possible that this problem is common to all platforms. So it's better to fix that for all platforms.
