### PR TITLE
Removed zap development install from `chip-cert-bins` docker image. 

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -5,11 +5,6 @@ ARG TARGETPLATFORM
 # COMMITHASH defines the target commit to build from. May be passed in using --build-arg.
 ARG COMMITHASH=7b99e6399c6069037c613782d78132c69b9dcabb
 
-# ZAP Development install, so that it runs on both x64 and arm64
-# Generally this should match with the ZAP version that is used for codegen within the
-# specified SHA
-ARG ZAP_VERSION=v2023.07.21-nightly
-
 # Ensure TARGETPLATFORM is set
 RUN case ${TARGETPLATFORM} in \
     "linux/amd64") \
@@ -156,45 +151,6 @@ RUN set -x \
     && cd ../.. \
     && rm -rf bloaty \
     && : # last line
-
-# NodeJS: install a newer version than what apt-get would read
-# This installs the latest LTS version of nodejs
-RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") \
-    set -x \
-    && mkdir node_js \
-    && cd node_js \
-    && wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz \
-    && tar xfvJ node-v12.22.12-linux-x64.tar.xz \
-    && mv node-v12.22.12-linux-x64 /opt/ \
-    && ln -s /opt/node-v12.22.12-linux-x64 /opt/node \
-    && ln -s /opt/node/bin/* /usr/bin \
-    && cd .. \
-    && rm -rf node_js \
-    ;; \
-    "linux/arm64")\
-    set -x \
-    && mkdir node_js \
-    && cd node_js \
-    && wget https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-arm64.tar.xz \
-    && tar xfvJ node-v12.22.12-linux-arm64.tar.xz \
-    && mv node-v12.22.12-linux-arm64 /opt/ \
-    && ln -s /opt/node-v12.22.12-linux-arm64 /opt/node \
-    && ln -s /opt/node/bin/* /usr/bin \
-    && cd .. \
-    && rm -rf node_js \
-    ;; \
-    *) ;; \
-    esac
-
-RUN set -x \
-    && mkdir -p /opt/zap-${ZAP_VERSION} \
-    && git clone https://github.com/project-chip/zap.git /opt/zap-${ZAP_VERSION} \
-    && cd /opt/zap-${ZAP_VERSION} \
-    && git checkout ${ZAP_VERSION} \
-    && npm config set user 0 \
-    && npm ci
-ENV ZAP_DEVELOPMENT_PATH=/opt/zap-${ZAP_VERSION}
 
 # Stage 1.5: Bootstrap Matter.
 RUN mkdir /root/connectedhomeip


### PR DESCRIPTION
Removed `nodejs`, `npm` and the development install of `zap` in the `chip-cert-bins` docker image. 

These can be removed now that `zap` is available as arm64 binaries, and bootstrap will take care of installing it."

Manually verified that `chip-cert-bins` docker image still builds. 

