### PR TITLE
Update ZAP to pick up swiftUnavailable changes.

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -8,7 +8,7 @@ ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 # ZAP Development install, so that it runs on both x64 and arm64
 # Generally this should match with the ZAP version that is used for codegen within the
 # specified SHA
-ARG ZAP_VERSION=v2023.05.22-nightly
+ARG ZAP_VERSION=v2023.07.19-nightly
 
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.05.22-nightly.1"]
+            "tags": ["version:2@v2023.07.19-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2023.05.22-nightly.1"]
+            "tags": ["version:2@v2023.07.19-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.05.22-nightly
+v2023.07.19-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.5.22'
+MIN_ZAP_VERSION = '2023.7.19'
 
 
 class ZapTool:

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -54,6 +54,13 @@
 #              Please examine codegen carefully when using "removed" to make
 #              sure all the things that should have been removed have been.
 #
+# * "swiftUnavailable": Can contain clusters, commands, attributes, etc as
+#                       described above for "introduced" and "deprecated".  This
+#                       can be used to mark APIs with NS_SWIFT_UNAVAILABLE,
+#                       typically when an API was renamed between two names that
+#                       map to the same Swift name and then both names were
+#                       deprecated.
+#
 # * "provisional": Can contain clusters, commands, attributes, etc as described
 #                  above for "introduced" and "deprecated".  Items can be
 #                  defined as provisional to prevent code generation for them.
@@ -7394,6 +7401,18 @@
           ModeSelect:
               Feature:
                   OnOff: DEPONOFF
+  swiftUnavailable:
+      bitmap values:
+          NetworkCommissioning:
+              WiFiSecurity:
+                  # The bitmap got renamed to WiFiSecurityBitmap, so now both
+                  # the Wpa* and WPA* names on WiFiSecurity are deprecated.
+                  # They get mapped to Swift with identical names, which leads
+                  # to the names being ambiguous.  Mark the "Wpa*" as
+                  # unavailable to Swift to work around this.
+                  - WpaPersonal
+                  - Wpa2Personal
+                  - Wpa3Personal
   provisional:
       clusters:
           ## Not ready at cutoff

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -19573,6 +19573,7 @@ typedef NS_OPTIONS(uint8_t, MTRNetworkCommissioningWiFiSecurity) {
     = 0x4,
     MTRNetworkCommissioningWiFiSecurityWpaPersonal MTR_DEPRECATED("Please use MTRNetworkCommissioningWiFiSecurityBitmapWPAPersonal",
         ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
+        NS_SWIFT_UNAVAILABLE("Please use MTRNetworkCommissioningWiFiSecurityBitmapWPAPersonal")
     = 0x4,
     MTRNetworkCommissioningWiFiSecurityWPA2Personal MTR_DEPRECATED(
         "Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA2Personal", ios(16.4, 17.0), macos(13.3, 14.0), watchos(9.4, 10.0),
@@ -19580,7 +19581,7 @@ typedef NS_OPTIONS(uint8_t, MTRNetworkCommissioningWiFiSecurity) {
     = 0x8,
     MTRNetworkCommissioningWiFiSecurityWpa2Personal MTR_DEPRECATED(
         "Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA2Personal", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
-        tvos(16.1, 16.4))
+        tvos(16.1, 16.4)) NS_SWIFT_UNAVAILABLE("Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA2Personal")
     = 0x8,
     MTRNetworkCommissioningWiFiSecurityWPA3Personal MTR_DEPRECATED(
         "Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA3Personal", ios(16.4, 17.0), macos(13.3, 14.0), watchos(9.4, 10.0),
@@ -19588,7 +19589,7 @@ typedef NS_OPTIONS(uint8_t, MTRNetworkCommissioningWiFiSecurity) {
     = 0x10,
     MTRNetworkCommissioningWiFiSecurityWpa3Personal MTR_DEPRECATED(
         "Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA3Personal", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4),
-        tvos(16.1, 16.4))
+        tvos(16.1, 16.4)) NS_SWIFT_UNAVAILABLE("Please use MTRNetworkCommissioningWiFiSecurityBitmapWPA3Personal")
     = 0x10,
 } MTR_DEPRECATED("Please use MTRNetworkCommissioningWiFiSecurityBitmap", ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0),
     tvos(16.1, 17.0));


### PR DESCRIPTION
And mark some Darwin codegen bits as swiftUnavailable.
