### PR TITLE
[Telink]: Replaced manual bootloader configuration by conf file

### DIFF
--- a/config/telink/app/bootloader.conf
+++ b/config/telink/app/bootloader.conf
@@ -1,0 +1,30 @@
+#
+#   Copyright (c) 2023 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Enable this option in case if restoring the slot0 partition is expected from slot1 
+# partition in case if slot0 is not bootable or damaged
+CONFIG_BOOT_BOOTSTRAP=n
+
+# Enable this option in case if SWAP_MOVE logic need to be used
+CONFIG_BOOT_SWAP_USING_MOVE=y
+
+# Enable this option in case if SWAP_MOVE using scratch logic need to be used
+# Enabling this option expecting the availability of scratch partition in DTS
+CONFIG_BOOT_SWAP_USING_SCRATCH=n
+
+# Enable this option in case if the whole slot0 image need to be validated
+# With disabled option the only image magic is validated
+CONFIG_BOOT_VALIDATE_SLOT0=y

--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -143,11 +143,17 @@ else()
     unset(GLOBAL_DTC_OVERLAY_FILE)
 endif()
 
+if(EXISTS "${CHIP_ROOT}/config/telink/app/bootloader.conf")
+    set(GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE "${CHIP_ROOT}/config/telink/app/bootloader.conf")
+else()
+    unset(GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE)
+endif()
+
 if (CONFIG_CHIP_OTA_IMAGE_BUILD)
     add_custom_target(build_mcuboot ALL
         COMMAND
         west build -b ${BOARD} -d build_mcuboot ${ZEPHYR_BASE}/../bootloader/mcuboot/boot/zephyr
-            -- -DCONFIG_BOOT_SWAP_USING_MOVE=y -DDTC_OVERLAY_FILE=${GLOBAL_DTC_OVERLAY_FILE}
+            -- -DOVERLAY_CONFIG=${GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE} -DDTC_OVERLAY_FILE=${GLOBAL_DTC_OVERLAY_FILE}
     )
 
     add_custom_target(merge_mcuboot ALL


### PR DESCRIPTION
Replaced manual definition-based overlays by conf file

The previous solution to configure the bootloader for Telink build was just adding the definitions directly to build command.
The new solution replaces the definitions by bootloader.conf file and applies it by overlay.

