### PR TITLE
Improve encoding of lists where first item can't fit in packet.

### DIFF
--- a/src/app/AttributeAccessInterface.cpp
+++ b/src/app/AttributeAccessInterface.cpp
@@ -130,6 +130,19 @@ void AttributeValueEncoder::EnsureListEnded()
 
     AttributeReportBuilder builder;
     VerifyOrDie(builder.FinishAttribute(mAttributeReportIBsBuilder) == CHIP_NO_ERROR);
+
+    if (!mEncodedAtLeastOneListItem)
+    {
+        // If we have not managed to encode any list items, we don't actually
+        // want to output the single "empty list" IB that will then be followed
+        // by one-IB-per-item in the next packet.  Just have the reporting
+        // engine roll back our entire attribute and put us in the next packet.
+        //
+        // If we succeeded at encoding the whole list (i.e. the list is in fact
+        // empty and we fit in the packet), mAllowPartialData will be ignored,
+        // so it's safe to set it to false even if encoding succeeded.
+        mEncodeState.mAllowPartialData = false;
+    }
 }
 
 } // namespace app

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -292,6 +292,7 @@ private:
 
         mCurrentEncodingListIndex++;
         mEncodeState.mCurrentEncodingListIndex++;
+        mEncodedAtLeastOneListItem = true;
         return CHIP_NO_ERROR;
     }
 
@@ -340,6 +341,8 @@ private:
     // started chunking it yet, so we're encoding a single attribute report IB
     // for the whole list, not one per item.
     bool mEncodingInitialList = false;
+    // mEncodedAtLeastOneListItem becomes true once we successfully encode a list item.
+    bool mEncodedAtLeastOneListItem = false;
     AttributeEncodeState mEncodeState;
     ListIndex mCurrentEncodingListIndex = kInvalidListIndex;
 };

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1309,8 +1309,8 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
                     !aPath.IsListItemOperation())
                 {
                     mGotStartOfSecondReport = true;
-                    // Wait for an actual data chunk.
-                    return;
+                    // We always have data chunks, so go ahead to mark things
+                    // dirty as needed.
                 }
 
                 if (!mGotStartOfSecondReport)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2359,12 +2359,12 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 #else
         // When EventList is not enabled, the packet boundaries shift and for the first
         // report for the list attribute we receive two of its items in the initial list,
-        // then 4 additional items.  For the second report we receive 0 items in
-        // the initial list followed by 6 additional items.
+        // then 4 additional items.  For the second report we receive 3 items in
+        // the initial list followed by 3 additional items.
         //
-        // Thus we should receive 29*2 + 4 + 6 = 68 attribute data when the eventlist
+        // Thus we should receive 29*2 + 4 + 3 = 65 attribute data when the eventlist
         // attribute is not available.
-        constexpr size_t kExpectedAttributeResponse = 68;
+        constexpr size_t kExpectedAttributeResponse = 65;
 #endif
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == kExpectedAttributeResponse);
         NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 12);


### PR DESCRIPTION
When the first item of a list can't fit in the current packet, it's better to just send the packet without the list at all, then encode as many items as we can in the packet that follows before we start doing IB-per-item.

Otherwise (before this change) we encode an empty list IB, then end up doing IB-per-item for the whole list.
