### PR TITLE
Fix memory leak when destroying ModeBase delegates

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
@@ -85,7 +85,8 @@ void DishwasherMode::Shutdown()
     }
     if (gDishwasherModeDelegate != nullptr)
     {
-        gDishwasherModeDelegate->~DishwasherModeDelegate();
+        delete gDishwasherModeDelegate;
+        gDishwasherModeDelegate = nullptr;
     }
 }
 

--- a/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
@@ -84,7 +84,8 @@ void LaundryWasherMode::Shutdown()
     }
     if (gLaundryWasherModeDelegate != nullptr)
     {
-        gLaundryWasherModeDelegate->~LaundryWasherModeDelegate();
+        delete gLaundryWasherModeDelegate;
+        gLaundryWasherModeDelegate = nullptr;
     }
 }
 

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
@@ -97,7 +97,8 @@ void RvcRunMode::Shutdown()
     }
     if (gRvcRunModeDelegate != nullptr)
     {
-        gRvcRunModeDelegate->~RvcRunModeDelegate();
+        delete gRvcRunModeDelegate;
+        gRvcRunModeDelegate = nullptr;
     }
 }
 
@@ -180,7 +181,8 @@ void RvcCleanMode::Shutdown()
     }
     if (gRvcCleanModeDelegate != nullptr)
     {
-        gRvcCleanModeDelegate->~RvcCleanModeDelegate();
+        delete gRvcCleanModeDelegate;
+        gRvcCleanModeDelegate = nullptr;
     }
 }
 

--- a/examples/all-clusters-app/all-clusters-common/src/tcc-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tcc-mode.cpp
@@ -84,7 +84,8 @@ void RefrigeratorAndTemperatureControlledCabinetMode::Shutdown()
     }
     if (gTccModeDelegate != nullptr)
     {
-        gTccModeDelegate->~TccModeDelegate();
+        delete gTccModeDelegate;
+        gTccModeDelegate = nullptr;
     }
 }
 

--- a/src/app/clusters/mode-base-server/mode-base-server.h
+++ b/src/app/clusters/mode-base-server/mode-base-server.h
@@ -241,7 +241,7 @@ public:
 // todo change once there is a clear public interface for the OnOff cluster data dependencies (#27508)
 static IntrusiveList<Instance> gModeBaseAliasesInstances;
 
-// This does not return a refernce to const IntrusiveList, because the caller might need
+// This does not return a reference to const IntrusiveList, because the caller might need
 // to change the state of the instances in the list and const IntrusiveList only allows
 // access to const Instance.
 IntrusiveList<Instance> & GetModeBaseInstanceList();


### PR DESCRIPTION
Fixes #28265

Deletes Mode Base derived cluster delegates in the all-clusters-app example created via `new` with `delete` to avoid memory leaks.
