### PR TITLE
Update pigweed, make android not use mapfiles

### DIFF
--- a/build/toolchain/android/android_toolchain.gni
+++ b/build/toolchain/android/android_toolchain.gni
@@ -37,7 +37,6 @@ template("android_clang_toolchain") {
   _android_toolchain_args = {
     current_os = "android"
     is_clang = true
-
     forward_variables_from(_invoker_toolchain_args, "*")
   }
 
@@ -70,5 +69,6 @@ template("android_clang_toolchain") {
     ar = _ndk_prefix + "llvm-ar"
     cc = _ndk_prefix + _tool_name_root + "clang"
     cxx = _ndk_prefix + _tool_name_root + "clang++"
+    link_generate_map_file = false
   }
 }

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -40,6 +40,10 @@ template("gcc_toolchain") {
       cxx = invoker.cxx
     }
 
+    if (defined(invoker.link_generate_map_file)) {
+      link_generate_map_file = invoker.link_generate_map_file
+    }
+
     is_host_toolchain = invoker_toolchain_args.current_os == host_os
     link_group = invoker_toolchain_args.current_os != "mac" &&
                  invoker_toolchain_args.current_os != "ios"

--- a/examples/platform/bouffalolab/common/rpc/Rpc.cpp
+++ b/examples/platform/bouffalolab/common/rpc/Rpc.cpp
@@ -168,7 +168,7 @@ Thread thread;
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 void RegisterServices(pw::rpc::Server & server)

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -285,7 +285,7 @@ Locking locking;
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 #if defined(PW_RPC_WIFI_SERVICE) && PW_RPC_WIFI_SERVICE

--- a/examples/platform/linux/Rpc.cpp
+++ b/examples/platform/linux/Rpc.cpp
@@ -80,7 +80,7 @@ Lighting lighting_service;
 #endif // defined(PW_RPC_LIGHTING_SERVICE) && PW_RPC_LIGHTING_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 void RegisterServices(pw::rpc::Server & server)

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -157,7 +157,7 @@ Thread thread;
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 void RegisterServices(pw::rpc::Server & server)

--- a/examples/platform/silabs/Rpc.cpp
+++ b/examples/platform/silabs/Rpc.cpp
@@ -149,7 +149,7 @@ Thread thread;
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 void RegisterServices(pw::rpc::Server & server)

--- a/examples/platform/telink/Rpc.cpp
+++ b/examples/platform/telink/Rpc.cpp
@@ -157,7 +157,7 @@ Thread thread;
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
+pw::trace::TraceService trace_service(pw::trace::GetTokenizedTracer());
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 
 void RegisterServices(pw::rpc::Server & server)


### PR DESCRIPTION
Update to latest pigweed version, which includes support for not creating mapfiles at link time.

Use the new flag in android builds, so that 800MB mapfiles are not created (and not dumped to stdout either).