### PR TITLE
Add another clean-output since CI seems to run out of space on builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,6 +201,8 @@ jobs:
                        --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/' \
                        check \
                     "
+            - name: Clean output
+              run: rm -rf ./out
             - name: Build using build_examples.py
               run: |
                   ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
We seem to have several 'out of space' errors in master CI, like:

https://github.com/project-chip/connectedhomeip/actions/runs/5646168381/job/15293483651


This attempts to do some more cleanup before attempting more builds.