### PR TITLE
[ci] Fix bloat-check after ghapi update to 1.0.4

### DIFF
--- a/scripts/tools/memory/memdf/util/github.py
+++ b/scripts/tools/memory/memdf/util/github.py
@@ -130,7 +130,7 @@ class Gh:
             page = 0
             for i in ghapi.all.paged(
                     self.ghapi.actions.list_artifacts_for_repo,
-                    per_page):
+                    per_page=per_page):
                 if not i.artifacts:
                     break
                 for a in i.artifacts:


### PR DESCRIPTION
per_page argument was passed as a positional argument to list_artifacts_for_repo action, which stopped working after a new argument has been added to the action in ghapi 1.0.4.
