### PR TITLE
Dockerfile: Update esp-idf to v5.1 and remove few pinned package version

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-1 : Moving to GHCR
+2 : Update esp-idf to v5.1 and remove few pinned package version

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -6,8 +6,8 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    gcc-arm-none-eabi=15:9-2019-q4-0ubuntu1 \
-    binutils-arm-none-eabi=2.34-4ubuntu1+13ubuntu1 \
+    gcc-arm-none-eabi \
+    binutils-arm-none-eabi \
     git-lfs \
     openjdk-17-jdk \
     python3-sphinx \

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
     git-lfs \
     openjdk-17-jdk \
     python3-sphinx \
-    ccache=3.7.7-1 \
+    ccache \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4.4 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v5.1 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
@@ -39,7 +39,7 @@ FROM ghcr.io/project-chip/chip-build:${VERSION}
 # Tools for building, flashing and accessing device logs
 RUN set -x \
     && apt-get update \
-    && apt-get install --no-install-recommends -fy device-tree-compiler=1.5.1-1 \
+    && apt-get install --no-install-recommends -fy device-tree-compiler \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/stage-2/chip-build-openiotsdk/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-openiotsdk/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    wget=1.20.3-1ubuntu2 \
+    wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -55,9 +55,9 @@ RUN set -x \
     ccache \
     dfu-util=0.9-1 \
     device-tree-compiler \
-    gcc-multilib=4:9.3.0-1ubuntu2 \
-    g++-multilib=4:9.3.0-1ubuntu2 \
-    libsdl2-dev=2.0.10+dfsg1-3 \
+    gcc-multilib \
+    g++-multilib \
+    libsdl2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -52,9 +52,9 @@ ENV ZEPHYR_SDK_INSTALL_DIR=/opt/telink/zephyr-sdk-0.16.1
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    ccache=3.7.7-1 \
+    ccache \
     dfu-util=0.9-1 \
-    device-tree-compiler=1.5.1-1 \
+    device-tree-compiler \
     gcc-multilib=4:9.3.0-1ubuntu2 \
     g++-multilib=4:9.3.0-1ubuntu2 \
     libsdl2-dev=2.0.10+dfsg1-3 \


### PR DESCRIPTION
- esp-idf v5.1 was released sometime back so, updating to the latest stable release
- Few of the pinned packages in docker file was not found when building them, removed the pinned versions from them. ( please check failures for [efr32](https://github.com/project-chip/connectedhomeip/actions/runs/5680974662/job/15396825377), [nrf](https://github.com/project-chip/connectedhomeip/actions/runs/5680974662/job/15396826942), [telink](https://github.com/project-chip/connectedhomeip/actions/runs/5680974662/job/15396827186), [openiotsdk](https://github.com/project-chip/connectedhomeip/actions/runs/5680974662/job/15396827864))
    - efr32: gcc-arm-none-eabi, binutils-arm-none-eabi, ccache
    - telink: gcc-multilib, g++-multilib, libsdl2-dev, ccache, device-tree-compiler
    - nrf: device-tree-compiler
    - openiotsdk: wget