### PR TITLE
[Tizen] Adjust the symbolic link for install-sdk folder

### DIFF
--- a/scripts/setup/tizen/sdk-installer
+++ b/scripts/setup/tizen/sdk-installer
@@ -1,1 +1,1 @@
-../../../integrations/docker/images/chip-build-tizen/tizen-sdk-installer
+../../../integrations/docker/images/stage-2/chip-build-tizen/tizen-sdk-installer


### PR DESCRIPTION
The source folder's path was modified. So we need to adjust the symbolic link for new path.