### PR TITLE
[dnssd] remove constants for _A subtype and AP TXT field

### DIFF
--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -35,12 +35,12 @@ constexpr size_t kHostNameMaxLength = 16; // MAC or 802.15.4 Extended Address in
  * Matter DNS service subtypes
  */
 
-constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
-constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
-constexpr size_t kSubTypeVendorIdMaxLength                = 7;  // _V<ddddd>
-constexpr size_t kSubTypeDeviceTypeMaxLength              = 12; // _T<dddddddddd>
-constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _CM
-constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; // _I<16-hex-digits>
+constexpr size_t kSubTypeShortDiscriminatorMaxLength = 4;  // _S<dd>
+constexpr size_t kSubTypeLongDiscriminatorMaxLength  = 6;  // _L<dddd>
+constexpr size_t kSubTypeVendorIdMaxLength           = 7;  // _V<ddddd>
+constexpr size_t kSubTypeDeviceTypeMaxLength         = 12; // _T<dddddddddd>
+constexpr size_t kSubTypeCommissioningModeMaxLength  = 3;  // _CM
+constexpr size_t kSubTypeCompressedFabricIdMaxLength = 18; // _I<16-hex-digits>
 
 /*
  * Matter operational node service settings

--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -39,8 +39,7 @@ constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
 constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
 constexpr size_t kSubTypeVendorIdMaxLength                = 7;  // _V<ddddd>
 constexpr size_t kSubTypeDeviceTypeMaxLength              = 12; // _T<dddddddddd>
-constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _C<d>
-constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3;  // _A<d>
+constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _CM
 constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; // _I<16-hex-digits>
 
 /*
@@ -68,8 +67,7 @@ namespace Commission {
 
 #define SUBTYPES                                                                                                                   \
     (std::initializer_list<size_t>{ kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength,                       \
-                                    kSubTypeVendorIdMaxLength, kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength,    \
-                                    kSubTypeAdditionalCommissioningMaxLength })
+                                    kSubTypeVendorIdMaxLength, kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength })
 
 constexpr size_t kInstanceNameMaxLength = 16; // 64-bit random number in hex
 constexpr size_t kSubTypeMaxNumber      = SUBTYPES.size();

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -38,14 +38,14 @@ static constexpr System::Clock::Milliseconds32 kMaxRetryInterval = 3600000_ms32;
 static constexpr size_t kKeyTcpSupportedMaxLength                = 1;
 
 // Commissionable/commissioner node TXT entries
-static constexpr size_t kKeyLongDiscriminatorMaxLength       = 5;
-static constexpr size_t kKeyVendorProductMaxLength           = 11;
-static constexpr size_t kKeyCommissioningModeMaxLength       = 1;
-static constexpr size_t kKeyDeviceTypeMaxLength              = 10;
-static constexpr size_t kKeyDeviceNameMaxLength              = 32;
-static constexpr size_t kKeyRotatingDeviceIdMaxLength        = 100;
-static constexpr size_t kKeyPairingInstructionMaxLength      = 128;
-static constexpr size_t kKeyPairingHintMaxLength             = 10;
+static constexpr size_t kKeyLongDiscriminatorMaxLength  = 5;
+static constexpr size_t kKeyVendorProductMaxLength      = 11;
+static constexpr size_t kKeyCommissioningModeMaxLength  = 1;
+static constexpr size_t kKeyDeviceTypeMaxLength         = 10;
+static constexpr size_t kKeyDeviceNameMaxLength         = 32;
+static constexpr size_t kKeyRotatingDeviceIdMaxLength   = 100;
+static constexpr size_t kKeyPairingInstructionMaxLength = 128;
+static constexpr size_t kKeyPairingHintMaxLength        = 10;
 
 enum class TxtKeyUse : uint8_t
 {

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -40,7 +40,6 @@ static constexpr size_t kKeyTcpSupportedMaxLength                = 1;
 // Commissionable/commissioner node TXT entries
 static constexpr size_t kKeyLongDiscriminatorMaxLength       = 5;
 static constexpr size_t kKeyVendorProductMaxLength           = 11;
-static constexpr size_t kKeyAdditionalCommissioningMaxLength = 1;
 static constexpr size_t kKeyCommissioningModeMaxLength       = 1;
 static constexpr size_t kKeyDeviceTypeMaxLength              = 10;
 static constexpr size_t kKeyDeviceNameMaxLength              = 32;
@@ -60,7 +59,6 @@ enum class TxtFieldKey : uint8_t
     kUnknown,
     kLongDiscriminator,
     kVendorProduct,
-    kAdditionalPairing,
     kCommissioningMode,
     kDeviceType,
     kDeviceName,
@@ -87,7 +85,6 @@ constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCoun
     { TxtFieldKey::kUnknown, 0, "", TxtKeyUse::kNone },
     { TxtFieldKey::kLongDiscriminator, kKeyLongDiscriminatorMaxLength, "D", TxtKeyUse::kCommission },
     { TxtFieldKey::kVendorProduct, kKeyVendorProductMaxLength, "VP", TxtKeyUse::kCommission },
-    { TxtFieldKey::kAdditionalPairing, kKeyAdditionalCommissioningMaxLength, "AP", TxtKeyUse::kCommission },
     { TxtFieldKey::kCommissioningMode, kKeyCommissioningModeMaxLength, "CM", TxtKeyUse::kCommission },
     { TxtFieldKey::kDeviceType, kKeyDeviceTypeMaxLength, "DT", TxtKeyUse::kCommission },
     { TxtFieldKey::kDeviceName, kKeyDeviceNameMaxLength, "DN", TxtKeyUse::kCommission },


### PR DESCRIPTION
The _A subtype and AP TXT field were removed from the spec long time ago but the constants describing the maximum lengths are still present in the SDK.