### PR TITLE
[Tizen] Add full wifi scan for empty ssid

### DIFF
--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -344,7 +344,8 @@ void WiFiManager::_ScanToConnectFinishedCb(wifi_manager_error_e wifiErr, void * 
     }
 }
 
-void WiFiManager::_UpdateScanCallback(void * scanCbData){
+void WiFiManager::_UpdateScanCallback(void * scanCbData)
+{
     auto networkScanned = static_cast<std::vector<WiFiScanResponse> *>(scanCbData);
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
@@ -360,26 +361,24 @@ void WiFiManager::_UpdateScanCallback(void * scanCbData){
 void WiFiManager::_SpecificScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
 {
     VerifyOrReturn(wifiErr == WIFI_MANAGER_ERROR_NONE,
-                  ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
+                   ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
 
     std::vector<WiFiScanResponse> networkScanned;
     int err = wifi_manager_foreach_found_specific_ap(sInstance.mWiFiManagerHandle, _FoundAPOnScanCb, &networkScanned);
 
-    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE,
-                   ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
+    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
     _UpdateScanCallback(&networkScanned);
 }
 
 void WiFiManager::_FullScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
 {
     VerifyOrReturn(wifiErr == WIFI_MANAGER_ERROR_NONE,
-                  ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
+                   ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
 
     std::vector<WiFiScanResponse> networkScanned;
     int err = wifi_manager_foreach_found_ap(sInstance.mWiFiManagerHandle, _FoundAPOnScanCb, &networkScanned);
 
-    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE,
-                   ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
+    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
     _UpdateScanCallback(&networkScanned);
 }
 
@@ -593,7 +592,8 @@ CHIP_ERROR WiFiManager::_WiFiScanToConnect(gpointer userData)
 
 CHIP_ERROR WiFiManager::_WiFiSpecificScan(gpointer userData)
 {
-    int wifiErr = wifi_manager_scan_specific_ap(sInstance.mWiFiManagerHandle, sInstance.mInterestedSSID, _SpecificScanFinishedCb, nullptr);
+    int wifiErr =
+        wifi_manager_scan_specific_ap(sInstance.mWiFiManagerHandle, sInstance.mInterestedSSID, _SpecificScanFinishedCb, nullptr);
 
     VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "FAIL: request WiFi scan [%s]", get_error_message(wifiErr)));
@@ -954,11 +954,11 @@ CHIP_ERROR WiFiManager::StartWiFiScan(ByteSpan ssid, DeviceLayer::NetworkCommiss
     {
         memcpy(sInstance.mInterestedSSID, ssid.data(), ssid.size());
         sInstance.mInterestedSSID[ssid.size()] = '\0';
-        err                  = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiSpecificScan, static_cast<void *>(nullptr));
+        err = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiSpecificScan, static_cast<void *>(nullptr));
     }
     else
     {
-        err                  = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiFullScan, static_cast<void *>(nullptr));
+        err = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiFullScan, static_cast<void *>(nullptr));
     }
 
     SuccessOrExit(err);

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -344,29 +344,43 @@ void WiFiManager::_ScanToConnectFinishedCb(wifi_manager_error_e wifiErr, void * 
     }
 }
 
-void WiFiManager::_ScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
+void WiFiManager::_UpdateScanCallback(void * scanCbData){
+    auto networkScanned = static_cast<std::vector<WiFiScanResponse> *>(scanCbData);
+
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    if (sInstance.mpScanCallback != nullptr)
+    {
+        TizenScanResponseIterator<WiFiScanResponse> iter(networkScanned);
+        sInstance.mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);
+        sInstance.mpScanCallback = nullptr;
+    }
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+}
+
+void WiFiManager::_SpecificScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
 {
-    if (wifiErr == WIFI_MANAGER_ERROR_NONE)
-    {
-        std::vector<WiFiScanResponse> networkScanned;
-        int err = wifi_manager_foreach_found_specific_ap(sInstance.mWiFiManagerHandle, _FoundAPOnScanCb, &networkScanned);
+    VerifyOrReturn(wifiErr == WIFI_MANAGER_ERROR_NONE,
+                  ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
 
-        VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE,
-                       ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
+    std::vector<WiFiScanResponse> networkScanned;
+    int err = wifi_manager_foreach_found_specific_ap(sInstance.mWiFiManagerHandle, _FoundAPOnScanCb, &networkScanned);
 
-        chip::DeviceLayer::PlatformMgr().LockChipStack();
-        if (sInstance.mpScanCallback != nullptr)
-        {
-            TizenScanResponseIterator<WiFiScanResponse> iter(&networkScanned);
-            sInstance.mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);
-            sInstance.mpScanCallback = nullptr;
-        }
-        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr));
-    }
+    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE,
+                   ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
+    _UpdateScanCallback(&networkScanned);
+}
+
+void WiFiManager::_FullScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
+{
+    VerifyOrReturn(wifiErr == WIFI_MANAGER_ERROR_NONE,
+                  ChipLogError(DeviceLayer, "FAIL: scan WiFi [%s]", get_error_message(wifiErr)));
+
+    std::vector<WiFiScanResponse> networkScanned;
+    int err = wifi_manager_foreach_found_ap(sInstance.mWiFiManagerHandle, _FoundAPOnScanCb, &networkScanned);
+
+    VerifyOrReturn(err == WIFI_MANAGER_ERROR_NONE,
+                   ChipLogError(DeviceLayer, "FAIL: get scan list [%s]", get_error_message(err)));
+    _UpdateScanCallback(&networkScanned);
 }
 
 bool WiFiManager::_FoundAPOnScanCb(wifi_manager_ap_h ap, void * userData)
