### PR TITLE
[ESP32] Allowing empty semantic tags list in SupportedModes attribute of ModeSelect

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -227,9 +227,13 @@ def get_fixed_label_dict(fixed_labels):
     return fl_dict
 
 # get_supported_modes_dict() converts the list of strings to per endpoint dictionaries.
-# example input  : ['0/label1/1/"1\0x8000, 2\0x8000",  1/label2/1/"1\0x8000, 2\0x8000"']
-# example outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
+# example with semantic tags
+# input  : ['0/label1/1/"1\0x8000, 2\0x8000" 1/label2/1/"1\0x8000, 2\0x8000"']
+# outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
 
+# example without semantic tags
+# input  : ['0/label1/1 1/label2/1']
+# outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': []}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': []}]}
 
 def get_supported_modes_dict(supported_modes):
     output_dict = {}
@@ -240,8 +244,10 @@ def get_supported_modes_dict(supported_modes):
         label = mode_label_strs[1]
         ep = mode_label_strs[2]
 
-        semantic_tag_strs = mode_label_strs[3].split(', ')
-        semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
+        semantic_tags = ''
+        if (len(mode_label_strs) is 4):
+            semantic_tag_strs = mode_label_strs[3].split(', ')
+            semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
 
         mode_dict = {"Label": label, "Mode": int(mode), "Semantic_Tag": semantic_tags}
 

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -203,7 +203,7 @@ def ishex(s):
 
 # get_fixed_label_dict() converts the list of strings to per endpoint dictionaries.
 # example input  : ['0/orientation/up', '1/orientation/down', '2/orientation/down']
-# example outout : {'0': [{'orientation': 'up'}], '1': [{'orientation': 'down'}], '2': [{'orientation': 'down'}]}
+# example output : {'0': [{'orientation': 'up'}], '1': [{'orientation': 'down'}], '2': [{'orientation': 'down'}]}
 
 
 def get_fixed_label_dict(fixed_labels):
@@ -229,11 +229,12 @@ def get_fixed_label_dict(fixed_labels):
 # get_supported_modes_dict() converts the list of strings to per endpoint dictionaries.
 # example with semantic tags
 # input  : ['0/label1/1/"1\0x8000, 2\0x8000" 1/label2/1/"1\0x8000, 2\0x8000"']
-# outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
+# output : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
 
 # example without semantic tags
 # input  : ['0/label1/1 1/label2/1']
-# outout : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': []}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': []}]}
+# output : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': []}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': []}]}
+
 
 def get_supported_modes_dict(supported_modes):
     output_dict = {}
@@ -245,7 +246,7 @@ def get_supported_modes_dict(supported_modes):
         ep = mode_label_strs[2]
 
         semantic_tags = ''
-        if (len(mode_label_strs) is 4):
+        if (len(mode_label_strs) == 4):
             semantic_tag_strs = mode_label_strs[3].split(', ')
             semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
 


### PR DESCRIPTION
- Problem

> Semantic Tags list can be empty.

- Changes

> Allowed empty semantic tags list.

- Testing

> Read `SupportedModes` and `change-to-mode` command