### PR TITLE
[Chef] Fix noip device linking error

### DIFF
--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -150,8 +150,10 @@ void printQRCode()
 }
 #endif // CONFIG_HAVE_DISPLAY
 
+#if EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::ESPWiFiDriver::GetInstance()));
+#endif
 
 void InitServer(intptr_t)
 {
@@ -162,7 +164,9 @@ void InitServer(intptr_t)
 
     // Device Attestation & Onboarding codes
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
+#if EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
     sWiFiNetworkCommissioningInstance.Init();
+#endif
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
 
     if (chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow() != CHIP_NO_ERROR)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -101,6 +101,7 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::app::Clusters;
 
+#if EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
 // Network comissioning implementation
 namespace {
 // If secondaryNetworkCommissioningEndpoint has a value and both Thread and WiFi
@@ -217,6 +218,7 @@ void InitNetworkCommissioning()
     }
 }
 } // anonymous namespace
+#endif // EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
 
 #if defined(ENABLE_CHIP_SHELL)
 using chip::Shell::Engine;
@@ -366,7 +368,9 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     err = ParseArguments(argc, argv, customOptions);
     SuccessOrExit(err);
 
+#if EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
     sSecondaryNetworkCommissioningEndpoint = secondaryNetworkCommissioningEndpoint;
+#endif
 
 #ifdef CHIP_CONFIG_KVS_PATH
     if (LinuxDeviceOptions::GetInstance().KVS == nullptr)
@@ -557,7 +561,9 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 #endif // defined(ENABLE_CHIP_SHELL)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+#if EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER
     InitNetworkCommissioning();
+#endif
 
     ApplicationInit();
 

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -33,12 +33,6 @@ steps:
       args:
           - ./examples/chef/chef.py --build_all --build_include
             linux_arm64_ipv6only.*noip
-      # Temporarely allow failure since this is known to fail:
-      #   AppMain tries to setup commissioning in general (even if all things are
-      #   disabled, ethernet assumes network commissioning cluster) and link fails
-      #   when the cluster is fully disabled
-      # TODO: completely remove this target or fix compilation
-      allowFailure: true
       id: CompileNoip
       waitFor:
           - CompileAll


### PR DESCRIPTION
In Chef "noip" device we'll not enable `NetworkCommissioning` cluster which cause  `examples/platform/linux/AppMain.cpp` linking error when build code. The solution is apply  EMBER_AF_PLUGIN_NETWORK_COMMISSIONING_SERVER macro (which is defined when NetworkCommissiong cluster is enabled)  for conditional compilation.