### PR TITLE
Fix thread race in test-only XPC code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.mm
@@ -170,9 +170,12 @@
                     [handle.proxy stopReportsWithController:controller
                                                      nodeId:nodeID.unsignedLongLongValue
                                                  completion:^{
+                                                     // Make sure handle stays alive until we get to this
+                                                     // completion (in particular while we are working
+                                                     // with handle.proxy).
                                                      __auto_type handleRetainer = handle;
                                                      (void) handleRetainer;
-                                                     clearRegistry();
+                                                     dispatch_async(queue, clearRegistry);
                                                  }];
                 } else {
                     MTR_LOG_ERROR("CHIP XPC connection failed to stop reporting");


### PR DESCRIPTION
The clearRegistry block is touching various members of "self" that should only be touched on self.workQueue.  But it was being called on whatever queue the client-provided stopReportsWithController method called its completion on.

The fix is to dispatch to the queue that getProxyHandleWithCompletion is passed, which is in fact our work queue.
