### PR TITLE
Update AppDelegate to report error param and callback for when session establishment starts

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -85,8 +85,9 @@ namespace {
 class AppCallbacks : public AppDelegate
 {
 public:
+    void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { bluetoothLED.Set(true); }
-    void OnCommissioningSessionStopped() override
+    void OnCommissioningSessionStopped(CHIP_ERROR err) override
     {
         bluetoothLED.Set(false);
         pairingWindowLED.Set(false);

--- a/examples/all-clusters-minimal-app/esp32/main/main.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/main.cpp
@@ -84,8 +84,9 @@ namespace {
 class AppCallbacks : public AppDelegate
 {
 public:
+    void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { bluetoothLED.Set(true); }
-    void OnCommissioningSessionStopped() override
+    void OnCommissioningSessionStopped(CHIP_ERROR err) override
     {
         bluetoothLED.Set(false);
         pairingWindowLED.Set(false);

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -138,8 +138,9 @@ class AppCallbacks : public AppDelegate
     bool isComissioningStarted;
 
 public:
+    void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { isComissioningStarted = true; }
-    void OnCommissioningSessionStopped() override { isComissioningStarted = false; }
+    void OnCommissioningSessionStopped(CHIP_ERROR err) override { isComissioningStarted = false; }
     void OnCommissioningWindowClosed() override
     {
         if (!isComissioningStarted)

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -29,7 +29,7 @@ class AppDelegate
 public:
     virtual ~AppDelegate() {}
     /**
-     * This is called on start of session establishment process 
+     * This is called on start of session establishment process
      */
     virtual void OnCommissioningSessionEstablishmentStarted() {}
     virtual void OnCommissioningSessionStarted() {}

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -28,6 +28,9 @@ class AppDelegate
 {
 public:
     virtual ~AppDelegate() {}
+    /**
+     * This is called on start of session establishment process 
+     */
     virtual void OnCommissioningSessionEstablishmentStarted() {}
     virtual void OnCommissioningSessionStarted() {}
     virtual void OnCommissioningSessionStopped(CHIP_ERROR err) {}

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -22,12 +22,15 @@
 
 #pragma once
 
+#include <lib/core/CHIPError.h>
+
 class AppDelegate
 {
 public:
     virtual ~AppDelegate() {}
+    virtual void OnCommissioningSessionEstablishmentStarted() {}
     virtual void OnCommissioningSessionStarted() {}
-    virtual void OnCommissioningSessionStopped() {}
+    virtual void OnCommissioningSessionStopped(CHIP_ERROR err) {}
 
     /*
      * This is called anytime a basic or enhanced commissioning window is opened.

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -165,7 +165,7 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
 
         if (mAppDelegate != nullptr)
         {
-            mAppDelegate->OnCommissioningSessionStopped();
+            mAppDelegate->OnCommissioningSessionStopped(err);
         }
     }
 }
@@ -175,6 +175,12 @@ void CommissioningWindowManager::OnSessionEstablishmentStarted()
     // As per specifications, section 5.5: Commissioning Flows
     constexpr System::Clock::Timeout kPASESessionEstablishmentTimeout = System::Clock::Seconds16(60);
     DeviceLayer::SystemLayer().StartTimer(kPASESessionEstablishmentTimeout, HandleSessionEstablishmentTimeout, this);
+
+    ChipLogProgress(AppServer, "Commissioning session establishment step started");
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCommissioningSessionEstablishmentStarted();
+    }
 }
 
 void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & session)


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/28136

### Problem
1. As an app developer, I need a mechanism from the Matter SDK, to know at what point the establishment of a commissioning session started (say for some cues to the user during the commissioning process).

2. As an app developer, I need a mechanism from the Matter SDK, to know the error code for when a commissioning session stopped.

### Solution
Updated the AppDelegate to allow for the above use cases. And called new callback from the CommissioningWIndowManager.