### PR TITLE
Revert "Cancel incomplete BLE connection when CloseAllBleConnections() is called (#27304)"

### DIFF
--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -308,13 +308,6 @@ void BleLayer::Shutdown()
 
 void BleLayer::CloseAllBleConnections()
 {
-    // Cancel any ongoing attempt to establish new BLE connection
-    CHIP_ERROR err = CancelBleIncompleteConnection();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Ble, "CancelBleIncompleteConnection() failed, err = %" CHIP_ERROR_FORMAT, err.Format());
-    }
-
     // Close and free all BLE end points.
     for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
     {


### PR DESCRIPTION
This reverts commit ad5403e8e537612c2d2f903895642445d45d1e08.

There are two issues:

* https://github.com/project-chip/connectedhomeip/issues/27607 which has had no response for weeks.
* https://github.com/project-chip/connectedhomeip/issues/28139 which breaks commissioning on Mac, and would break it on Linux if it implemented BLE connection cancellation.

We need to sort out why CHIPDeviceController is canceling BLE connections when starting PASE over BLE (!).

Fixes https://github.com/project-chip/connectedhomeip/issues/28139