### PR TITLE
Factor out secure channel type definitions into a separate static library.

### DIFF
--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -92,6 +92,7 @@ static_library("credentials") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/src/protocols:type_definitions",
     "${nlassert_root}:nlassert",
   ]
 }

--- a/src/lib/format/BUILD.gn
+++ b/src/lib/format/BUILD.gn
@@ -64,6 +64,7 @@ source_set("protocol-decoder") {
     ":tlv-metadata-headers",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/protocols:type_definitions",
   ]
 
   public_configs = [ "${chip_root}/src:includes" ]

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -72,6 +72,7 @@ static_library("messaging") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/src/protocols/secure_channel:type_definitions",
     "${chip_root}/src/transport",
     "${chip_root}/src/transport/raw",
   ]

--- a/src/protocols/BUILD.gn
+++ b/src/protocols/BUILD.gn
@@ -14,6 +14,10 @@
 
 import("//build_overrides/chip.gni")
 
+source_set("type_definitions") {
+  sources = [ "Protocols.h" ]
+}
+
 static_library("protocols") {
   output_name = "libChipProtocols"
 
@@ -35,6 +39,7 @@ static_library("protocols") {
 
   public_deps = [
     ":im_status",
+    ":type_definitions",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
@@ -52,6 +57,7 @@ static_library("im_status") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    ":type_definitions",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -1,5 +1,24 @@
 import("//build_overrides/chip.gni")
 
+static_library("type_definitions") {
+  output_name = "libSecureChannelTypes"
+
+  sources = [
+    "Constants.h",
+    "StatusReport.cpp",
+    "StatusReport.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/protocols:type_definitions",
+    "${chip_root}/src/system",
+  ]
+
+  deps = [ "${chip_root}/src/lib/support" ]
+}
+
 static_library("secure_channel") {
   output_name = "libSecureChannel"
 
@@ -10,7 +29,6 @@ static_library("secure_channel") {
     "CASEServer.h",
     "CASESession.cpp",
     "CASESession.h",
-    "Constants.h",
     "DefaultSessionResumptionStorage.cpp",
     "DefaultSessionResumptionStorage.h",
     "PASESession.cpp",
@@ -24,8 +42,6 @@ static_library("secure_channel") {
     "SessionResumptionStorage.h",
     "SimpleSessionResumptionStorage.cpp",
     "SimpleSessionResumptionStorage.h",
-    "StatusReport.cpp",
-    "StatusReport.h",
     "UnsolicitedStatusHandler.cpp",
     "UnsolicitedStatusHandler.h",
   ]
@@ -33,24 +49,13 @@ static_library("secure_channel") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    ":type_definitions",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/system",
     "${chip_root}/src/tracing",
     "${chip_root}/src/tracing:macros",
-    "${chip_root}/src/transport",
-  ]
-
-  # secure channel requires messaging so it can send messages (e.g. for
-  # CASE/PASE handshakes).  messaging requires secure channel so that it can do
-  # things like send standalone acks, which are a secure channel concept.
-  #
-  # secure channel requires transport so it can deal with sessions.  transport
-  # requires secure channel so it can detect control messages, which are a
-  # secure channel concept.
-  allow_circular_includes_from = [
-    "${chip_root}/src/messaging",
     "${chip_root}/src/transport",
   ]
 }

--- a/src/setup_payload/BUILD.gn
+++ b/src/setup_payload/BUILD.gn
@@ -42,6 +42,7 @@ source_set("additional_data_payload") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/protocols:type_definitions",
     "${chip_root}/src/setup_payload:additional_data_payload_buildconfig",
   ]
 }

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -64,6 +64,7 @@ static_library("transport") {
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/src/protocols/secure_channel:type_definitions",
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/tracing",
     "${chip_root}/src/tracing:macros",


### PR DESCRIPTION
This allows us to get rid of circular includes.

