### PR TITLE
[yaml] Update IDM and SC test scripts to match Test Plan and Specification

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
@@ -13,8 +13,7 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name:
-    3.4.2. [TC-IDM-4.2] Subscription Response Messages from DUT Test Cases.
+name: 3.4.2. [TC-IDM-4.2] Subscription Response Messages from DUT Test Cases.
     [{DUT_Server}]
 
 PICS:
@@ -33,10 +32,19 @@ tests:
       disabled: true
 
     - label:
-          "Step 1: TH sends a subscription message to the DUT with
-          MaxIntervalCeiling set to a value greater than 60 mins. DUT sends a
-          report data action to the TH. TH sends a success status response to
-          the DUT. DUT sends a Subscribe Response Message to the TH to activate
+          If the device is has the ICD Management cluster, TH reads from the DUT the IdleModeInterval attribute
+          and sets the SubscriptionMaxIntervalPublisherLimit to the value read.
+          If the device does not have the ICD Management cluster, set the SubscriptionMaxIntervalPublisherLimit
+          to 60 minutes.
+      verification: |
+          The cluster used in the below command is an example,
+          icdmanagement read idle-mode-interval 12344321 0
+      disabled: true
+
+    - label: "Step 1: TH sends a subscription message to the DUT with
+          MaxIntervalCeiling set to a value greater than the SubscriptionMaxIntervalPublisherLimit.
+          DUT sends a report data action to the TH. TH sends a success status response to the DUT.
+          DUT sends a Subscribe Response Message to the TH to activate
           the subscription."
       verification: |
           onoff subscribe on-off  100  3900 1 1 --keepSubscriptions true
@@ -71,10 +79,9 @@ tests:
           [1686294743.441504][101362:101364] CHIP:DMG: MoveToState ReadClient[0x7fc7ec011c50]: Moving to [Subscripti]
       disabled: true
 
-    - label:
-          "Step 2: TH sends a subscription message to the DUT with
-          MaxIntervalCeiling set to a value less than 60 mins. DUT sends a
-          report data action to the TH. TH sends a success status response to
+    - label: "Step 2: TH sends a subscription message to the DUT with
+          MaxIntervalCeiling set to a value less than han the SubscriptionMaxIntervalPublisherLimit.
+          DUT sends a report data action to the TH. TH sends a success status response to
           the DUT. DUT sends a Subscribe Response Message to the TH to activate
           the subscription."
       verification: |
@@ -84,7 +91,7 @@ tests:
            Verify on the TH the Subscribe Response has the following fields,
            SubscriptionId - Verify it is of type uint32.
            MaxInterval - Verify it is of type uint32.
-           Verify that the MaxInterval is less than or equal to 60 mins.
+           Verify that the MaxInterval is less than or equal to the MaxIntervalCeiling.
 
           [1686294932.404445][101362:101364] CHIP:DMG:         InteractionModelRevision = 1
           [1686294932.404449][101362:101364] CHIP:DMG: }
@@ -107,7 +114,7 @@ tests:
           [1686294932.420847][101362:101364] CHIP:DMG: MoveToState ReadClient[0x7fc7ec00e400]: Moving to [Subscripti]
 
 
-           MaxInterval and MaxIntervalCeiling are different parameters. One is sent from the TH the other from DUT, verify MaxInterval >=  MaxIntervalCeiling
+           MaxInterval and MaxIntervalCeiling are different parameters. One is sent from the TH the other from DUT, verify MaxInterval <=  MaxIntervalCeiling
       disabled: true
 
     - label:
@@ -455,8 +462,7 @@ tests:
           On TH(chip-tool) Verify that the Subscription succeeds and the DUT sends back the attribute values for the global attribute
       disabled: true
 
-    - label:
-          "Step 11: TH sends a subscription request to subscribe to a global
+    - label: "Step 11: TH sends a subscription request to subscribe to a global
           attribute on an endpoint on all clusters. AttributePath = [[Attribute
           = Global Attribute, Endpoint = EndpointID ]]. +"
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name: 3.4.2. [TC-IDM-4.2] Subscription Response Messages from DUT Test Cases.
+name:
+    3.4.2. [TC-IDM-4.2] Subscription Response Messages from DUT Test Cases.
     [{DUT_Server}]
 
 PICS:
@@ -32,20 +33,22 @@ tests:
       disabled: true
 
     - label:
-          If the device is has the ICD Management cluster, TH reads from the DUT the IdleModeInterval attribute
-          and sets the SubscriptionMaxIntervalPublisherLimit to the value read.
-          If the device does not have the ICD Management cluster, set the SubscriptionMaxIntervalPublisherLimit
-          to 60 minutes.
+          If the device is has the ICD Management cluster, TH reads from the DUT
+          the IdleModeInterval attribute and sets the
+          SubscriptionMaxIntervalPublisherLimit to the value read. If the device
+          does not have the ICD Management cluster, set the
+          SubscriptionMaxIntervalPublisherLimit to 60 minutes.
       verification: |
           The cluster used in the below command is an example,
           icdmanagement read idle-mode-interval 12344321 0
       disabled: true
 
-    - label: "Step 1: TH sends a subscription message to the DUT with
-          MaxIntervalCeiling set to a value greater than the SubscriptionMaxIntervalPublisherLimit.
-          DUT sends a report data action to the TH. TH sends a success status response to the DUT.
-          DUT sends a Subscribe Response Message to the TH to activate
-          the subscription."
+    - label:
+          "Step 1: TH sends a subscription message to the DUT with
+          MaxIntervalCeiling set to a value greater than the
+          SubscriptionMaxIntervalPublisherLimit. DUT sends a report data action
+          to the TH. TH sends a success status response to the DUT. DUT sends a
+          Subscribe Response Message to the TH to activate the subscription."
       verification: |
           onoff subscribe on-off  100  3900 1 1 --keepSubscriptions true
 
