### PR TITLE
Enable missing attribute and events of Switch cluster in lightning app

### DIFF
--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1551,7 +1551,6 @@ server cluster Switch = 59 {
 
   readonly attribute int8u numberOfPositions = 0;
   readonly attribute int8u currentPosition = 1;
-  readonly attribute int8u multiPressMax = 2;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -2360,11 +2359,8 @@ endpoint 0 {
     emits event LongPress;
     emits event ShortRelease;
     emits event LongRelease;
-    emits event MultiPressOngoing;
-    emits event MultiPressComplete;
     ram      attribute numberOfPositions default = 2;
     ram      attribute currentPosition;
-    ram      attribute multiPressMax default = 2;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1551,6 +1551,7 @@ server cluster Switch = 59 {
 
   readonly attribute int8u numberOfPositions = 0;
   readonly attribute int8u currentPosition = 1;
+  readonly attribute int8u multiPressMax = 2;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -2354,8 +2355,16 @@ endpoint 0 {
   }
 
   server cluster Switch {
+    emits event SwitchLatched;
+    emits event InitialPress;
+    emits event LongPress;
+    emits event ShortRelease;
+    emits event LongRelease;
+    emits event MultiPressOngoing;
+    emits event MultiPressComplete;
     ram      attribute numberOfPositions default = 2;
     ram      attribute currentPosition;
+    ram      attribute multiPressMax default = 2;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -2355,10 +2355,6 @@ endpoint 0 {
 
   server cluster Switch {
     emits event SwitchLatched;
-    emits event InitialPress;
-    emits event LongPress;
-    emits event ShortRelease;
-    emits event LongRelease;
     ram      attribute numberOfPositions default = 2;
     ram      attribute currentPosition;
     ram      attribute featureMap default = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -3978,22 +3978,6 @@
               "reportableChange": 0
             },
             {
-              "name": "MultiPressMax",
-              "code": 2,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int8u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "2",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -4058,20 +4042,6 @@
             {
               "name": "LongRelease",
               "code": 4,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "MultiPressOngoing",
-              "code": 5,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "MultiPressComplete",
-              "code": 6,
               "mfgCode": null,
               "side": "server",
               "included": 1

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -4017,34 +4017,6 @@
               "mfgCode": null,
               "side": "server",
               "included": 1
-            },
-            {
-              "name": "InitialPress",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "LongPress",
-              "code": 2,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "ShortRelease",
-              "code": 3,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            },
-            {
-              "name": "LongRelease",
-              "code": 4,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
             }
           ]
         },

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -3978,6 +3978,22 @@
               "reportableChange": 0
             },
             {
+              "name": "MultiPressMax",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int8u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "2",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -4008,6 +4024,57 @@
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
+            }
+          ],
+          "events": [
+            {
+              "name": "SwitchLatched",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "InitialPress",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "LongPress",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "ShortRelease",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "LongRelease",
+              "code": 4,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "MultiPressOngoing",
+              "code": 5,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
+            },
+            {
+              "name": "MultiPressComplete",
+              "code": 6,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
             }
           ]
         },


### PR DESCRIPTION
Enable missing attribute and events of Switch cluster in lightning app.

It looks we can use those events even without enabling them in zap now, but it is better to enable them explicitly in case cogdegen enforce check on zap later.

