### PR TITLE
AppDelegate updates: new callback and docs

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -87,7 +87,7 @@ class AppCallbacks : public AppDelegate
 public:
     void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { bluetoothLED.Set(true); }
-    void OnCommissioningSessionStopped(CHIP_ERROR err) override
+    void OnCommissioningSessionStopped() override
     {
         bluetoothLED.Set(false);
         pairingWindowLED.Set(false);

--- a/examples/all-clusters-minimal-app/esp32/main/main.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/main.cpp
@@ -86,7 +86,7 @@ class AppCallbacks : public AppDelegate
 public:
     void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { bluetoothLED.Set(true); }
-    void OnCommissioningSessionStopped(CHIP_ERROR err) override
+    void OnCommissioningSessionStopped() override
     {
         bluetoothLED.Set(false);
         pairingWindowLED.Set(false);

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -140,7 +140,7 @@ class AppCallbacks : public AppDelegate
 public:
     void OnCommissioningSessionEstablishmentStarted() {}
     void OnCommissioningSessionStarted() override { isComissioningStarted = true; }
-    void OnCommissioningSessionStopped(CHIP_ERROR err) override { isComissioningStarted = false; }
+    void OnCommissioningSessionStopped() override { isComissioningStarted = false; }
     void OnCommissioningWindowClosed() override
     {
         if (!isComissioningStarted)

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -39,19 +39,22 @@ public:
     virtual void OnCommissioningSessionStarted() {}
 
     /**
-     * This is called when there is an error in establishing a commissioning session (such as, when an invalid passcode is provided)
+     * This is called when the PASE establishment failed (such as, when an invalid passcode is provided) or PASE was established
+     * fine but then the fail-safe expired (including being expired by the commissioner)
      *
      * @param err CHIP_ERROR indicating the error that occurred during session establishment
      */
     virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
 
     /**
-     * This is called when the commissioning session establishment stops
+     * This is called when the PASE establishment failed or PASE was established fine but then the fail-safe expired (including
+     * being expired by the commissioner) AND the commissioning window is closed. The window may be closed because the commissioning
+     * attempts limit was reached or advertising/listening for PASE failed.
      */
     virtual void OnCommissioningSessionStopped() {}
 
     /*
-     * This is called anytime a basic or enhanced commissioning window is opened.
+     * This is called any time a basic or enhanced commissioning window is opened.
      *
      * The type of the window can be retrieved by calling
      * CommissioningWindowManager::CommissioningWindowStatusForCluster(), but
@@ -61,7 +64,7 @@ public:
     virtual void OnCommissioningWindowOpened() {}
 
     /*
-     * This is called anytime a basic or enhanced commissioning window is closed.
+     * This is called any time a basic or enhanced commissioning window is closed.
      */
     virtual void OnCommissioningWindowClosed() {}
 };

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -29,12 +29,26 @@ class AppDelegate
 public:
     virtual ~AppDelegate() {}
     /**
-     * This is called on start of session establishment process
+     * This is called when the PBKDFParamRequest is received and indicates the start of the session establishment process
      */
     virtual void OnCommissioningSessionEstablishmentStarted() {}
+
+    /**
+     * This is called when the commissioning session has been established
+     */
     virtual void OnCommissioningSessionStarted() {}
+
+    /**
+     * This is called when there is an error in establishing a commissioning session (such as, when an invalid passcode is provided)
+     *
+     * @param err CHIP_ERROR indicating the error that occurred during session establishment
+     */
     virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
-    virtual void OnCommissioningSessionStopped(CHIP_ERROR err) {}
+
+    /**
+     * This is called when the commissioning session establishment stops
+     */
+    virtual void OnCommissioningSessionStopped() {}
 
     /*
      * This is called anytime a basic or enhanced commissioning window is opened.
@@ -45,5 +59,9 @@ public:
      * fact open.
      */
     virtual void OnCommissioningWindowOpened() {}
+
+    /*
+     * This is called anytime a basic or enhanced commissioning window is closed.
+     */
     virtual void OnCommissioningWindowClosed() {}
 };

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -42,7 +42,8 @@ public:
      * This is called when the PASE establishment failed (such as, when an invalid passcode is provided) or PASE was established
      * fine but then the fail-safe expired (including being expired by the commissioner)
      *
-     * @param err CHIP_ERROR indicating the error that occurred during session establishment or the error accompanying the fail-safe timeout.
+     * @param err CHIP_ERROR indicating the error that occurred during session establishment or the error accompanying the fail-safe
+     * timeout.
      */
     virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
 

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -42,16 +42,11 @@ public:
      * This is called when there is an error in establishing a commissioning session (such as, when an invalid passcode is provided)
      *
      * @param err CHIP_ERROR indicating the error that occurred during session establishment
-     *
-     * @return true if the commissioning window should be closed, false otherwise
      */
-    virtual bool OnCommissioningSessionEstablishmentError(CHIP_ERROR err) { return false; }
+    virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
 
     /**
-     * This is called in addition to OnCommissioningSessionEstablishmentError i.e. when there is an error in establishing a
-     * commissioning session AND the commissioning window is closed. The window may be closed because
-     * OnCommissioningSessionEstablishmentError returned 'true', the commissioning attempts limit was reached or listening for PASE
-     * failed.
+     * This is called when the commissioning session establishment stops
      */
     virtual void OnCommissioningSessionStopped() {}
 

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -42,11 +42,16 @@ public:
      * This is called when there is an error in establishing a commissioning session (such as, when an invalid passcode is provided)
      *
      * @param err CHIP_ERROR indicating the error that occurred during session establishment
+     *
+     * @return true if the commissioning window should be closed, false otherwise
      */
-    virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
+    virtual bool OnCommissioningSessionEstablishmentError(CHIP_ERROR err) { return false; }
 
     /**
-     * This is called when the commissioning session establishment stops
+     * This is called in addition to OnCommissioningSessionEstablishmentError i.e. when there is an error in establishing a
+     * commissioning session AND the commissioning window is closed. The window may be closed because
+     * OnCommissioningSessionEstablishmentError returned 'true', the commissioning attempts limit was reached or listening for PASE
+     * failed.
      */
     virtual void OnCommissioningSessionStopped() {}
 

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -33,6 +33,7 @@ public:
      */
     virtual void OnCommissioningSessionEstablishmentStarted() {}
     virtual void OnCommissioningSessionStarted() {}
+    virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
     virtual void OnCommissioningSessionStopped(CHIP_ERROR err) {}
 
     /*

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -42,7 +42,7 @@ public:
      * This is called when the PASE establishment failed (such as, when an invalid passcode is provided) or PASE was established
      * fine but then the fail-safe expired (including being expired by the commissioner)
      *
-     * @param err CHIP_ERROR indicating the error that occurred during session establishment
+     * @param err CHIP_ERROR indicating the error that occurred during session establishment or the error accompanying the fail-safe timeout.
      */
     virtual void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) {}
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -151,17 +151,17 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
     mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
 
