### PR TITLE
[chip-tool] Add read-none/subscribe-none commands

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -33,21 +33,24 @@ public:
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mSupportsMultipleEndpoints(supportsMultipleEndpoints)
     {}
 
-    void AddArguments()
+    void AddArguments(bool skipEndpoints = false)
     {
         AddArgument(
             "destination-id", 0, UINT64_MAX, &mDestinationId,
             "64-bit node or group identifier.\n  Group identifiers are detected by being in the 0xFFFF'FFFF'FFFF'xxxx range.");
-        if (mSupportsMultipleEndpoints)
+        if (skipEndpoints == false)
         {
-            AddArgument("endpoint-ids", 0, UINT16_MAX, &mEndPointId,
-                        "Comma-separated list of endpoint ids (e.g. \"1\" or \"1,2,3\").\n  Allowed to be 0xFFFF to indicate a "
-                        "wildcard endpoint.");
-        }
-        else
-        {
-            AddArgument("endpoint-id-ignored-for-group-commands", 0, UINT16_MAX, &mEndPointId,
-                        "Endpoint the command is targeted at.");
+            if (mSupportsMultipleEndpoints)
+            {
+                AddArgument("endpoint-ids", 0, UINT16_MAX, &mEndPointId,
+                            "Comma-separated list of endpoint ids (e.g. \"1\" or \"1,2,3\").\n  Allowed to be 0xFFFF to indicate a "
+                            "wildcard endpoint.");
+            }
+            else
+            {
+                AddArgument("endpoint-id-ignored-for-group-commands", 0, UINT16_MAX, &mEndPointId,
+                            "Endpoint the command is targeted at.");
+            }
         }
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -415,6 +415,33 @@ private:
     std::vector<chip::EventId> mEventIds;
 };
 
+class ReadNone : public ReadCommand
+{
+public:
+    ReadNone(CredentialIssuerCommands * credsIssuerConfig) : ReadCommand("read-none", credsIssuerConfig)
+    {
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
+                    "Boolean indicating whether to do a fabric-filtered read. Defaults to true.");
+        AddArgument("data-versions", 0, UINT32_MAX, &mDataVersions,
+                    "Comma-separated list of data versions for the clusters being read.");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
+        ReadCommand::AddArguments(true /* skipEndpoints */);
+    }
+
+    ~ReadNone() {}
+
+    void OnDone(chip::app::ReadClient * aReadClient) override
+    {
+        InteractionModelReports::CleanupReadClient(aReadClient);
+        SetCommandExitStatus(mError);
+    }
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        return ReadCommand::ReadNone(device);
+    }
+};
+
 class ReadAll : public ReadCommand
 {
 public:
@@ -454,6 +481,31 @@ private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
     std::vector<chip::EventId> mEventIds;
+};
+
+class SubscribeNone : public SubscribeCommand
+{
+public:
+    SubscribeNone(CredentialIssuerCommands * credsIssuerConfig) : SubscribeCommand("subscribe-none", credsIssuerConfig)
+    {
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval,
+                    "The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.");
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval,
+                    "The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.");
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
+                    "Boolean indicating whether to do a fabric-filtered read. Defaults to true.");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
+                    "false - Terminate existing subscriptions from initiator.\n  true - Leave existing subscriptions in place.");
+        SubscribeCommand::AddArguments(true /* skipEndpoints */);
+    }
+
+    ~SubscribeNone() {}
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        return SubscribeCommand::SubscribeNone(device);
+    }
 };
 
 class SubscribeAll : public SubscribeCommand

--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -22,7 +22,9 @@ _ANY_COMMANDS_LIST = [
     'SubscribeById',
     'ReadEventById',
     'SubscribeEventById',
+    'ReadNone',
     'ReadAll',
+    'SubscribeNone',
     'SubscribeAll',
 ]
 
@@ -79,6 +81,9 @@ _ALIASES = {
                     'EventId': 'event-id',
                 },
             },
