### PR TITLE
ICD: Monitoring table, KVS keys minimized.

### DIFF
--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -97,7 +97,7 @@ void ICDManager::UpdateIcdMode()
         for (const auto & fabricInfo : *mFabricTable)
         {
             // We only need 1 valid entry to ensure LIT compliance
-            IcdMonitoringTable table(*mStorage, fabricInfo.GetFabricIndex(), 1 /*Table entry limit*/);
+            IcdMonitoringTable table(*mStorage, fabricInfo.GetFabricIndex());
             if (!table.IsEmpty())
             {
                 tempMode = ICDMode::LIT;

--- a/src/app/icd/IcdManagementServer.cpp
+++ b/src/app/icd/IcdManagementServer.cpp
@@ -12,24 +12,26 @@ Status IcdManagementServer::RegisterClient(PersistentStorageDelegate & storage, 
                                            uint64_t monitored_subject, chip::ByteSpan key,
                                            Optional<chip::ByteSpan> verification_key, bool is_admin)
 {
-    IcdMonitoringTable table(storage, fabric_index, GetClientsSupportedPerFabric());
+    IcdMonitoringTable table(storage, fabric_index);
 
     // Get current entry, if exists
     IcdMonitoringEntry entry;
     CHIP_ERROR err = table.Find(node_id, entry);
+
     if (CHIP_NO_ERROR == err)
     {
         // Existing entry: Validate Key if, and only if, the ISD has NOT administrator permissions
         if (!is_admin)
         {
+            ByteSpan current_key(entry.key);
             VerifyOrReturnError(verification_key.HasValue(), InteractionModel::Status::Failure);
-            VerifyOrReturnError(verification_key.Value().data_equal(entry.key), InteractionModel::Status::Failure);
+            VerifyOrReturnError(verification_key.Value().data_equal(current_key), InteractionModel::Status::Failure);
         }
     }
     else if (CHIP_ERROR_NOT_FOUND == err)
     {
         // New entry
-        VerifyOrReturnError(entry.index < table.Limit(), InteractionModel::Status::ResourceExhausted);
+        VerifyOrReturnError(table.Count() < table.Limit(), InteractionModel::Status::ResourceExhausted);
     }
     else
     {
@@ -38,10 +40,12 @@ Status IcdManagementServer::RegisterClient(PersistentStorageDelegate & storage, 
     }
 
     // Save
+    VerifyOrReturnError(IcdMonitoringEntry::kKeyMaxSize == key.size(), InteractionModel::Status::ConstraintError);
+
     entry.checkInNodeID    = node_id;
     entry.monitoredSubject = monitored_subject;
-    entry.key              = key;
-    err                    = table.Set(entry.index, entry);
+    memcpy(entry.key, key.data(), IcdMonitoringEntry::kKeyMaxSize);
+    err = table.Set(entry);
     VerifyOrReturnError(CHIP_ERROR_INVALID_ARGUMENT != err, InteractionModel::Status::ConstraintError);
     VerifyOrReturnError(CHIP_NO_ERROR == err, InteractionModel::Status::Failure);
 
@@ -51,7 +55,7 @@ Status IcdManagementServer::RegisterClient(PersistentStorageDelegate & storage, 
 Status IcdManagementServer::UnregisterClient(PersistentStorageDelegate & storage, FabricIndex fabric_index, chip::NodeId node_id,
                                              Optional<chip::ByteSpan> verificationKey, bool is_admin)
 {
-    IcdMonitoringTable table(storage, fabric_index, GetClientsSupportedPerFabric());
+    IcdMonitoringTable table(storage, fabric_index);
 
     // Get current entry, if exists
     IcdMonitoringEntry entry;
@@ -62,11 +66,12 @@ Status IcdManagementServer::UnregisterClient(PersistentStorageDelegate & storage
     // Existing entry: Validate Key if, and only if, the ISD has NOT administrator permissions
     if (!is_admin)
     {
+        ByteSpan current_key(entry.key);
         VerifyOrReturnError(verificationKey.HasValue(), InteractionModel::Status::Failure);
-        VerifyOrReturnError(verificationKey.Value().data_equal(entry.key), InteractionModel::Status::Failure);
+        VerifyOrReturnError(verificationKey.Value().data_equal(current_key), InteractionModel::Status::Failure);
     }
 
-    err = table.Remove(entry.index);
+    err = table.Remove(entry);
     VerifyOrReturnError(CHIP_NO_ERROR == err, InteractionModel::Status::Failure);
 
     return InteractionModel::Status::Success;

--- a/src/app/icd/IcdMonitoringTable.cpp
+++ b/src/app/icd/IcdMonitoringTable.cpp
@@ -5,37 +5,51 @@ namespace chip {
 
 enum class Fields : uint8_t
 {
-    kCheckInNodeID    = 1,
-    kMonitoredSubject = 2,
-    kKey              = 3,
+    kCheckInNodeID = static_cast<uint8_t>(PersistentTags::kList) + 1,
+    kMonitoredSubject,
+    kKey,
 };
 
-CHIP_ERROR IcdMonitoringEntry::UpdateKey(StorageKeyName & skey)
+CHIP_ERROR IcdMonitoringTable::UpdateKey(StorageKeyName & skey)
 {
-    VerifyOrReturnError(kUndefinedFabricIndex != this->fabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
-    skey = DefaultStorageKeyAllocator::IcdManagementTableEntry(this->fabricIndex, index);
+    VerifyOrReturnError(kUndefinedFabricIndex != this->mFabric, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    skey = DefaultStorageKeyAllocator::IcdManagementTableEntries(this->mFabric);
+    return CHIP_NO_ERROR;
+}
+
+bool IcdMonitoringEntry::Compare(const IcdMonitoringEntry & other)
+{
+    return this->checkInNodeID == other.checkInNodeID;
+}
+
+CHIP_ERROR IcdMonitoringEntry::Copy(const IcdMonitoringEntry & other)
+{
+    VerifyOrReturnError(kUndefinedNodeId != other.checkInNodeID, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(kUndefinedNodeId != other.monitoredSubject, CHIP_ERROR_INVALID_ARGUMENT);
+    checkInNodeID    = other.checkInNodeID;
+    monitoredSubject = other.monitoredSubject;
+    memcpy(key, other.key, kKeyMaxSize);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR IcdMonitoringEntry::Serialize(TLV::TLVWriter & writer) const
 {
     TLV::TLVType outer;
+
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kCheckInNodeID), checkInNodeID));
-    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kMonitoredSubject), monitoredSubject));
-    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kKey), key));
+    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kCheckInNodeID), this->checkInNodeID));
+    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kMonitoredSubject), this->monitoredSubject));
+    ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kKey), ByteSpan(this->key, IcdMonitoringEntry::kKeyMaxSize)));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR IcdMonitoringEntry::Deserialize(TLV::TLVReader & reader)
 {
-
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
 
-    ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
     ReturnErrorOnFailure(reader.EnterContainer(outer));
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
@@ -44,14 +58,17 @@ CHIP_ERROR IcdMonitoringEntry::Deserialize(TLV::TLVReader & reader)
             switch (TLV::TagNumFromTag(reader.GetTag()))
             {
             case to_underlying(Fields::kCheckInNodeID):
-                ReturnErrorOnFailure(reader.Get(checkInNodeID));
+                ReturnErrorOnFailure(reader.Get(this->checkInNodeID));
                 break;
             case to_underlying(Fields::kMonitoredSubject):
-                ReturnErrorOnFailure(reader.Get(monitoredSubject));
+                ReturnErrorOnFailure(reader.Get(this->monitoredSubject));
                 break;
-            case to_underlying(Fields::kKey):
-                ReturnErrorOnFailure(reader.Get(key));
+            case to_underlying(Fields::kKey): {
+                ByteSpan span;
+                ReturnErrorOnFailure(reader.Get(span));
+                memcpy(this->key, span.data(), IcdMonitoringEntry::kKeyMaxSize);
                 break;
+            }
             default:
                 break;
             }
@@ -63,97 +80,10 @@ CHIP_ERROR IcdMonitoringEntry::Deserialize(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-void IcdMonitoringEntry::Clear()
-{
-    this->checkInNodeID    = kUndefinedNodeId;
-    this->monitoredSubject = kUndefinedNodeId;
-    this->key              = ByteSpan();
-}
-
-CHIP_ERROR IcdMonitoringTable::Get(uint16_t index, IcdMonitoringEntry & entry) const
-{
-    entry.fabricIndex = this->mFabric;
-    entry.index       = index;
-    ReturnErrorOnFailure(entry.Load(this->mStorage));
-    entry.fabricIndex = this->mFabric;
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR IcdMonitoringTable::Find(NodeId id, IcdMonitoringEntry & entry)
 {
-    uint16_t index = 0;
-    while (index < this->Limit())
-    {
-        ReturnErrorOnFailure(this->Get(index++, entry));
-        if (id == entry.checkInNodeID)
-        {
-            return CHIP_NO_ERROR;
-        }
-    }
-    entry.index = index;
-    return CHIP_ERROR_NOT_FOUND;
-}
-
-CHIP_ERROR IcdMonitoringTable::Set(uint16_t index, const IcdMonitoringEntry & entry)
-{
-    VerifyOrReturnError(index < this->Limit(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(kUndefinedNodeId != entry.checkInNodeID, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(kUndefinedNodeId != entry.monitoredSubject, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(entry.key.size() == IcdMonitoringEntry::kKeyMaxSize, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(nullptr != entry.key.data(), CHIP_ERROR_INVALID_ARGUMENT);
-    IcdMonitoringEntry e(this->mFabric, index);
-    e.checkInNodeID    = entry.checkInNodeID;
-    e.monitoredSubject = entry.monitoredSubject;
-    e.key              = entry.key;
-    e.index            = index;
-    return e.Save(this->mStorage);
-}
-
-CHIP_ERROR IcdMonitoringTable::Remove(uint16_t index)
-{
-    IcdMonitoringEntry entry(this->mFabric, index);
-
-    // Shift remaining entries down one position
-    while (CHIP_NO_ERROR == this->Get(static_cast<uint16_t>(index + 1), entry))
-    {
-        // WARNING: The key data is held in the entry's serializing buffer
-        IcdMonitoringEntry copy = entry;
-        this->Set(index++, copy);
-    }
-
-    // Remove last entry
-    entry.fabricIndex = this->mFabric;
-    entry.index       = index;
-    return entry.Delete(this->mStorage);
-}
-
-CHIP_ERROR IcdMonitoringTable::RemoveAll()
-{
-    IcdMonitoringEntry entry(this->mFabric);
-    uint16_t index = 0;
-    while (index < this->Limit())
-    {
-        CHIP_ERROR err = this->Get(index++, entry);
-        if (CHIP_ERROR_NOT_FOUND == err)
-        {
-            break;
-        }
-        ReturnErrorOnFailure(err);
-        entry.fabricIndex = this->mFabric;
-        entry.Delete(this->mStorage);
-    }
-    return CHIP_NO_ERROR;
-}
-
-bool IcdMonitoringTable::IsEmpty()
-{
-    IcdMonitoringEntry entry(this->mFabric);
-    return (this->Get(0, entry) == CHIP_ERROR_NOT_FOUND);
-}
-
-uint16_t IcdMonitoringTable::Limit() const
-{
-    return mLimit;
+    entry.checkInNodeID = id;
+    return this->Get(entry);
 }
 
 } // namespace chip

--- a/src/app/tests/TestIcdMonitoringTable.cpp
+++ b/src/app/tests/TestIcdMonitoringTable.cpp
@@ -26,8 +26,6 @@ using namespace chip;
 
 namespace {
 
-constexpr uint16_t kMaxTestClients1     = 2;
-constexpr uint16_t kMaxTestClients2     = 1;
 constexpr FabricIndex kTestFabricIndex1 = 1;
 constexpr FabricIndex kTestFabricIndex2 = kMaxValidFabricIndex;
 constexpr uint64_t kClientNodeId11      = 0x100001;
@@ -35,10 +33,7 @@ constexpr uint64_t kClientNodeId12      = 0x100002;
 constexpr uint64_t kClientNodeId13      = 0x100003;
 constexpr uint64_t kClientNodeId21      = 0x200001;
 constexpr uint64_t kClientNodeId22      = 0x200002;
-
-constexpr uint8_t kKeyBuffer0a[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
-constexpr uint8_t kKeyBuffer0b[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-                                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+constexpr uint64_t kClientNodeId23      = 0x200003;
 
 constexpr uint8_t kKeyBuffer1a[] = {
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
@@ -55,55 +50,49 @@ constexpr uint8_t kKeyBuffer2b[] = {
 constexpr uint8_t kKeyBuffer3a[] = {
     0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f
 };
-// constexpr uint8_t kKeyBuffer3b[] = { 0xf3, 0xe3, 0xd3, 0xc3, 0xb3, 0xa3, 0x93, 0x83, 0x73, 0x63, 0x53, 0x14, 0x33, 0x23, 0x13,
-// 0x03 };
 
 void TestSaveAndLoadRegistrationValue(nlTestSuite * aSuite, void * aContext)
 {
     TestPersistentStorageDelegate storage;
-    IcdMonitoringTable saving(storage, kTestFabricIndex1, kMaxTestClients1);
-    IcdMonitoringTable loading(storage, kTestFabricIndex1, kMaxTestClients1);
+    IcdMonitoringTable saving(storage, kTestFabricIndex1);
+    IcdMonitoringTable loading(storage, kTestFabricIndex1);
     IcdMonitoringEntry entry;
     CHIP_ERROR err;
 
     // Insert first entry
     entry.checkInNodeID    = kClientNodeId11;
     entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer1a);
-    err                    = saving.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize);
+    err = saving.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert second entry
     entry.checkInNodeID    = kClientNodeId12;
     entry.monitoredSubject = kClientNodeId11;
-    entry.key              = ByteSpan(kKeyBuffer2a);
-    err                    = saving.Set(1, entry);
+    memcpy(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize);
+    err = saving.Set(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert one too many
     entry.checkInNodeID    = kClientNodeId13;
     entry.monitoredSubject = kClientNodeId13;
-    entry.key              = ByteSpan(kKeyBuffer3a);
-    err                    = saving.Set(2, entry);
+    memcpy(entry.key, kKeyBuffer3a, IcdMonitoringEntry::kKeyMaxSize);
+    err = saving.Set(2, entry);
     NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
 
     // Retrieve first entry
     err = loading.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer1a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer1a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve second entry
     err = loading.Get(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 
     // No more entries
     err = loading.Get(2, entry);
@@ -113,163 +102,140 @@ void TestSaveAndLoadRegistrationValue(nlTestSuite * aSuite, void * aContext)
     // Overwrite first entry
     entry.checkInNodeID    = kClientNodeId13;
     entry.monitoredSubject = kClientNodeId11;
-    entry.key              = ByteSpan(kKeyBuffer1b);
-    err                    = saving.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1b, IcdMonitoringEntry::kKeyMaxSize);
+    err = saving.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Retrieve first entry (modified)
+    err = loading.Load();
+    NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
     err = loading.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId13 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer1b) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer1b, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer1b, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve second entry (not modified)
     err = loading.Get(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 }
 
 void TestSaveAllInvalidRegistrationValues(nlTestSuite * aSuite, void * aContext)
 {
     TestPersistentStorageDelegate storage;
-    IcdMonitoringTable table(storage, kTestFabricIndex1, kMaxTestClients1);
+    IcdMonitoringTable table(storage, kTestFabricIndex1);
     IcdMonitoringEntry entry;
     CHIP_ERROR err;
 
     // Invalid checkInNodeID
     entry.checkInNodeID    = kUndefinedNodeId;
     entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer1a);
-    err                    = table.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
 
     // Invalid monitoredSubject
     entry.checkInNodeID    = kClientNodeId11;
     entry.monitoredSubject = kUndefinedNodeId;
-    entry.key              = ByteSpan(kKeyBuffer1a);
-    err                    = table.Set(0, entry);
-    NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
-
-    // Invalid key (empty)
-    entry.checkInNodeID    = kClientNodeId11;
-    entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan();
-    err                    = table.Set(0, entry);
-
-    NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
-    // Invalid key (too short)
-    entry.checkInNodeID    = kClientNodeId11;
-    entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer0a);
-    err                    = table.Set(0, entry);
-    NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
-
-    // Invalid key (too long)
-    entry.checkInNodeID    = kClientNodeId11;
-    entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer0b);
-    err                    = table.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
 }
 
 void TestSaveLoadRegistrationValueForMultipleFabrics(nlTestSuite * aSuite, void * aContext)
 {
     TestPersistentStorageDelegate storage;
-    IcdMonitoringTable table1(storage, kTestFabricIndex1, kMaxTestClients1);
-    IcdMonitoringTable table2(storage, kTestFabricIndex2, kMaxTestClients2);
+    IcdMonitoringTable table1(storage, kTestFabricIndex1);
+    IcdMonitoringTable table2(storage, kTestFabricIndex2);
     IcdMonitoringEntry entry;
     CHIP_ERROR err;
 
     // Insert in first fabric
     entry.checkInNodeID    = kClientNodeId11;
     entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer1a);
-    err                    = table1.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table1.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert in first fabric
     entry.checkInNodeID    = kClientNodeId12;
     entry.monitoredSubject = kClientNodeId11;
-    entry.key              = ByteSpan(kKeyBuffer1b);
-    err                    = table1.Set(1, entry);
+    memcpy(entry.key, kKeyBuffer1b, IcdMonitoringEntry::kKeyMaxSize);
+    err = table1.Set(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert in second fabric
     entry.checkInNodeID    = kClientNodeId21;
     entry.monitoredSubject = kClientNodeId22;
-    entry.key              = ByteSpan(kKeyBuffer2a);
-    err                    = table2.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table2.Set(0, entry);
+    NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
+
+    entry.checkInNodeID    = kClientNodeId22;
+    entry.monitoredSubject = kClientNodeId21;
+    memcpy(entry.key, kKeyBuffer2b, IcdMonitoringEntry::kKeyMaxSize);
+    err = table2.Set(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert in second fabric (one too many)
-    entry.checkInNodeID    = kClientNodeId22;
+    entry.checkInNodeID    = kClientNodeId23;
     entry.monitoredSubject = kClientNodeId21;
-    entry.key              = ByteSpan(kKeyBuffer2b);
-    err                    = table2.Set(1, entry);
+    memcpy(entry.key, kKeyBuffer2b, IcdMonitoringEntry::kKeyMaxSize);
+    err = table2.Set(2, entry);
     NL_TEST_ASSERT(aSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
 
     // Retrieve fabric1, first entry
     err = table1.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer1a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer1a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve fabric2, second entry
     err = table1.Get(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer1b) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer1b, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer1b, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve fabric2, first entry
     err = table2.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex2 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId21 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId22 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 }
 
 void TestDeleteValidEntryFromStorage(nlTestSuite * aSuite, void * context)
 {
     TestPersistentStorageDelegate storage;
-    IcdMonitoringTable table1(storage, kTestFabricIndex1, kMaxTestClients1);
-    IcdMonitoringTable table2(storage, kTestFabricIndex2, kMaxTestClients2);
+    IcdMonitoringTable table1(storage, kTestFabricIndex1);
+    IcdMonitoringTable table2(storage, kTestFabricIndex2);
     IcdMonitoringEntry entry;
     CHIP_ERROR err;
 
     // Insert first entry
     entry.checkInNodeID    = kClientNodeId11;
     entry.monitoredSubject = kClientNodeId12;
-    entry.key              = ByteSpan(kKeyBuffer1a);
-    err                    = table1.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table1.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert second entry
     entry.checkInNodeID    = kClientNodeId12;
     entry.monitoredSubject = kClientNodeId11;
-    entry.key              = ByteSpan(kKeyBuffer2a);
-    err                    = table1.Set(1, entry);
+    memcpy(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table1.Set(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Insert in second fabric
     entry.checkInNodeID    = kClientNodeId21;
     entry.monitoredSubject = kClientNodeId22;
-    entry.key              = ByteSpan(kKeyBuffer2a);
-    err                    = table2.Set(0, entry);
+    memcpy(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize);
+    err = table2.Set(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
 
     // Remove (invalid)
@@ -279,20 +245,16 @@ void TestDeleteValidEntryFromStorage(nlTestSuite * aSuite, void * context)
     // Retrieve fabric1
     err = table1.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer1a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer1a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer1a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve second entry (not modified)
     err = table1.Get(1, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Remove (existing)
     err = table1.Remove(0);
@@ -304,20 +266,16 @@ void TestDeleteValidEntryFromStorage(nlTestSuite * aSuite, void * context)
 
     err = table1.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex1 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId12 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId11 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Retrieve fabric2, first entry
     err = table2.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex2 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId21 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId22 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Remove all (fabric 1)
     err = table1.RemoveAll();
@@ -325,15 +283,15 @@ void TestDeleteValidEntryFromStorage(nlTestSuite * aSuite, void * context)
 
     err = table1.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_ERROR_NOT_FOUND == err);
+    err = table1.Get(1, entry);
+    NL_TEST_ASSERT(aSuite, CHIP_ERROR_NOT_FOUND == err);
 
     // Check fabric 2
     err = table2.Get(0, entry);
     NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(aSuite, kTestFabricIndex2 == entry.fabricIndex);
     NL_TEST_ASSERT(aSuite, kClientNodeId21 == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, kClientNodeId22 == entry.monitoredSubject);
-    NL_TEST_ASSERT(aSuite, sizeof(kKeyBuffer2a) == entry.key.size());
-    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key.data(), kKeyBuffer2a, entry.key.size()));
+    NL_TEST_ASSERT(aSuite, 0 == memcmp(entry.key, kKeyBuffer2a, IcdMonitoringEntry::kKeyMaxSize));
 
     // Remove all (fabric 2)
     err = table2.RemoveAll();

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -72,7 +72,7 @@ public:
                 Platform::CopyString(name, groupName);
             }
         }
-        bool operator==(const GroupInfo & other)
+        bool operator==(const GroupInfo & other) const
         {
             return (this->group_id == other.group_id) && !strncmp(this->name, other.name, kGroupNameMax);
         }

--- a/src/lib/support/CommonPersistentData.h
+++ b/src/lib/support/CommonPersistentData.h
@@ -41,8 +41,10 @@ struct StoredDataList : public PersistentData<kMaxSerializedSize>
     EntryType first_entry = kdefaultUndefinedEntry;
     uint16_t entry_count  = 0;
 
-    StoredDataList() = default;
-    StoredDataList(EntryType first) : first_entry(first), entry_count(1) {}
+    StoredDataList(PersistentStorageDelegate * storage) : PersistentData<kMaxSerializedSize>(storage) {}
+    StoredDataList(PersistentStorageDelegate * storage, EntryType first) :
+        PersistentData<kMaxSerializedSize>(storage), first_entry(first), entry_count(1)
+    {}
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
@@ -77,14 +79,7 @@ struct StoredDataList : public PersistentData<kMaxSerializedSize>
 constexpr size_t kPersistentFabricBufferMax = 32;
 struct FabricList : StoredDataList<FabricIndex, kPersistentFabricBufferMax>
 {
-    // Subclasses need to define UpdateKey to be whatever fabric list key they
-    // care about.
-
-    void Clear() override
-    {
-        first_entry = kUndefinedFabricIndex;
-        entry_count = 0;
-    }
+    FabricList(PersistentStorageDelegate * storage) : StoredDataList<FabricIndex, kPersistentFabricBufferMax>(storage) {}
 };
 } // namespace CommonPersistentData
 } // namespace chip

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -185,9 +185,9 @@ public:
 
     // ICD Management
 
-    static StorageKeyName IcdManagementTableEntry(chip::FabricIndex fabric, uint16_t index)
+    static StorageKeyName IcdManagementTableEntries(chip::FabricIndex fabric)
     {
-        return StorageKeyName::Formatted("f/%x/icd/%x", fabric, index);
+        return StorageKeyName::Formatted("f/%x/icd", fabric);
     }
 
     static StorageKeyName OTADefaultProviders() { return StorageKeyName::FromConst("g/o/dp"); }

--- a/src/lib/support/PersistentArray.h
+++ b/src/lib/support/PersistentArray.h
@@ -1,0 +1,317 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/support/PersistentData.h>
+
+namespace chip {
+
+enum class PersistentTags : uint8_t
+{
+    kCount = 1,
+    kList  = 2,
+};
+
+static constexpr size_t kPersistentArraySerializedMinSize =
+    7; // ContainerTag(1) + CountTag(1) + Count(2) + ListTag(1) + EndListTag(1) + EndContainerTag(1)
+
+template <size_t kMaxListSize, size_t kMaxSerializedEntrySize, typename EntryType>
+struct PersistentArray : public PersistentData<kPersistentArraySerializedMinSize + kMaxListSize * kMaxSerializedEntrySize>
+{
+
+    PersistentArray(PersistentStorageDelegate * storage) :
+        PersistentData<kPersistentArraySerializedMinSize + kMaxListSize * kMaxSerializedEntrySize>(storage), mLimit(kMaxListSize)
+    {}
+
+    size_t Limit() { return this->mLimit; }
+    uint16_t Count() { return this->mCount; }
+
+    /**
+     * Stores an entry at a given position. This method does not validate the order
+     * in which the entries are stored. New entries must be inserted with index == count,
+     * if index < count, the existing entry is replaced, generating an implicit remove of
+     * the existing entry.
+     * The Compare() method is used to ensure that the entry is unique. If the new entry matches
+     * an existing entry, the index must also match, otherwise CHIP_ERROR_DUPLICATE_KEY_ID is
+     * returned.
+     * @param index Zero-based position within the table.
+     * @param entry Value to be store in the table.
+     * @return CHIP_NO_ERROR on success. CHIP_ERROR_DUPLICATE_KEY_ID if the entry is already
+     * stored in different index. CHIP_ERROR_INVALID_ARGUMENT if index >= limit.
+     */
+    CHIP_ERROR Set(size_t index, const EntryType & value)
+    {
+        CHIP_ERROR err = this->Load(true);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, err);
+
+        // Check existing
+        for (size_t i = 0; i < this->mCount; ++i)
+        {
+            EntryType & e = mEntries[i];
+            if (e.Compare(value))
+            {
+                // Existing value, index must match
+                VerifyOrReturnError(i == index, CHIP_ERROR_DUPLICATE_KEY_ID);
+                EntryType old;
+                ReturnErrorOnFailure(old.Copy(e));
+                ReturnErrorOnFailure(e.Copy(value));
+                ReturnErrorOnFailure(this->Save());
+                OnEntryModified(old, value);
+                return CHIP_NO_ERROR;
+            }
+        }
+
+        // New value
+        if (index < this->mCount)
+        {
+            // Override (implicit remove)
+            EntryType old;
+            old.Copy(mEntries[index]);
+            ReturnErrorOnFailure(mEntries[index].Copy(value));
+            ReturnErrorOnFailure(this->Save());
+            OnEntryRemoved(old);
+        }
+        else
+        {
+            // Insert last
+            VerifyOrReturnError(this->mCount < this->mLimit, CHIP_ERROR_INVALID_ARGUMENT);
+            ReturnErrorOnFailure(mEntries[this->mCount++].Copy(value));
+            ReturnErrorOnFailure(this->Save());
+        }
+        OnEntryAdded(value);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * Stores a new entry. The Compare() method is used to ensure that the entry is unique.
+     * If the new entry matches an existing entry, do_override must be true, otherwise
+     * CHIP_ERROR_DUPLICATE_KEY_ID is returned.
+     * @param index Zero-based position within the table.
+     * @param entry Value to be store in the table.
+     * @return CHIP_NO_ERROR on success. CHIP_ERROR_DUPLICATE_KEY_ID is the entry is
+     * already stored in the table. CHIP_ERROR_INVALID_ARGUMENT if index >= limit.
+     */
+    CHIP_ERROR Set(const EntryType & value, bool do_override = true)
+    {
+        CHIP_ERROR err = this->Load(true);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, err);
+
+        // Check existing
+        for (size_t i = 0; i < this->mCount; ++i)
+        {
+            EntryType & e = mEntries[i];
+            if (e.Compare(value))
+            {
+                // Already registered
+                VerifyOrReturnError(do_override, CHIP_ERROR_DUPLICATE_KEY_ID);
+                EntryType old;
+                ReturnErrorOnFailure(old.Copy(e));
+                ReturnErrorOnFailure(e.Copy(value));
+                ReturnErrorOnFailure(this->Save());
+                OnEntryModified(old, value);
+                return CHIP_NO_ERROR;
+            }
+        }
+        // Insert last
+        VerifyOrReturnError(this->mCount < this->mLimit, CHIP_ERROR_INVALID_LIST_LENGTH);
+        ReturnErrorOnFailure(mEntries[this->mCount++].Copy(value));
+        ReturnErrorOnFailure(this->Save());
+        OnEntryAdded(value);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Returns the stored entry at a given index. Is up to the implementation
+     *        to handle how the de-serialized values are copied into the given output.
+     *        The output should be considered valid only as the lifetime of the
+     *        PersistentArray itself, and no other Get, Set or Remove operation is performed.
+     * @param index Zero-based position within the table.
+     * @param entry [out] On success, contains the value matching the given index.
+     * @return CHIP_NO_ERROR on success,
+     *         CHIP_ERROR_NOT_FOUND if index is greater than the index of the last entry on the table.
+     */
+    CHIP_ERROR Get(size_t index, EntryType & value)
+    {
+        ReturnErrorOnFailure(this->Load(true));
+        VerifyOrReturnError(index < this->mLimit, CHIP_ERROR_NOT_FOUND);
+        VerifyOrReturnError(index < this->mCount, CHIP_ERROR_NOT_FOUND);
+        ReturnErrorOnFailure(value.Copy(mEntries[index]));
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Returns the value matching the given entry. The Compare() method
+     *        is used to identify the matching entry within the table.
+     *        Is up to the implementation to handle how the de-serialized values
+     *        are copied into the given output.
+     *        The output should be considered valid only as the lifetime of the
+     *        PersistentArray itself, and no other Get, Set or Remove operation is performed.
+     *
+     * @param value [in, out] Used as an input for comparison, and output for the rest of the values.
+     * @param do_create When true, if no matching entry is found, the entire value will be stored
+     *                  as a new entry in the table.
+     * @return CHIP_NO_ERROR on success,
+     *         CHIP_ERROR_NOT_FOUND if no entry matches the given input.
+     */
+    CHIP_ERROR Get(EntryType & value, bool do_create = false)
+    {
+        CHIP_ERROR err = this->Load(true);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, err);
+
+        // Check existing
+        for (size_t i = 0; i < this->mCount; ++i)
+        {
+            EntryType & e = mEntries[i];
+            if (e.Compare(value))
+            {
+                ReturnErrorOnFailure(value.Copy(e));
+                return CHIP_NO_ERROR;
+            }
+        }
+        // Insert last ?
+        VerifyOrReturnError(do_create, CHIP_ERROR_NOT_FOUND);
+        VerifyOrReturnError(this->mCount < this->mLimit, CHIP_ERROR_INVALID_LIST_LENGTH);
+        ReturnErrorOnFailure(mEntries[this->mCount++].Copy(value));
+        return this->Save();
+    }
+
+    /**
+     * @brief Removes the stored entry at a given index. Remaining entries are
+     *        shifted one position down.
+     * @param index Zero-based position within the table.
+     * @return CHIP_NO_ERROR on success,
+     *         CHIP_ERROR_NOT_FOUND if index is greater than the index of the last entry on the table.
+     */
+    CHIP_ERROR Remove(size_t index)
+    {
+        ReturnErrorOnFailure(this->Load(true));
+        VerifyOrReturnError(index < this->mLimit, CHIP_ERROR_NOT_FOUND);
+        VerifyOrReturnError(index < this->mCount, CHIP_ERROR_NOT_FOUND);
+        EntryType old;
+        old.Copy(mEntries[index]);
+        this->mCount--;
+        for (size_t i = index; i < this->mCount; ++i)
+        {
+            mEntries[i].Copy(mEntries[i + 1]);
+        }
+        ReturnErrorOnFailure(this->Save());
+        OnEntryRemoved(old);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Removes the value matching the given entry. The Compare() method
+     *        is used to identify the matching entry within the table.
+     * @param entry Identifies the value to be removed.
+     * @return CHIP_NO_ERROR on success,
+     *         CHIP_ERROR_NOT_FOUND if no entry matches the given input.
+     */
+    CHIP_ERROR Remove(const EntryType & value)
+    {
+        ReturnErrorOnFailure(this->Load(true));
+        for (size_t i = 0; i < this->mCount; ++i)
+        {
+            if (mEntries[i].Compare(value))
+            {
+                return Remove(i);
+            }
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Removes all the entries in the table.
+     * @return CHIP_NO_ERROR on success.
+     */
+    CHIP_ERROR RemoveAll()
+    {
+        ReturnErrorOnFailure(this->Load());
+        for (uint16_t i = 0; i < mLimit; ++i)
+        {
+            OnEntryRemoved(mEntries[i]);
+        }
+        mCount = 0;
+        ReturnErrorOnFailure(this->Save());
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Check if the table is empty
+     * @return True when there is no entry in the table. False if there is at least one
+     */
+    bool IsEmpty()
+    {
+        VerifyOrReturnError(CHIP_NO_ERROR == this->Load(true), true);
+        return 0 == this->mCount;
+    }
+
+protected:
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        TLV::TLVType container, list;
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
+
+        // Count
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(PersistentTags::kCount), this->mCount));
+
+        // Entries
+        ReturnErrorOnFailure(writer.StartContainer(TLV::ContextTag(PersistentTags::kList), TLV::kTLVType_Array, list));
+        for (size_t i = 0; (i < this->mCount) && (i < this->mLimit); ++i)
+        {
+            ReturnErrorOnFailure(mEntries[i].Serialize(writer));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(list));
+
+        CHIP_ERROR err = writer.EndContainer(container);
+        return err;
+    }
+
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+
+        TLV::TLVType container, list;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // Count
+        ReturnErrorOnFailure(reader.Next(TLV::ContextTag(PersistentTags::kCount)));
+        ReturnErrorOnFailure(reader.Get(this->mCount));
+
+        // Entries
+        ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Array, TLV::ContextTag(PersistentTags::kList)));
+        ReturnErrorOnFailure(reader.EnterContainer(list));
+        for (size_t i = 0; (i < this->mCount) && (i < this->mLimit); ++i)
+        {
+            ReturnErrorOnFailure(mEntries[i].Deserialize(reader));
+        }
+        ReturnErrorOnFailure(reader.ExitContainer(list));
+
+        return reader.ExitContainer(container);
+    }
+
+    virtual void OnEntryAdded(const EntryType & entry) {}
+    virtual void OnEntryRemoved(const EntryType & entry) {}
+    virtual void OnEntryModified(const EntryType & old_value, const EntryType & new_value) {}
+
+private:
+    // EntryType & At(size_t index) { return (index < this->mLimit) ? mEntries[index] : mEntries[0]; }
+    EntryType mEntries[kMaxListSize];
+    const size_t mLimit = 0;
+    uint16_t mCount     = 0;
+};
+
+} // namespace chip


### PR DESCRIPTION
* Now one KVS key is used per fabric.
* Fixes [#24288](https://github.com/project-chip/connectedhomeip/issues/24288).
ICD Monitoring table and server tests ran successfully.
