### PR TITLE
[Silabs] Add user configurable paths for board configuration files

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -55,12 +55,12 @@ jobs:
         with:
           gh-context: ${{ toJson(github) }}
 
-# - name: Test SLC gen
-      #   timeout-minutes: 30
-      #   run: |
-      #     scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
-      #     scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4164A --slc_generate --docker
-      #     rm -rf ./out/
+      - name: Test SLC gen
+        timeout-minutes: 30
+        run: |
+           scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
+           scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4164A --slc_generate --docker
+           rm -rf ./out/
       - name: Build some BRD4187C variants
         run: |
           ./scripts/run_in_build_env.sh \

--- a/examples/lighting-app/silabs/BUILD.gn
+++ b/examples/lighting-app/silabs/BUILD.gn
@@ -60,6 +60,7 @@ if (slc_generate) {
                       "${use_wstk_leds}",
                       "${use_external_flash}",
                       "${silabs_mcu}",
+                      "${slc_gen_path}",
                     ],
                     "list lines"))
 }

--- a/examples/lighting-app/silabs/BUILD.gn
+++ b/examples/lighting-app/silabs/BUILD.gn
@@ -60,7 +60,7 @@ if (slc_generate) {
                       "${use_wstk_leds}",
                       "${use_external_flash}",
                       "${silabs_mcu}",
-                      "${slc_gen_path}",
+                      rebase_path(slc_gen_path),
                     ],
                     "list lines"))
 }

--- a/examples/smoke-co-alarm-app/silabs/BUILD.gn
+++ b/examples/smoke-co-alarm-app/silabs/BUILD.gn
@@ -60,6 +60,7 @@ if (slc_generate) {
                       "${use_wstk_leds}",
                       "${use_external_flash}",
                       "${silabs_mcu}",
+                      "${slc_gen_path}",
                     ],
                     "list lines"))
 }

--- a/examples/smoke-co-alarm-app/silabs/BUILD.gn
+++ b/examples/smoke-co-alarm-app/silabs/BUILD.gn
@@ -60,7 +60,7 @@ if (slc_generate) {
                       "${use_wstk_leds}",
                       "${use_external_flash}",
                       "${silabs_mcu}",
-                      "${slc_gen_path}",
+                      rebase_path(slc_gen_path),
                     ],
                     "list lines"))
 }

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -98,6 +98,12 @@ if [ "$#" == "0" ]; then
             Periodic query timeout variable for OTA in seconds
         rs91x_wpa3_transition
             Support for WPA3 transition mode on RS91x
+        slc_gen_path
+            Allow users to define a path where slc generates boards files. (requires --slc_generate or --slc_reuse_files)
+            (default: /third_party/silabs/slc_gen/<board>/)
+        sl_pre_gen_path
+            Allow users to define a path to pre-generated boards files
+            (default: /third_party/silabs/matter_support/matter/<family>/<board>/)
         sl_matter_version
             Use provided software version at build time
         sl_matter_version_str

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -99,10 +99,10 @@ if [ "$#" == "0" ]; then
         rs91x_wpa3_transition
             Support for WPA3 transition mode on RS91x
         slc_gen_path
-            Allow users to define a path where slc generates boards files. (requires --slc_generate or --slc_reuse_files)
+            Allow users to define a path where slc generates board files. (requires --slc_generate or --slc_reuse_files)
             (default: /third_party/silabs/slc_gen/<board>/)
         sl_pre_gen_path
-            Allow users to define a path to pre-generated boards files
+            Allow users to define a path to pre-generated board files
             (default: /third_party/silabs/matter_support/matter/<family>/<board>/)
         sl_matter_version
             Use provided software version at build time
@@ -287,7 +287,6 @@ else
     fi
 
     if [ "$USE_SLC" == true ]; then
-        PYTHON_PATH="/usr/bin/python3"
         if [ "$GN_PATH_PROVIDED" == false ]; then
             GN_PATH=./.environment/cipd/packages/pigweed/gn
         fi
@@ -295,9 +294,9 @@ else
         # Activation needs to be after SLC generation which is done in gn gen.
         # Zap generation requires activation and is done in the build phase
         source "$CHIP_ROOT/scripts/activate.sh"
-        PYTHON_PATH=$VIRTUAL_ENV"/bin/python3"
     fi
 
