### PR TITLE
Replace define with static constexpr in clusters headers

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -636,7 +636,7 @@ void ColorControlServer::startColorLoop(EndpointId endpoint, uint8_t startFromSt
 
     Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
 
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 }
 
 /**
@@ -947,7 +947,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
     Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1079,7 +1079,7 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1188,7 +1188,7 @@ bool ColorControlServer::moveToHueAndSaturationCommand(app::CommandHandler * com
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1286,7 +1286,7 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1360,7 +1360,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1423,7 +1423,7 @@ bool ColorControlServer::moveToSaturationCommand(app::CommandHandler * commandOb
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1486,7 +1486,7 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     SetHSVRemainingTime(endpoint);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1636,7 +1636,7 @@ void ColorControlServer::updateHueSatCommand(EndpointId endpoint)
     }
     else
     {
-        scheduleTimerCallbackMs(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
+        scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
     }
 
     if (colorHueTransitionState->isEnhancedHue)
@@ -1804,7 +1804,7 @@ bool ColorControlServer::moveToColorCommand(app::CommandHandler * commandObj, co
     Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1899,7 +1899,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     }
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureXYEventControl(endpoint), UPDATE_TIME_MS);
+    scheduleTimerCallbackMs(configureXYEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -1970,7 +1970,7 @@ bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, cons
     Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -2000,7 +2000,7 @@ void ColorControlServer::updateXYCommand(EndpointId endpoint)
     }
     else
     {
-        scheduleTimerCallbackMs(configureXYEventControl(endpoint), UPDATE_TIME_MS);
+        scheduleTimerCallbackMs(configureXYEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
     }
 
     // update the attributes
@@ -2084,7 +2084,7 @@ Status ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorT
     colorTempTransitionState->highLimit      = temperatureMax;
 
     // kick off the state machine
-    scheduleTimerCallbackMs(configureTempEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureTempEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
     return Status::Success;
 }
 
@@ -2198,7 +2198,7 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
     }
     else
     {
-        scheduleTimerCallbackMs(configureTempEventControl(endpoint), UPDATE_TIME_MS);
+        scheduleTimerCallbackMs(configureTempEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
     }
 
     Attributes::ColorTemperatureMireds::Set(endpoint, colorTempTransitionState->currentValue);
@@ -2313,7 +2313,7 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureTempEventControl(endpoint), UPDATE_TIME_MS);
+    scheduleTimerCallbackMs(configureTempEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 
 exit:
     commandObj->AddStatus(commandPath, status);
@@ -2429,7 +2429,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
-    scheduleTimerCallbackMs(configureTempEventControl(endpoint), transitionTime ? UPDATE_TIME_MS : 0);
+    scheduleTimerCallbackMs(configureTempEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
 exit:
     commandObj->AddStatus(commandPath, status);

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -629,8 +629,8 @@ void ColorControlServer::startColorLoop(EndpointId endpoint, uint8_t startFromSt
     colorHueTransitionState->up     = (direction == to_underlying(ColorLoopDirection::kIncrementHue));
     colorHueTransitionState->repeat = true;
 
-    colorHueTransitionState->stepsRemaining = static_cast<uint16_t>(time * TRANSITION_TIME_1S);
-    colorHueTransitionState->stepsTotal     = static_cast<uint16_t>(time * TRANSITION_TIME_1S);
+    colorHueTransitionState->stepsRemaining = static_cast<uint16_t>(time * TRANSITION_STEPS_PER_1S);
+    colorHueTransitionState->stepsTotal     = static_cast<uint16_t>(time * TRANSITION_STEPS_PER_1S);
     colorHueTransitionState->timeRemaining  = MAX_INT16U_VALUE;
     colorHueTransitionState->endpoint       = endpoint;
 
@@ -937,8 +937,8 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
         colorHueTransitionState->up = false;
     }
 
-    colorHueTransitionState->stepsRemaining = TRANSITION_TIME_1S;
-    colorHueTransitionState->stepsTotal     = TRANSITION_TIME_1S;
+    colorHueTransitionState->stepsRemaining = TRANSITION_STEPS_PER_1S;
+    colorHueTransitionState->stepsTotal     = TRANSITION_STEPS_PER_1S;
     colorHueTransitionState->timeRemaining  = MAX_INT16U_VALUE;
     colorHueTransitionState->endpoint       = endpoint;
     colorHueTransitionState->repeat         = true;
@@ -1557,7 +1557,7 @@ bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, cons
         // Checks if color loop is active and stays active
         if (isColorLoopActive && !deactiveColorLoop)
         {
-            colorHueTransitionState->stepsTotal         = static_cast<uint16_t>(time * TRANSITION_TIME_1S);
+            colorHueTransitionState->stepsTotal         = static_cast<uint16_t>(time * TRANSITION_STEPS_PER_1S);
             colorHueTransitionState->initialEnhancedHue = colorHueTransitionState->currentEnhancedHue;
 
             if (colorHueTransitionState->up)

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -31,8 +31,8 @@
  * Defines and Macros
  *********************************************************/
 
