### PR TITLE
[matter_yamltests] Add an implicit rule that the key 'value' in argum…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/errors.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/errors.py
@@ -198,3 +198,15 @@ class TestStepResponseVariableError(TestStepError):
         super().__init__(message)
 
         self.tag_key_with_error(content, 'response')
+
+
+class TestStepArgumentsValueError(TestStepError):
+    """Raise when a test step arguments use the 'value' keyword but the command is not trying to write to an attribute"""
+
+    def __init__(self, content):
+        message = 'The "value" key can not be used in conjuction with a command that is not "writeAttribute"'
+        super().__init__(message)
+
+        self.tag_key_with_error(content, 'command')
+        arguments = content.get('arguments')
+        self.tag_key_with_error(arguments, 'value')

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -15,9 +15,9 @@
 
 from typing import Tuple, Union
 
-from .errors import (TestStepError, TestStepGroupEndPointError, TestStepGroupResponseError, TestStepInvalidTypeError,
-                     TestStepKeyError, TestStepNodeIdAndGroupIdError, TestStepResponseVariableError, TestStepValueAndValuesError,
-                     TestStepVerificationStandaloneError, TestStepWaitResponseError)
+from .errors import (TestStepArgumentsValueError, TestStepError, TestStepGroupEndPointError, TestStepGroupResponseError,
+                     TestStepInvalidTypeError, TestStepKeyError, TestStepNodeIdAndGroupIdError, TestStepResponseVariableError,
+                     TestStepValueAndValuesError, TestStepVerificationStandaloneError, TestStepWaitResponseError)
 from .fixes import add_yaml_support_for_scientific_notation_without_dot
 
 try:
@@ -120,6 +120,7 @@ class YamlLoader:
             content)
         self.__rule_wait_should_not_expect_a_response(content)
         self.__rule_response_variable_should_exist_in_config(config, content)
+        self.__rule_argument_value_is_only_when_writing_attributes(content)
 
         if 'arguments' in content:
             arguments = content.get('arguments')
@@ -260,3 +261,10 @@ class YamlLoader:
             response = content.get('response')
             if isinstance(response, str) and response not in config:
                 raise TestStepResponseVariableError(content)
+
+    def __rule_argument_value_is_only_when_writing_attributes(self, content):
+        if 'arguments' in content:
+            command = content.get('command')
+            arguments = content.get('arguments')
+            if 'value' in arguments and command != 'writeAttribute':
+                raise TestStepArgumentsValueError(content)

--- a/scripts/py_matter_yamltests/test_yaml_loader.py
+++ b/scripts/py_matter_yamltests/test_yaml_loader.py
@@ -267,7 +267,8 @@ class TestYamlLoader(unittest.TestCase):
         load = YamlLoader().load
 
         content = ('tests:\n'
-                   '  - {key}: {value}')
+                   '  - command: writeAttribute\n'
+                   '    {key}: {value}')
         keys = [
             'arguments',
         ]
@@ -278,7 +279,8 @@ class TestYamlLoader(unittest.TestCase):
         for key in keys:
             _, _, _, _, tests = load(
                 content.format(key=key, value=valid_value))
-            self.assertEqual(tests, [{key: {'value': True}}])
+            self.assertEqual(
+                tests, [{'command': 'writeAttribute', key: {'value': True}}])
 
             for value in wrong_values:
                 x = content.format(key=key, value=value)


### PR DESCRIPTION
…ents can not be used if the command is not a 'writeAttribute'

#### Problem

If someone write a yaml test and use the 'value' key in 'arguments' but the command is not 'writeAttribute' it will fails with a cryptic error.
This PR makes it clear by explaining the error and showing the related keys.