@@ -79,11 +82,12 @@ tests:
           [1686294743.441504][101362:101364] CHIP:DMG: MoveToState ReadClient[0x7fc7ec011c50]: Moving to [Subscripti]
       disabled: true
 
-    - label: "Step 2: TH sends a subscription message to the DUT with
-          MaxIntervalCeiling set to a value less than han the SubscriptionMaxIntervalPublisherLimit.
-          DUT sends a report data action to the TH. TH sends a success status response to
-          the DUT. DUT sends a Subscribe Response Message to the TH to activate
-          the subscription."
+    - label:
+          "Step 2: TH sends a subscription message to the DUT with
+          MaxIntervalCeiling set to a value less than han the
+          SubscriptionMaxIntervalPublisherLimit. DUT sends a report data action
+          to the TH. TH sends a success status response to the DUT. DUT sends a
+          Subscribe Response Message to the TH to activate the subscription."
       verification: |
           basicinformation subscribe location 10 2400 1 0 --keepSubscriptions true
           On the TH(chip-tool), verify a report data message is received and verify it contains the following data :
@@ -459,7 +463,8 @@ tests:
           On TH(chip-tool) Verify that the Subscription succeeds and the DUT sends back the attribute values for the global attribute
       disabled: true
 
-    - label: "Step 11: TH sends a subscription request to subscribe to a global
+    - label:
+          "Step 11: TH sends a subscription request to subscribe to a global
           attribute on an endpoint on all clusters. AttributePath = [[Attribute
           = Global Attribute, Endpoint = EndpointID ]]. +"
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_IDM_4_2.yaml
@@ -112,9 +112,6 @@ tests:
           [1686294932.420822][101362:101364] CHIP:DMG: }
           [1686294932.420834][101362:101364] CHIP:DMG: Subscription established with SubscriptionID = 0xcbbba269 MinInterval = 10s MaxInterval = 2400s Peer = 01:0000000000000001
           [1686294932.420847][101362:101364] CHIP:DMG: MoveToState ReadClient[0x7fc7ec00e400]: Moving to [Subscripti]
-
-
-           MaxInterval and MaxIntervalCeiling are different parameters. One is sent from the TH the other from DUT, verify MaxInterval <=  MaxIntervalCeiling
       disabled: true
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_SC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_2_1.yaml
@@ -13,8 +13,7 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name:
-    14.2.1. [TC-SC-2.1] Session Establishment - Passcode Authenticated Session
+name: 14.2.1. [TC-SC-2.1] Session Establishment - Passcode Authenticated Session
     Establishment (PASE)
 
 PICS:
@@ -26,18 +25,17 @@ config:
     endpoint: 0
 
 tests:
-    - label:
-          "Initiator constructs and sends a TLV-encoded PBKDFParamRequest
+    - label: "Initiator constructs and sends a TLV-encoded PBKDFParamRequest
           message"
       verification: |
-          Verify that the responder receives the PBKDFParamRequest message. Verify that the protocol header is properly constructed: Message Flags: S Flag is set to 0, and DSIZ field is set to 0 Session ID is set to 0 Security Flags: Session Type bits are set to 0 Exchange Flags: I Flag is set to 1 Protocol Opcode is set to 32 (0x20) Protocol ID is set to 0 Verify, if possible in a debug mode, that the PBKDFParamRequest message contains: initiatorRandom - randomly generated 32-bit octet string initiatorSessionId - max size 16-bits unsigned integer that does not overlap with existing initiator session identifiers passcodeId - max size 16-bits unsigned integer hasPBKDFParameters - boolean If hasPBKDFParameters is set to true then PBKDF parameters are not known for the given passcodeId If hasPBKDFParameters is set to false then PBKDF parameters are known for the given passcodeId initiatorSEDParams - optional sed-parameter-struct which contains SLEEPY_IDLE_INTERVAL - max size 16-bits unsigned integer SLEEPY_ACTIVE_INTERVAL - max size 16-bits unsigned integer
+          Verify that the responder receives the PBKDFParamRequest message. Verify that the protocol header is properly constructed: Message Flags: S Flag is set to 0, and DSIZ field is set to 0 Session ID is set to 0 Security Flags: Session Type bits are set to 0 Exchange Flags: I Flag is set to 1 Protocol Opcode is set to 32 (0x20) Protocol ID is set to 0 Verify, if possible in a debug mode, that the PBKDFParamRequest message contains: initiatorRandom - randomly generated 32-bit octet string initiatorSessionId - max size 16-bits unsigned integer that does not overlap with existing initiator session identifiers passcodeId - max size 16-bits unsigned integer hasPBKDFParameters - boolean If hasPBKDFParameters is set to true then PBKDF parameters are not known for the given passcodeId If hasPBKDFParameters is set to false then PBKDF parameters are known for the given passcodeId initiatorSessionParams - optional session-parameter-struct which contains SESSION_IDLE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_THRESHOLD - max size 16-bits unsigned integer
       disabled: true
 
     - label:
           "Responder verifies the passcodeID, constructs and sends a TLV-encoded
           PBKDFParamResponse message"
       verification: |