-static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
-static constexpr uint16_t TRANSITION_STEPS_PER_1S                   = 10;
+static constexpr chip::System::Clock::Milliseconds32 TRANSITION_UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
+static constexpr uint16_t TRANSITION_STEPS_PER_1S                              = 10;
 
 static constexpr uint16_t MIN_CIE_XY_VALUE = 0;
 static constexpr uint16_t MAX_CIE_XY_VALUE = 0xfeff; // this value comes directly from the ZCL specification table 5.3

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -31,30 +31,30 @@
  * Defines and Macros
  *********************************************************/
 
-#define UPDATE_TIME_MS 100
-#define TRANSITION_TIME_1S 10
+static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
+static constexpr uint16_t TRANSITION_TIME_1S                        = 10;
 
-#define MIN_CIE_XY_VALUE 0
-#define MAX_CIE_XY_VALUE 0xfeff // this value comes directly from the ZCL specification table 5.3
+static constexpr uint16_t MIN_CIE_XY_VALUE = 0;
+static constexpr uint16_t MAX_CIE_XY_VALUE = 0xfeff; // this value comes directly from the ZCL specification table 5.3
 
-#define MIN_TEMPERATURE_VALUE 0
-#define MAX_TEMPERATURE_VALUE 0xfeff
+static constexpr uint16_t MIN_TEMPERATURE_VALUE = 0;
+static constexpr uint16_t MAX_TEMPERATURE_VALUE = 0xfeff;
 
-#define MIN_HUE_VALUE 0
-#define MAX_HUE_VALUE 254
+static constexpr uint8_t MIN_HUE_VALUE = 0;
+static constexpr uint8_t MAX_HUE_VALUE = 254;
 
-#define MIN_SATURATION_VALUE 0
-#define MAX_SATURATION_VALUE 254
+static constexpr uint8_t MIN_SATURATION_VALUE = 0;
+static constexpr uint8_t MAX_SATURATION_VALUE = 254;
 
-#define HALF_MAX_UINT8T 127
-#define HALF_MAX_UINT16T 0x7FFF
+static constexpr uint8_t HALF_MAX_UINT8T   = 127;
+static constexpr uint16_t HALF_MAX_UINT16T = 0x7FFF;
 
-#define MAX_ENHANCED_HUE_VALUE 0xFFFF
+static constexpr uint16_t MAX_ENHANCED_HUE_VALUE = 0xFFFF;
 
-#define MIN_CURRENT_LEVEL 0x01
-#define MAX_CURRENT_LEVEL 0xFE
+static constexpr uint8_t MIN_CURRENT_LEVEL = 0x01;
+static constexpr uint8_t MAX_CURRENT_LEVEL = 0xFE;
 
-#define REPORT_FAILED 0xFF
+static constexpr uint8_t REPORT_FAILED = 0xFF;
 
 /**
  * @brief color-control-server class

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -32,7 +32,7 @@
  *********************************************************/
 
 static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
-static constexpr uint16_t TRANSITION_TIME_1S                        = 10;
+static constexpr uint16_t TRANSITION_STEPS_PER_1S                   = 10;
 
 static constexpr uint16_t MIN_CIE_XY_VALUE = 0;
 static constexpr uint16_t MAX_CIE_XY_VALUE = 0xfeff; // this value comes directly from the ZCL specification table 5.3

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -729,19 +729,19 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
 uint32_t OnOffServer::calculateNextWaitTimeMS()
 {
     const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
-    chip::System::Clock::Timestamp waitTime          = UPDATE_TIME_MS;
+    chip::System::Clock::Timestamp waitTime          = ON_OFF_UPDATE_TIME_MS;
     chip::System::Clock::Timestamp latency;
 
     if (currentTime > nextDesiredOnWithTimedOffTimestamp)
     {
         latency = currentTime - nextDesiredOnWithTimedOffTimestamp;
-        if (latency >= UPDATE_TIME_MS)
+        if (latency >= ON_OFF_UPDATE_TIME_MS)
             waitTime = chip::System::Clock::Milliseconds32(1);
         else
             waitTime -= latency;
     }
 
-    nextDesiredOnWithTimedOffTimestamp += UPDATE_TIME_MS;
+    nextDesiredOnWithTimedOffTimestamp += ON_OFF_UPDATE_TIME_MS;
 
     return (uint32_t) waitTime.count();
 }
