### PR TITLE
Do not consider template a real device type for chef

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -37,7 +37,7 @@ _CHEF_SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 _REPO_BASE_PATH = os.path.join(_CHEF_SCRIPT_PATH, "../../")
 _DEVICE_FOLDER = os.path.join(_CHEF_SCRIPT_PATH, "devices")
 _DEVICE_LIST = [file[:-4]
-                for file in os.listdir(_DEVICE_FOLDER) if file.endswith(".zap")]
+                for file in os.listdir(_DEVICE_FOLDER) if file.endswith(".zap") and file != 'template.zap']
 _CICD_CONFIG_FILE_NAME = os.path.join(_CHEF_SCRIPT_PATH, "cicd_config.json")
 _CD_STAGING_DIR = os.path.join(_CHEF_SCRIPT_PATH, "staging")
 


### PR DESCRIPTION
Without this `build-all` tries to compile the device `template` and fails the compile.