### PR TITLE
dynamic endpoints: add automatic attr storage, instantiation from ZAP templates 

### DIFF
--- a/src/app/util/BUILD.gn
+++ b/src/app/util/BUILD.gn
@@ -29,7 +29,6 @@ source_set("nullable-primitives") {
   public_configs = [ "${chip_root}/src:includes" ]
 }
 
-# These headers/cpp only depend on core/common
 source_set("types") {
   sources = [
     "att-storage.h",
@@ -52,7 +51,6 @@ source_set("types") {
   public_configs = [ "${chip_root}/src:includes" ]
 }
 
-# This source set also depends on data-model
 source_set("af-types") {
   sources = [ "af-types.h" ]
   deps = [
@@ -60,6 +58,7 @@ source_set("af-types") {
     "${chip_root}/src/app:paths",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/messaging",
+    "${chip_root}/src/platform:platform_config_header",
     "${chip_root}/src/protocols/interaction_model",
   ]
 }

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -51,6 +51,15 @@
 typedef uint8_t EmberAfClusterMask;
 
 /**
+ * @brief Type for specifiying cluster including mask, to differentiate server & client
+ */
+typedef struct
+{
+    chip::ClusterId clusterId;
+    EmberAfClusterMask mask;
+} EmberAfClusterSpec;
+
+/**
  * @brief Generic function type, used for either of the cluster function.
  *
  * This type is used for the array of the cluster functions, and should

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -234,12 +234,13 @@ struct EmberAfDefinedEndpoint
 
 #if CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT > 0
     /**
-     * Pointer to the memory block to be used for automatic attribute storage if
-     * this is a dynamic endpoint. If set, the memory block pointed at
-     * must have a size equal to endpointType->endpointSize (which is
+     * Span describing a memory block to be used for automatic attribute storage if
+     * this is a dynamic endpoint. If not empty, the Span must have
+     * a size at least equal to endpointType->endpointSize (which is
      * the sum of all endpointType->clusters[*].clustersize).
      */
-    uint8_t * dynamicAttributeStorage = nullptr;
+    chip::Span<uint8_t> dynamicAttributeStorage;
+
 #endif
 
     /**

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -24,6 +24,8 @@
  */
 
 #include "att-storage.h"
+#include <platform/CHIPDeviceConfig.h> // For CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT
+
 #include <stdbool.h> // For bool
 #include <stdint.h>  // For various uint*_t types
 
@@ -180,7 +182,7 @@ typedef struct
      */
     uint8_t clusterCount;
     /**
-     * Size of all non-external, non-singlet attribute in this endpoint type.
+     * Size of all non-external, non-singleton attributes in this endpoint type.
      */
     uint16_t endpointSize;
 } EmberAfEndpointType;
@@ -220,6 +222,16 @@ struct EmberAfDefinedEndpoint
      * endpoint
      */
     chip::DataVersion * dataVersions = nullptr;
+
+#if CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT > 0
+    /**
+     * Pointer to the memory block to be used for automatic attribute storage if
+     * this is a dynamic endpoint. If set, the memory block pointed at
+     * must have a size equal to endpointType->endpointSize (which is
+     * the sum of all endpointType->clusters[*].clustersize).
+     */
+    uint8_t * dynamicAttributeStorage = nullptr;
+#endif
 
     /**
      * Root endpoint id for composed device type.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -302,7 +302,7 @@ void emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, 
         // Note: we cannot struct assignment here, because cluster in EmberAfEndpointType is const due
         //   to the way static cluster code generation works. So we have to resort to memcpy as a workaround
         //   until the much more intrusive changes as suggested by the TODO above can be applied.
-        memcpy((void *) &endpointType.cluster[i], cluster, sizeof(EmberAfCluster));
+        const_cast<EmberAfCluster&>(endpointType.cluster[i]) = *cluster;
         // sum up the needed storage
         endpointType.endpointSize = (uint16_t) (endpointType.endpointSize + cluster->clusterSize);
     }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -313,7 +313,7 @@ CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpoint
         // TODO: make endpointType use a pointer to a list of EmberAfCluster* instead, so we can re-use cluster definitions
         //   instead of duplicating them here once for every instance.
         newClusters[i] = *cluster;
-        // sum up the needed storage, result must
+        // sum up the needed storage, result must fit into endpointSize member (which is smaller than size_t)
         endpointSize += cluster->clusterSize;
         if (!CanCastTo<typeof(endpointType.endpointSize)>(endpointSize))
         {

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -295,7 +295,7 @@ CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpoint
     // allocate new cluster array
     auto newClusters = new EmberAfCluster[clusterCount];
     VerifyOrReturnError(newClusters != nullptr, CHIP_ERROR_NO_MEMORY);
-    uint16_t endpointSize = 0;
+    size_t endpointSize = 0;
     // get the actual cluster pointers and sum up memory size
     for (size_t i = 0; i < clusterCount; i++)
     {
@@ -313,13 +313,18 @@ CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpoint
         // TODO: make endpointType use a pointer to a list of EmberAfCluster* instead, so we can re-use cluster definitions
         //   instead of duplicating them here once for every instance.
         newClusters[i] = *cluster;
-        // sum up the needed storage
+        // sum up the needed storage, result must
         endpointSize += cluster->clusterSize;
+        if (!CanCastTo<typeof(endpointType.endpointSize)>(endpointSize))
+        {
+            delete[] newClusters;
+            return CHIP_ERROR_NO_MEMORY;
+        }
     }
     // set up dynamic endpoint
-    endpointType.clusterCount = static_cast<uint8_t>(clusterCount);
+    endpointType.clusterCount = static_cast<typeof(endpointType.clusterCount)>(clusterCount);
     endpointType.cluster      = newClusters;
-    endpointType.endpointSize = endpointSize;
+    endpointType.endpointSize = static_cast<typeof(endpointType.endpointSize)>(endpointSize);
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -732,7 +732,8 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                             }
 
                             {
-                                // attribute storage can be
+                                // Determine the attribute storage base address
+                                // Attribute storage can be
                                 // - singleton: statically allocated in singletonAttributeData global
                                 // - static endpoint: statically allocated in attributeData global
                                 // - dynamic endpoint with dynamic storage: in memory block provided at endpoint instantiation
@@ -751,6 +752,8 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                                 {
                                     attributeLocation = attributeData;
                                 }
+                                // Apply the offset to the attribute
+                                attributeLocation += attributeStorageOffset;
 
                                 uint8_t *src, *dst;
                                 if (write)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -706,7 +706,7 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                 attributeStorageOffset = 0;
             }
 #else
-            constexpr bool hasDynamicAttributeStorage = false;
+            const bool hasDynamicAttributeStorage = false;
 #endif
 
             for (clusterIndex = 0; clusterIndex < endpointType->clusterCount; clusterIndex++)
@@ -736,10 +736,12 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                                 {
                                     attributeLocation = singletonAttributeLocation(am);
                                 }
+#if CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT > 0
                                 else if (hasDynamicAttributeStorage)
                                 {
                                     attributeLocation = emAfEndpoints[ep].dynamicAttributeStorage.data();
                                 }
+#endif
                                 else
                                 {
                                     attributeLocation = attributeData;

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -291,7 +291,7 @@ CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpoint
     VerifyOrReturnError(endpointType.clusterCount == 0, CHIP_ERROR_INVALID_ARGUMENT);
     // check cluster count fits target struct's clusterCount field
     size_t clusterCount = templateClusterSpecs.size();
-    VerifyOrReturnError(CanCastTo<typeof(endpointType.clusterCount)>(clusterCount), CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(CanCastTo<decltype(endpointType.clusterCount)>(clusterCount), CHIP_ERROR_NO_MEMORY);
     // allocate new cluster array
     auto newClusters = new EmberAfCluster[clusterCount];
     VerifyOrReturnError(newClusters != nullptr, CHIP_ERROR_NO_MEMORY);
@@ -315,16 +315,16 @@ CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpoint
         newClusters[i] = *cluster;
         // sum up the needed storage, result must fit into endpointSize member (which is smaller than size_t)
         endpointSize += cluster->clusterSize;
-        if (!CanCastTo<typeof(endpointType.endpointSize)>(endpointSize))
+        if (!CanCastTo<decltype(endpointType.endpointSize)>(endpointSize))
         {
             delete[] newClusters;
             return CHIP_ERROR_NO_MEMORY;
         }
     }
     // set up dynamic endpoint
-    endpointType.clusterCount = static_cast<typeof(endpointType.clusterCount)>(clusterCount);
+    endpointType.clusterCount = static_cast<decltype(endpointType.clusterCount)>(clusterCount);
     endpointType.cluster      = newClusters;
-    endpointType.endpointSize = static_cast<typeof(endpointType.endpointSize)>(endpointSize);
+    endpointType.endpointSize = static_cast<decltype(endpointType.endpointSize)>(endpointSize);
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -251,6 +251,10 @@ void emberAfEndpointConfigure();
 //
 // An optional parent endpoint id should be passed for child endpoints of composed device.
 //
+// An optional dynamicAttributeStorage can be passed to allow automatic attribute storage.
+// This must point to a memory block of ep->endpointSize bytes size. If provided, the memory
+// needs to remain allocated until this dynamic endpoint is cleared.
+//
 // Returns  CHIP_NO_ERROR                   No error.
 //          CHIP_ERROR_NO_MEMORY            MAX_ENDPOINT_COUNT is reached or when no storage is left for clusters
 //          CHIP_ERROR_INVALID_ARGUMENT     The EndpointId value passed is kInvalidEndpointId
@@ -259,7 +263,8 @@ void emberAfEndpointConfigure();
 CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep,
                                      const chip::Span<chip::DataVersion> & dataVersionStorage,
                                      chip::Span<const EmberAfDeviceType> deviceTypeList = {},
-                                     chip::EndpointId parentEndpointId                  = chip::kInvalidEndpointId);
+                                     chip::EndpointId parentEndpointId                  = chip::kInvalidEndpointId,
+                                     uint8_t * dynamicAttributeStorage                  = nullptr);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 /**

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -286,8 +286,8 @@ void emberAfResetDynamicEndpointDeclaration(EmberAfEndpointType & endpointType);
 //
 // An optional parent endpoint id should be passed for child endpoints of composed device.
 //
-// An optional dynamicAttributeStorage can be passed to allow automatic attribute storage.
-// This must point to a memory block of ep->endpointSize bytes size. If provided, the memory
+// An optional dynamicAttributeStorage Span can be passed to allow automatic attribute storage.
+// This must describe a memory block of at least ep->endpointSize bytes size. If provided, the memory
 // needs to remain allocated until this dynamic endpoint is cleared.
 //
 // Returns  CHIP_NO_ERROR                   No error.
@@ -299,7 +299,7 @@ CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const 
                                      const chip::Span<chip::DataVersion> & dataVersionStorage,
                                      chip::Span<const EmberAfDeviceType> deviceTypeList = {},
                                      chip::EndpointId parentEndpointId                  = chip::kInvalidEndpointId,
-                                     uint8_t * dynamicAttributeStorage                  = nullptr);
+                                     chip::Span<uint8_t> dynamicAttributeStorage        = chip::Span<uint8_t>());
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 /**

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -250,18 +250,20 @@ void emberAfEndpointConfigure();
 // templateClusterSpecs is a list of clusterId/mask to specify the clusters to
 // be used from the template for the new endpoint.
 //
+// endpointType must be passed in with all members zero (cluster, clusterCount, endpointSize)
+// to express the endpoint has not yet been configured before.
 // endpointType will be setup with the specified clusters and their storage size so
 // it can be used in a subsequent call to emberAfSetDynamicEndpoint instead of
 // an endpoint manually constructed with DECLARE_DYNAMIC_*.
 //
 // Note: passing invalid templateEndpointId/templateClusterIds combinations, i.e. clusters
-//   not present in the specified template endpoint, will cause the function will die with
-//   an error message as this indicates severe internal inconsistency of the setup.
+//   not present in the specified template endpoint, will cause the function to
+//   return CHIP_ERROR_NOT_FOUND and endpointType unmodified.
 //
 // Note: function may allocate memory for the endpoint declaration.
-//   Use emberAfResetEndpointDeclaration to properly dispose of an endpoint declaration.
-void emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
-                                            const chip::Span<const EmberAfClusterSpec> & templateClusterSpecs);
+//   Use emberAfResetEndpointDeclaration to properly dispose of a dynamic endpoint declaration.
+CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
+                                                  const chip::Span<const EmberAfClusterSpec> & templateClusterSpecs);
 
 // reset an endpoint declaration that was setup with emberAfSetupDynamicEndpointDeclaration
 // to free all extra memory that might have been allocated.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -235,6 +235,18 @@ const EmberAfCluster * emberAfFindClusterInType(const EmberAfEndpointType * endp
 // Initial configuration
 void emberAfEndpointConfigure();
 
+// setup a dynamic endpoint's EmberAfEndpointType from a list of template clusters.
+//
+// This is a alternative to declaring dynamic endpoint metadata using DECLARE_DYNAMIC_* macros.
+//
+// As clusters to be used in dynamic endpoint setup need to be defined in ZAP anyway
+// (usually on a special endpoint which remains always disabled), the cluster's
+// metadata including all attributes already exists and can be re-used this way,
+// without error prone manual duplicating with DECLARE_DYNAMIC_*
+//
+CHIP_ERROR setupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
+                                           const chip::Span<const chip::ClusterId> & templateClusterIds);
+
 // Register a dynamic endpoint. This involves registering descriptors that describe
 // the composition of the endpoint (encapsulated in the 'ep' argument) as well as providing
 // storage for data versions.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -260,7 +260,7 @@ void emberAfEndpointConfigure();
 //   not present in the specified template endpoint, will cause the function to
 //   return CHIP_ERROR_NOT_FOUND and endpointType unmodified.
 //
-// Note: function may allocate memory for the endpoint declaration.
+// Note: function will allocate dynamic memory for the endpoint declaration.
 //   Use emberAfResetEndpointDeclaration to properly dispose of a dynamic endpoint declaration.
 CHIP_ERROR emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
                                                   const chip::Span<const EmberAfClusterSpec> & templateClusterSpecs);

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -244,8 +244,30 @@ void emberAfEndpointConfigure();
 // metadata including all attributes already exists and can be re-used this way,
 // without error prone manual duplicating with DECLARE_DYNAMIC_*
 //
-CHIP_ERROR setupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
-                                           const chip::Span<const chip::ClusterId> & templateClusterIds);
+// templateEndpointId specifies a endpoint which is usually disabled, but containing
+// cluster definitions that should be used for instantiating active endpoints.
+//
+// templateClusterIds is a list of clusterIds to be used for the new endpoint.
+//
+// endpointType will be setup with the specified clusters and their storage size so
+// it can be used in a subsequent call to emberAfSetDynamicEndpoint instead of
+// an endpoint manually constructed with DECLARE_DYNAMIC_*.
+//
+// Note: passing invalid templateEndpointId/templateClusterIds combinations, i.e. clusters
+//   not present in the specified template endpoint, will cause the function will die with
+//   an error message as this indicates severe internal inconsistency of the setup.
+//
+// Note: function may allocate memory for the endpoint declaration.
+//   Use emberAfResetEndpointDeclaration to properly dispose of an endpoint declaration.
+void emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
+                                            const chip::Span<const chip::ClusterId> & templateClusterIds);
+
+// reset an endpoint declaration that was setup with emberAfSetupDynamicEndpointDeclaration
+// to free all extra memory that might have been allocated.
+//
+// Warning: passing endpoint declarations that are not set up with
+//   emberAfSetupDynamicEndpointDeclaration is NOT allowed and likely causes undefined crashes.
+void emberAfResetDynamicEndpointDeclaration(EmberAfEndpointType & endpointType);
 
 // Register a dynamic endpoint. This involves registering descriptors that describe
 // the composition of the endpoint (encapsulated in the 'ep' argument) as well as providing

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -247,7 +247,8 @@ void emberAfEndpointConfigure();
 // templateEndpointId specifies a endpoint which is usually disabled, but containing
 // cluster definitions that should be used for instantiating active endpoints.
 //
-// templateClusterIds is a list of clusterIds to be used for the new endpoint.
+// templateClusterSpecs is a list of clusterId/mask to specify the clusters to
+// be used from the template for the new endpoint.
 //
 // endpointType will be setup with the specified clusters and their storage size so
 // it can be used in a subsequent call to emberAfSetDynamicEndpoint instead of
@@ -260,7 +261,7 @@ void emberAfEndpointConfigure();
 // Note: function may allocate memory for the endpoint declaration.
 //   Use emberAfResetEndpointDeclaration to properly dispose of an endpoint declaration.
 void emberAfSetupDynamicEndpointDeclaration(EmberAfEndpointType & endpointType, chip::EndpointId templateEndpointId,
-                                            const chip::Span<const chip::ClusterId> & templateClusterIds);
+                                            const chip::Span<const EmberAfClusterSpec> & templateClusterSpecs);
 
 // reset an endpoint declaration that was setup with emberAfSetupDynamicEndpointDeclaration
 // to free all extra memory that might have been allocated.


### PR DESCRIPTION
This PR originates from the discussion in #28166 and solves two problems when working with dynamic endpoints, as is the case in bridge-type apps.

There is no change in behaviour unless dynamic endpoint storage is explicitly assigned by an app. The `DECLARE_DYNAMIC_xxx` macros can still be used to define dynamic endpoints,
(but cannot use automatic attribute storage because the macros force all attributes to be "external").

## automatic attribute storage for dynamic endpoints

- Dynamically defined endpoints can now have their own block of storage
(to be provided by the caller of emberAfSetDynamicEndpoint()).

- If no storage is set for a dynamic endpoint, it behaves exactly as before,
which is treating all attributes as "external", regardless of the respective
bit in the attribute's metadata.

- With a storage block provided, attributes behave the same way as static endpoint's
do, that is, only those marked "external" need to be handled programmatically
in the respective callbacks, other attributes' storage is automatic.

## creating dynamic endpoints from ZAP templates instead via macros

- Instead of re-creating dynamic endpoint's cluster declarations
using the DECLARE_DYNAMIC_xxx macros, the new
`setupDynamicEndpointDeclaration()` function allows setting
up a dynamic endpoint by using clusters defined in another
endpoint as templates. Usually that endpoint is a disabled endpoint created
in ZAP with all clusters possibly to be used dynamically assigned.

- In combination with dynamic endpoint attribute storage, this
greatly simplifies implementing dynamic endpoints and allows
configuring them using the ZAP tool to ensure specs conformance,
much the same way as with statically defined endpoints.