@@ -577,15 +591,25 @@ CHIP_ERROR WiFiManager::_WiFiScanToConnect(gpointer userData)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WiFiManager::_WiFiScan(gpointer userData)
+CHIP_ERROR WiFiManager::_WiFiSpecificScan(gpointer userData)
 {
-    int wifiErr;
+    int wifiErr = wifi_manager_scan_specific_ap(sInstance.mWiFiManagerHandle, sInstance.mInterestedSSID, _SpecificScanFinishedCb, nullptr);
 
-    wifiErr = wifi_manager_scan_specific_ap(sInstance.mWiFiManagerHandle, sInstance.mInterestedSSID, _ScanFinishedCb, nullptr);
     VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "FAIL: request WiFi scan [%s]", get_error_message(wifiErr)));
 
-    ChipLogProgress(DeviceLayer, "WiFi scan is requested");
+    ChipLogProgress(DeviceLayer, "WiFi specific scan is requested");
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WiFiManager::_WiFiFullScan(gpointer userData)
+{
+    int wifiErr = wifi_manager_scan(sInstance.mWiFiManagerHandle, _FullScanFinishedCb, nullptr);
+
+    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "FAIL: request WiFi scan [%s]", get_error_message(wifiErr)));
+
+    ChipLogProgress(DeviceLayer, "WiFi full scan is requested");
     return CHIP_NO_ERROR;
 }
 
@@ -919,19 +943,25 @@ CHIP_ERROR WiFiManager::StartWiFiScan(ByteSpan ssid, DeviceLayer::NetworkCommiss
     int wifiErr          = WIFI_MANAGER_ERROR_NONE;
     bool isWiFiActivated = false;
 
-    memcpy(sInstance.mInterestedSSID, ssid.data(), ssid.size());
-    sInstance.mInterestedSSID[ssid.size()] = '\0';
-
     wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
                  ChipLogError(DeviceLayer, "FAIL: check whether WiFi is activated [%s]", get_error_message(wifiErr)));
 
     VerifyOrExit(isWiFiActivated == true, ChipLogProgress(DeviceLayer, "WiFi is deactivated"));
-
     sInstance.mpScanCallback = callback;
-    err                      = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiScan, static_cast<void *>(nullptr));
-    SuccessOrExit(err);
 
+    if (ssid.size() > 0)
+    {
+        memcpy(sInstance.mInterestedSSID, ssid.data(), ssid.size());
+        sInstance.mInterestedSSID[ssid.size()] = '\0';
+        err                  = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiSpecificScan, static_cast<void *>(nullptr));
+    }
+    else
+    {
+        err                  = PlatformMgrImpl().GLibMatterContextInvokeSync(_WiFiFullScan, static_cast<void *>(nullptr));
+    }
+
+    SuccessOrExit(err);
 exit:
     return err;
 }

--- a/src/platform/Tizen/WiFiManager.h
+++ b/src/platform/Tizen/WiFiManager.h
@@ -70,16 +70,19 @@ private:
     static void _ActivateCb(wifi_manager_error_e wifiErr, void * userData);
     static void _DeactivateCb(wifi_manager_error_e wifiErr, void * userData);
     static void _ScanToConnectFinishedCb(wifi_manager_error_e wifiErr, void * userData);
-    static void _ScanFinishedCb(wifi_manager_error_e wifiErr, void * userData);
+    static void _SpecificScanFinishedCb(wifi_manager_error_e wifiErr, void * userData);
+    static void _FullScanFinishedCb(wifi_manager_error_e wifiErr, void * userData);
     static bool _FoundAPOnScanCb(wifi_manager_ap_h ap, void * userData);
     static bool _FoundAPCb(wifi_manager_ap_h ap, void * userData);
     static void _ConnectedCb(wifi_manager_error_e wifiErr, void * userData);
     static bool _ConfigListCb(const wifi_manager_config_h config, void * userData);
+    static void _UpdateScanCallback(void * scanCbData);
 
     static CHIP_ERROR _WiFiInitialize(gpointer userData);
     static CHIP_ERROR _WiFiActivate(gpointer userData);
     static CHIP_ERROR _WiFiDeactivate(gpointer userData);
-    static CHIP_ERROR _WiFiScan(gpointer userData);
+    static CHIP_ERROR _WiFiSpecificScan(gpointer userData);
+    static CHIP_ERROR _WiFiFullScan(gpointer userData);
     static CHIP_ERROR _WiFiScanToConnect(gpointer userData);
     static CHIP_ERROR _WiFiConnect(wifi_manager_ap_h ap);
 


### PR DESCRIPTION

**Problem**

- No Wi-Fi network was searched if TizenWiFiDriver::ScanNetworks(...) passed empty ssid.

**Changes**

- Added full Wi-Fi scan for the case ssid passed is empty.

**Testing** 

- Manually tested network commissioning on Tizen.