-          Verify that the Initiator receives the PBKDFParamResponse message. Verify that the protocol header is properly constructed: Message Flags: S Flag is set to 0, and DSIZ field is set to 0 Session ID is set to 0 Security Flags: Session Type bits are set to 0 Exchange Flags: I Flag is set to 0 Protocol Opcode is set to 33 (0x21) Protocol ID is set to 0 Verify, if possible in a debug mode, that the PBKDFParamResponse message contains: initiatorRandom - value from the PBKDFParamRequest message responderRandom - randomly generated 32-bit octet string responderSessionId - max size 16-bits unsigned integer that does not overlap with existing that does not overlap with existing responder session identifiers pbkdf_parameters If hasPBKDFParameters from the PBKDFParamRequest message is true, then pbkdf_parameters should not be included. If hasPBKDFParameters from the PBKDFParamRequest message is false, then PBKDFParameters should contain a + Crypto_PBKDFParameterSet struct with values for iterations (max size 32 bit unsigned integer) and salt (octet string with a minimum of 16 bits and maximum of 32 bits) responderSEDParams - optional sed-parameter-struct SLEEPY_IDLE_INTERVAL - max size 16-bits unsigned integer SLEEPY_ACTIVE_INTERVAL - max size 16-bits unsigned integer
+          Verify that the Initiator receives the PBKDFParamResponse message. Verify that the protocol header is properly constructed: Message Flags: S Flag is set to 0, and DSIZ field is set to 0 Session ID is set to 0 Security Flags: Session Type bits are set to 0 Exchange Flags: I Flag is set to 0 Protocol Opcode is set to 33 (0x21) Protocol ID is set to 0 Verify, if possible in a debug mode, that the PBKDFParamResponse message contains: initiatorRandom - value from the PBKDFParamRequest message responderRandom - randomly generated 32-bit octet string responderSessionId - max size 16-bits unsigned integer that does not overlap with existing that does not overlap with existing responder session identifiers pbkdf_parameters If hasPBKDFParameters from the PBKDFParamRequest message is true, then pbkdf_parameters should not be included. If hasPBKDFParameters from the PBKDFParamRequest message is false, then PBKDFParameters should contain a + Crypto_PBKDFParameterSet struct with values for iterations (max size 32 bit unsigned integer) and salt (octet string with a minimum of 16 bits and maximum of 32 bits) responderSessionParams - optional session-parameter-struct SESSION_IDLE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_THRESHOLD - max size 16-bits unsigned integer
       disabled: true
 
     - label: "Initiator constructs and sends a TLV-encoded Pake1 message"

--- a/src/app/tests/suites/certification/Test_TC_SC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_2_1.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name: 14.2.1. [TC-SC-2.1] Session Establishment - Passcode Authenticated Session
+name:
+    14.2.1. [TC-SC-2.1] Session Establishment - Passcode Authenticated Session
     Establishment (PASE)
 
 PICS:
@@ -25,7 +26,8 @@ config:
     endpoint: 0
 
 tests:
-    - label: "Initiator constructs and sends a TLV-encoded PBKDFParamRequest
+    - label:
+          "Initiator constructs and sends a TLV-encoded PBKDFParamRequest
           message"
       verification: |
           Verify that the responder receives the PBKDFParamRequest message. Verify that the protocol header is properly constructed: Message Flags: S Flag is set to 0, and DSIZ field is set to 0 Session ID is set to 0 Security Flags: Session Type bits are set to 0 Exchange Flags: I Flag is set to 1 Protocol Opcode is set to 32 (0x20) Protocol ID is set to 0 Verify, if possible in a debug mode, that the PBKDFParamRequest message contains: initiatorRandom - randomly generated 32-bit octet string initiatorSessionId - max size 16-bits unsigned integer that does not overlap with existing initiator session identifiers passcodeId - max size 16-bits unsigned integer hasPBKDFParameters - boolean If hasPBKDFParameters is set to true then PBKDF parameters are not known for the given passcodeId If hasPBKDFParameters is set to false then PBKDF parameters are known for the given passcodeId initiatorSessionParams - optional session-parameter-struct which contains SESSION_IDLE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_INTERVAL - max size 32-bits unsigned integer SESSION_ACTIVE_THRESHOLD - max size 16-bits unsigned integer

--- a/src/app/tests/suites/certification/Test_TC_SC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_3_2.yaml
@@ -28,7 +28,7 @@ tests:
           "Step 1: Initiator constructs and sends a TLV-encoded Sigma1 message
           to Responder with resumption containing initiatorRandom
           initiatorSessionId destinationId resumptionID initiatorResumeMIC
-          initiatorEphPubKey initiatorSEDParams"
+          initiatorEphPubKey initiatorSessionParams"
       verification: |
           On Initiator(chip-tool) verify that, Initiator(chip-tool)  constructs and sends a TLV-encoded Sigma1 message to Responder with resumption containing
           initiatorRandom
@@ -37,7 +37,7 @@ tests:
           resumptionID
           initiatorResumeMIC
           initiatorEphPubKey
-          initiatorSEDParams
+          initiatorSessionParams
           here is the log to verify on chip-tool
 
           1683884120.041635][5134:5136] CHIP:DMG: Decrypted Payload (182 bytes) =
@@ -88,9 +88,10 @@ tests:
           resumptionID is of Octet String maximum of length 16 bytes
           responderSessionID is of uint16
            sigma2ResumeMIC is of Octet String maximum of length 16 bytes
-          responderSEDParams is from any one of the following:
-                SLEEPY_IDLE_INTERVAL - Verify that it is of uint32
-                SLEEPY_ACTIVE_INTERVAL - Verify that it is of uint32
+          responderSessionParams is from any one of the following:
+                SESSION_IDLE_INTERVAL - Verify that it is of uint32
+                SESSION_ACTIVE_INTERVAL - Verify that it is of uint32
+                SESSION_ACTIVE_THRESHOLD - Verify that it is of uint16
 
           here is the log to verify on chip-tool
 

--- a/src/app/tests/suites/certification/Test_TC_SC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_3_3.yaml
@@ -47,8 +47,7 @@ tests:
             In the response of above read request command, please verify the below test steps
       disabled: true
 
