### PR TITLE
Make C++17 the default everywhere

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,6 +174,8 @@ jobs:
                   BUILD_TYPE=gcc_release scripts/build/gn_gen.sh --args="is_debug=false"
                   scripts/run_in_build_env.sh "ninja -C ./out/gcc_release"
                   BUILD_TYPE=gcc_release scripts/tests/gn_tests.sh
+            - name: Clean output
+              run: rm -rf ./out
             - name: Run Tests with sanitizers
               env:
                   LSAN_OPTIONS: detect_leaks=1

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -43,12 +43,7 @@ declare_args() {
   c_standard = "gnu11"
 
   # C++ standard level (value for -std flag).
-  if (current_os == "linux" || current_os == "mac" || current_os == "ios" ||
-      current_os == "android") {
-    cpp_standard = "gnu++17"
-  } else {
-    cpp_standard = "gnu++14"
-  }
+  cpp_standard = "gnu++17"
 
   # enable libfuzzer
   is_libfuzzer = false

--- a/config/ameba/args.gni
+++ b/config/ameba/args.gni
@@ -37,4 +37,3 @@ custom_toolchain = "//third_party/connectedhomeip/config/ameba/toolchain:ameba"
 
 pw_build_PIP_CONSTRAINTS =
     [ "//third_party/connectedhomeip/scripts/setup/constraints.txt" ]
-

--- a/config/ameba/args.gni
+++ b/config/ameba/args.gni
@@ -37,4 +37,4 @@ custom_toolchain = "//third_party/connectedhomeip/config/ameba/toolchain:ameba"
 
 pw_build_PIP_CONSTRAINTS =
     [ "//third_party/connectedhomeip/scripts/setup/constraints.txt" ]
-cpp_standard = "c++17"
+

--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -106,9 +106,7 @@ matter_get_compiler_flags_from_targets("${CONFIG_CHIP_EXTERNAL_TARGETS}")
 matter_add_flags(-D__LINUX_ERRNO_EXTENSIONS__=1)
 matter_add_flags(-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>)
 
-if (CONFIG_CHIP_PW_RPC)
-    matter_add_gnu_cpp_standard("17")
-endif()
+matter_add_gnu_cpp_standard("17")
 
 if (CONFIG_MBED_BSD_SOCKET_TRACE)
     matter_add_flags(-DMBED_BSD_SOCKET_TRACE=1)

--- a/examples/chef/silabs/with_pw_rpc.gni
+++ b/examples/chef/silabs/with_pw_rpc.gni
@@ -24,7 +24,5 @@ silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"
-
 # Light app on EFR enables tracing server
 pw_trace_BACKEND = "$dir_pw_trace_tokenized"

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -25,8 +25,5 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
 
-# Perfetto requires C++17
-cpp_standard = "gnu++17"
-
 matter_log_json_payload_hex = true
 matter_log_json_payload_decode_full = true

--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -19,10 +19,7 @@ import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/lib/lib.gni")
 
 declare_args() {
-  # TODO: cpp_standard check is not ideal, it should be >= 17,
-  #       however for now this is what we use in compilations
-  matter_commandline_enable_perfetto_tracing =
-      current_os == "linux" && cpp_standard == "gnu++17"
+  matter_commandline_enable_perfetto_tracing = current_os == "linux"
 }
 
 config("default_config") {

--- a/examples/light-switch-app/genio/with_pw_rpc.gni
+++ b/examples/light-switch-app/genio/with_pw_rpc.gni
@@ -24,4 +24,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/light-switch-app/genio/with_pw_rpc.gni
+++ b/examples/light-switch-app/genio/with_pw_rpc.gni
@@ -23,4 +23,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl602/with_pw_rpc.gni
@@ -22,8 +22,6 @@ import("${chip_root}/examples/platform/bouffalolab/bl602/args.gni")
 
 chip_enable_pw_rpc = true
 
-cpp_standard = "gnu++17"
-
 # pigweed updated to a1bd248 makes compile conversion errors;
 # it seems riscv gcc (version > 10) can fixes this issue.
 # let's disable strict warnings for RPC enabled for now.

--- a/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl702/with_pw_rpc.gni
@@ -22,8 +22,6 @@ import("${chip_root}/examples/platform/bouffalolab/bl702/args.gni")
 
 chip_enable_pw_rpc = true
 
-cpp_standard = "gnu++17"
-
 # pigweed updated to a1bd248 makes compile conversion errors;
 # it seems riscv gcc (version > 10) can fixes this issue.
 # let's disable strict warnings for RPC enabled for now.

--- a/examples/lighting-app/bouffalolab/bl702l/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl702l/with_pw_rpc.gni
@@ -23,5 +23,4 @@ import("${chip_root}/examples/platform/bouffalolab/bl702l/args.gni")
 chip_enable_pw_rpc = true
 chip_build_pw_trace_lib = false
 
-cpp_standard = "gnu++17"
 #pw_trace_BACKEND = "$dir_pw_trace_tokenized"

--- a/examples/lighting-app/bouffalolab/bl702l/with_pw_rpc.gni
+++ b/examples/lighting-app/bouffalolab/bl702l/with_pw_rpc.gni
@@ -22,5 +22,4 @@ import("${chip_root}/examples/platform/bouffalolab/bl702l/args.gni")
 
 chip_enable_pw_rpc = true
 chip_build_pw_trace_lib = false
-
 #pw_trace_BACKEND = "$dir_pw_trace_tokenized"

--- a/examples/lighting-app/genio/with_pw_rpc.gni
+++ b/examples/lighting-app/genio/with_pw_rpc.gni
@@ -24,4 +24,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/lighting-app/genio/with_pw_rpc.gni
+++ b/examples/lighting-app/genio/with_pw_rpc.gni
@@ -23,4 +23,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/lighting-app/qpg/with_pw_rpc.gni
+++ b/examples/lighting-app/qpg/with_pw_rpc.gni
@@ -22,4 +22,3 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/lighting-app/qpg/with_pw_rpc.gni
+++ b/examples/lighting-app/qpg/with_pw_rpc.gni
@@ -23,4 +23,3 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/lighting-app/silabs/with_pw_rpc.gni
+++ b/examples/lighting-app/silabs/with_pw_rpc.gni
@@ -25,7 +25,5 @@ app_data_model = "${chip_root}/examples/lighting-app/lighting-common"
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"
-
 # Light app on EFR enables tracing server
 pw_trace_BACKEND = "$dir_pw_trace_tokenized"

--- a/examples/lock-app/genio/with_pw_rpc.gni
+++ b/examples/lock-app/genio/with_pw_rpc.gni
@@ -24,4 +24,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/lock-app/genio/with_pw_rpc.gni
+++ b/examples/lock-app/genio/with_pw_rpc.gni
@@ -23,4 +23,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/lock-app/qpg/with_pw_rpc.gni
+++ b/examples/lock-app/qpg/with_pw_rpc.gni
@@ -23,4 +23,3 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 
-cpp_standard = "gnu++17"

--- a/examples/lock-app/qpg/with_pw_rpc.gni
+++ b/examples/lock-app/qpg/with_pw_rpc.gni
@@ -22,4 +22,3 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
-

--- a/examples/lock-app/silabs/with_pw_rpc.gni
+++ b/examples/lock-app/silabs/with_pw_rpc.gni
@@ -26,8 +26,6 @@ chip_enable_pw_rpc = true
 chip_enable_openthread = true
 chip_openthread_ftd = true
 
-cpp_standard = "gnu++17"
-
 # To fit in flash
 chip_detail_logging = false
 show_qr_code = false

--- a/examples/ota-requestor-app/genio/with_pw_rpc.gni
+++ b/examples/ota-requestor-app/genio/with_pw_rpc.gni
@@ -24,4 +24,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/ota-requestor-app/genio/with_pw_rpc.gni
+++ b/examples/ota-requestor-app/genio/with_pw_rpc.gni
@@ -23,4 +23,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/pump-app/silabs/with_pw_rpc.gni
+++ b/examples/pump-app/silabs/with_pw_rpc.gni
@@ -26,7 +26,5 @@ chip_enable_pw_rpc = true
 chip_enable_openthread = true
 chip_build_pw_trace_lib = true
 
-cpp_standard = "gnu++17"
-
 # Light app on EFR enables tracing server
 pw_trace_BACKEND = "$dir_pw_trace_tokenized"

--- a/examples/smoke-co-alarm-app/silabs/with_pw_rpc.gni
+++ b/examples/smoke-co-alarm-app/silabs/with_pw_rpc.gni
@@ -26,4 +26,3 @@ app_data_model =
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/smoke-co-alarm-app/silabs/with_pw_rpc.gni
+++ b/examples/smoke-co-alarm-app/silabs/with_pw_rpc.gni
@@ -25,4 +25,3 @@ app_data_model =
     "${chip_root}/examples/smoke-co-alarm-app/smoke-co-alarm-common"
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/examples/thermostat/genio/with_pw_rpc.gni
+++ b/examples/thermostat/genio/with_pw_rpc.gni
@@ -24,4 +24,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
 
-cpp_standard = "gnu++17"

--- a/examples/thermostat/genio/with_pw_rpc.gni
+++ b/examples/thermostat/genio/with_pw_rpc.gni
@@ -23,4 +23,3 @@ mt793x_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -21,7 +21,6 @@ import("${chip_root}/src/platform/silabs/efr32/args.gni")
 silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
-cpp_standard = "gnu++17"
 chip_build_tests = true
 chip_enable_openthread = true
 chip_openthread_ftd = true


### PR DESCRIPTION
Start using C++17 instead of C++14.

- changes the default for all platforms
- removes individual "set C++17" from various places