### PR TITLE
[OpenThread] Clean the code for older API versions

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -78,6 +78,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
+static_assert(OPENTHREAD_API_VERSION >= 219, "OpenThread version too old");
+
 // Network commissioning
 namespace {
 #ifndef _NO_NETWORK_COMMISSIONING_DRIVER_
@@ -189,17 +191,6 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
 {
     if (event->Type == DeviceEventType::kThreadStateChange)
     {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT && (OPENTHREAD_API_VERSION < 218)
-        if (event->ThreadStateChange.AddressChanged)
-        {
-            const otSrpClientHostInfo * hostInfo = otSrpClientGetHostInfo(Impl()->OTInstance());
-            if (hostInfo && hostInfo->mName)
-            {
-                Impl()->_SetupSrpHost(hostInfo->mName);
-            }
-        }
-#endif
-
         bool isThreadAttached = Impl()->_IsThreadAttached();
         // Avoid sending muliple events if the attachement state didn't change (Child->router or disable->Detached)
         if (event->ThreadStateChange.RoleChanged && (isThreadAttached != mIsAttached))
@@ -1568,12 +1559,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
         otOperationalDataset activeDataset;
         otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
         VerifyOrReturnError(otErr == OT_ERROR_NONE, MapOpenThreadError(otErr));
-#if OPENTHREAD_API_VERSION >= 219
         uint64_t activeTimestamp = (activeDataset.mActiveTimestamp.mSeconds << 16) | (activeDataset.mActiveTimestamp.mTicks << 1) |
             activeDataset.mActiveTimestamp.mAuthoritative;
-#else
-        uint64_t activeTimestamp  = activeDataset.mActiveTimestamp;
-#endif
         err = encoder.Encode(activeTimestamp);
     }
     break;
@@ -1582,12 +1569,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
         otOperationalDataset activeDataset;
         otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
         VerifyOrReturnError(otErr == OT_ERROR_NONE, MapOpenThreadError(otErr));
-#if OPENTHREAD_API_VERSION >= 219
         uint64_t pendingTimestamp = (activeDataset.mPendingTimestamp.mSeconds << 16) |
             (activeDataset.mPendingTimestamp.mTicks << 1) | activeDataset.mPendingTimestamp.mAuthoritative;
-#else
-        uint64_t pendingTimestamp = activeDataset.mPendingTimestamp;
-#endif
         err = encoder.Encode(pendingTimestamp);
     }
     break;
@@ -2118,8 +2101,6 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_UpdateNetworkStatus()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
-static_assert(OPENTHREAD_API_VERSION >= 156, "SRP Client requires a more recent OpenThread version");
-
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnSrpClientNotification(otError aError,
                                                                                   const otSrpClientHostInfo * aHostInfo,
@@ -2459,9 +2440,6 @@ template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(const char * aHostName)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-#if OPENTHREAD_API_VERSION < 218
-    Inet::IPAddress hostAddress;
-#endif
 
     VerifyOrReturnError(mSrpClient.mIsInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
 
@@ -2477,20 +2455,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
         error = MapOpenThreadError(otSrpClientSetHostName(mOTInst, mSrpClient.mHostName));
         SuccessOrExit(error);
 
-#if OPENTHREAD_API_VERSION >= 218
         error = MapOpenThreadError(otSrpClientEnableAutoHostAddress(mOTInst));
-#endif
     }
-
-#if OPENTHREAD_API_VERSION < 218
-    // Check if device has any external IPv6 assigned. If not, host will be set without IPv6 addresses
-    // and updated later on.
-    if (ThreadStackMgr().GetExternalIPv6Address(hostAddress) == CHIP_NO_ERROR)
-    {
-        memcpy(&mSrpClient.mHostAddress.mFields.m32, hostAddress.Addr, sizeof(hostAddress.Addr));
-        error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, &mSrpClient.mHostAddress, 1));
-    }
-#endif
 
 exit:
     Impl()->UnlockThreadStack();

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -96,14 +96,8 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
 {
 #if CHIP_DETAIL_LOGGING
 
-#if OPENTHREAD_API_VERSION >= 126
     const uint32_t kParamsChanged = (OT_CHANGED_THREAD_NETWORK_NAME | OT_CHANGED_THREAD_PANID | OT_CHANGED_THREAD_EXT_PANID |
                                      OT_CHANGED_THREAD_CHANNEL | OT_CHANGED_NETWORK_KEY | OT_CHANGED_PSKC);
-#else
-    const uint32_t kParamsChanged = (OT_CHANGED_THREAD_NETWORK_NAME | OT_CHANGED_THREAD_PANID | OT_CHANGED_THREAD_EXT_PANID |
-                                     OT_CHANGED_THREAD_CHANNEL | OT_CHANGED_MASTER_KEY | OT_CHANGED_PSKC);
-#endif
-
     static char strBuf[64];
 
     ChipLogDetail(DeviceLayer, "OpenThread State Changed (Flags: 0x%08" PRIx32 ")", flags);
@@ -132,13 +126,8 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
         }
 #if CHIP_CONFIG_SECURITY_TEST_MODE
         {
-#if OPENTHREAD_API_VERSION >= 126
             const otNetworkKey * otKey = otThreadGetNetworkKey(otInst);
             for (int i = 0; i < OT_NETWORK_KEY_SIZE; i++)
-#else
-            const otMasterKey * otKey = otThreadGetMasterKey(otInst);
-            for (int i = 0; i < OT_MASTER_KEY_SIZE; i++)
-#endif
                 snprintf(&strBuf[i * 2], 3, "%02X", otKey->m8[i]);
             ChipLogDetail(DeviceLayer, "   Network Key: %s", strBuf);
         }


### PR DESCRIPTION
All platform should already switch to something newer than OPENTHREAD_API_REVISION 219 from a year ago.