### PR TITLE
Remove gdbgui requirement for esp32

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -64,6 +64,8 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: esp32
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
             - name: CI Examples ESP32
               shell: bash
               run: |

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -46,6 +46,9 @@ jobs:
               with:
                 platform: esp32
 
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+
             - name: Set up environment for size reports
               uses: ./.github/actions/setup-size-reports
               if: ${{ !env.ACT }}
@@ -138,6 +141,9 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: esp32
+
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
 
             - name: Build example Bridge App
               run: scripts/examples/esp_example.sh bridge-app

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -50,6 +50,9 @@ jobs:
               with:
                 platform: esp32
 
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+
             - name: Build ESP32 QEMU test images
               run: |
                   scripts/run_in_build_env.sh "         \

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -10,4 +10,9 @@ kconfiglib==13.7.1
 construct==2.10.54
 python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
-gdbgui==0.13.2.0 ; python_version < "3.11" and platform_machine != 'aarch64' and sys_platform == 'linux'
+#
+# gdbgui pulls in gevent which fails to compile due to cython updates.
+# Could not find a good way to fix this dependency, so commenting it
+# out here.
+#
+# gdbgui==0.13.2.0 ; python_version < "3.11" and platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
Remove GDBGui requirement and stop espressif SDK from enforcing it.