### PR TITLE
Make the Darwin compat story for struct/event renames better

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -65,6 +65,16 @@ NS_ASSUME_NONNULL_BEGIN
 {{#*inline "oldNameImpl"}}
 {{#if (isSupported cluster struct=structName)}}
 @implementation MTR{{cluster}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
+{{#zcl_struct_items}}
+{{#if (isSupported ../cluster struct=../structName structField=(asStructPropertyName label))}}
+@dynamic {{asStructPropertyName label}};
+{{/if}}
+{{#if (hasOldName ../cluster struct=../structName structField=(asStructPropertyName label))}}
+{{#if (isSupported ../cluster struct=../structName structField=(oldName ../cluster struct=../structName structField=(asStructPropertyName label)))}}
+@dynamic {{oldName ../cluster struct=../structName structField=(asStructPropertyName label)}};
+{{/if}}
+{{/if}}
+{{/zcl_struct_items}}
 @end
 {{/if}}
 {{/inline}}
@@ -139,6 +149,16 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported cluster event=eventName)}}
 
 @implementation MTR{{cluster}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
+{{#zcl_event_fields}}
+{{#if (isSupported ../cluster event=../eventName eventField=(asStructPropertyName name))}}
+@dynamic {{asStructPropertyName name}};
+{{/if}}
+{{#if (hasOldName ../cluster event=../eventName eventField=(asStructPropertyName name))}}
+{{#if (isSupported ../cluster event=../eventName eventField=(oldName ../cluster event=../eventName eventField=(asStructPropertyName name)))}}
+@dynamic {{oldName ../cluster event=../event eventField=(asStructPropertyName name)}};
+{{/if}}
+{{/if}}
+{{/zcl_event_fields}}
 @end
 {{/if}}
 {{/inline}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -63,8 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{! Takes the name of the struct to use as structName. }}
 {{#*inline "oldNameImpl"}}
-{{#if (isSupported (compatClusterNameRemapping parent.name) struct=structName)}}
-@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
+{{#if (isSupported cluster struct=structName)}}
+@implementation MTR{{cluster}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 @end
 {{/if}}
 {{/inline}}
@@ -73,9 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (or oldStructName
           (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
 {{#if oldStructName}}
-{{> oldNameImpl structName=oldStructName}}
+{{> oldNameImpl cluster=(compatClusterNameRemapping parent.name) structName=oldStructName}}
 {{else}}
-{{> oldNameImpl structName=(asUpperCamelCase name preserveAcronyms=true)}}
+{{> oldNameImpl cluster=(compatClusterNameRemapping parent.name) structName=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
 {{/if}}
 {{/inline}}
@@ -136,9 +136,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{! Takes the name of the event to use as eventName. }}
 {{#*inline "oldNameImpl"}}
-{{#if (isSupported (compatClusterNameRemapping parent.name) event=eventName)}}
+{{#if (isSupported cluster event=eventName)}}
 
-@implementation MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
+@implementation MTR{{cluster}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 @end
 {{/if}}
 {{/inline}}
@@ -147,9 +147,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (or oldEventName
           (hasOldName (asUpperCamelCase parent.name preserveAcronyms=true)))}}
 {{#if oldEventName}}
-{{> oldNameImpl eventName=oldEventName}}
+{{> oldNameImpl cluster=(compatClusterNameRemapping parent.name) eventName=oldEventName}}
 {{else}}
-{{> oldNameImpl eventName=(asUpperCamelCase name preserveAcronyms=true)}}
+{{> oldNameImpl cluster=(compatClusterNameRemapping parent.name) eventName=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
 {{/if}}
 {{/inline}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -30,8 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (compatClusterNameRemapping parent.name) struct=structName)}}
 {{availability (compatClusterNameRemapping parent.name) struct=structName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
-{{!TODO {{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) struct=structName}}
+{{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) struct=structName}}
 @end
+
 {{/if}}
 {{/inline}}
 {{! Takes the old name of the struct, if any, as oldStructName. }}
@@ -66,15 +67,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
 {{> interfaceDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
+
 {{/if}}
 {{! Takes the name of the event to use as eventName. }}
 {{#*inline "oldNameDecl"}}
 {{#if (isSupported (compatClusterNameRemapping parent.name) event=eventName)}}
-
 {{availability (compatClusterNameRemapping parent.name) event=eventName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
-{{!TODO {{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) event=eventName}}
+{{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) event=eventName}}
 @end
+
 {{/if}}
 {{/inline}}
 {{! Takes the old name of the event, if any, as oldEventName. }}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -8,12 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_structs}}
 {{#*inline "interfaceDecl"}}
 {{#zcl_struct_items}}
-{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label))}}
-{{> struct_field_decl cluster=parent.parent.name type=type label=label}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
+{{#if (isSupported ../cluster struct=../struct structField=(asStructPropertyName label))}}
+{{> struct_field_decl cluster=../cluster type=type label=label}} {{availability (asUpperCamelCase ../cluster preserveAcronyms=true) struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
 {{/if}}
-{{#if (hasOldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}}
-{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)))}}
-{{> struct_field_decl cluster=../../name type=type label=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(oldName (asUpperCamelCase ../../name preserveAcronyms=true) struct=(asUpperCamelCase ../name preserveAcronyms=true) structField=(asStructPropertyName label)) deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{#if (hasOldName ../cluster struct=../struct structField=(asStructPropertyName label))}}
+{{#if (isSupported ../cluster struct=../struct structField=(oldName ../cluster struct=../struct structField=(asStructPropertyName label)))}}
+{{> struct_field_decl cluster=../cluster type=type label=(oldName ../cluster struct=../struct structField=(asStructPropertyName label))}} {{availability ../cluster struct=../struct structField=(oldName ../cluster struct=../struct structField=(asStructPropertyName label)) deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
 {{/if}}
 {{/if}}
 {{/zcl_struct_items}}
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true))}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true) deprecationMessage="This struct is unused and will be removed"}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}} : NSObject <NSCopying>
-{{> interfaceDecl struct=(asUpperCamelCase name preserveAcronyms=true)}}
+{{> interfaceDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) struct=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
 
 {{/if}}
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (compatClusterNameRemapping parent.name) struct=structName)}}
 {{availability (compatClusterNameRemapping parent.name) struct=structName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true))}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{structName}} : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
+{{!TODO {{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) struct=structName}}
 @end
 {{/if}}
 {{/inline}}
@@ -48,19 +49,22 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_structs}}
 
 {{#zcl_events}}
-{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
-{{availability (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
-@interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
+{{#*inline "interfaceDecl"}}
 {{#zcl_event_fields}}
-{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
-{{> struct_field_decl cluster=parent.parent.name type=type label=name}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)}};
+{{#if (isSupported ../cluster event=../event eventField=(asStructPropertyName name))}}
+{{> struct_field_decl cluster=../cluster type=type label=name}} {{availability ../cluster event=../event eventField=(asStructPropertyName name) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true) "Event")}};
 {{/if}}
-{{#if (hasOldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}}
-{{#if (isSupported (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)))}}
-{{> struct_field_decl cluster=parent.parent.name type=type label=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name))}} {{availability (asUpperCamelCase ../../name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(oldName (asUpperCamelCase ../parent.name preserveAcronyms=true) event=(asUpperCamelCase ../name preserveAcronyms=true) eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
+{{#if (hasOldName ../cluster event=../event eventField=(asStructPropertyName name))}}
+{{#if (isSupported ../cluster event=../event eventField=(oldName ../cluster event=../event eventField=(asStructPropertyName name)))}}
+{{> struct_field_decl cluster=../cluster type=type label=(oldName ../cluster event=../event eventField=(asStructPropertyName name))}} {{availability ../cluster event=../event eventField=(oldName ../cluster event=../event eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
 {{/if}}
 {{/if}}
 {{/zcl_event_fields}}
+{{/inline}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
+{{availability (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
+@interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
+{{> interfaceDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
 {{/if}}
 {{! Takes the name of the event to use as eventName. }}
@@ -69,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{availability (compatClusterNameRemapping parent.name) event=eventName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
+{{!TODO {{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) event=eventName}}
 @end
 {{/if}}
 {{/inline}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -46,6 +46,8 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 MTR_DEPRECATED(
     "Please use MTRDescriptorClusterDeviceTypeStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRDescriptorClusterDeviceType : MTRDescriptorClusterDeviceTypeStruct
+@property (nonatomic, copy) NSNumber * _Nonnull revision MTR_DEPRECATED(
+    "Please use MTRDescriptorClusterDeviceTypeStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -67,7 +69,17 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlTargetStruct", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRAccessControlClusterTarget : MTRAccessControlClusterAccessControlTargetStruct
+@property (nonatomic, copy)
+    NSNumber * _Nullable cluster MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlTargetStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nullable endpoint MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlTargetStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nullable deviceType MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlTargetStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRAccessControlClusterAccessControlEntryStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull privilege API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -80,7 +92,22 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRAccessControlClusterAccessControlEntry : MTRAccessControlClusterAccessControlEntryStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull privilege MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull authMode MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nullable subjects MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nullable targets MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fabricIndex MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlEntryStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRAccessControlClusterAccessControlExtensionStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSData * _Nonnull data API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -90,6 +117,11 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlExtensionStruct", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRAccessControlClusterExtensionEntry : MTRAccessControlClusterAccessControlExtensionStruct
+@property (nonatomic, copy) NSData * _Nonnull data MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlExtensionStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fabricIndex MTR_DEPRECATED("Please use MTRAccessControlClusterAccessControlExtensionStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -158,7 +190,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRBasicInformationClusterCapabilityMinimaStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRBasicClusterCapabilityMinimaStruct : MTRBasicInformationClusterCapabilityMinimaStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull caseSessionsPerFabric MTR_DEPRECATED("Please use MTRBasicInformationClusterCapabilityMinimaStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull subscriptionsPerFabric MTR_DEPRECATED("Please use MTRBasicInformationClusterCapabilityMinimaStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 @interface MTRBasicInformationClusterProductAppearanceStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull finish API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0));
@@ -173,6 +212,8 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRBasicInformationClusterStartUpEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRBasicClusterStartUpEvent : MTRBasicInformationClusterStartUpEvent
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion MTR_DEPRECATED(
+    "Please use MTRBasicInformationClusterStartUpEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -192,6 +233,8 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRBasicInformationClusterLeaveEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRBasicClusterLeaveEvent : MTRBasicInformationClusterLeaveEvent
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex MTR_DEPRECATED(
+    "Please use MTRBasicInformationClusterLeaveEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -202,6 +245,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRBasicInformationClusterReachableChangedEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRBasicClusterReachableChangedEvent : MTRBasicInformationClusterReachableChangedEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull reachableNewValue MTR_DEPRECATED("Please use MTRBasicInformationClusterReachableChangedEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -214,6 +260,15 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterProviderLocation", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTROtaSoftwareUpdateRequestorClusterProviderLocation : MTROTASoftwareUpdateRequestorClusterProviderLocation
+@property (nonatomic, copy)
+    NSNumber * _Nonnull providerNodeID MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterProviderLocation",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull endpoint MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterProviderLocation", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fabricIndex MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterProviderLocation",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -229,6 +284,18 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterStateTransitionEvent", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : MTROTASoftwareUpdateRequestorClusterStateTransitionEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull previousState MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterStateTransitionEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy, getter=getNewState)
+    NSNumber * _Nonnull newState MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterStateTransitionEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull reason MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterStateTransitionEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable targetSoftwareVersion MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterStateTransitionEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -240,6 +307,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull softwareVersion MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull productID MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -253,6 +326,18 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull softwareVersion MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull bytesDownloaded MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable progressPercent MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable platformCode MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 MTR_DEPRECATED("This struct is unused and will be removed", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
@@ -314,7 +399,13 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterNetworkInfoStruct", ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0),
     tvos(16.1, 17.0))
 @interface MTRNetworkCommissioningClusterNetworkInfo : MTRNetworkCommissioningClusterNetworkInfoStruct
+@property (nonatomic, copy) NSData * _Nonnull networkID MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterNetworkInfoStruct",
+    ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull connected MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterNetworkInfoStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
+
 API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 @interface MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull panId API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0));
@@ -330,7 +421,32 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRNetworkCommissioningClusterThreadInterfaceScanResult : MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull panId MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull extendedPanId MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSString * _Nonnull networkName MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull channel MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull version MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSData * _Nonnull extendedAddress MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull rssi MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull lqi MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
+
 API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 @interface MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull security API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0));
@@ -344,6 +460,24 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRNetworkCommissioningClusterWiFiInterfaceScanResult : MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull security MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSData * _Nonnull ssid MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSData * _Nonnull bssid MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull channel MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull wiFiBand MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull rssi MTR_DEPRECATED("Please use MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -363,6 +497,28 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRGeneralDiagnosticsClusterNetworkInterfaceType : MTRGeneralDiagnosticsClusterNetworkInterface
+@property (nonatomic, copy) NSString * _Nonnull name MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull isOperational MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable offPremiseServicesReachableIPv4 MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable offPremiseServicesReachableIPv6 MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSData * _Nonnull hardwareAddress MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nonnull iPv4Addresses MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nonnull iPv6Addresses MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull type MTR_DEPRECATED("Please use MTRGeneralDiagnosticsClusterNetworkInterface",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -400,6 +556,19 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRSoftwareDiagnosticsClusterThreadMetrics : MTRSoftwareDiagnosticsClusterThreadMetricsStruct
+@property (nonatomic, copy) NSNumber * _Nonnull id MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable name MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable stackFreeCurrent MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable stackFreeMinimum MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable stackSize MTR_DEPRECATED("Please use MTRSoftwareDiagnosticsClusterThreadMetricsStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -430,7 +599,50 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRThreadNetworkDiagnosticsClusterNeighborTable : MTRThreadNetworkDiagnosticsClusterNeighborTableStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull extAddress MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull age MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull rloc16 MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull linkFrameCounter MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull mleFrameCounter MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull lqi MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nullable averageRssi MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nullable lastRssi MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull frameErrorRate MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull messageErrorRate MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull rxOnWhenIdle MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fullThreadDevice MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fullNetworkData MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull isChild MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterNeighborTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
+
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject <NSCopying>
 @property (nonatomic, copy)
@@ -469,7 +681,37 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRThreadNetworkDiagnosticsClusterRouteTable : MTRThreadNetworkDiagnosticsClusterRouteTableStruct
+@property (nonatomic, copy)
+    NSNumber * _Nonnull extAddress MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull rloc16 MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull routerId MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull nextHop MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull pathCost MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull lqiIn MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull lqiOut MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy) NSNumber * _Nonnull age MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct",
+    ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull allocated MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct", ios(16.1, 17.0),
+        macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull linkEstablished MTR_DEPRECATED("Please use MTRThreadNetworkDiagnosticsClusterRouteTableStruct",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
+
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull rotationTime API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
@@ -513,7 +755,16 @@ API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5))
 MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterDSTOffsetStruct", ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5),
     tvos(16.1, 16.5))
 @interface MTRTimeSynchronizationClusterDstOffsetType : MTRTimeSynchronizationClusterDSTOffsetStruct
+@property (nonatomic, copy) NSNumber * _Nonnull offset MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterDSTOffsetStruct",
+    ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull validStarting MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterDSTOffsetStruct", ios(16.1, 16.5),
+        macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
+@property (nonatomic, copy)
+    NSNumber * _Nullable validUntil MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterDSTOffsetStruct", ios(16.1, 16.5),
+        macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
 @end
+
 API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5))
 @interface MTRTimeSynchronizationClusterTimeZoneStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull offset API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5));
@@ -524,6 +775,12 @@ API_AVAILABLE(ios(16.5), macos(13.4), watchos(9.5), tvos(16.5))
 MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterTimeZoneStruct", ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5),
     tvos(16.1, 16.5))
 @interface MTRTimeSynchronizationClusterTimeZoneType : MTRTimeSynchronizationClusterTimeZoneStruct
+@property (nonatomic, copy) NSNumber * _Nonnull offset MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterTimeZoneStruct",
+    ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
+@property (nonatomic, copy) NSNumber * _Nonnull validAt MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterTimeZoneStruct",
+    ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
+@property (nonatomic, copy) NSString * _Nullable name MTR_DEPRECATED("Please use MTRTimeSynchronizationClusterTimeZoneStruct",
+    ios(16.1, 16.5), macos(13.0, 13.4), watchos(9.1, 9.5), tvos(16.1, 16.5));
 @end
 
 API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
@@ -540,6 +797,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterStartUpEvent", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRBridgedDeviceBasicClusterStartUpEvent : MTRBridgedDeviceBasicInformationClusterStartUpEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull softwareVersion MTR_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterStartUpEvent",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -568,6 +828,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterReachableChangedEvent", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTRBridgedDeviceBasicClusterReachableChangedEvent : MTRBridgedDeviceBasicInformationClusterReachableChangedEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull reachableNewValue MTR_DEPRECATED("Please use MTRBridgedDeviceBasicInformationClusterReachableChangedEvent",
+        ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -634,7 +897,17 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTROperationalCredentialsClusterFabricDescriptorStruct", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTROperationalCredentialsClusterFabricDescriptor : MTROperationalCredentialsClusterFabricDescriptorStruct
+@property (nonatomic, copy)
+    NSData * _Nonnull rootPublicKey MTR_DEPRECATED("Please use MTROperationalCredentialsClusterFabricDescriptorStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSString * _Nonnull label MTR_DEPRECATED("Please use MTROperationalCredentialsClusterFabricDescriptorStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fabricIndex MTR_DEPRECATED("Please use MTROperationalCredentialsClusterFabricDescriptorStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTROperationalCredentialsClusterNOCStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSData * _Nonnull noc API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
@@ -696,7 +969,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRModeSelectClusterSemanticTagStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRModeSelectClusterSemanticTag : MTRModeSelectClusterSemanticTagStruct
+@property (nonatomic, copy) NSNumber * _Nonnull mfgCode MTR_DEPRECATED(
+    "Please use MTRModeSelectClusterSemanticTagStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull value MTR_DEPRECATED(
+    "Please use MTRModeSelectClusterSemanticTagStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRModeSelectClusterModeOptionStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSString * _Nonnull label API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
@@ -713,6 +991,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRDoorLockClusterCredentialStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRDoorLockClusterDlCredential : MTRDoorLockClusterCredentialStruct
+@property (nonatomic, copy) NSNumber * _Nonnull credentialType MTR_DEPRECATED(
+    "Please use MTRDoorLockClusterCredentialStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull credentialIndex MTR_DEPRECATED(
+    "Please use MTRDoorLockClusterCredentialStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
@@ -844,7 +1126,18 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRChannelClusterChannelInfo : MTRChannelClusterChannelInfoStruct
+@property (nonatomic, copy) NSNumber * _Nonnull majorNumber MTR_DEPRECATED(
+    "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull minorNumber MTR_DEPRECATED(
+    "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable name MTR_DEPRECATED(
+    "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable callSign MTR_DEPRECATED(
+    "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable affiliateCallSign MTR_DEPRECATED(
+    "Please use MTRChannelClusterChannelInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRChannelClusterLineupInfoStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSString * _Nonnull operatorName API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -856,6 +1149,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRChannelClusterLineupInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRChannelClusterLineupInfo : MTRChannelClusterLineupInfoStruct
+@property (nonatomic, copy) NSString * _Nonnull operatorName MTR_DEPRECATED(
+    "Please use MTRChannelClusterLineupInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable lineupName MTR_DEPRECATED(
+    "Please use MTRChannelClusterLineupInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nullable postalCode MTR_DEPRECATED(
+    "Please use MTRChannelClusterLineupInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull lineupInfoType MTR_DEPRECATED(
+    "Please use MTRChannelClusterLineupInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -867,6 +1168,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRTargetNavigatorClusterTargetInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTargetNavigatorClusterTargetInfo : MTRTargetNavigatorClusterTargetInfoStruct
+@property (nonatomic, copy) NSNumber * _Nonnull identifier MTR_DEPRECATED("Please use MTRTargetNavigatorClusterTargetInfoStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull name MTR_DEPRECATED("Please use MTRTargetNavigatorClusterTargetInfoStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -878,6 +1183,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRMediaPlaybackClusterPlaybackPositionStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRMediaPlaybackClusterPlaybackPosition : MTRMediaPlaybackClusterPlaybackPositionStruct
+@property (nonatomic, copy) NSNumber * _Nonnull updatedAt MTR_DEPRECATED("Please use MTRMediaPlaybackClusterPlaybackPositionStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nullable position MTR_DEPRECATED("Please use MTRMediaPlaybackClusterPlaybackPositionStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -891,6 +1200,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRMediaInputClusterInputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRMediaInputClusterInputInfo : MTRMediaInputClusterInputInfoStruct
+@property (nonatomic, copy) NSNumber * _Nonnull index MTR_DEPRECATED(
+    "Please use MTRMediaInputClusterInputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull inputType MTR_DEPRECATED(
+    "Please use MTRMediaInputClusterInputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull name MTR_DEPRECATED(
+    "Please use MTRMediaInputClusterInputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull descriptionString MTR_DEPRECATED(
+    "Please use MTRMediaInputClusterInputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -903,7 +1220,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRContentLauncherClusterDimensionStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterDimension : MTRContentLauncherClusterDimensionStruct
+@property (nonatomic, copy) NSNumber * _Nonnull width MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterDimensionStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull height MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterDimensionStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull metric MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterDimensionStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRContentLauncherClusterAdditionalInfoStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSString * _Nonnull name API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -913,7 +1237,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRContentLauncherClusterAdditionalInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterAdditionalInfo : MTRContentLauncherClusterAdditionalInfoStruct
+@property (nonatomic, copy) NSString * _Nonnull name MTR_DEPRECATED("Please use MTRContentLauncherClusterAdditionalInfoStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull value MTR_DEPRECATED("Please use MTRContentLauncherClusterAdditionalInfoStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRContentLauncherClusterParameterStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull type API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -924,7 +1253,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRContentLauncherClusterParameterStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterParameter : MTRContentLauncherClusterParameterStruct
+@property (nonatomic, copy) NSNumber * _Nonnull type MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterParameterStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull value MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterParameterStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nullable externalIDList MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterParameterStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRContentLauncherClusterContentSearchStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSArray * _Nonnull parameterList API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -933,7 +1269,11 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRContentLauncherClusterContentSearchStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterContentSearch : MTRContentLauncherClusterContentSearchStruct
+@property (nonatomic, copy)
+    NSArray * _Nonnull parameterList MTR_DEPRECATED("Please use MTRContentLauncherClusterContentSearchStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRContentLauncherClusterStyleInformationStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSString * _Nullable imageURL API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -947,7 +1287,13 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRContentLauncherClusterStyleInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterStyleInformation : MTRContentLauncherClusterStyleInformationStruct
+@property (nonatomic, copy) NSString * _Nullable color MTR_DEPRECATED("Please use MTRContentLauncherClusterStyleInformationStruct",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterDimensionStruct * _Nullable size MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterStyleInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRContentLauncherClusterBrandingInformationStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSString * _Nonnull providerName API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -966,6 +1312,24 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRContentLauncherClusterBrandingInformation : MTRContentLauncherClusterBrandingInformationStruct
+@property (nonatomic, copy)
+    NSString * _Nonnull providerName MTR_DEPRECATED("Please use MTRContentLauncherClusterBrandingInformationStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformationStruct * _Nullable background MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformationStruct * _Nullable logo MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformationStruct * _Nullable progressBar MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformationStruct * _Nullable splash MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformationStruct * _Nullable waterMark MTR_DEPRECATED(
+    "Please use MTRContentLauncherClusterBrandingInformationStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -978,6 +1342,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRAudioOutputClusterOutputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRAudioOutputClusterOutputInfo : MTRAudioOutputClusterOutputInfoStruct
+@property (nonatomic, copy) NSNumber * _Nonnull index MTR_DEPRECATED(
+    "Please use MTRAudioOutputClusterOutputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull outputType MTR_DEPRECATED(
+    "Please use MTRAudioOutputClusterOutputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull name MTR_DEPRECATED(
+    "Please use MTRAudioOutputClusterOutputInfoStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -994,6 +1364,7 @@ MTR_DEPRECATED("Please use MTRApplicationLauncherClusterApplicationStruct", ios(
     tvos(16.1, 16.4))
 @interface MTRApplicationLauncherClusterApplication : MTRApplicationLauncherClusterApplicationStruct
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRApplicationLauncherClusterApplicationEPStruct : NSObject <NSCopying>
 @property (nonatomic, copy) MTRApplicationLauncherClusterApplicationStruct * _Nonnull application API_AVAILABLE(
@@ -1004,6 +1375,12 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRApplicationLauncherClusterApplicationEPStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRApplicationLauncherClusterApplicationEP : MTRApplicationLauncherClusterApplicationEPStruct
+@property (nonatomic, copy) MTRApplicationLauncherClusterApplicationStruct * _Nonnull application MTR_DEPRECATED(
+    "Please use MTRApplicationLauncherClusterApplicationEPStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable endpoint MTR_DEPRECATED("Please use MTRApplicationLauncherClusterApplicationEPStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -1036,7 +1413,24 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterSimpleStruct : MTRUnitTestingClusterSimpleStruct
+@property (nonatomic, copy) NSNumber * _Nonnull a MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull b MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull c MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSData * _Nonnull d MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull e MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull f MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull g MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull h MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterSimpleStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterTestFabricScoped : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull fabricSensitiveInt8u API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -1059,7 +1453,24 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterTestFabricScoped : MTRUnitTestingClusterTestFabricScoped
+@property (nonatomic, copy) NSNumber * _Nonnull fabricSensitiveInt8u MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nullable optionalFabricSensitiveInt8u MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nullable nullableFabricSensitiveInt8u MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalFabricSensitiveInt8u MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSString * _Nonnull fabricSensitiveCharString MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull fabricSensitiveStruct MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull fabricSensitiveInt8uList MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestFabricScoped", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterNullablesAndOptionalsStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nullable nullableInt API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -1085,7 +1496,44 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRTestClusterClusterNullablesAndOptionalsStruct : MTRUnitTestingClusterNullablesAndOptionalsStruct
+@property (nonatomic, copy)
+    NSNumber * _Nullable nullableInt MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable optionalInt MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSNumber * _Nullable nullableOptionalInt MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSString * _Nullable nullableString MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSString * _Nullable optionalString MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSString * _Nullable nullableOptionalString MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableStruct MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable optionalStruct MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
+    tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nullable nullableList MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nullable optionalList MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy)
+    NSArray * _Nullable nullableOptionalList MTR_DEPRECATED("Please use MTRUnitTestingClusterNullablesAndOptionalsStruct",
+        ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterNestedStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull a API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -1097,7 +1545,14 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterNestedStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterNestedStruct : MTRUnitTestingClusterNestedStruct
+@property (nonatomic, copy) NSNumber * _Nonnull a MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull b MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull c MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStruct", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterNestedStructList : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull a API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -1113,7 +1568,22 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterNestedStructList : MTRUnitTestingClusterNestedStructList
+@property (nonatomic, copy) NSNumber * _Nonnull a MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull b MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull c MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull d MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull e MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull f MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull g MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterDoubleNestedStructList : NSObject <NSCopying>
 @property (nonatomic, copy) NSArray * _Nonnull a API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -1122,7 +1592,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRUnitTestingClusterDoubleNestedStructList", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRTestClusterClusterDoubleNestedStructList : MTRUnitTestingClusterDoubleNestedStructList
+@property (nonatomic, copy) NSArray * _Nonnull a MTR_DEPRECATED("Please use MTRUnitTestingClusterDoubleNestedStructList",
+    ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
+
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 @interface MTRUnitTestingClusterTestListStructOctet : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull member1 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
@@ -1132,6 +1605,10 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterTestListStructOctet", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterTestListStructOctet : MTRUnitTestingClusterTestListStructOctet
+@property (nonatomic, copy) NSNumber * _Nonnull member1 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestListStructOctet", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSData * _Nonnull member2 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestListStructOctet", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -1148,6 +1625,18 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED(
     "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRTestClusterClusterTestEventEvent : MTRUnitTestingClusterTestEventEvent
+@property (nonatomic, copy) NSNumber * _Nonnull arg1 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull arg2 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSNumber * _Nonnull arg3 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull arg4 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull arg5 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+@property (nonatomic, copy) NSArray * _Nonnull arg6 MTR_DEPRECATED(
+    "Please use MTRUnitTestingClusterTestEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
@@ -1158,6 +1647,9 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 MTR_DEPRECATED("Please use MTRUnitTestingClusterTestFabricScopedEventEvent", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
     tvos(16.1, 16.4))
 @interface MTRTestClusterClusterTestFabricScopedEventEvent : MTRUnitTestingClusterTestFabricScopedEventEvent
+@property (nonatomic, copy)
+    NSNumber * _Nonnull fabricIndex MTR_DEPRECATED("Please use MTRUnitTestingClusterTestFabricScopedEventEvent", ios(16.1, 16.4),
+        macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -143,6 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRDescriptorClusterDeviceType : MTRDescriptorClusterDeviceTypeStruct
+@dynamic revision;
 @end
 
 @implementation MTRBindingClusterTargetStruct
@@ -220,6 +221,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRAccessControlClusterTarget : MTRAccessControlClusterAccessControlTargetStruct
+@dynamic cluster;
+@dynamic endpoint;
+@dynamic deviceType;
 @end
 
 @implementation MTRAccessControlClusterAccessControlEntryStruct
@@ -264,6 +268,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRAccessControlClusterAccessControlEntry : MTRAccessControlClusterAccessControlEntryStruct
+@dynamic privilege;
+@dynamic authMode;
+@dynamic subjects;
+@dynamic targets;
+@dynamic fabricIndex;
 @end
 
 @implementation MTRAccessControlClusterAccessControlExtensionStruct
@@ -298,6 +307,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRAccessControlClusterExtensionEntry : MTRAccessControlClusterAccessControlExtensionStruct
+@dynamic data;
+@dynamic fabricIndex;
 @end
 
 @implementation MTRAccessControlClusterAccessControlEntryChangedEvent
@@ -566,6 +577,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBasicClusterCapabilityMinimaStruct : MTRBasicInformationClusterCapabilityMinimaStruct
+@dynamic caseSessionsPerFabric;
+@dynamic subscriptionsPerFabric;
 @end
 
 @implementation MTRBasicInformationClusterProductAppearanceStruct
@@ -628,6 +641,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBasicClusterStartUpEvent : MTRBasicInformationClusterStartUpEvent
+@dynamic softwareVersion;
 @end
 
 @implementation MTRBasicInformationClusterShutDownEvent
@@ -685,6 +699,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBasicClusterLeaveEvent : MTRBasicInformationClusterLeaveEvent
+@dynamic fabricIndex;
 @end
 
 @implementation MTRBasicInformationClusterReachableChangedEvent
@@ -716,6 +731,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBasicClusterReachableChangedEvent : MTRBasicInformationClusterReachableChangedEvent
+@dynamic reachableNewValue;
 @end
 
 @implementation MTROTASoftwareUpdateRequestorClusterProviderLocation
@@ -753,6 +769,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTROtaSoftwareUpdateRequestorClusterProviderLocation : MTROTASoftwareUpdateRequestorClusterProviderLocation
+@dynamic providerNodeID;
+@dynamic endpoint;
+@dynamic fabricIndex;
 @end
 
 @implementation MTROTASoftwareUpdateRequestorClusterStateTransitionEvent
@@ -794,6 +813,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : MTROTASoftwareUpdateRequestorClusterStateTransitionEvent
+@dynamic previousState;
+@dynamic newState;
+@dynamic reason;
+@dynamic targetSoftwareVersion;
 @end
 
 @implementation MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent
@@ -828,6 +851,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent
+@dynamic softwareVersion;
+@dynamic productID;
 @end
 
 @implementation MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent
@@ -869,6 +894,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent
+@dynamic softwareVersion;
+@dynamic bytesDownloaded;
+@dynamic progressPercent;
+@dynamic platformCode;
 @end
 
 @implementation MTRPowerSourceClusterBatChargeFaultChangeType
@@ -1122,6 +1151,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRNetworkCommissioningClusterNetworkInfo : MTRNetworkCommissioningClusterNetworkInfoStruct
+@dynamic networkID;
+@dynamic connected;
 @end
 
 @implementation MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct
@@ -1178,6 +1209,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTRNetworkCommissioningClusterThreadInterfaceScanResult
     : MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct
+@dynamic panId;
+@dynamic extendedPanId;
+@dynamic networkName;
+@dynamic channel;
+@dynamic version;
+@dynamic extendedAddress;
+@dynamic rssi;
+@dynamic lqi;
 @end
 
 @implementation MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct
@@ -1226,6 +1265,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRNetworkCommissioningClusterWiFiInterfaceScanResult : MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct
+@dynamic security;
+@dynamic ssid;
+@dynamic bssid;
+@dynamic channel;
+@dynamic wiFiBand;
+@dynamic rssi;
 @end
 
 @implementation MTRGeneralDiagnosticsClusterNetworkInterface
@@ -1281,6 +1326,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRGeneralDiagnosticsClusterNetworkInterfaceType : MTRGeneralDiagnosticsClusterNetworkInterface
+@dynamic name;
+@dynamic isOperational;
+@dynamic offPremiseServicesReachableIPv4;
+@dynamic offPremiseServicesReachableIPv6;
+@dynamic hardwareAddress;
+@dynamic iPv4Addresses;
+@dynamic iPv6Addresses;
+@dynamic type;
 @end
 
 @implementation MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent
@@ -1446,6 +1499,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRSoftwareDiagnosticsClusterThreadMetrics : MTRSoftwareDiagnosticsClusterThreadMetricsStruct
+@dynamic id;
+@dynamic name;
+@dynamic stackFreeCurrent;
+@dynamic stackFreeMinimum;
+@dynamic stackSize;
 @end
 
 @implementation MTRSoftwareDiagnosticsClusterSoftwareFaultEvent
@@ -1555,6 +1613,20 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRThreadNetworkDiagnosticsClusterNeighborTable : MTRThreadNetworkDiagnosticsClusterNeighborTableStruct
+@dynamic extAddress;
+@dynamic age;
+@dynamic rloc16;
+@dynamic linkFrameCounter;
+@dynamic mleFrameCounter;
+@dynamic lqi;
+@dynamic averageRssi;
+@dynamic lastRssi;
+@dynamic frameErrorRate;
+@dynamic messageErrorRate;
+@dynamic rxOnWhenIdle;
+@dynamic fullThreadDevice;
+@dynamic fullNetworkData;
+@dynamic isChild;
 @end
 
 @implementation MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents
@@ -1682,6 +1754,16 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRThreadNetworkDiagnosticsClusterRouteTable : MTRThreadNetworkDiagnosticsClusterRouteTableStruct
+@dynamic extAddress;
+@dynamic rloc16;
+@dynamic routerId;
+@dynamic nextHop;
+@dynamic pathCost;
+@dynamic lqiIn;
+@dynamic lqiOut;
+@dynamic age;
+@dynamic allocated;
+@dynamic linkEstablished;
 @end
 
 @implementation MTRThreadNetworkDiagnosticsClusterSecurityPolicy
@@ -1896,6 +1978,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTimeSynchronizationClusterDstOffsetType : MTRTimeSynchronizationClusterDSTOffsetStruct
+@dynamic offset;
+@dynamic validStarting;
+@dynamic validUntil;
 @end
 
 @implementation MTRTimeSynchronizationClusterTimeZoneStruct
@@ -1933,6 +2018,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTimeSynchronizationClusterTimeZoneType : MTRTimeSynchronizationClusterTimeZoneStruct
+@dynamic offset;
+@dynamic validAt;
+@dynamic name;
 @end
 
 @implementation MTRBridgedDeviceBasicInformationClusterProductAppearanceStruct
@@ -1995,6 +2083,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBridgedDeviceBasicClusterStartUpEvent : MTRBridgedDeviceBasicInformationClusterStartUpEvent
+@dynamic softwareVersion;
 @end
 
 @implementation MTRBridgedDeviceBasicInformationClusterShutDownEvent
@@ -2078,6 +2167,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRBridgedDeviceBasicClusterReachableChangedEvent : MTRBridgedDeviceBasicInformationClusterReachableChangedEvent
+@dynamic reachableNewValue;
 @end
 
 @implementation MTRSwitchClusterSwitchLatchedEvent
@@ -2367,6 +2457,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTROperationalCredentialsClusterFabricDescriptor : MTROperationalCredentialsClusterFabricDescriptorStruct
+@dynamic rootPublicKey;
+@dynamic label;
+@dynamic fabricIndex;
 @end
 
 @implementation MTROperationalCredentialsClusterNOCStruct
@@ -2650,6 +2743,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRModeSelectClusterSemanticTag : MTRModeSelectClusterSemanticTagStruct
+@dynamic mfgCode;
+@dynamic value;
 @end
 
 @implementation MTRModeSelectClusterModeOptionStruct
@@ -2718,6 +2813,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRDoorLockClusterDlCredential : MTRDoorLockClusterCredentialStruct
+@dynamic credentialType;
+@dynamic credentialIndex;
 @end
 
 @implementation MTRDoorLockClusterDoorLockAlarmEvent
@@ -3382,6 +3479,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRChannelClusterChannelInfo : MTRChannelClusterChannelInfoStruct
+@dynamic majorNumber;
+@dynamic minorNumber;
+@dynamic name;
+@dynamic callSign;
+@dynamic affiliateCallSign;
 @end
 
 @implementation MTRChannelClusterLineupInfoStruct
@@ -3423,6 +3525,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRChannelClusterLineupInfo : MTRChannelClusterLineupInfoStruct
+@dynamic operatorName;
+@dynamic lineupName;
+@dynamic postalCode;
+@dynamic lineupInfoType;
 @end
 
 @implementation MTRTargetNavigatorClusterTargetInfoStruct
@@ -3457,6 +3563,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTargetNavigatorClusterTargetInfo : MTRTargetNavigatorClusterTargetInfoStruct
+@dynamic identifier;
+@dynamic name;
 @end
 
 @implementation MTRMediaPlaybackClusterPlaybackPositionStruct
@@ -3491,6 +3599,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRMediaPlaybackClusterPlaybackPosition : MTRMediaPlaybackClusterPlaybackPositionStruct
+@dynamic updatedAt;
+@dynamic position;
 @end
 
 @implementation MTRMediaInputClusterInputInfoStruct
@@ -3531,6 +3641,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRMediaInputClusterInputInfo : MTRMediaInputClusterInputInfoStruct
+@dynamic index;
+@dynamic inputType;
+@dynamic name;
+@dynamic descriptionString;
 @end
 
 @implementation MTRContentLauncherClusterDimensionStruct
@@ -3568,6 +3682,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterDimension : MTRContentLauncherClusterDimensionStruct
+@dynamic width;
+@dynamic height;
+@dynamic metric;
 @end
 
 @implementation MTRContentLauncherClusterAdditionalInfoStruct
@@ -3602,6 +3719,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterAdditionalInfo : MTRContentLauncherClusterAdditionalInfoStruct
+@dynamic name;
+@dynamic value;
 @end
 
 @implementation MTRContentLauncherClusterParameterStruct
@@ -3639,6 +3758,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterParameter : MTRContentLauncherClusterParameterStruct
+@dynamic type;
+@dynamic value;
+@dynamic externalIDList;
 @end
 
 @implementation MTRContentLauncherClusterContentSearchStruct
@@ -3670,6 +3792,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterContentSearch : MTRContentLauncherClusterContentSearchStruct
+@dynamic parameterList;
 @end
 
 @implementation MTRContentLauncherClusterStyleInformationStruct
@@ -3717,6 +3840,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterStyleInformation : MTRContentLauncherClusterStyleInformationStruct
+@dynamic color;
+@dynamic size;
 @end
 
 @implementation MTRContentLauncherClusterBrandingInformationStruct
@@ -3764,6 +3889,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRContentLauncherClusterBrandingInformation : MTRContentLauncherClusterBrandingInformationStruct
+@dynamic providerName;
+@dynamic background;
+@dynamic logo;
+@dynamic progressBar;
+@dynamic splash;
+@dynamic waterMark;
 @end
 
 @implementation MTRAudioOutputClusterOutputInfoStruct
@@ -3801,6 +3932,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRAudioOutputClusterOutputInfo : MTRAudioOutputClusterOutputInfoStruct
+@dynamic index;
+@dynamic outputType;
+@dynamic name;
 @end
 
 @implementation MTRApplicationLauncherClusterApplicationStruct
@@ -3889,6 +4023,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRApplicationLauncherClusterApplicationEP : MTRApplicationLauncherClusterApplicationEPStruct
+@dynamic application;
+@dynamic endpoint;
 @end
 
 @implementation MTRApplicationBasicClusterApplicationStruct
@@ -3996,6 +4132,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterSimpleStruct : MTRUnitTestingClusterSimpleStruct
+@dynamic a;
+@dynamic b;
+@dynamic c;
+@dynamic d;
+@dynamic e;
+@dynamic f;
+@dynamic g;
+@dynamic h;
 @end
 
 @implementation MTRUnitTestingClusterTestFabricScoped
@@ -4053,6 +4197,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterTestFabricScoped : MTRUnitTestingClusterTestFabricScoped
+@dynamic fabricSensitiveInt8u;
+@dynamic optionalFabricSensitiveInt8u;
+@dynamic nullableFabricSensitiveInt8u;
+@dynamic nullableOptionalFabricSensitiveInt8u;
+@dynamic fabricSensitiveCharString;
+@dynamic fabricSensitiveStruct;
+@dynamic fabricSensitiveInt8uList;
+@dynamic fabricIndex;
 @end
 
 @implementation MTRUnitTestingClusterNullablesAndOptionalsStruct
@@ -4122,6 +4274,18 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterNullablesAndOptionalsStruct : MTRUnitTestingClusterNullablesAndOptionalsStruct
+@dynamic nullableInt;
+@dynamic optionalInt;
+@dynamic nullableOptionalInt;
+@dynamic nullableString;
+@dynamic optionalString;
+@dynamic nullableOptionalString;
+@dynamic nullableStruct;
+@dynamic optionalStruct;
+@dynamic nullableOptionalStruct;
+@dynamic nullableList;
+@dynamic optionalList;
+@dynamic nullableOptionalList;
 @end
 
 @implementation MTRUnitTestingClusterNestedStruct
@@ -4159,6 +4323,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterNestedStruct : MTRUnitTestingClusterNestedStruct
+@dynamic a;
+@dynamic b;
+@dynamic c;
 @end
 
 @implementation MTRUnitTestingClusterNestedStructList
@@ -4208,6 +4375,13 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterNestedStructList : MTRUnitTestingClusterNestedStructList
+@dynamic a;
+@dynamic b;
+@dynamic c;
+@dynamic d;
+@dynamic e;
+@dynamic f;
+@dynamic g;
 @end
 
 @implementation MTRUnitTestingClusterDoubleNestedStructList
@@ -4238,6 +4412,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterDoubleNestedStructList : MTRUnitTestingClusterDoubleNestedStructList
+@dynamic a;
 @end
 
 @implementation MTRUnitTestingClusterTestListStructOctet
@@ -4272,6 +4447,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterTestListStructOctet : MTRUnitTestingClusterTestListStructOctet
+@dynamic member1;
+@dynamic member2;
 @end
 
 @implementation MTRUnitTestingClusterTestEventEvent
@@ -4318,6 +4495,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterTestEventEvent : MTRUnitTestingClusterTestEventEvent
+@dynamic arg1;
+@dynamic arg2;
+@dynamic arg3;
+@dynamic arg4;
+@dynamic arg5;
+@dynamic arg6;
 @end
 
 @implementation MTRUnitTestingClusterTestFabricScopedEventEvent
@@ -4349,6 +4532,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation MTRTestClusterClusterTestFabricScopedEventEvent : MTRUnitTestingClusterTestFabricScopedEventEvent
+@dynamic fabricIndex;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Make our renamed struct/event codegen more backwards compatible.
    
When we just moved all the members to the super-class, it left the subclass in a
situation where none of its properties are available in the release where the
subclass itself is available.
    
This change restores those properties on the subclasses.
    
The `@dynamic` in implementations is needed to avoid compiler errors.

REVIEW NOTE: The first changeset refactors the templates without changing any codegen output from those templates, and is probably best reviewed separately.  The second changeset makes fairly small template changes and actually affects the codegen.