### PR TITLE
Timesync commissioner: Fix TrustedTimeSource.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2678,7 +2678,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
             return;
         }
         TimeSynchronization::Commands::SetTrustedTimeSource::Type request;
-        request.trustedTimeSource.SetNull();
+        request.trustedTimeSource = params.GetTrustedTimeSource().Value();
         SendCommand(proxy, request, OnBasicSuccess, OnBasicFailure, endpoint, timeout);
         break;
     }


### PR DESCRIPTION
Turns out I never set it, and the tests didn't catch it because I was so preoccupied with validating the state machine that I never checked the actual values. Whoops.

Test: Please see test included in PR.

Issue: ##28135
