### PR TITLE
Apply esp32 fix for cloudbuild as well

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -11,7 +11,9 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - source ./scripts/bootstrap.sh
+          - |
+            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+            source ./scripts/bootstrap.sh
       id: Bootstrap
       waitFor:
           - Submodules

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -4,7 +4,9 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - source ./scripts/bootstrap.sh
+          - |
+            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+            source ./scripts/bootstrap.sh
       id: Bootstrap
       entrypoint: /usr/bin/bash
       volumes:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -12,7 +12,9 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - source ./scripts/bootstrap.sh
+          - |
+            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+            source ./scripts/bootstrap.sh
       id: Bootstrap
       waitFor:
           - Submodules


### PR DESCRIPTION
ESP32 forces gdbgui installation even though that installation fails (due to cython and gevent changes).

Remove that requirement from esp sdk since things can be built without it.