### PR TITLE
[fix]dishwasher mode select server’s file wrong dependency

### DIFF
--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -146,7 +146,7 @@
         "DEVICE_TEMP_CLUSTER": [],
         "DIAGNOSTIC_LOGS_CLUSTER": ["diagnostic-logs-server"],
         "DISHWASHER_ALARM_CLUSTER": ["dishwasher-alarm-server"],
-        "DISHWASHER_MODE_CLUSTER": ["mode-select-server"],
+        "DISHWASHER_MODE_CLUSTER": ["mode-base-server"],
         "DOOR_LOCK_CLUSTER": ["door-lock-server"],
         "ELECTRICAL_MEASUREMENT_CLUSTER": [],
         "ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER": [


### PR DESCRIPTION
issue:
Dishwasher mode select server's file wrong dependency in src/app/zap_cluster_list.json