-    - label:
-          "Step 2b: Responder receives the Sigma1 message and extracts the
+    - label: "Step 2b: Responder receives the Sigma1 message and extracts the
           following initiatorRandom initiatorSessionId destinationId
           resumptionID initiatorResumeMIC initiatorEphPubKey initiatorSEDParams"
       verification: |
@@ -73,10 +72,10 @@ tests:
           resumptionID is of Octet String maximum of length 16 bytes
           responderSessionID is of uint16
            sigma2ResumeMIC is of Octet String maximum of length 16 bytes
-          responderSEDParams is from any one of the following:
-                SLEEPY_IDLE_INTERVAL - Verify that it is of uint32
-                SLEEPY_ACTIVE_INTERVAL - Verify that it is of uint32
-
+          responderSessionParams is from any one of the following:
+                SESSION_IDLE_INTERVAL - Verify that it is of uint32
+                SESSION_ACTIVE_INTERVAL - Verify that it is of uint32
+                SESSION_ACTIVE_THRESHOLD - Verify that it is of uint16
 
           [1683973658.044236][21637:21637] CHIP:EM: Rxd Ack; Removing MessageCounter:113416101 from Retrans Table on exchange 32995r
           [1683973662.299442][21637:21637] CHIP:DMG: << from UDP:[fe80::e9f6:2c08:2794:357d%wlp0s20f3]:41363 | 167307433 | [Secure Channel  (0) / Certificate Authenticated Session Establishment Sigma '1' (0x30) / Session = 0 / Exchange = 32997]
@@ -123,8 +122,7 @@ tests:
           [1683973662.299943][21637:21637] CHIP:EM: >>> [E:32997r S:0 M:167307433] (U) Msg RX from 0:D379FA4FB43AD140 [0000] --- Type 0000:30 (SecureChannel:CASE_Sigma1)
       disabled: true
 
-    - label:
-          "Step 2c: Responder sends a TLV-encoded Sigma2_Resume message to
+    - label: "Step 2c: Responder sends a TLV-encoded Sigma2_Resume message to
           Initiator containing resumptionID responderSessionID sigma2ResumeMIC
           responderMRPParams"
       verification: |
@@ -181,8 +179,7 @@ tests:
           [1683973662.301880][21648:21650] CHIP:SC: Peer assigned session session ID 688
       disabled: true
 
