### PR TITLE
Fix note message from gcc about uninitialized member

### DIFF
--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -177,7 +177,7 @@ CHIP_ERROR AccessControlAttribute::ReadAcl(AttributeValueEncoder & aEncoder)
         {
             auto fabric = info.GetFabricIndex();
             ReturnErrorOnFailure(GetAccessControl().Entries(fabric, iterator));
-            CHIP_ERROR err;
+            CHIP_ERROR err = CHIP_NO_ERROR;
             while ((err = iterator.Next(entry)) == CHIP_NO_ERROR)
             {
                 ReturnErrorOnFailure(encoder.Encode(encodableEntry));


### PR DESCRIPTION
### Problem

After change to C++17, on Tizen, we've got a note message from gcc about uninitialized member of `chip::ChipError` class (which needs to be trivial) in a lambda function. This is a false positive report (the `ChipError` instance is overwritten on a next line with properly initialized members), but by initializing CHIP_ERROR variable we can get rid of it and get a clean build once again.

Full gcc report:
```
INFO    [141/357] c++ obj/third_party/connectedhomeip/src/app/clusters/access-control-server/lighting-common.access-control-server.cpp.o
INFO    In file included from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/support/CodeUtils.h:30,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/core/CASEAuthTag.h:25,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/access/SubjectDescriptor.h:23,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/access/AccessControl.h:23,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/app/clusters/access-control-server/access-control-server.cpp:18:
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/app/clusters/access-control-server/access-control-server.cpp: In instantiation of ‘{anonymous}::AccessControlAttrib
ute::ReadAcl(chip::app::AttributeValueEncoder&)::<lambda(const auto:9&)> [with auto:9 = chip::app::AttributeValueEncoder::ListEncodeHelper; CHIP_ERROR = chip::ChipError]’:
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/app/AttributeAccessInterface.h:227:35:   required from ‘CHIP_ERROR chip::app::AttributeValueEncoder::EncodeList(Lis
tGenerator) [with ListGenerator = {anonymous}::AccessControlAttribute::ReadAcl(chip::app::AttributeValueEncoder&)::<lambda(const auto:9&)>; CHIP_ERROR = chip::ChipError]’
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/app/clusters/access-control-server/access-control-server.cpp:188:6:   required from here
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/core/CHIPError.h:51:7: note: ‘using CHIP_ERROR = class chip::ChipError’ {aka ‘class chip::ChipError’} has no us
er-provided default constructor
INFO       51 | class ChipError
INFO          |       ^~~~~~~~~
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/core/CHIPError.h:112:5: note: constructor is not user-provided because it is explicitly defaulted in the class
body
INFO      112 |     ChipError() = default;
INFO          |     ^~~~~~~~~
INFO    In file included from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/support/CodeUtils.h:30,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/core/CASEAuthTag.h:25,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/access/SubjectDescriptor.h:23,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/access/AccessControl.h:23,
INFO                     from ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/app/clusters/access-control-server/access-control-server.cpp:18:
INFO    ../../examples/lighting-app/tizen/third_party/connectedhomeip/src/lib/core/CHIPError.h:409:17: note: and the implicitly-defined constructor does not initialize ‘chip::ChipError::Sto
rageType chip::ChipError::mError’
INFO      409 |     StorageType mError;
```