### PR TITLE
Update cloudbuild esp32 to not run out of bss when linking

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -32,7 +32,7 @@ steps:
               ./scripts/build/build_examples.py --enable-flashbundle --target
               esp32-devkitc-light-rpc --target
               esp32-m5stack-all-clusters-ipv6only --target
-              esp32-m5stack-all-clusters-rpc --target
+              esp32-m5stack-all-clusters-rpc-ipv6only --target
               esp32-m5stack-light --target
               esp32-m5stack-light-ipv6only --target
               esp32-m5stack-ota-requestor build --create-archives


### PR DESCRIPTION
After #28104, ESP32 fails to link esp32-m5stack-all-clusters-rpc (out of RAM by 40 bytes).

Updating to only build ipv6only to save a bit of RAM (although we are probably still too close for comfort).