-    - label:
-          "Step 3a: Responder receives the SigmaFinished message and extracts
+    - label: "Step 3a: Responder receives the SigmaFinished message and extracts
           the following 1.ProtocolId 2.ProtocolCode"
       verification: |
           On Responder(chip-tool),  verify that responder(chip-tool) received  the SigmaFinished(The status report should be GeneralCode:SUCCESS,

--- a/src/app/tests/suites/certification/Test_TC_SC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_3_3.yaml
@@ -47,7 +47,8 @@ tests:
             In the response of above read request command, please verify the below test steps
       disabled: true
 
-    - label: "Step 2b: Responder receives the Sigma1 message and extracts the
+    - label:
+          "Step 2b: Responder receives the Sigma1 message and extracts the
           following initiatorRandom initiatorSessionId destinationId
           resumptionID initiatorResumeMIC initiatorEphPubKey initiatorSEDParams"
       verification: |
@@ -122,7 +123,8 @@ tests:
           [1683973662.299943][21637:21637] CHIP:EM: >>> [E:32997r S:0 M:167307433] (U) Msg RX from 0:D379FA4FB43AD140 [0000] --- Type 0000:30 (SecureChannel:CASE_Sigma1)
       disabled: true
 
-    - label: "Step 2c: Responder sends a TLV-encoded Sigma2_Resume message to
+    - label:
+          "Step 2c: Responder sends a TLV-encoded Sigma2_Resume message to
           Initiator containing resumptionID responderSessionID sigma2ResumeMIC
           responderMRPParams"
       verification: |
@@ -179,7 +181,8 @@ tests:
           [1683973662.301880][21648:21650] CHIP:SC: Peer assigned session session ID 688
       disabled: true
 
-    - label: "Step 3a: Responder receives the SigmaFinished message and extracts
+    - label:
+          "Step 3a: Responder receives the SigmaFinished message and extracts
           the following 1.ProtocolId 2.ProtocolCode"
       verification: |
           On Responder(chip-tool),  verify that responder(chip-tool) received  the SigmaFinished(The status report should be GeneralCode:SUCCESS,

--- a/src/app/tests/suites/certification/Test_TC_SC_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_1.yaml
@@ -53,7 +53,8 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Step 1a: DUT is put in Commissioning Mode using Open Basic
+    - label:
+          "Step 1a: DUT is put in Commissioning Mode using Open Basic
           Commissioning Window command "
       cluster: "Administrator Commissioning"
       command: "OpenBasicCommissioningWindow"
@@ -194,7 +195,8 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label: "Step 2f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label:
+          "Step 2f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -206,7 +208,8 @@ tests:
               - name: "value"
                 value: deviceType
 
-    - label: "Step 2g: Check Commissioning Mode (_CM) subtype _CM must be present"
+    - label:
+          "Step 2g: Check Commissioning Mode (_CM) subtype _CM must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionableByCommissioningMode"
 
@@ -320,7 +323,8 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label: "Step 2q: If (MCORE.SC.RI_KEY ) present, key RI must include the
+    - label:
+          "Step 2q: If (MCORE.SC.RI_KEY ) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -332,7 +336,8 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label: "Step 2r: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label:
+          "Step 2r: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -344,7 +349,8 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label: "Step 2s: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label:
+          "Step 2s: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -355,7 +361,8 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label: "Step 2t: DUT must publish AAAA records for each IPv6 address upon
+    - label:
+          "Step 2t: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages."
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -473,7 +480,8 @@ tests:
                 value: "y"
 
     #validate the service type and the service domain not implemented in CI
-    - label: "Step 4c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
+    - label:
+          "Step 4c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
           target hostname is derived from the 48bit or 64bit MAC address
           expressed as a twelve or sixteen capital letter hex string"
       PICS: "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR"
@@ -488,7 +496,8 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label: "Step 4c: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label:
+          "Step 4c: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC address expressed as a twelve or
           sixteen capital letter hex string"
       PICS: "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR"
@@ -531,7 +540,8 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label: "Step 4g: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label:
+          "Step 4g: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -626,7 +636,8 @@ tests:
                 constraints:
                     maxValue: 65535
 
-    - label: "Step 4o: TXT key for commissioning mode (CM) key CM=1 must be present"
+    - label:
+          "Step 4o: TXT key for commissioning mode (CM) key CM=1 must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
       response:
@@ -658,7 +669,8 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label: "Step 4r: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label:
+          "Step 4r: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -670,7 +682,8 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label: "Step 4s: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label:
+          "Step 4s: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -682,7 +695,8 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label: "Step 4t: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label:
+          "Step 4t: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -693,7 +707,8 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label: "Step 4u: DUT must publish AAAA records for each IPv6 address upon
+    - label:
+          "Step 4u: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages."
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -791,7 +806,8 @@ tests:
               - name: "ms"
                 value: waitAfterCommissioning
 
-    - label: "Step 7a: DNS-SD instance name must be 64-bit randomly selected ID
+    - label:
+          "Step 7a: DNS-SD instance name must be 64-bit randomly selected ID
           expressed as a sixteen-char hex string with capital letters"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -823,7 +839,8 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label: "Step 7b: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label:
+          "Step 7b: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC extended address expressed as a
           twelve or sixteen capital letter hex string."
       # On macOS the hostname is the device name and because of it this test is disabled for now.
@@ -867,7 +884,8 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label: "Step 7f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label:
+          "Step 7f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -906,7 +924,8 @@ tests:
               - name: "productId"
                 value: productId
 
-    - label: "Step 7j: Optional TXT key for MRP Retry Interval Idle. if
+    - label:
+          "Step 7j: Optional TXT key for MRP Retry Interval Idle. if
           (MCORE.SC.SII_OP_DISCOVERY_KEY) present, SII key must be an unsigned
           integer with units of milliseconds and shall be encoded as a variable
           length decimal number in ASCII, omitting leading zeros. Shall not
@@ -920,7 +939,8 @@ tests:
                 constraints:
                     maxValue: 3600000
 
-    - label: "Step 7k: Optional TXT key for MRP Retry Interval Active. if
+    - label:
+          "Step 7k: Optional TXT key for MRP Retry Interval Active. if
           (MCORE.SC.SAI_OP_DISCOVERY_KEY) present, SAI key must be an unsigned
           integer with units of milliseconds and shall be encoded as a variable
           length decimal number in ASCII, omitting leading zeros. Shall not
@@ -934,11 +954,12 @@ tests:
                 constraints:
                     maxValue: 3600000
 
-    - label: "Step 7l: Optional TXT key for MRP Retry Active Mode Threshold.
-          If (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be
-          an unsigned integer with units of milliseconds and shall be encoded as
-          a variable length decimal number in ASCII, omitting leading zeros.
-          Shall not exceed 65535."
+    - label:
+          "Step 7l: Optional TXT key for MRP Retry Active Mode Threshold. If
+          (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be an unsigned
+          integer with units of milliseconds and shall be encoded as a variable
+          length decimal number in ASCII, omitting leading zeros. Shall not
+          exceed 65535."
       PICS: MCORE.SC.SAI_OP_DISCOVERY_KEY
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -980,7 +1001,8 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label: "Step 7p: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label:
+          "Step 7p: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -992,7 +1014,8 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label: "Step 7q: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label:
+          "Step 7q: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -1004,7 +1027,8 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label: "Step 7r: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label:
+          "Step 7r: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -1015,7 +1039,8 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label: "Step 7s: DUT must publish AAAA records for each IPv6 address upon
+    - label:
+          "Step 7s: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1092,11 +1117,13 @@ tests:
 
     #validate the service type and the service domain
 
-    - label: "Step 10c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
+    - label:
+          "Step 10c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
           target hostname is derived from the 48bit or 64bit MAC address
           expressed as a twelve or sixteen capital letter hex string"
       # On macOS the hostname is the device name and because of it this test is disabled for now.
-      PICS: "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR &&
+      PICS:
+          "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR &&
           MCORE.SC.EXTENDED_DISCOVERY"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1109,11 +1136,13 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label: "Step 10c: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label:
+          "Step 10c: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC extended address expressed as a
           twelve or sixteen capital letter hex string."
       # On macOS the hostname is the device name and because of it this test is disabled for now.
-      PICS: "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR &&
+      PICS:
+          "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR &&
           MCORE.SC.EXTENDED_DISCOVERY"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1255,7 +1284,8 @@ tests:
                 constraints:
                     maxValue: 65535
 
-    - label: "Step 10o: TXT key for commissioning mode (CM), CM=0 may be present"
+    - label:
+          "Step 10o: TXT key for commissioning mode (CM), CM=0 may be present"
       PICS: MCORE.SC.EXTENDED_DISCOVERY
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1264,7 +1294,8 @@ tests:
               - name: "commissioningMode"
                 value: 0
 
-    - label: "Step 10p: If (MCORE.SC.DT_KEY) present, DT key must contain the
+    - label:
+          "Step 10p: If (MCORE.SC.DT_KEY) present, DT key must contain the
           device type identifier from Data Model Device Types and must be
           encoded as a variable length decimal ASCII number without leading
           zeros"
@@ -1276,7 +1307,8 @@ tests:
               - name: "deviceType"
                 value: deviceType
 
-    - label: "Step 10q: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8
+    - label:
+          "Step 10q: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8
           encoded string with a maximum length of 32B"
       PICS: MCORE.SC.DN_KEY && MCORE.SC.EXTENDED_DISCOVERY
       cluster: "DiscoveryCommands"
@@ -1287,7 +1319,8 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label: "Step 10r: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label:
+          "Step 10r: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY && MCORE.SC.EXTENDED_DISCOVERY

--- a/src/app/tests/suites/certification/Test_TC_SC_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_1.yaml
@@ -53,8 +53,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label:
-          "Step 1a: DUT is put in Commissioning Mode using Open Basic
+    - label: "Step 1a: DUT is put in Commissioning Mode using Open Basic
           Commissioning Window command "
       cluster: "Administrator Commissioning"
       command: "OpenBasicCommissioningWindow"
@@ -195,8 +194,7 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label:
-          "Step 2f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label: "Step 2f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -208,8 +206,7 @@ tests:
               - name: "value"
                 value: deviceType
 
-    - label:
-          "Step 2g: Check Commissioning Mode (_CM) subtype _CM must be present"
+    - label: "Step 2g: Check Commissioning Mode (_CM) subtype _CM must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionableByCommissioningMode"
 
@@ -277,7 +274,21 @@ tests:
                 constraints:
                     maxValue: 3600000
 
-    - label: "Step 2m: TXT key for commissioning mode (CM) CM=1 must be present"
+    - label:
+          "Step 2m: If (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be
+          an unsigned integer with units of milliseconds and shall be encoded as
+          a variable length decimal number in ASCII, omitting leading zeros.
+          Shall not exceed 65535."
+      PICS: MCORE.SC.SAI_OP_DISCOVERY_KEY
+      cluster: "DiscoveryCommands"
+      command: "FindCommissionable"
+      response:
+          values:
+              - name: "mrpRetryActiveThreshold"
+                constraints:
+                    maxValue: 65535
+
+    - label: "Step 2n: TXT key for commissioning mode (CM) CM=1 must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
       response:
@@ -286,7 +297,7 @@ tests:
                 value: 1
 
     - label:
-          "Step 2n: If (MCORE.SC.DT_KEY) present, DT key must contain the device
+          "Step 2o: If (MCORE.SC.DT_KEY) present, DT key must contain the device
           type identifier from Data Model Device Types and must be encoded as a
           variable length decimal ASCII number without leading zeros"
       PICS: MCORE.SC.DT_KEY
@@ -298,7 +309,7 @@ tests:
                 value: deviceType
 
     - label:
-          "Step 2o: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
+          "Step 2p: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
           string with a maximum length of 32B"
       PICS: MCORE.SC.DN_KEY
       cluster: "DiscoveryCommands"
@@ -309,8 +320,7 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label:
-          "Step 2p: If (MCORE.SC.RI_KEY ) present, key RI must include the
+    - label: "Step 2q: If (MCORE.SC.RI_KEY ) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -322,8 +332,7 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label:
-          "Step 2q: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label: "Step 2r: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -335,8 +344,7 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label:
-          "Step 2r: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label: "Step 2s: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -347,8 +355,7 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label:
-          "Step 2s: DUT must publish AAAA records for each IPv6 address upon
+    - label: "Step 2t: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages."
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -466,8 +473,7 @@ tests:
                 value: "y"
 
     #validate the service type and the service domain not implemented in CI
-    - label:
-          "Step 4c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
+    - label: "Step 4c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
           target hostname is derived from the 48bit or 64bit MAC address
           expressed as a twelve or sixteen capital letter hex string"
       PICS: "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR"
@@ -482,8 +488,7 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label:
-          "Step 4c: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label: "Step 4c: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC address expressed as a twelve or
           sixteen capital letter hex string"
       PICS: "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR"
@@ -526,8 +531,7 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label:
-          "Step 4g: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label: "Step 4g: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -609,7 +613,20 @@ tests:
                     maxValue: 3600000
 
     - label:
-          "Step 4n: TXT key for commissioning mode (CM) key CM=1 must be present"
+          "Step 4n: If (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be
+          an unsigned integer with units of milliseconds and shall be encoded as
+          a variable length decimal number in ASCII, omitting leading zeros.
+          Shall not exceed 65535."
+      PICS: MCORE.SC.SAI_OP_DISCOVERY_KEY
+      cluster: "DiscoveryCommands"
+      command: "FindCommissionable"
+      response:
+          values:
+              - name: "mrpRetryActiveThreshold"
+                constraints:
+                    maxValue: 65535
+
+    - label: "Step 4o: TXT key for commissioning mode (CM) key CM=1 must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
       response:
@@ -618,7 +635,7 @@ tests:
                 value: 1
 
     - label:
-          "Step 4o: If (MCORE.SC.DT_KEY) present, DT key must contain the device
+          "Step 4p: If (MCORE.SC.DT_KEY) present, DT key must contain the device
           type identifier from Data Model Device Types and must be encoded as a
           variable length decimal ASCII number without leading zeros"
       PICS: MCORE.SC.DT_KEY
@@ -630,7 +647,7 @@ tests:
                 value: deviceType
 
     - label:
-          "Step 4p: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
+          "Step 4q: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
           string with a maximum length of 32B"
       PICS: MCORE.SC.DN_KEY
       cluster: "DiscoveryCommands"
@@ -641,8 +658,7 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label:
-          "Step 4q: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label: "Step 4r: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -654,8 +670,7 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label:
-          "Step 4r: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label: "Step 4s: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -667,8 +682,7 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label:
-          "Step 4s: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label: "Step 4t: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -679,8 +693,7 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label:
-          "Step 4t: DUT must publish AAAA records for each IPv6 address upon
+    - label: "Step 4u: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages."
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -778,8 +791,7 @@ tests:
               - name: "ms"
                 value: waitAfterCommissioning
 
-    - label:
-          "Step 7a: DNS-SD instance name must be 64-bit randomly selected ID
+    - label: "Step 7a: DNS-SD instance name must be 64-bit randomly selected ID
           expressed as a sixteen-char hex string with capital letters"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -811,8 +823,7 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label:
-          "Step 7b: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label: "Step 7b: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC extended address expressed as a
           twelve or sixteen capital letter hex string."
       # On macOS the hostname is the device name and because of it this test is disabled for now.
@@ -856,8 +867,7 @@ tests:
               - name: "value"
                 value: vendorId
 
-    - label:
-          "Step 7f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
+    - label: "Step 7f: If (MCORE.SC.DEVTYPE_SUBTYPE) present, subtype _T<ddd> is
           present, <ddd> represents device type from Data Model and must be
           represented as a variable length decimal number in ASCII without
           leading zeros"
@@ -896,8 +906,7 @@ tests:
               - name: "productId"
                 value: productId
 
-    - label:
-          "Step 7j: Optional TXT key for MRP Retry Interval Idle. if
+    - label: "Step 7j: Optional TXT key for MRP Retry Interval Idle. if
           (MCORE.SC.SII_OP_DISCOVERY_KEY) present, SII key must be an unsigned
           integer with units of milliseconds and shall be encoded as a variable
           length decimal number in ASCII, omitting leading zeros. Shall not
@@ -911,8 +920,7 @@ tests:
                 constraints:
                     maxValue: 3600000
 
-    - label:
-          "Step 7k: Optional TXT key for MRP Retry Interval Active. if
+    - label: "Step 7k: Optional TXT key for MRP Retry Interval Active. if
           (MCORE.SC.SAI_OP_DISCOVERY_KEY) present, SAI key must be an unsigned
           integer with units of milliseconds and shall be encoded as a variable
           length decimal number in ASCII, omitting leading zeros. Shall not
@@ -926,7 +934,21 @@ tests:
                 constraints:
                     maxValue: 3600000
 
-    - label: "Step 7l: TXT key for commissioning mode. CM=2 must be present"
+    - label: "Step 7l: Optional TXT key for MRP Retry Active Mode Threshold.
+          If (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be
+          an unsigned integer with units of milliseconds and shall be encoded as
+          a variable length decimal number in ASCII, omitting leading zeros.
+          Shall not exceed 65535."
+      PICS: MCORE.SC.SAI_OP_DISCOVERY_KEY
+      cluster: "DiscoveryCommands"
+      command: "FindCommissionable"
+      response:
+          values:
+              - name: "mrpRetryActiveThreshold"
+                constraints:
+                    maxValue: 65535
+
+    - label: "Step 7m: TXT key for commissioning mode. CM=2 must be present"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
       response:
@@ -935,7 +957,7 @@ tests:
                 value: 2
 
     - label:
-          "Step 7m: If (MCORE.SC.DT_KEY) present, DT key must contain the device
+          "Step 7n: If (MCORE.SC.DT_KEY) present, DT key must contain the device
           type identifier from Data Model Device Types and must be encoded as a
           variable length decimal ASCII number without leading zeros"
       PICS: MCORE.SC.DT_KEY
@@ -947,7 +969,7 @@ tests:
                 value: deviceType
 
     - label:
-          "Step 7n: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
+          "Step 7o: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8 encoded
           string with a maximum length of 32B"
       PICS: MCORE.SC.DN_KEY
       cluster: "DiscoveryCommands"
@@ -958,8 +980,7 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label:
-          "Step 7o: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label: "Step 7p: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY
@@ -971,8 +992,7 @@ tests:
                 constraints:
                     maxValue: 100
 
-    - label:
-          "Step 7p: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+    - label: "Step 7q: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY
@@ -984,8 +1004,7 @@ tests:
                 constraints:
                     notValue: 0
 
-    - label:
-          "Step 7q: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+    - label: "Step 7r: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY
       cluster: "DiscoveryCommands"
@@ -996,8 +1015,7 @@ tests:
                 constraints:
                     maxLength: 128
 
-    - label:
-          "Step 7r: DUT must publish AAAA records for each IPv6 address upon
+    - label: "Step 7s: DUT must publish AAAA records for each IPv6 address upon
           which they are willing to accept Matter messages"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1074,13 +1092,11 @@ tests:
 
     #validate the service type and the service domain
 
-    - label:
-          "Step 10c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
+    - label: "Step 10c: Check Hostname. If (MCORE.COM.WIFI) OR (MCORE.COM.ETH)
           target hostname is derived from the 48bit or 64bit MAC address
           expressed as a twelve or sixteen capital letter hex string"
       # On macOS the hostname is the device name and because of it this test is disabled for now.
-      PICS:
-          "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR &&
+      PICS: "(MCORE.COM.WIFI || MCORE.COM.ETH) && !MCORE.COM.THR &&
           MCORE.SC.EXTENDED_DISCOVERY"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1093,13 +1109,11 @@ tests:
                     isUpperCase: true
                     isHexString: true
 
-    - label:
-          "Step 10c: Check Hostname. If (MCORE.COM.THR) target hostname is
+    - label: "Step 10c: Check Hostname. If (MCORE.COM.THR) target hostname is
           derived from the 48bit or 64bit MAC extended address expressed as a
           twelve or sixteen capital letter hex string."
       # On macOS the hostname is the device name and because of it this test is disabled for now.
-      PICS:
-          "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR &&
+      PICS: "(!MCORE.COM.WIFI && !MCORE.COM.ETH) && MCORE.COM.THR &&
           MCORE.SC.EXTENDED_DISCOVERY"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1228,7 +1242,20 @@ tests:
                     maxValue: 3600000
 
     - label:
-          "Step 10n: TXT key for commissioning mode (CM), CM=0 may be present"
+          "Step 10n: If (MCORE.SC.SAT_OP_DISCOVERY_KEY) present, SAT key must be
+          an unsigned integer with units of milliseconds and shall be encoded as
+          a variable length decimal number in ASCII, omitting leading zeros.
+          Shall not exceed 65535."
+      PICS: MCORE.SC.SAI_OP_DISCOVERY_KEY
+      cluster: "DiscoveryCommands"
+      command: "FindCommissionable"
+      response:
+          values:
+              - name: "mrpRetryActiveThreshold"
+                constraints:
+                    maxValue: 65535
+
+    - label: "Step 10o: TXT key for commissioning mode (CM), CM=0 may be present"
       PICS: MCORE.SC.EXTENDED_DISCOVERY
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -1237,8 +1264,7 @@ tests:
               - name: "commissioningMode"
                 value: 0
 
-    - label:
-          "Step 10o: If (MCORE.SC.DT_KEY) present, DT key must contain the
+    - label: "Step 10p: If (MCORE.SC.DT_KEY) present, DT key must contain the
           device type identifier from Data Model Device Types and must be
           encoded as a variable length decimal ASCII number without leading
           zeros"
@@ -1250,8 +1276,7 @@ tests:
               - name: "deviceType"
                 value: deviceType
 
-    - label:
-          "Step 10p: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8
+    - label: "Step 10q: If (MCORE.SC.DN_KEY) present, DN key must be a UTF-8
           encoded string with a maximum length of 32B"
       PICS: MCORE.SC.DN_KEY && MCORE.SC.EXTENDED_DISCOVERY
       cluster: "DiscoveryCommands"
@@ -1262,8 +1287,7 @@ tests:
                 constraints:
                     maxLength: 32
 
-    - label:
-          "Step 10q: If (MCORE.SC.RI_KEY) present, key RI must include the
+    - label: "Step 10r: If (MCORE.SC.RI_KEY) present, key RI must include the
           Rotating Device Identifier encoded as a uppercase string with a
           maximum length of 100 chars"
       PICS: MCORE.SC.RI_KEY && MCORE.SC.EXTENDED_DISCOVERY
@@ -1276,7 +1300,7 @@ tests:
                     maxValue: 100
 
     - label:
-          "Step 10r: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
+          "Step 10s: If (MCORE.SC.PH_KEY) present, key PH must be encoded as a
           variable-length decimal number in ASCII text, omitting any leading
           zeros. If present value must be different of 0"
       PICS: MCORE.SC.PH_KEY && MCORE.SC.EXTENDED_DISCOVERY
@@ -1289,7 +1313,7 @@ tests:
                     notValue: 0
 
     - label:
-          "Step 10s: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
+          "Step 10t: If (MCORE.SC.PI_KEY) present, key PI must be encoded as a
           valid UTF-8 string with a maximum length of 128 bytes"
       PICS: MCORE.SC.PI_KEY && MCORE.SC.EXTENDED_DISCOVERY
       cluster: "DiscoveryCommands"

--- a/src/app/tests/suites/certification/Test_TC_SC_4_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_10.yaml
@@ -13,12 +13,11 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name:
-    15.4.10. [TC-SC-4.10] Operational Discovery - Sleepy Node [DUT as
-    Commissionee]
+name: 15.4.10. [TC-SC-4.10] Operational Discovery - SIT ICD Node [{DUT_Commissionee}]
 
 PICS:
     - MCORE.ROLE.COMMISSIONEE
+    - MCORE.SC.SIT_ICD
 
 config:
     nodeId: 0x12344321
@@ -41,10 +40,13 @@ tests:
              hostname = [D21165B5F440B033.local]
              address = [fd11:22::4b31:9932:cffe:b41a]
              port = [5540]
-             txt = ["T=0" "SAI=300" "SII=5000"]
+             txt = ["T=0" "SAI=300" "SII=5000" "SAT=4000"]
           =   eth0 IPv6 3A235FF3FA2DAC10-0000000000000055             _matter._tcp         local
              hostname = [D21165B5F440B033.local]
              address = [fd11:22::4b31:9932:cffe:b41a]
              port = [5540]
              txt = ["T=0" "SAI=300" "SII=5000"]
+
+           - SII key is higher than the SESSION_IDLE_INTERVAL default value (> 300 milliseconds)
+           - SII key and SAI key is less than 3600000 (1hour in milliseconds)
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_SC_4_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_10.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 # Auto-generated scripts for harness use only, please review before automation. The endpoints and cluster names are currently set to default
 
-name: 15.4.10. [TC-SC-4.10] Operational Discovery - SIT ICD Node [{DUT_Commissionee}]
+name:
+    15.4.10. [TC-SC-4.10] Operational Discovery - SIT ICD Node
+    [{DUT_Commissionee}]
 
 PICS:
     - MCORE.ROLE.COMMISSIONEE


### PR DESCRIPTION
#### Description 
PR updates IDM and SC tests scripts to match test plan and specification

* Add steps for the Session Active Threshold Discovery Key
* Replace SED by Short Idle Time ICD for the yaml tests
* Update Terminology to match specification
