### PR TITLE
Make sure we clean up properly if StartWatchingSocket fails.

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -469,7 +469,14 @@ CHIP_ERROR UDPEndPointImplSockets::GetSocket(IPAddressType addressType)
         {
             return CHIP_ERROR_POSIX(errno);
         }
-        ReturnErrorOnFailure(static_cast<System::LayerSockets *>(&GetSystemLayer())->StartWatchingSocket(mSocket, &mWatch));
+        CHIP_ERROR err = static_cast<System::LayerSockets *>(&GetSystemLayer())->StartWatchingSocket(mSocket, &mWatch);
+        if (err != CHIP_NO_ERROR)
+        {
+            // Our mWatch is not valid; make sure we never use it.
+            close(mSocket);
+            mSocket = kInvalidSocketFd;
+            return err;
+        }
 
         mAddrType = addressType;
 


### PR DESCRIPTION
If StartWatchingSocket failed (e.g. due to us being out of socket watch pool space), we would leave the UDPEndPointImplSockets in a bad state where its destructor would try to treat the un-initialized mWatch value as a pointer.

The fix is to make sure we clean up properly on StartWatchingSocket failure.
