### PR TITLE
Make TLVReader getter const for ByteSpan and CharSpan

### DIFF
--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -573,7 +573,8 @@ CHIP_ERROR TLVReader::Next()
 
     VerifyOrReturnError(elemType != TLVElementType::EndOfContainer, CHIP_END_OF_TLV);
 
-    if (TLVTypeIsString(ElementType()) && (GetLength() != 0)) {
+    if (TLVTypeIsString(ElementType()) && (GetLength() != 0))
+    {
         // Ensure that GetDataPtr calls can be called immediately after next
         // so that `Get(ByteSpan&)` does not need to advance buffers and just
         // works

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -256,7 +256,7 @@ float BitCastToFloat(const uint64_t elemLenOrVal)
 // between float and double wherever possible, because these conversions are
 // relatively expensive on platforms that use soft-float instruction sets.
 
-CHIP_ERROR TLVReader::Get(float & v)
+CHIP_ERROR TLVReader::Get(float & v) const
 {
     switch (ElementType())
     {
@@ -270,7 +270,7 @@ CHIP_ERROR TLVReader::Get(float & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(double & v)
+CHIP_ERROR TLVReader::Get(double & v) const
 {
     switch (ElementType())
     {

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -573,11 +573,10 @@ CHIP_ERROR TLVReader::Next()
 
     VerifyOrReturnError(elemType != TLVElementType::EndOfContainer, CHIP_END_OF_TLV);
 
-    if (TLVTypeIsString(ElementType()) && (GetLength() != 0))
+    // Ensure that GetDataPtr calls can be called immediately after Next, so
+    // that `Get(ByteSpan&)` does not need to advance buffers and just works
+    if (TLVTypeIsString(elemType) && (GetLength() != 0))
     {
-        // Ensure that GetDataPtr calls can be called immediately after next
-        // so that `Get(ByteSpan&)` does not need to advance buffers and just
-        // works
         ReturnErrorOnFailure(EnsureData(CHIP_ERROR_TLV_UNDERRUN));
     }
 

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -290,7 +290,7 @@ CHIP_ERROR TLVReader::Get(double & v) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(ByteSpan & v)
+CHIP_ERROR TLVReader::Get(ByteSpan & v) const
 {
     const uint8_t * val;
     ReturnErrorOnFailure(GetDataPtr(val));
@@ -304,7 +304,7 @@ constexpr int kUnicodeInformationSeparator1       = 0x1F;
 constexpr size_t kMaxLocalizedStringIdentifierLen = 2 * sizeof(LocalizedStringIdentifier);
 } // namespace
 
-CHIP_ERROR TLVReader::Get(CharSpan & v)
+CHIP_ERROR TLVReader::Get(CharSpan & v) const
 {
     if (!TLVTypeIsUTF8String(ElementType()))
     {
@@ -460,12 +460,9 @@ CHIP_ERROR TLVReader::DupString(char *& buf)
     return err;
 }
 
-CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data)
+CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data) const
 {
-    CHIP_ERROR err;
-
-    if (!TLVTypeIsString(ElementType()))
-        return CHIP_ERROR_WRONG_TLV_TYPE;
+    VerifyOrReturnError(TLVTypeIsString(ElementType()), CHIP_ERROR_WRONG_TLV_TYPE);
 
     if (GetLength() == 0)
     {
@@ -473,19 +470,12 @@ CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data)
         return CHIP_NO_ERROR;
     }
 
-    err = EnsureData(CHIP_ERROR_TLV_UNDERRUN);
-    if (err != CHIP_NO_ERROR)
-        return err;
-
     uint32_t remainingLen = static_cast<decltype(mMaxLen)>(mBufEnd - mReadPoint);
 
     // Verify that the entirety of the data is available in the buffer.
     // Note that this may not be possible if the reader is reading from a chain of buffers.
-    if (remainingLen < static_cast<uint32_t>(mElemLenOrVal))
-        return CHIP_ERROR_TLV_UNDERRUN;
-
+    VerifyOrReturnError(remainingLen >= static_cast<uint32_t>(mElemLenOrVal), CHIP_ERROR_TLV_UNDERRUN);
     data = mReadPoint;
-
     return CHIP_NO_ERROR;
 }
 
@@ -576,20 +566,19 @@ CHIP_ERROR TLVReader::VerifyEndOfContainer()
 
 CHIP_ERROR TLVReader::Next()
 {
-    CHIP_ERROR err;
+    ReturnErrorOnFailure(Skip());
+    ReturnErrorOnFailure(ReadElement());
+
     TLVElementType elemType = ElementType();
 
-    err = Skip();
-    if (err != CHIP_NO_ERROR)
-        return err;
+    VerifyOrReturnError(elemType != TLVElementType::EndOfContainer, CHIP_END_OF_TLV);
 
-    err = ReadElement();
-    if (err != CHIP_NO_ERROR)
-        return err;
-
-    elemType = ElementType();
-    if (elemType == TLVElementType::EndOfContainer)
-        return CHIP_END_OF_TLV;
+    if (TLVTypeIsString(ElementType()) && (GetLength() != 0)) {
+        // Ensure that GetDataPtr calls can be called immediately after next
+        // so that `Get(ByteSpan&)` does not need to advance buffers and just
+        // works
+        ReturnErrorOnFailure(EnsureData(CHIP_ERROR_TLV_UNDERRUN));
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -117,7 +117,7 @@ uint32_t TLVReader::GetLength() const
     return 0;
 }
 
-CHIP_ERROR TLVReader::Get(bool & v)
+CHIP_ERROR TLVReader::Get(bool & v) const
 {
     TLVElementType elemType = ElementType();
     if (elemType == TLVElementType::BooleanFalse)
@@ -129,7 +129,7 @@ CHIP_ERROR TLVReader::Get(bool & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(int8_t & v)
+CHIP_ERROR TLVReader::Get(int8_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -141,7 +141,7 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int16_t & v)
+CHIP_ERROR TLVReader::Get(int16_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -153,7 +153,7 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int32_t & v)
+CHIP_ERROR TLVReader::Get(int32_t & v) const
 {
     int64_t v64    = 0;
     CHIP_ERROR err = Get(v64);
@@ -165,7 +165,7 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(int64_t & v)
+CHIP_ERROR TLVReader::Get(int64_t & v) const
 {
     // Internal callers of this method depend on it not modifying "v" on failure.
     switch (ElementType())
@@ -189,7 +189,7 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Get(uint8_t & v)
+CHIP_ERROR TLVReader::Get(uint8_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -201,7 +201,7 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint16_t & v)
+CHIP_ERROR TLVReader::Get(uint16_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -213,7 +213,7 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint32_t & v)
+CHIP_ERROR TLVReader::Get(uint32_t & v) const
 {
     uint64_t v64   = 0;
     CHIP_ERROR err = Get(v64);
@@ -225,7 +225,7 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
     return err;
 }
 
-CHIP_ERROR TLVReader::Get(uint64_t & v)
+CHIP_ERROR TLVReader::Get(uint64_t & v) const
 {
     // Internal callers of this method depend on it not modifying "v" on failure.
     switch (ElementType())

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -283,7 +283,7 @@ public:
      * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV boolean type, or the
      *                                      reader is not positioned on an element.
      */
-    CHIP_ERROR Get(bool & v);
+    CHIP_ERROR Get(bool & v) const;
 
     /**
      * Get the value of the current element as an 8-bit signed integer.
@@ -298,7 +298,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int8_t & v);
+    CHIP_ERROR Get(int8_t & v) const;
 
     /**
      * Get the value of the current element as a 16-bit signed integer.
@@ -313,7 +313,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int16_t & v);
+    CHIP_ERROR Get(int16_t & v) const;
 
     /**
      * Get the value of the current element as a 32-bit signed integer.
@@ -328,7 +328,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int32_t & v);
+    CHIP_ERROR Get(int32_t & v) const;
 
     /**
      * Get the value of the current element as a 64-bit signed integer.
@@ -343,7 +343,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(int64_t & v);
+    CHIP_ERROR Get(int64_t & v) const;
 
     /**
      * Get the value of the current element as an 8-bit unsigned integer.
@@ -359,7 +359,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint8_t & v);
+    CHIP_ERROR Get(uint8_t & v) const;
 
     /**
      * Get the value of the current element as a 16-bit unsigned integer.
@@ -375,7 +375,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint16_t & v);
+    CHIP_ERROR Get(uint16_t & v) const;
 
     /**
      * Get the value of the current element as a 32-bit unsigned integer.
@@ -391,7 +391,7 @@ public:
      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint32_t & v);
+    CHIP_ERROR Get(uint32_t & v) const;
 
     /**
      * Get the value of the current element as a 64-bit unsigned integer.
@@ -405,7 +405,7 @@ public:
      *                                      unsigned), or the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(uint64_t & v);
+    CHIP_ERROR Get(uint64_t & v) const;
 
     /**
      * Get the value of the current element as a double-precision floating point number.

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -441,7 +441,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(ByteSpan & v);
+    CHIP_ERROR Get(ByteSpan & v) const;
 
     /**
      * Get the value of the current element as a FixedByteSpan
@@ -454,7 +454,7 @@ public:
      *
      */
     template <size_t N>
-    CHIP_ERROR Get(FixedByteSpan<N> & v)
+    CHIP_ERROR Get(FixedByteSpan<N> & v) const
     {
         const uint8_t * val;
         ReturnErrorOnFailure(GetDataPtr(val));
@@ -473,7 +473,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(CharSpan & v);
+    CHIP_ERROR Get(CharSpan & v) const;
 
     /**
      * Get the Localized String Identifier contained in the current element..
@@ -635,9 +635,8 @@ public:
      * Get a pointer to the initial encoded byte of a TLV byte or UTF8 string element.
      *
      * This method returns a direct pointer to the encoded string value within the underlying input buffer
-     * if a non-zero length string payload is present. To succeed, the method requires that the entirety of the
-     * string value be present in a single buffer. Otherwise the method returns #CHIP_ERROR_TLV_UNDERRUN.
-     * This makes the method of limited use when reading data from multiple discontiguous buffers.
+     * as fetched by `Next`. To succeed, the method requires that the entirety of the
+     * string value be present in a single buffer.
      *
      * If no string data is present (i.e the length is zero), data shall be updated to point to null.
      *
@@ -654,7 +653,7 @@ public:
      *                                      TLVBackingStore.
      *
      */
-    CHIP_ERROR GetDataPtr(const uint8_t *& data);
+    CHIP_ERROR GetDataPtr(const uint8_t *& data) const;
 
     /**
      * Prepares a TLVReader object for reading the members of TLV container element.

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -417,7 +417,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(double & v);
+    CHIP_ERROR Get(double & v) const;
 
     /**
      * Get the value of the current element as a single-precision floating point number.
@@ -429,7 +429,7 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(float & v);
+    CHIP_ERROR Get(float & v) const;
 
     /**
      * Get the value of the current element as a ByteSpan

--- a/src/lib/format/protocol_decoder.cpp
+++ b/src/lib/format/protocol_decoder.cpp
@@ -45,7 +45,7 @@ private:
     const Tag mTag;
 };
 
-CHIP_ERROR FormatCurrentValue(TLVReader & reader, chip::StringBuilderBase & out)
+CHIP_ERROR FormatCurrentValue(const TLVReader & reader, chip::StringBuilderBase & out)
 {
     switch (reader.GetType())
     {
@@ -105,7 +105,7 @@ CHIP_ERROR FormatCurrentValue(TLVReader & reader, chip::StringBuilderBase & out)
 }
 
 // Returns a null terminated string containing the current reader value
-void PrettyPrintCurrentValue(TLVReader & reader, chip::StringBuilderBase & out, PayloadDecoderBase::DecodePosition & position)
+void PrettyPrintCurrentValue(const TLVReader & reader, chip::StringBuilderBase & out, PayloadDecoderBase::DecodePosition & position)
 {
     CHIP_ERROR err = FormatCurrentValue(reader, out);
 


### PR DESCRIPTION
This builds on #28167 to make ByteSpan and CharSpan getters const for TLVReader.
This makes Next() for string values auto-execute EnsureData so that byte buffers are automatically available to getters.
