### PR TITLE
Fix handling of cluster state cache min event number.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1186,7 +1186,12 @@ CHIP_ERROR ReadClient::GetMinEventNumber(const ReadPrepareParams & aReadPrepareP
     }
     else
     {
-        return mpCallback.GetHighestReceivedEventNumber(aEventMin);
+        ReturnErrorOnFailure(mpCallback.GetHighestReceivedEventNumber(aEventMin));
+        if (aEventMin.HasValue())
+        {
+            // We want to start with the first event _after_ the last one we received.
+            aEventMin.SetValue(aEventMin.Value() + 1);
+        }
     }
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1484,6 +1484,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
 
     XCTAssertNotEqual(attributeReportsReceived, 0);
+    XCTAssertNotEqual(eventReportsReceived, 0);
 
     attributeReportsReceived = 0;
     eventReportsReceived = 0;


### PR DESCRIPTION
When initializing a new ReadClient with an existing ClusterStateCache, we should be setting the min event number to 1 more than the last event the cache saw. ReadClient was not doing this correctly.