+            'ReadNone': {
+                'alias': 'read-none',
+            },
             'ReadAll': {
                 'alias': 'read-all',
                 'arguments': {
@@ -86,6 +91,9 @@ _ALIASES = {
                     'AttributeId': 'attribute-ids',
                     'EventId': 'event-ids',
                 },
+            },
+            'SubscribeNone': {
+                'alias': 'subscribe-none',
             },
             'SubscribeAll': {
                 'alias': 'subscribe-all',
@@ -99,6 +107,14 @@ _ALIASES = {
     },
     'AnyCommands': {
         'alias': 'any',
+        'commands': {
+            'ReadNone': {
+                'has_endpoint': False,
+            },
+            'SubscribeNone': {
+                'has_endpoint': False,
+            }
+        }
     },
     'CommissionerCommands': {
         'alias': 'pairing',

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -132,7 +132,9 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<SubscribeAttribute>(credsIssuerConfig), //
         make_unique<ReadEvent>(credsIssuerConfig),       //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
+        make_unique<ReadNone>(credsIssuerConfig),         //
         make_unique<ReadAll>(credsIssuerConfig),         //
+        make_unique<SubscribeNone>(credsIssuerConfig),         //
         make_unique<SubscribeAll>(credsIssuerConfig),         //
     };
 

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -138,7 +138,7 @@ def _GetInDevelopmentTests() -> Set[str]:
         "TestAttributesById.yaml",           # chip-repl does not support AnyCommands (06/06/2023)
         "TestCommandsById.yaml",             # chip-repl does not support AnyCommands (06/06/2023)
         "TestEventsById.yaml",               # chip-repl does not support AnyCommands (06/06/2023)
-        "TestReadSubscribeNone.yaml",        # chip-repl does not support AnyCommands (07/27/2023)
+        "TestReadNoneSubscribeNone.yaml",    # chip-repl does not support AnyCommands (07/27/2023)
         "Test_TC_DRLK_2_8.yaml",   # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27011#issuecomment-1593339855
         "Test_TC_ACE_1_6.yaml",    # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27910#issuecomment-1632485584
         "Test_TC_PSCFG_1_1.yaml",  # Power source configuration cluster is deprecated and removed from all-clusters

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -138,6 +138,7 @@ def _GetInDevelopmentTests() -> Set[str]:
         "TestAttributesById.yaml",           # chip-repl does not support AnyCommands (06/06/2023)
         "TestCommandsById.yaml",             # chip-repl does not support AnyCommands (06/06/2023)
         "TestEventsById.yaml",               # chip-repl does not support AnyCommands (06/06/2023)
+        "TestReadSubscribeNone.yaml",        # chip-repl does not support AnyCommands (07/27/2023)
         "Test_TC_DRLK_2_8.yaml",   # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27011#issuecomment-1593339855
         "Test_TC_ACE_1_6.yaml",    # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27910#issuecomment-1632485584
         "Test_TC_PSCFG_1_1.yaml",  # Power source configuration cluster is deprecated and removed from all-clusters

--- a/src/app/tests/suites/TestReadNoneSubscribeNone.yaml
+++ b/src/app/tests/suites/TestReadNoneSubscribeNone.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ReadNone/SuscribeNone Tests
+
+config:
+    nodeId: 0x12344321
+    cluster: "Unit Testing"
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Read Request Message with no paths."
+      cluster: "AnyCommands"
+      command: "ReadNone"
+
+    - label: "Subscribe Request Message with no paths."
+      cluster: "AnyCommands"
+      command: "SubscribeNone"
+      minInterval: 1
+      maxInterval: 2
+      response:
+          error: INVALID_ACTION

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -90,11 +90,18 @@ protected:
                            std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
                            chip::app::ReadClient::InteractionType interactionType);
 
+    CHIP_ERROR ReadNone(chip::DeviceProxy * device) { return ReportNone(device, chip::app::ReadClient::InteractionType::Read); }
+
     CHIP_ERROR ReadAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                        std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
                        std::vector<chip::EventId> eventIds)
     {
         return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Read);
+    }
+
+    CHIP_ERROR SubscribeNone(chip::DeviceProxy * device)
+    {
+        return ReportNone(device, chip::app::ReadClient::InteractionType::Subscribe);
     }
 
     CHIP_ERROR SubscribeAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
@@ -104,6 +111,8 @@ protected:
         return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds,
                          chip::app::ReadClient::InteractionType::Subscribe);
     }
+
+    CHIP_ERROR ReportNone(chip::DeviceProxy * device, chip::app::ReadClient::InteractionType interactionType);
 
     CHIP_ERROR ReportAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
                          std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -19841,7 +19841,9 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<SubscribeAttribute>(credsIssuerConfig), //
         make_unique<ReadEvent>(credsIssuerConfig),          //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
+        make_unique<ReadNone>(credsIssuerConfig),           //
         make_unique<ReadAll>(credsIssuerConfig),            //
+        make_unique<SubscribeNone>(credsIssuerConfig),      //
         make_unique<SubscribeAll>(credsIssuerConfig),       //
     };
 


### PR DESCRIPTION
#### Problem

The step 12 of `TC-IDM-4.2` requires to issue a subscribe with no paths. This PR add such ability to `chip-tool` and YAML.