### PR TITLE
CommissioningWindowManager should only listen for platform events when a commissioning window is open.

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -129,6 +129,8 @@ void CommissioningWindowManager::ResetState()
 
     DeviceLayer::SystemLayer().CancelTimer(HandleCommissioningWindowTimeout, this);
     mCommissioningTimeoutTimerArmed = false;
+
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 }
 
 void CommissioningWindowManager::Cleanup()


### PR DESCRIPTION
Right now, a CommissioningWindowManager starts listening for platform events if a commissioning window is opened, and then never stops.  That means it can end up reacting to fail-safe expirations that have nothing to do with a commissioning window (e.g. CASE updates of state that needs a fail-safe).

The fix is to not listen for platform events if the commissioning window is closed.

