### PR TITLE
[TIMESYNC] Add "time-zone" and "dst-offset" arguments to chip-tool pairing commands

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -212,6 +212,9 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
     switch (arg.type)
     {
     case ArgumentType::Complex: {
+        // Complex arguments may be optional, but they are not currently supported via the <chip::Optional> class.
+        // Instead, they must be explicitly specified as optional using the kOptional flag,
+        // and the base TypedComplexArgument<T> class is still referenced.
         auto complexArgument = static_cast<ComplexArgument *>(arg.value);
         return CHIP_NO_ERROR == complexArgument->Parse(arg.name, argValue);
     }
@@ -731,13 +734,13 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, ComplexArgument * value, const char * desc)
+size_t Command::AddArgument(const char * name, ComplexArgument * value, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Complex;
     arg.name  = name;
     arg.value = static_cast<void *>(value);
-    arg.flags = 0;
+    arg.flags = flags;
     arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
@@ -955,8 +958,11 @@ void Command::ResetArguments()
             switch (type)
             {
             case ArgumentType::Complex: {
-                // No optional complex arguments so far.
-                VerifyOrDie(false);
+                // Optional Complex arguments are not currently supported via the <chip::Optional> class.
+                // Instead, they must be explicitly specified as optional using the kOptional flag,
+                // and the base TypedComplexArgument<T> class is referenced.
+                auto argument = static_cast<ComplexArgument *>(arg.value);
+                argument->Reset();
                 break;
             }
             case ArgumentType::Custom: {

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -144,7 +144,10 @@ public:
     size_t AddArgument(const char * name, chip::ByteSpan * value, const char * desc = "", uint8_t flags = 0);
     size_t AddArgument(const char * name, chip::Span<const char> * value, const char * desc = "", uint8_t flags = 0);
     size_t AddArgument(const char * name, AddressWithInterface * out, const char * desc = "", uint8_t flags = 0);
-    size_t AddArgument(const char * name, ComplexArgument * value, const char * desc = "");
+    // Optional Complex arguments are not currently supported via the <chip::Optional> class.
+    // Instead, they must be explicitly specified as optional using kOptional in the flags parameter,
+    // and the base TypedComplexArgument<T> class is referenced.
+    size_t AddArgument(const char * name, ComplexArgument * value, const char * desc = "", uint8_t flags = 0);
     size_t AddArgument(const char * name, CustomArgument * value, const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, const char * desc = "", uint8_t flags = 0)
     {

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -116,6 +116,22 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         params.SetCountryCode(CharSpan::fromCharString(mCountryCode.Value()));
     }
 
+    // mTimeZoneList is an optional argument managed by TypedComplexArgument mComplex_TimeZones.
+    // Since optional Complex arguments are not currently supported via the <chip::Optional> class,
+    // we will use mTimeZoneList.data() value to determine if the argument was provided.
+    if (mTimeZoneList.data())
+    {
+        params.SetTimeZone(mTimeZoneList);
+    }
+
+    // miDSTOffsetList is an optional argument managed by TypedComplexArgument mComplex_DSTOffsets.
+    // Since optional Complex arguments are not currently supported via the <chip::Optional> class,
+    // we will use mTimeZoneList.data() value to determine if the argument was provided.
+    if (mDSTOffsetList.data())
+    {
+        params.SetDSTOffsets(mDSTOffsetList);
+    }
+
     return params;
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -59,6 +59,8 @@ public:
         CHIPCommand(commandName, credIssuerCmds),
         mPairingMode(mode), mNetworkType(networkType),
         mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() },
+        mComplex_TimeZones(&mTimeZoneList),
+        mComplex_DSTOffsets(&mDSTOffsetList),
         mCurrentFabricRemoveCallback(OnCurrentFabricRemove, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
@@ -162,6 +164,18 @@ public:
         {
             AddArgument("country-code", &mCountryCode,
                         "Country code to use to set the Basic Information cluster's Location attribute");
+
+            // mTimeZoneList is an optional argument managed by TypedComplexArgument mComplex_TimeZones.
+            // Since optional Complex arguments are not currently supported via the <chip::Optional> class,
+            // we explicitly set the kOptional flag.
+            AddArgument("time-zone", &mComplex_TimeZones,
+                        "TimeZone list to use when setting Time Synchronization cluster's TimeZone attribute", Argument::kOptional);
+
+            // mDSTOffsetList is an optional argument managed by TypedComplexArgument mComplex_DSTOffsets.
+            // Since optional Complex arguments are not currently supported via the <chip::Optional> class,
+            // we explicitly set the kOptional flag.
+            AddArgument("dst-offset", &mComplex_DSTOffsets,
+                        "DSTOffset list to use when setting Time Synchronization cluster's DSTOffset attribute", Argument::kOptional);
         }
 
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
@@ -210,6 +224,12 @@ private:
     chip::Optional<bool> mBypassAttestationVerifier;
     chip::Optional<std::vector<uint32_t>> mCASEAuthTags;
     chip::Optional<char *> mCountryCode;
+    chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type> mTimeZoneList;
+    TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type>>
+        mComplex_TimeZones;
+    chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type> mDSTOffsetList;
+    TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type>>
+        mComplex_DSTOffsets;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -58,10 +58,8 @@ public:
                    chip::Dnssd::DiscoveryFilterType filterType = chip::Dnssd::DiscoveryFilterType::kNone) :
         CHIPCommand(commandName, credIssuerCmds),
         mPairingMode(mode), mNetworkType(networkType),
-        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() },
-        mComplex_TimeZones(&mTimeZoneList),
-        mComplex_DSTOffsets(&mDSTOffsetList),
-        mCurrentFabricRemoveCallback(OnCurrentFabricRemove, this)
+        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() }, mComplex_TimeZones(&mTimeZoneList),
+        mComplex_DSTOffsets(&mDSTOffsetList), mCurrentFabricRemoveCallback(OnCurrentFabricRemove, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("bypass-attestation-verifier", 0, 1, &mBypassAttestationVerifier,
@@ -175,7 +173,8 @@ public:
             // Since optional Complex arguments are not currently supported via the <chip::Optional> class,
             // we explicitly set the kOptional flag.
             AddArgument("dst-offset", &mComplex_DSTOffsets,
-                        "DSTOffset list to use when setting Time Synchronization cluster's DSTOffset attribute", Argument::kOptional);
+                        "DSTOffset list to use when setting Time Synchronization cluster's DSTOffset attribute",
+                        Argument::kOptional);
         }
 
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);


### PR DESCRIPTION
Add "time-zone" and "dst-offset" arguments to chip-tool pairing commands

Provides optional command-line arguments for chip-tool that can be provided for the `pairing` command:

Argument:
time-zone: TimeZone list to use when setting Time Synchronization cluster's TimeZone attribute
dst-offset: DSTOffset list to use when setting Time Synchronization cluster's DSTOffset attribute

These arguments are used to populate the corresponding attributes in the Time Synchronization cluster IF the device being commissioned support the cluster as well as the TZ (TimeZone) feature.

Example:
```
chip-tool pairing ble-thread 1 hex:<network-cfg> <pincode> <disc> --time-zone '[ {"offset":-25200, "validAt":0} ]' --dst-offset '[ {"offset":3600, "validStarting":800000000000000, "validUntil":900000000000000 } ]'