@@ -755,7 +755,7 @@ bool OnOffServer::OnWithTimedOffCommand(app::CommandHandler * commandObj, const 
     Status status                       = Status::Success;
     chip::EndpointId endpoint           = commandPath.mEndpointId;
     bool isOn                           = false;
-    uint16_t currentOffWaitTime         = MAX_TIME_VALUE;
+    uint16_t currentOffWaitTime         = MAX_ON_OFF_TIME_VALUE;
     uint16_t currentOnTime              = 0;
 
     EmberEventControl * event = configureEventControl(endpoint);
@@ -795,10 +795,10 @@ bool OnOffServer::OnWithTimedOffCommand(app::CommandHandler * commandObj, const 
 
     ChipLogProgress(Zcl, "On Time:  %d | off wait Time: %d", currentOnTime, currentOffWaitTime);
 
-    if (currentOnTime < MAX_TIME_VALUE && currentOffWaitTime < MAX_TIME_VALUE)
+    if (currentOnTime < MAX_ON_OFF_TIME_VALUE && currentOffWaitTime < MAX_ON_OFF_TIME_VALUE)
     {
-        nextDesiredOnWithTimedOffTimestamp = chip::System::SystemClock().GetMonotonicTimestamp() + UPDATE_TIME_MS;
-        scheduleTimerCallbackMs(configureEventControl(endpoint), (uint32_t) UPDATE_TIME_MS.count());
+        nextDesiredOnWithTimedOffTimestamp = chip::System::SystemClock().GetMonotonicTimestamp() + ON_OFF_UPDATE_TIME_MS;
+        scheduleTimerCallbackMs(configureEventControl(endpoint), ON_OFF_UPDATE_TIME_MS.count());
     }
 
 exit:
@@ -824,7 +824,7 @@ void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
         scheduleTimerCallbackMs(configureEventControl(endpoint), calculateNextWaitTimeMS());
 
         // Update onTime values
-        uint16_t onTime = MIN_TIME_VALUE;
+        uint16_t onTime = MIN_ON_OFF_TIME_VALUE;
         OnOff::Attributes::OnTime::Get(endpoint, &onTime);
         ChipLogProgress(Zcl, "Timer callback - On Time:  %d", onTime);
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -29,11 +29,10 @@
  * Defines and Macros
  *********************************************************/
 
-static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
-static constexpr uint16_t TRANSITION_STEPS_PER_1S                   = 10;
+static constexpr chip::System::Clock::Milliseconds32 ON_OFF_UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
 
-static constexpr uint16_t MIN_TIME_VALUE = 1;
-static constexpr uint16_t MAX_TIME_VALUE = 0xFFFF;
+static constexpr uint16_t MIN_ON_OFF_TIME_VALUE = 1;
+static constexpr uint16_t MAX_ON_OFF_TIME_VALUE = 0xFFFF;
 
 /**
  * @brief

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -32,8 +32,8 @@
 static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
 static constexpr uint16_t TRANSITION_TIME_1S                        = 10;
 
+static constexpr uint16_t MIN_TIME_VALUE = 1;
 static constexpr uint16_t MAX_TIME_VALUE = 0xFFFF;
-static constexpr uint8_t MIN_TIME_VALUE  = 1;
 
 /**
  * @brief

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -30,7 +30,7 @@
  *********************************************************/
 
 static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
-static constexpr uint16_t TRANSITION_TIME_1S                        = 10;
+static constexpr uint16_t TRANSITION_STEPS_PER_1S                   = 10;
 
 static constexpr uint16_t MIN_TIME_VALUE = 1;
 static constexpr uint16_t MAX_TIME_VALUE = 0xFFFF;

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -25,10 +25,10 @@
 
 #include <app/data-model/Nullable.h>
 
-#define WC_PERCENT100THS_MIN_OPEN 0
-#define WC_PERCENT100THS_MAX_CLOSED 10000
-#define WC_PERCENT100THS_MIDDLE 5000
-#define WC_PERCENT100THS_COEF 100
+static constexpr chip::Percent100ths WC_PERCENT100THS_MIN_OPEN   = 0;
+static constexpr chip::Percent100ths WC_PERCENT100THS_MAX_CLOSED = 10000;
+static constexpr chip::Percent100ths WC_PERCENT100THS_MIDDLE     = 5000;
+static constexpr chip::Percent100ths WC_PERCENT100THS_COEF       = 100;
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
### Problem

It's not possible to include headers in that order:
```c++
#include <app/clusters/color-control-server/color-control-server.h>
#include <app/clusters/on-off-server/on-off-server.h>
```

The `color-control-server.h` defines macros with the same names as variables in `on-off-server.h`. As a result we've got `error: expected unqualified-id before numeric constant`.

### Changes

- declare const values as constexpr in all headers
- rename `TRANSITION_TIME_1S` to `TRANSITION_STEPS_PER_1S` to be more self-explanatory

### Testing

CI will test potential build breaks