### PR TITLE
[Silabs] Move declare_args to gni in examples platform

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -22,37 +22,8 @@ import("${efr32_sdk_build_root}/SiWx917_sdk.gni")
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
 wifi_sdk_dir = "${chip_root}/src/platform/silabs/SiWx917/wifi"
 
-declare_args() {
-  enable_heap_monitoring = false
-
-  # OTA timeout in seconds
-  ota_periodic_query_timeout_sec = 86400
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to force enable WPA3 security on rs91x
-  rs91x_wpa3_transition = false
-
-  # use commissionable data for SiWx917
-  siwx917_commissionable_data = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-
-  # Enable TestEventTrigger in GeneralDiagnostics cluster
-  silabs_test_event_trigger_enabled = false
-
-  # The EnableKey in hex string format used by TestEventTrigger command in
-  # GeneralDiagnostics cluster. The length of the string should be 32.
-  silabs_test_event_trigger_enable_key = "00112233445566778899aabbccddeeff"
-}
-
 import("${chip_root}/src/platform/silabs/wifi_args.gni")
+import("${silabs_common_plat_dir}/SiWx917/args.gni")
 import("${silabs_common_plat_dir}/args.gni")
 
 # Sanity check

--- a/examples/platform/silabs/SiWx917/args.gni
+++ b/examples/platform/silabs/SiWx917/args.gni
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  enable_heap_monitoring = false
+
+  # OTA timeout in seconds
+  ota_periodic_query_timeout_sec = 86400
+
+  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
+  sl_wfx_config_softap = false
+  sl_wfx_config_scan = true
+
+  # Argument to force enable WPA3 security on rs91x
+  rs91x_wpa3_transition = false
+
+  # use commissionable data for SiWx917
+  siwx917_commissionable_data = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
+
+  # Enable TestEventTrigger in GeneralDiagnostics cluster
+  silabs_test_event_trigger_enabled = false
+
+  # The EnableKey in hex string format used by TestEventTrigger command in
+  # GeneralDiagnostics cluster. The length of the string should be 32.
+  silabs_test_event_trigger_enable_key = "00112233445566778899aabbccddeeff"
+}

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -15,45 +15,15 @@
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
-import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
 import("${efr32_sdk_build_root}/silabs_board.gni")
 
-declare_args() {
-  enable_heap_monitoring = false
-
-  # OTA timeout in seconds
-  ota_periodic_query_timeout_sec = 86400
-
-  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
-  sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
-
-  # Argument to force enable WPA3 security on rs91x
-  rs91x_wpa3_transition = false
-
-  #default WiFi SSID
-  chip_default_wifi_ssid = ""
-
-  #default Wifi Password
-  chip_default_wifi_psk = ""
-
-  # Use default handler to negotiate subscription max interval
-  chip_config_use_icd_subscription_callbacks = chip_enable_icd_server
-
-  # Enable TestEventTrigger in GeneralDiagnostics cluster
-  silabs_test_event_trigger_enabled = false
-
-  # The EnableKey in hex string format used by TestEventTrigger command in
-  # GeneralDiagnostics cluster. The length of the string should be 32.
-  silabs_test_event_trigger_enable_key = "00112233445566778899aabbccddeeff"
-}
-
 silabs_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
 import("${silabs_common_plat_dir}/args.gni")
+import("${silabs_common_plat_dir}/efr32/args.gni")
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))

--- a/examples/platform/silabs/efr32/args.gni
+++ b/examples/platform/silabs/efr32/args.gni
@@ -1,0 +1,46 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/icd/icd.gni")
+
+declare_args() {
+  enable_heap_monitoring = false
+
+  # OTA timeout in seconds
+  ota_periodic_query_timeout_sec = 86400
+
+  # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
+  sl_wfx_config_softap = false
+  sl_wfx_config_scan = true
+
+  # Argument to force enable WPA3 security on rs91x
+  rs91x_wpa3_transition = false
+
+  #default WiFi SSID
+  chip_default_wifi_ssid = ""
+
+  #default Wifi Password
+  chip_default_wifi_psk = ""
+
+  # Use default handler to negotiate subscription max interval
+  chip_config_use_icd_subscription_callbacks = chip_enable_icd_server
+
+  # Enable TestEventTrigger in GeneralDiagnostics cluster
+  silabs_test_event_trigger_enabled = false
+
+  # The EnableKey in hex string format used by TestEventTrigger command in
+  # GeneralDiagnostics cluster. The length of the string should be 32.
+  silabs_test_event_trigger_enable_key = "00112233445566778899aabbccddeeff"
+}


### PR DESCRIPTION
Fixes #28194