### PR TITLE
Add Reset() calls to have clean names and error text

### DIFF
--- a/src/lib/format/protocol_decoder.cpp
+++ b/src/lib/format/protocol_decoder.cpp
@@ -295,8 +295,8 @@ void PayloadDecoderBase::ExitContainer(PayloadEntry & entry)
         CHIP_ERROR err = mReader.ExitContainer(mNestingEnters[--mCurrentNesting]);
         if (err != CHIP_NO_ERROR)
         {
-            mValueBuilder.AddFormat("ERROR: %" CHIP_ERROR_FORMAT, err.Format());
-            mNameBuilder.AddFormat("END CONTAINER");
+            mValueBuilder.Reset().AddFormat("ERROR: %" CHIP_ERROR_FORMAT, err.Format());
+            mNameBuilder.Reset().AddFormat("END CONTAINER");
             entry  = PayloadEntry::SimpleValue(mNameBuilder.c_str(), mValueBuilder.c_str());
             mState = State::kDone;
             return;


### PR DESCRIPTION
Protocol decoder errors were looking odd like:

```
"ContextTag(0xFF)EXIT CONTAINER" : "1ERROR: src/lib/core/TLVReader.cpp:733: CHIP Error 0x00000021: End of TLV",
```

because no stringbuilder reset was performed. Do a proper reset to have clean values.