### PR TITLE
[ICD] Stay in active mode when a reliable message context is awaiting an ack

### DIFF
--- a/src/app/icd/ICDEventManager.h
+++ b/src/app/icd/ICDEventManager.h
@@ -48,6 +48,7 @@ private:
      */
     static void ICDEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     static uint8_t expectedMsgCount;
+    static uint8_t awaitingAckCount;
     ICDManager * mICDManager;
 };
 

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -48,6 +48,7 @@ public:
         kCommissioningWindowOpen = 0x01,
         kFailSafeArmed           = 0x02,
         kExpectingMsgResponse    = 0x03,
+        kAwaitingMsgAck          = 0x04,
     };
 
     ICDManager() {}

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -275,6 +275,16 @@ enum PublicEventTypes
     kChipMsgRxEventHandled,
 
     /**
+     * This event is used to sync the ICD with any Reliable Message exchange
+     * expecting an ack. The ICD shall stay in active Mode
+     * until the Reliable Message exchange post this event again
+     * informing the ICD that it is no longer awaiting the ack.
+     *
+     * This event contains an AckSync structure.
+     */
+    kICDMsgAckSyncEvent,
+
+    /**
      * An application event occured that should wake up the system/device
      */
     kAppWakeUpEvent,
@@ -580,6 +590,15 @@ struct ChipDeviceEvent final
             bool wasReceived;
             bool clearsExpectedResponse;
         } RxEventContext;
+
+        struct
+        {
+            /*
+             * Set to true when a Reliable Message Context is awaiting for a ack to a message sent
+             * Set to false when the Reliable Message Context is no longer awaiting for a ack
+             */
+            bool awaitingAck;
+        } AckSync;
     };
 
     void Clear() { memset(this, 0, sizeof(*this)); }

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -241,11 +241,6 @@ inline void ReliableMessageContext::SetAckPending(bool inAckPending)
     mFlags.Set(Flags::kFlagAckPending, inAckPending);
 }
 
-inline void ReliableMessageContext::SetMessageNotAcked(bool messageNotAcked)
-{
-    mFlags.Set(Flags::kFlagMessageNotAcked, messageNotAcked);
-}
-
 inline void ReliableMessageContext::SetRequestingActiveMode(bool activeMode)
 {
     mFlags.Set(Flags::kFlagActiveMode, activeMode);


### PR DESCRIPTION
fixes #28107
Add event tied to reliable message acks.
Request ICD active mode while waiting on at least 1 ack from any reliable message context.



