### PR TITLE
[cloudbuild] Fix CHEF builds for esp32.

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -16,8 +16,9 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
-          - ./examples/chef/chef.py --build_all --keep_going --build_exclude
-            noip
+          - >-
+              perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
+              ./examples/chef/chef.py --build_all --build_exclude noip
       id: CompileAll
       waitFor:
           - Bootstrap
@@ -30,7 +31,7 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
-          - ./examples/chef/chef.py --build_all --keep_going --build_include
+          - ./examples/chef/chef.py --build_all --build_include
             linux_arm64_ipv6only.*noip
       id: CompileNoip
       waitFor:


### PR DESCRIPTION
Adds the workaround for gdbgui for chef builds as well.

Chef failures were missed because we had a 'keep going' flag to builds. Removed that one as we should actually fix errors not ignore them.

Hotfix since github CI cannot validate cloudbuild.