### PR TITLE
Fix uninitialised values in KeySet and AttributePathExpandIterator

### DIFF
--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -65,8 +65,7 @@ AttributePathExpandIterator::AttributePathExpandIterator(ObjectList<AttributePat
                   "Our index won't be able to hold the value we need to hold.");
     static_assert(std::is_same<decltype(mGlobalAttributeIndex), uint8_t>::value,
                   "If this changes audit all uses where we set to UINT8_MAX");
-    mGlobalAttributeIndex    = UINT8_MAX;
-    mGlobalAttributeEndIndex = 0;
+    mGlobalAttributeIndex = UINT8_MAX;
 
     // Make the iterator ready to emit the first valid path in the list.
     Next();
@@ -141,6 +140,11 @@ void AttributePathExpandIterator::PrepareAttributeIndexRange(const AttributePath
                 }
             }
             mGlobalAttributeEndIndex = static_cast<uint8_t>(mGlobalAttributeIndex + 1);
+        }
+        else
+        {
+            mGlobalAttributeIndex    = UINT8_MAX;
+            mGlobalAttributeEndIndex = 0;
         }
     }
 }

--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -65,7 +65,8 @@ AttributePathExpandIterator::AttributePathExpandIterator(ObjectList<AttributePat
                   "Our index won't be able to hold the value we need to hold.");
     static_assert(std::is_same<decltype(mGlobalAttributeIndex), uint8_t>::value,
                   "If this changes audit all uses where we set to UINT8_MAX");
-    mGlobalAttributeIndex = UINT8_MAX;
+    mGlobalAttributeIndex    = UINT8_MAX;
+    mGlobalAttributeEndIndex = 0;
 
     // Make the iterator ready to emit the first valid path in the list.
     Next();

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -654,9 +654,10 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
 
     // Set the Identity Protection Key (IPK)
     // The IPK SHALL be the operational group key under GroupKeySetID of 0
-    keyset.keyset_id     = Credentials::GroupDataProvider::kIdentityProtectionKeySetId;
-    keyset.policy        = GroupKeyManagement::GroupKeySecurityPolicyEnum::kTrustFirst;
-    keyset.num_keys_used = 1;
+    keyset.keyset_id                = Credentials::GroupDataProvider::kIdentityProtectionKeySetId;
+    keyset.policy                   = GroupKeyManagement::GroupKeySecurityPolicyEnum::kTrustFirst;
+    keyset.num_keys_used            = 1;
+    keyset.epoch_keys[0].start_time = 0;
     memcpy(keyset.epoch_keys[0].key, ipkValue.data(), Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES);
 
     err = newFabricInfo->GetCompressedFabricIdBytes(compressed_fabric_id);

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -202,7 +202,7 @@ public:
     virtual ~GroupDataProvider() = default;
 
     // Not copyable
-    GroupDataProvider(const GroupDataProvider &)             = delete;
+    GroupDataProvider(const GroupDataProvider &) = delete;
     GroupDataProvider & operator=(const GroupDataProvider &) = delete;
 
     uint16_t GetMaxGroupsPerFabric() const { return mMaxGroupsPerFabric; }

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -121,7 +121,7 @@ public:
     {
         static constexpr size_t kLengthBytes = Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES;
         // Validity start time in microseconds since 2000-01-01T00:00:00 UTC ("the Epoch")
-        uint64_t start_time;
+        uint64_t start_time = 0;
         // Actual key bits. Depending on context, it may be a raw epoch key (as seen within `SetKeySet` calls)
         // or it may be the derived operational group key (as seen in any other usage).
         uint8_t key[kLengthBytes];
@@ -143,7 +143,7 @@ public:
         {}
 
         // The actual keys for the group key set
-        EpochKey epoch_keys[kEpochKeysMax] = {};
+        EpochKey epoch_keys[kEpochKeysMax];
         // Logical id provided by the Administrator that configured the entry
         uint16_t keyset_id = 0;
         // Security policy to use for groups that use this keyset
@@ -202,7 +202,7 @@ public:
     virtual ~GroupDataProvider() = default;
 
     // Not copyable
-    GroupDataProvider(const GroupDataProvider &) = delete;
+    GroupDataProvider(const GroupDataProvider &)             = delete;
     GroupDataProvider & operator=(const GroupDataProvider &) = delete;
 
     uint16_t GetMaxGroupsPerFabric() const { return mMaxGroupsPerFabric; }

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -143,7 +143,7 @@ public:
         {}
 
         // The actual keys for the group key set
-        EpochKey epoch_keys[kEpochKeysMax];
+        EpochKey epoch_keys[kEpochKeysMax] = {};
         // Logical id provided by the Administrator that configured the entry
         uint16_t keyset_id = 0;
         // Security policy to use for groups that use this keyset
@@ -202,7 +202,7 @@ public:
     virtual ~GroupDataProvider() = default;
 
     // Not copyable
-    GroupDataProvider(const GroupDataProvider &) = delete;
+    GroupDataProvider(const GroupDataProvider &)             = delete;
     GroupDataProvider & operator=(const GroupDataProvider &) = delete;
 
     uint16_t GetMaxGroupsPerFabric() const { return mMaxGroupsPerFabric; }

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -121,7 +121,7 @@ public:
     {
         static constexpr size_t kLengthBytes = Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES;
         // Validity start time in microseconds since 2000-01-01T00:00:00 UTC ("the Epoch")
-        uint64_t start_time = 0;
+        uint64_t start_time;
         // Actual key bits. Depending on context, it may be a raw epoch key (as seen within `SetKeySet` calls)
         // or it may be the derived operational group key (as seen in any other usage).
         uint8_t key[kLengthBytes];


### PR DESCRIPTION
### Problem

During commissioning, the valgrind tool reports errors due to conditional jumps being made based on uninitialized memory.

### Changes

Fix uninitialised values. 
Set default value in the KeySet.
Initialize mGlobalAttributeEndIndex in AttributePathExpandIterator;

### Testing

Perform commissioning test using valgrind.