### PR TITLE
Enable events within Switch cluster in all-clusters-app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -6549,6 +6549,12 @@ endpoint 1 {
 
   server cluster Switch {
     emits event SwitchLatched;
+    emits event InitialPress;
+    emits event LongPress;
+    emits event ShortRelease;
+    emits event LongRelease;
+    emits event MultiPressOngoing;
+    emits event MultiPressComplete;
     ram      attribute numberOfPositions default = 2;
     ram      attribute currentPosition;
     ram      attribute multiPressMax default = 2;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -6553,8 +6553,6 @@ endpoint 1 {
     emits event LongPress;
     emits event ShortRelease;
     emits event LongRelease;
-    emits event MultiPressOngoing;
-    emits event MultiPressComplete;
     ram      attribute numberOfPositions default = 2;
     ram      attribute currentPosition;
     ram      attribute multiPressMax default = 2;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -13022,20 +13022,6 @@
               "mfgCode": null,
               "side": "server",
               "included": 1
-            },
-            {
-              "name": "MultiPressOngoing",
-              "code": 5,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "MultiPressComplete",
-              "code": 6,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
             }
           ]
         },

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -12994,6 +12994,48 @@
               "mfgCode": null,
               "side": "server",
               "included": 1
+            },
+            {
+              "name": "InitialPress",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "LongPress",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "ShortRelease",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "LongRelease",
+              "code": 4,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "MultiPressOngoing",
+              "code": 5,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "MultiPressComplete",
+              "code": 6,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
             }
           ]
         },


### PR DESCRIPTION
Enable events within Switch cluster from zap in all-clusters-app, we have already implemented the logic to trigger and handle those events in all-clusters-app

