### PR TITLE
Switch gecko_sdk submodule back to 4.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -247,7 +247,7 @@
 [submodule "third_party/silabs/gecko_sdk"]
 	path = third_party/silabs/gecko_sdk
 	url = https://github.com/SiliconLabs/gecko_sdk.git
-	branch = gsdk_4.1
+	branch = v4.2.3
 	platforms = efr32
 [submodule "third_party/silabs/wiseconnect-wifi-bt-sdk"]
 	path = third_party/silabs/wiseconnect-wifi-bt-sdk


### PR DESCRIPTION
#28140 reverted gecko_sdk (likely because gitmodules branch was wrong). Corrected gitmodules and pulled the same version as dockerfile currently uses.

This makes `./scripts/build/build_examples.py --log-level info --enable-flashbundle --target efr32-brd4187c-light-rpc build` compile again.