+    PYTHON_PATH="$(which python3)"
     BUILD_DIR=$OUTDIR/$SILABS_BOARD
     echo BUILD_DIR="$BUILD_DIR"
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -75,6 +75,9 @@ declare_args() {
   # board related pre-generated files path (default)
   sl_pre_gen_path =
       "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}/"
+
+  # board related generated files path (used if slc_generate or slc_reuse_files is set)
+  slc_gen_path = "${chip_root}/third_party/silabs/slc_gen/${silabs_board}/"
 }
 
 if (slc_generate || slc_reuse_files) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -56,7 +56,6 @@ declare_args() {
   # Argument to enable IPv4 for wifi
   # aligning to match chip_inet_config_enable_ipv4 default configuration
   chip_enable_wifi_ipv4 = false
-  silabs_gen_folder = ""
 
   # Calls SLC-CLI at run time
   slc_generate = false
@@ -72,14 +71,17 @@ declare_args() {
   sl_ot_efr32_root =
       "${efr32_sdk_root}/protocol/openthread/platform-abstraction/efr32"
   sl_openthread_root = "${efr32_sdk_root}/util/third_party/openthread"
+
+  # board related pre-generated files path (default)
+  sl_pre_gen_path =
+      "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}/"
 }
 
 if (slc_generate || slc_reuse_files) {
-  silabs_gen_folder = "${chip_root}/third_party/silabs/slc_gen/${silabs_board}/"
+  silabs_gen_folder = slc_gen_path
 } else {
   print("Using pre-generate files")
-  silabs_gen_folder =
-      "${sdk_support_root}/matter/efr32/${silabs_family}/${silabs_board}/"
+  silabs_gen_folder = sl_pre_gen_path
 }
 
 # Defines an efr32 SDK build target.

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -48,9 +48,6 @@ declare_args() {
 declare_args() {
   # Enables LCD Qr Code on supported devices
   show_qr_code = !disable_lcd
-
-  # board related generated files path (used if slc_generate or slc_reuse_files is set)
-  slc_gen_path = "${chip_root}/third_party/silabs/slc_gen/${silabs_board}/"
 }
 
 if (silabs_board == "") {

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -48,6 +48,9 @@ declare_args() {
 declare_args() {
   # Enables LCD Qr Code on supported devices
   show_qr_code = !disable_lcd
+
+  # board related generated files path (used if slc_generate or slc_reuse_files is set)
+  slc_gen_path = "${chip_root}/third_party/silabs/slc_gen/${silabs_board}/"
 }
 
 if (silabs_board == "") {

--- a/third_party/silabs/slc_gen/run_slc.py
+++ b/third_party/silabs/slc_gen/run_slc.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-if len(sys.argv) != 8:
+if len(sys.argv) != 9:
     print("wrong number of arguments")
     sys.exit(1)
 

--- a/third_party/silabs/slc_gen/run_slc.py
+++ b/third_party/silabs/slc_gen/run_slc.py
@@ -58,6 +58,16 @@ slc_arguments += silabs_board
 
 print(slc_arguments)
 
+if "GSDK_ROOT" in os.environ:
+    gsdk_root = os.getenv('GSDK_ROOT')
+else:
+    # If no gsdk path is set in the environment, use the standard path to the submodule
+    gsdk_root = os.path.join(root_path, "third_party/silabs/gecko_sdk/")
+
+# make sure we have a configured and trusted gsdk in slc
+subprocess.run(["slc", "configuration", "--sdk", gsdk_root], check=True)
+subprocess.run(["slc", "signature", "trust", "--sdk", gsdk_root], check=True)
+
 subprocess.run(["slc", "generate", slcp_file_path, "-d", output_path, "--with", slc_arguments], check=True)
 
 # cleanup of unwanted files

--- a/third_party/silabs/slc_gen/run_slc.py
+++ b/third_party/silabs/slc_gen/run_slc.py
@@ -27,10 +27,10 @@ use_wstk_buttons = asBoolean(sys.argv[4])
 use_wstk_leds = asBoolean(sys.argv[5])
 use_external_flash = asBoolean(sys.argv[6])
 silabs_mcu = str(sys.argv[7])
+output_path = str(sys.argv[8])
 
 slcp_file_path = os.path.join(root_path, "examples/platform/silabs/matter-platform.slcp")
 template_path = os.path.join(root_path, "third_party/silabs/slc_gen/")
-output_path = template_path + sys.argv[2] + '/'
 
 slc_arguments = ""
 


### PR DESCRIPTION
Users can now define a path to pre-generated board configuration files with the `sl_pre_gen_path` argument

Users using SLC to generate those configurations can also decide where to generate those files with the `slc_gen_path` argument. the build system will then fetch the needed files from that new location.

The default location for both of those options remains unchanged.