-    bool closeWindow = false;
-    if (mAppDelegate != nullptr)
-    {
-        closeWindow = mAppDelegate->OnCommissioningSessionEstablishmentError(err);
-    }
-
-    if (!closeWindow && mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
+    CHIP_ERROR prevErr = err;
+    if (mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
     {
         // If the number of commissioning attempts has not exceeded maximum
         // retries, let's start listening for commissioning connections again.
         err = AdvertiseAndListenForPASE();
+    }
+
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCommissioningSessionEstablishmentError(prevErr);
     }
 
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -151,17 +151,17 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
     mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
 
-    CHIP_ERROR prevErr = err;
-    if (mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
+    bool closeWindow = false;
+    if (mAppDelegate != nullptr)
+    {
+        closeWindow = mAppDelegate->OnCommissioningSessionEstablishmentError(err);
+    }
+
+    if (!closeWindow && mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
     {
         // If the number of commissioning attempts has not exceeded maximum
         // retries, let's start listening for commissioning connections again.
         err = AdvertiseAndListenForPASE();
-    }
-
-    if (mAppDelegate != nullptr)
-    {
-        mAppDelegate->OnCommissioningSessionEstablishmentError(prevErr);
     }
 
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -150,11 +150,19 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
 #if CONFIG_NETWORK_LAYER_BLE
     mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
+
+    CHIP_ERROR prevErr = err;
     if (mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
     {
         // If the number of commissioning attempts has not exceeded maximum
         // retries, let's start listening for commissioning connections again.
         err = AdvertiseAndListenForPASE();
+    }
+
+    if (mAppDelegate != nullptr)
+    {
+        ChipLogProgress(AppServer, "Calling mAppDelegate->OnCommissioningSessionEstablishmentError");
+        mAppDelegate->OnCommissioningSessionEstablishmentError(prevErr);
     }
 
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -161,7 +161,6 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
 
     if (mAppDelegate != nullptr)
     {
-        ChipLogProgress(AppServer, "Calling mAppDelegate->OnCommissioningSessionEstablishmentError");
         mAppDelegate->OnCommissioningSessionEstablishmentError(prevErr);
     }
 
@@ -173,7 +172,7 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
 
         if (mAppDelegate != nullptr)
         {
-            mAppDelegate->OnCommissioningSessionStopped(err);
+            mAppDelegate->OnCommissioningSessionStopped();
         }
     }
 }


### PR DESCRIPTION
Fixes bullet # 1 of https://github.com/project-chip/connectedhomeip/issues/28230

### Problem
1. We require a way to inform a client (commissionee) when and why PASE session establishment failed.
2. The change from this PR: OnCommissioningSessionStopped to add a CHIP_ERROR param to the OnCommissioningSessionStopped should be removed
3. Need more docs for AppDelegate functions

### Change summary
1. Introduced new OnCommissioningSessionEstablishmentError(err) callback
2. Removed CHIP_ERROR err param from OnCommissioningSessionStopped (and its various implementations)
3. Added docs to AppDelegate functions.