### PR TITLE
CASEServer: Register UMH for Sigma1 only on server startup

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -48,6 +48,9 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     // Set up the group state provider that persists across all handshakes.
     GetSession().SetGroupDataProvider(mGroupDataProvider);
 
+    ChipLogProgress(Inet, "CASE Server enabling CASE session setups");
+    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1, this);
+
     PrepareForSessionEstablishment();
 
     return CHIP_NO_ERROR;
@@ -113,11 +116,6 @@ exit:
 
 void CASEServer::PrepareForSessionEstablishment(const ScopedNodeId & previouslyEstablishedPeer)
 {
-    // Let's re-register for CASE Sigma1 message, so that the next CASE session setup request can be processed.
-    // https://github.com/project-chip/connectedhomeip/issues/8342
-    ChipLogProgress(Inet, "CASE Server enabling CASE session setups");
-    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1, this);
-
     GetSession().Clear();
 
     //


### PR DESCRIPTION
With #27226, we are no longer unregistering the unsolicited message hander for sigma1. Based on handshake state and failure to schedule work, decide what to do:

But, the registration was happening on every CASE success or failure.

This change registers the UMH for sigma1 only on server startup.

Fixes Item (1) in https://github.com/project-chip/connectedhomeip/issues/27474