### PR TITLE
Update cloudbuild image to 1 from 0.8

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -85,7 +85,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 2700s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -26,7 +26,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -42,7 +42,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -63,7 +63,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -85,7 +85,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -138,7 +138,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:0.8"
+    - name: "ghcr.io/project-chip/chip-build-vscode:1"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#27878 used version `:1` instead of `:0.8`. Updating cloudbuild to match.

Hotfix because github CI cannot validate cloudbuild.