### PR TITLE
[Silabs] re-enable a compilation flag

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -504,9 +504,6 @@ template("efr32_sdk") {
 
       # see https://github.com/project-chip/connectedhomeip/issues/26058
       "-Wno-error=array-parameter",
-
-      # see https://github.com/project-chip/connectedhomeip/issues/26170
-      "-Wno-error=array-bounds",
     ]
 
     if (silabs_family == "efr32mg24" || silabs_family == "mgm24") {


### PR DESCRIPTION
fixes #26170
The latest GSDK update brought the fix that allows us to re-enable this flag. It was disabled when updating to GCC 12.2.1

