### PR TITLE
Move cloudbuild esp32 fix

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -11,9 +11,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - |
-            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
-            source ./scripts/bootstrap.sh
+          - source ./scripts/bootstrap.sh
       id: Bootstrap
       waitFor:
           - Submodules

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -4,9 +4,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - |
-            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
-            source ./scripts/bootstrap.sh
+          - source ./scripts/bootstrap.sh
       id: Bootstrap
       entrypoint: /usr/bin/bash
       volumes:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -12,9 +12,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - |
-            perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
-            source ./scripts/bootstrap.sh
+          - source ./scripts/bootstrap.sh
       id: Bootstrap
       waitFor:
           - Submodules
@@ -30,6 +28,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
+              perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
               ./scripts/build/build_examples.py --enable-flashbundle --target
               esp32-devkitc-light-rpc --target
               esp32-m5stack-all-clusters-ipv6only --target


### PR DESCRIPTION
Images in cloudbuild do not persist, so esp32 fix has to be applied when esp32 is compiled.