### PR TITLE
Add some `const` to TLVReader get methods

### DIFF
--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -256,7 +256,7 @@ float BitCastToFloat(const uint64_t elemLenOrVal)
 // between float and double wherever possible, because these conversions are
 // relatively expensive on platforms that use soft-float instruction sets.
 
-CHIP_ERROR TLVReader::Get(float & v)
+CHIP_ERROR TLVReader::Get(float & v) const
 {
     switch (ElementType())
     {
@@ -270,7 +270,7 @@ CHIP_ERROR TLVReader::Get(float & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(double & v)
+CHIP_ERROR TLVReader::Get(double & v) const
 {
     switch (ElementType())
     {

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -117,7 +117,7 @@ uint32_t TLVReader::GetLength() const
     return 0;
 }
 
-CHIP_ERROR TLVReader::Get(bool & v)
+CHIP_ERROR TLVReader::Get(bool & v) const
 {
     TLVElementType elemType = ElementType();
     if (elemType == TLVElementType::BooleanFalse)
@@ -129,7 +129,7 @@ CHIP_ERROR TLVReader::Get(bool & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(int8_t & v)
+CHIP_ERROR TLVReader::Get(int8_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -141,7 +141,7 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int16_t & v)
+CHIP_ERROR TLVReader::Get(int16_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -153,7 +153,7 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int32_t & v)
+CHIP_ERROR TLVReader::Get(int32_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -165,7 +165,7 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int64_t & v)
+CHIP_ERROR TLVReader::Get(int64_t & v) const
 {
     // Internal callers of this method depend on it not modifying "v" on failure.
     switch (ElementType())
@@ -189,7 +189,7 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(uint8_t & v)
+CHIP_ERROR TLVReader::Get(uint8_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -201,7 +201,7 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint16_t & v)
+CHIP_ERROR TLVReader::Get(uint16_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -213,7 +213,7 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint32_t & v)
+CHIP_ERROR TLVReader::Get(uint32_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -225,7 +225,7 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint64_t & v)
+CHIP_ERROR TLVReader::Get(uint64_t & v) const
 {
     // Internal callers of this method depend on it not modifying "v" on failure.
     switch (ElementType())

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -283,7 +283,7 @@ public:
      * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV boolean type, or the
      *                                      reader is not positioned on an element.
      */
-    CHIP_ERROR Get(bool & v);
+    CHIP_ERROR Get(bool & v) const;
 
     /**
      * Get the value of the current element as an 8-bit signed integer.
@@ -298,7 +298,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int8_t & v);
+    CHIP_ERROR Get(int8_t & v) const;
 
     /**
      * Get the value of the current element as a 16-bit signed integer.
@@ -313,7 +313,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int16_t & v);
+    CHIP_ERROR Get(int16_t & v) const;
 
     /**
      * Get the value of the current element as a 32-bit signed integer.
@@ -328,7 +328,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int32_t & v);
+    CHIP_ERROR Get(int32_t & v) const;
 
     /**
      * Get the value of the current element as a 64-bit signed integer.
@@ -343,7 +343,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int64_t & v);
+    CHIP_ERROR Get(int64_t & v) const;
 
     /**
      * Get the value of the current element as an 8-bit unsigned integer.
@@ -359,7 +359,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint8_t & v);
+    CHIP_ERROR Get(uint8_t & v) const;
 
     /**
      * Get the value of the current element as a 16-bit unsigned integer.
@@ -375,7 +375,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint16_t & v);
+    CHIP_ERROR Get(uint16_t & v) const;
 
     /**
      * Get the value of the current element as a 32-bit unsigned integer.
@@ -391,7 +391,7 @@ public:
      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint32_t & v);
+    CHIP_ERROR Get(uint32_t & v) const;
 
     /**
      * Get the value of the current element as a 64-bit unsigned integer.
@@ -405,7 +405,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint64_t & v);
+    CHIP_ERROR Get(uint64_t & v) const;
 
     /**
      * Get the value of the current element as a double-precision floating point number.

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -31,7 +31,6 @@
 #include <lib/core/Optional.h>
 
 #include "TLVCommon.h"
-
 #include "TLVWriter.h"
 
 /**

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -417,7 +417,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(double & v);
+    CHIP_ERROR Get(double & v) const;
 
     /**
      * Get the value of the current element as a single-precision floating point number.
@@ -429,7 +429,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(float & v);
+    CHIP_ERROR Get(float & v) const;
 
     /**
      * Get the value of the current element as a ByteSpan


### PR DESCRIPTION
Unfortunately buffer gets are not possible to be const yet because those may move the current backing buffer (even though we probably are never spanning multiple buffers for our TLV readers).

For now at least make the integer/float/bool getters const.