### PR TITLE
Add RVC device type to XML + fix RVC Clean/Run XML issue

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1990,6 +1990,24 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-robotic-vacuum-cleaner</name>
+        <domain>CHIP</domain>
+        <typeName>Matter Robotic Vacuum Cleaner</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0074</deviceId>
+        <clusters lockOthers="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>IDENTIFY_TIME</requireAttribute>
+                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
+                <requireCommand>Identify</requireCommand>
+            </include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="RVC Run Mode" client="false" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="RVC Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-temperature-controlled-cabinet</name>
         <domain>CHIP</domain>
         <typeName>Matter Temperature Controlled Cabinet</typeName>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1997,12 +1997,9 @@ limitations under the License.
         <deviceId editable="false">0x0074</deviceId>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>IDENTIFY_TIME</requireAttribute>
-                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
-                <requireCommand>Identify</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="RVC Run Mode" client="false" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="RVC Run Mode" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="RVC Clean Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="RVC Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
@@ -30,7 +30,7 @@ limitations under the License.
   </enum>
 
   <cluster>
-    <domain>General</domain>
+    <domain>Robots</domain>
     <name>RVC Clean Mode</name>
     <code>0x0055</code>
     <define>RVC_CLEAN_MODE_CLUSTER</define>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -36,7 +36,7 @@ limitations under the License.
   </enum>
 
   <cluster>
-    <domain>General</domain>
+    <domain>Robots</domain>
     <name>RVC Run Mode</name>
     <code>0x0054</code>
     <define>RVC_RUN_MODE_CLUSTER</define>


### PR DESCRIPTION
Add the RVC device type.

Fix a small issue - the group for the RVC Clean Mode and RVC Run Mode clusters, in the XML, was incorrect.