### PR TITLE
[chip-tool] Raise the number of paths that can be used in a single re…

### DIFF
--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -28,7 +28,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>
 
-constexpr uint8_t kMaxAllowedPaths = 10;
+constexpr uint8_t kMaxAllowedPaths = 64;
 
 namespace chip {
 namespace test_utils {


### PR DESCRIPTION
…quest from 10 to 64

#### Problem

Yesterday I have been asked a question that involved making a request with at least *33* paths in the request. By default `chip-tool` use a limit of *10*. I don't think it hurts to allow more paths.
