### PR TITLE
[cloudbuild] Allow failure for noip builds for chef

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -33,6 +33,12 @@ steps:
       args:
           - ./examples/chef/chef.py --build_all --build_include
             linux_arm64_ipv6only.*noip
+      # Temporarely allow failure since this is known to fail:
+      #   AppMain tries to setup commissioning in general (even if all things are
+      #   disabled, ethernet assumes network commissioning cluster) and link fails
+      #   when the cluster is fully disabled
+      # TODO: completely remove this target or fix compilation
+      allowFailure: true
       id: CompileNoip
       waitFor:
           - CompileAll


### PR DESCRIPTION
Chef builds for NoIP fail due to linux/AppMain.cpp assuming there is always a network commissioning cluster.

This is the immediate fix to not fail the entire chef builds, however we should figure out if a no-network-commissioning-cluster build is valid.