### PR TITLE
Start switching platforms to C++17 (linux, mac)

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -43,7 +43,7 @@ declare_args() {
   c_standard = "gnu11"
 
   # C++ standard level (value for -std flag).
-  if (current_os == "android") {
+  if (current_os == "linux" || current_os == "mac" || current_os == "android") {
     cpp_standard = "gnu++17"
   } else {
     cpp_standard = "gnu++14"

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -43,7 +43,7 @@ declare_args() {
   c_standard = "gnu11"
 
   # C++ standard level (value for -std flag).
-  if (current_os == "linux" || current_os == "mac" || current_os == "android") {
+  if (current_os == "linux" || current_os == "mac" || current_os == "ios" || current_os == "android") {
     cpp_standard = "gnu++17"
   } else {
     cpp_standard = "gnu++14"

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -43,7 +43,8 @@ declare_args() {
   c_standard = "gnu11"
 
   # C++ standard level (value for -std flag).
-  if (current_os == "linux" || current_os == "mac" || current_os == "ios" || current_os == "android") {
+  if (current_os == "linux" || current_os == "mac" || current_os == "ios" ||
+      current_os == "android") {
     cpp_standard = "gnu++17"
   } else {
     cpp_standard = "gnu++14"

--- a/examples/all-clusters-app/linux/args.gni
+++ b/examples/all-clusters-app/linux/args.gni
@@ -27,6 +27,3 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
 matter_log_json_payload_decode_full = true
 matter_log_json_payload_hex = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/all-clusters-minimal-app/linux/args.gni
+++ b/examples/all-clusters-minimal-app/linux/args.gni
@@ -25,6 +25,3 @@ chip_project_config_include_dirs =
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/bridge-app/linux/args.gni
+++ b/examples/bridge-app/linux/args.gni
@@ -25,6 +25,3 @@ chip_project_config_include_dirs =
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/chef/linux/with_pw_rpc.gni
+++ b/examples/chef/linux/with_pw_rpc.gni
@@ -21,8 +21,6 @@ import("${chip_root}/config/standalone/args.gni")
 
 import("//build_overrides/pigweed.gni")
 
-cpp_standard = "gnu++17"
-
 pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"

--- a/examples/contact-sensor-app/linux/args.gni
+++ b/examples/contact-sensor-app/linux/args.gni
@@ -26,6 +26,3 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/contact-sensor-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -27,6 +27,3 @@ chip_project_config_include_dirs =
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/lighting-app/linux/with_pw_rpc.gni
+++ b/examples/lighting-app/linux/with_pw_rpc.gni
@@ -21,8 +21,6 @@ import("${chip_root}/config/standalone/args.gni")
 
 import("//build_overrides/pigweed.gni")
 
-cpp_standard = "gnu++17"
-
 pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"

--- a/examples/lock-app/linux/args.gni
+++ b/examples/lock-app/linux/args.gni
@@ -24,6 +24,3 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/lock-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/log-source-app/linux/args.gni
+++ b/examples/log-source-app/linux/args.gni
@@ -17,6 +17,3 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/ota-provider-app/linux/args.gni
+++ b/examples/ota-provider-app/linux/args.gni
@@ -24,6 +24,3 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/ota-provider-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -26,6 +26,3 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_enable_ota_requestor = true
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/persistent-storage/linux/args.gni
+++ b/examples/persistent-storage/linux/args.gni
@@ -16,6 +16,3 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/placeholder/linux/args.gni
+++ b/examples/placeholder/linux/args.gni
@@ -23,6 +23,3 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/placeholder/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/thermostat/linux/args.gni
+++ b/examples/thermostat/linux/args.gni
@@ -16,6 +16,3 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/tv-app/linux/args.gni
+++ b/examples/tv-app/linux/args.gni
@@ -31,6 +31,3 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -33,6 +33,3 @@ chip_enable_rotating_device_id = true
 chip_max_discovered_ip_addresses = 20
 
 matter_enable_tracing_support = true
-
-# Perfetto requires C++17
-cpp_standard = "gnu++17"

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -43,10 +43,7 @@ declare_args() {
   # since tracing is very noisy, we generally expect it to be explicitly
   # set up.
   #
-  # TODO: cpp_standard check is not ideal, it should be >= 17,
-  #       however for now this is what we use in compilations
-  if ((current_os == "linux" || current_os == "android") &&
-      cpp_standard == "gnu++17") {
+  if (current_os == "linux" || current_os == "android") {
     matter_trace_config = "${chip_root}/src/tracing/perfetto:perfetto_tracing"
   } else {
     matter_trace_config = "${chip_root}/src/tracing/none"


### PR DESCRIPTION
Starting to move default C++ standard to C++17.

Starting  with linux and mac, since that starts allowing perfetto by default.