### PR TITLE
Add a way to update ReadPrepareParams based on CASE session.

### DIFF
--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -113,6 +113,11 @@ private:
         return mCallback.OnUnsolicitedMessageFromPublisher(apReadClient);
     }
 
+    void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) override
+    {
+        return mCallback.OnCASESessionEstablished(aSession, aSubscriptionParams);
+    }
+
     /*
      * Given a reader positioned at a list element, allocate a packet buffer, copy the list item where
      * the reader is positioned into that buffer and add it to our buffered list for tracking.

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -631,6 +631,11 @@ private:
         return mCallback.OnUnsolicitedMessageFromPublisher(apReadClient);
     }
 
+    void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) override
+    {
+        return mCallback.OnCASESessionEstablished(aSession, aSubscriptionParams);
+    }
+
     // Commit the pending cluster data version, if there is one.
     void CommitPendingDataVersion();
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1095,6 +1095,8 @@ void ReadClient::HandleDeviceConnected(void * context, Messaging::ExchangeManage
     _this->mReadPrepareParams.mSessionHolder.Grab(sessionHandle);
     _this->mpExchangeMgr = &exchangeMgr;
 
+    _this->mpCallback.OnCASESessionEstablished(sessionHandle, _this->mReadPrepareParams);
+
     auto err = _this->SendSubscribeRequest(_this->mReadPrepareParams);
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -249,6 +249,16 @@ public:
          * @param[in] apReadClient the ReadClient for the subscription.
          */
         virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) {}
+
+        /**
+         * OnCASESessionEstablished will be called for a subscription ReadClient when
+         * it finishes setting up a CASE session, as part of either automatic
+         * re-subscription or doing an initial subscribe based on ScopedNodeId.
+         *
+         * The callee is allowed to modify the ReadPrepareParams (e.g. to change
+         * things like min/max intervals based on the session parameters).
+         */
+        virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
     };
 
     enum class InteractionType : uint8_t


### PR DESCRIPTION
If the ReadClient is doing the CASE establishment itself, it should give the client a way to modify the ReadPrepareParams based on the session information.
