### PR TITLE
[ASR] add app/util/config.h to device manager, so that macros are visible

### DIFF
--- a/examples/platform/asr/CHIPDeviceManager.cpp
+++ b/examples/platform/asr/CHIPDeviceManager.cpp
@@ -27,6 +27,7 @@
 #include "CHIPDeviceManager.h"
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
+#include <app/util/config.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>


### PR DESCRIPTION
add #include <app/util/config.h>

Otherwise some macros will not take effect