### PR TITLE
Silabs Platform Changes - Added check for board control before including header/function calls

### DIFF
--- a/examples/platform/silabs/efr32/uart.cpp
+++ b/examples/platform/silabs/efr32/uart.cpp
@@ -28,7 +28,9 @@ extern "C" {
 #include "assert.h"
 #include "em_core.h"
 #include "em_usart.h"
+#ifdef SL_BOARD_NAME
 #include "sl_board_control.h"
+#endif
 #include "sl_uartdrv_instances.h"
 #ifdef SL_CATALOG_UARTDRV_EUSART_PRESENT
 #include "sl_uartdrv_eusart_vcom_config.h"
@@ -252,7 +254,9 @@ void uartConsoleInit(void)
         return;
     }
 
+#ifdef SL_BOARD_NAME
     sl_board_enable_vcom();
+#endif
     // Init a fifo for the data received on the uart
     InitFifo(&sReceiveFifo, sRxFifoBuffer, MAX_BUFFER_SIZE);
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -212,6 +212,7 @@ template("efr32_sdk") {
       "PLAT=EMBER_PLATFORM_CORTEXM3",
       "${silabs_mcu}=1",
       "${silabs_board}=1",
+      "SL_BOARD_NAME=${silabs_board}",
       "SL_SUPRESS_DEPRECATION_WARNINGS_SDK_3_1",
       "__HEAP_SIZE=0",
       "SL_CATALOG_FREERTOS_KERNEL_PRESENT=1",


### PR DESCRIPTION
- Added check for SL_BOARD_NAME, to allow compilation of project with just a target and no board (or custom boards)
- sl_board_enable_vcom() call should only be present if SL_BOARD_NAME (SL board) is being targeted
