### PR TITLE
Add `GroupKeyMulticastPolicy` to GroupKeySetStruct in group key management cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2290,9 +2290,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -2317,6 +2326,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -1929,9 +1929,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1956,6 +1965,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -1541,9 +1541,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1568,6 +1577,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1426,9 +1426,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1453,6 +1462,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -893,9 +893,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -920,6 +929,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
+++ b/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
@@ -1126,9 +1126,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1153,6 +1162,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -1186,9 +1186,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1213,6 +1222,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -1140,9 +1140,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1167,6 +1176,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1290,9 +1290,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1317,6 +1326,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -1140,9 +1140,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1167,6 +1176,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -1290,9 +1290,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1317,6 +1326,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
@@ -1127,9 +1127,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1154,6 +1163,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -1284,9 +1284,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1311,6 +1320,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -1290,9 +1290,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1317,6 +1326,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -1254,9 +1254,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1281,6 +1290,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -1189,9 +1189,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1216,6 +1225,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_pump_a811bb33a0.matter
+++ b/examples/chef/devices/rootnode_pump_a811bb33a0.matter
@@ -839,9 +839,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -866,6 +875,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -1284,9 +1284,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1311,6 +1320,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -1215,9 +1215,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1242,6 +1251,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -1140,9 +1140,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1167,6 +1176,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -1140,9 +1140,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1167,6 +1176,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -1351,9 +1351,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1378,6 +1387,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
@@ -971,9 +971,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -998,6 +1007,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1854,9 +1854,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1881,6 +1890,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
@@ -1459,9 +1459,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1486,6 +1495,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -1369,9 +1369,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1396,6 +1405,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1718,9 +1718,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1745,6 +1754,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/nxp/zap/lighting-on-off.matter
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.matter
@@ -1285,9 +1285,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1312,6 +1321,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/qpg/zap/light.matter
+++ b/examples/lighting-app/qpg/zap/light.matter
@@ -1351,9 +1351,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1378,6 +1387,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -1811,9 +1811,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1838,6 +1847,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -1700,9 +1700,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1727,6 +1736,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -1559,9 +1559,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1586,6 +1595,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lock-app/nxp/zap/lock-app.matter
+++ b/examples/lock-app/nxp/zap/lock-app.matter
@@ -903,9 +903,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -930,6 +939,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -1184,9 +1184,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1211,6 +1220,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -884,9 +884,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -911,6 +920,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -1067,9 +1067,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1094,6 +1103,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -1143,9 +1143,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1170,6 +1179,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -1143,9 +1143,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1170,6 +1179,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -1143,9 +1143,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1170,6 +1179,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -1068,9 +1068,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1095,6 +1104,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
+++ b/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
@@ -1403,9 +1403,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1430,6 +1439,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -1470,9 +1470,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1497,6 +1506,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
@@ -935,9 +935,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -962,6 +971,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -1555,9 +1555,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1582,6 +1591,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1704,9 +1704,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1731,6 +1740,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1267,9 +1267,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1294,6 +1303,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -1493,9 +1493,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1520,6 +1529,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1687,9 +1687,18 @@ server cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 server cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -1714,6 +1723,7 @@ server cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/src/app/tests/suites/TestGroupDemoConfig.yaml
+++ b/src/app/tests/suites/TestGroupDemoConfig.yaml
@@ -56,6 +56,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Write Group Keys (endpoint 0)"

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -89,6 +89,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2 CacheAndSync"
@@ -107,6 +108,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2 TrustFirst"
@@ -125,6 +127,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 3 CacheAndSync"
@@ -146,6 +149,7 @@ tests:
                         EpochKey2:
                             "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 3 TrustFirst"
@@ -167,6 +171,7 @@ tests:
                         EpochKey2:
                             "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Read"
@@ -188,6 +193,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: null,
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Read All Indices"
@@ -564,6 +570,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: null,
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Read (not removed) TrustFirst"
@@ -586,6 +593,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: null,
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Remove Group 1"
@@ -671,6 +679,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2 CacheAndSync"
@@ -689,6 +698,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2 TrustFirst"
@@ -707,6 +717,7 @@ tests:
                         EpochStartTime1: 2110001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Map Group 1 and Group 2 to KeySet 1 and group 2 to KeySet 2"

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -58,6 +58,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2"
@@ -75,6 +76,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Write Group Keys"
@@ -308,6 +310,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "KeySet Write 2 for gamma"
@@ -326,6 +329,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Write Group Keys for gamma"

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -86,6 +86,7 @@ tests:
                         EpochStartTime1: 1110001,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 1110002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Write Group Keys"

--- a/src/app/tests/suites/certification/Test_TC_ACE_1_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACE_1_6.yaml
@@ -73,6 +73,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: "hex:d2d1d2d3d4d5d6d7d8d9dadbdcdddedf",
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_SC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_1.yaml
@@ -84,6 +84,7 @@ tests:
                         EpochStartTime1: 222,
                         EpochKey2: "hex:00000000000000000000000000000003",
                         EpochStartTime2: 333,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Step 2b: TH sends KeySetWrite command with TH key"
@@ -102,6 +103,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: "hex:d2d1d2d3d4d5d6d7d8d9dadbdcdddedf",
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Step 3: TH binds GroupId to GroupKeySet"
@@ -181,6 +183,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: null,
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_5_2.yaml
@@ -82,6 +82,7 @@ tests:
                         EpochStartTime1: 2220001,
                         EpochKey2: "hex:d2d1d2d3d4d5d6d7d8d9dadbdcdddedf",
                         EpochStartTime2: 2220002,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label: "Step 3: TH binds GroupId to GroupKeySet"

--- a/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
@@ -68,6 +68,7 @@ tests:
                         EpochStartTime1: 0,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 0,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
@@ -65,6 +65,7 @@ tests:
                         EpochStartTime1: 0,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 0,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_S_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_4.yaml
@@ -57,6 +57,7 @@ tests:
                         EpochStartTime1: 0,
                         EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
                         EpochStartTime2: 0,
+                        GroupKeyMulticastPolicy: 0,
                     }
 
     - label:

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -30,6 +30,23 @@ limitations under the License.
     <item fieldId="3" name="GroupName" type="CHAR_STRING" length="16" optional="true"/>
   </struct>
 
+  <enum name="GroupKeySecurityPolicyEnum" type="ENUM8">
+    <cluster code="0x003F"/>
+    <item name="TrustFirst" value="0x00"/>
+    <item name="CacheAndSync" value="0x01"/>
+  </enum>
+
+  <enum name="GroupKeyMulticastPolicyEnum" type="ENUM8">
+    <cluster code="0x003F"/>
+    <item name="PerGroupID" value="0x00"/>
+    <item name="AllNodes" value="0x01"/>
+  </enum>
+
+  <bitmap name="Feature" type="BITMAP32">
+      <cluster code="0x003F"/>
+      <field name="CacheAndSync" mask="0x1"/>
+  </bitmap>
+
   <struct name="GroupKeySetStruct">
     <cluster code="0x003F"/>
     <item fieldId="0" name="GroupKeySetID" type="INT16U"/>
@@ -40,13 +57,8 @@ limitations under the License.
     <item fieldId="5" name="EpochStartTime1" type="epoch_us" isNullable="true"/>
     <item fieldId="6" name="EpochKey2" type="OCTET_STRING" length="16" isNullable="true"/>
     <item fieldId="7" name="EpochStartTime2" type="epoch_us" isNullable="true"/>
+    <item fieldId="8" name="GroupKeyMulticastPolicy" type="GroupKeyMulticastPolicyEnum" isNullable="false"/>
   </struct>
-
-  <enum name="GroupKeySecurityPolicyEnum" type="ENUM8">
-    <cluster code="0x003F"/>
-    <item name="TrustFirst" value="0x00"/>
-    <item name="CacheAndSync" value="0x01"/>
-  </enum>
 
   <cluster>
     <domain>General</domain>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2572,9 +2572,18 @@ client cluster OperationalCredentials = 62 {
 
 /** The Group Key Management Cluster is the mechanism by which group keys are managed. */
 client cluster GroupKeyManagement = 63 {
+  enum GroupKeyMulticastPolicyEnum : ENUM8 {
+    kPerGroupID = 0;
+    kAllNodes = 1;
+  }
+
   enum GroupKeySecurityPolicyEnum : ENUM8 {
     kTrustFirst = 0;
     kCacheAndSync = 1;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kCacheAndSync = 0x1;
   }
 
   fabric_scoped struct GroupInfoMapStruct {
@@ -2599,6 +2608,7 @@ client cluster GroupKeyManagement = 63 {
     nullable epoch_us epochStartTime1 = 5;
     nullable octet_string<16> epochKey2 = 6;
     nullable epoch_us epochStartTime2 = 7;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = 8;
   }
 
   attribute access(write: manage) GroupKeyMapStruct groupKeyMap[] = 0;

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -2631,6 +2631,12 @@ void CHIPGroupKeyManagementClusterKeySetReadResponseCallback::CallbackFn(
             GroupKeySet_epochStartTime2ClassName.c_str(), GroupKeySet_epochStartTime2CtorSignature.c_str(),
             dataResponse.groupKeySet.epochStartTime2.Value(), GroupKeySet_epochStartTime2);
     }
+    jobject GroupKeySet_groupKeyMulticastPolicy;
+    std::string GroupKeySet_groupKeyMulticastPolicyClassName     = "java/lang/Integer";
+    std::string GroupKeySet_groupKeyMulticastPolicyCtorSignature = "(I)V";
+    chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
+        GroupKeySet_groupKeyMulticastPolicyClassName.c_str(), GroupKeySet_groupKeyMulticastPolicyCtorSignature.c_str(),
+        static_cast<uint8_t>(dataResponse.groupKeySet.groupKeyMulticastPolicy), GroupKeySet_groupKeyMulticastPolicy);
 
     jclass groupKeySetStructStructClass_0;
     err = chip::JniReferences::GetInstance().GetClassRef(
@@ -2640,19 +2646,19 @@ void CHIPGroupKeyManagementClusterKeySetReadResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeySetStruct");
         return;
     }
-    jmethodID groupKeySetStructStructCtor_0 =
-        env->GetMethodID(groupKeySetStructStructClass_0, "<init>",
-                         "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;[BLjava/lang/Long;[BLjava/lang/Long;)V");
+    jmethodID groupKeySetStructStructCtor_0 = env->GetMethodID(
+        groupKeySetStructStructClass_0, "<init>",
+        "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;[BLjava/lang/Long;[BLjava/lang/Long;Ljava/lang/Integer;)V");
     if (groupKeySetStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupKeySetStruct constructor");
         return;
     }
 
-    GroupKeySet =
-        env->NewObject(groupKeySetStructStructClass_0, groupKeySetStructStructCtor_0, GroupKeySet_groupKeySetID,
-                       GroupKeySet_groupKeySecurityPolicy, GroupKeySet_epochKey0, GroupKeySet_epochStartTime0,
-                       GroupKeySet_epochKey1, GroupKeySet_epochStartTime1, GroupKeySet_epochKey2, GroupKeySet_epochStartTime2);
+    GroupKeySet = env->NewObject(groupKeySetStructStructClass_0, groupKeySetStructStructCtor_0, GroupKeySet_groupKeySetID,
+                                 GroupKeySet_groupKeySecurityPolicy, GroupKeySet_epochKey0, GroupKeySet_epochStartTime0,
+                                 GroupKeySet_epochKey1, GroupKeySet_epochStartTime1, GroupKeySet_epochKey2,
+                                 GroupKeySet_epochStartTime2, GroupKeySet_groupKeyMulticastPolicy);
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, GroupKeySet);
 }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -1434,6 +1434,7 @@ public @Nullable byte[] epochKey1;
 public @Nullable Long epochStartTime1;
 public @Nullable byte[] epochKey2;
 public @Nullable Long epochStartTime2;
+public Integer groupKeyMulticastPolicy;
 
   public GroupKeyManagementClusterGroupKeySetStruct(
     Integer groupKeySetID
@@ -1444,6 +1445,7 @@ public @Nullable Long epochStartTime2;
       , @Nullable Long epochStartTime1
       , @Nullable byte[] epochKey2
       , @Nullable Long epochStartTime2
+      , Integer groupKeyMulticastPolicy
   ) {
     this.groupKeySetID = groupKeySetID;
     this.groupKeySecurityPolicy = groupKeySecurityPolicy;
@@ -1453,6 +1455,7 @@ public @Nullable Long epochStartTime2;
     this.epochStartTime1 = epochStartTime1;
     this.epochKey2 = epochKey2;
     this.epochStartTime2 = epochStartTime2;
+    this.groupKeyMulticastPolicy = groupKeyMulticastPolicy;
   }
 
   @Override
@@ -1482,6 +1485,9 @@ public @Nullable Long epochStartTime2;
     output.append("\n");
     output.append("\tepochStartTime2: ");
     output.append(epochStartTime2);
+        output.append("\n");
+    output.append("\tgroupKeyMulticastPolicy: ");
+    output.append(groupKeyMulticastPolicy);
         output.append("\n");
     output.append("}\n");
     return output.toString();

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -13442,6 +13442,15 @@ class GroupKeyManagement(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
+        class GroupKeyMulticastPolicyEnum(MatterIntEnum):
+            kPerGroupID = 0x00
+            kAllNodes = 0x01
+            # All received enum values that are not listed above will be mapped
+            # to kUnknownEnumValue. This is a helper enum value that should only
+            # be used by code to process how it handles receiving and unknown
+            # enum value. This specific should never be transmitted.
+            kUnknownEnumValue = 2,
+
         class GroupKeySecurityPolicyEnum(MatterIntEnum):
             kTrustFirst = 0x00
             kCacheAndSync = 0x01
@@ -13450,6 +13459,10 @@ class GroupKeyManagement(Cluster):
             # be used by code to process how it handles receiving and unknown
             # enum value. This specific should never be transmitted.
             kUnknownEnumValue = 2,
+
+    class Bitmaps:
+        class Feature(IntFlag):
+            kCacheAndSync = 0x1
 
     class Structs:
         @dataclass
@@ -13498,6 +13511,7 @@ class GroupKeyManagement(Cluster):
                         ClusterObjectFieldDescriptor(Label="epochStartTime1", Tag=5, Type=typing.Union[Nullable, uint]),
                         ClusterObjectFieldDescriptor(Label="epochKey2", Tag=6, Type=typing.Union[Nullable, bytes]),
                         ClusterObjectFieldDescriptor(Label="epochStartTime2", Tag=7, Type=typing.Union[Nullable, uint]),
+                        ClusterObjectFieldDescriptor(Label="groupKeyMulticastPolicy", Tag=8, Type=GroupKeyManagement.Enums.GroupKeyMulticastPolicyEnum),
                     ])
 
             groupKeySetID: 'uint' = 0
@@ -13508,6 +13522,7 @@ class GroupKeyManagement(Cluster):
             epochStartTime1: 'typing.Union[Nullable, uint]' = NullValue
             epochKey2: 'typing.Union[Nullable, bytes]' = NullValue
             epochStartTime2: 'typing.Union[Nullable, uint]' = NullValue
+            groupKeyMulticastPolicy: 'GroupKeyManagement.Enums.GroupKeyMulticastPolicyEnum' = 0
 
     class Commands:
         @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.h
@@ -404,6 +404,10 @@ typedef void (*OperationalCredentialsClusterNodeOperationalCertStatusEnumAttribu
     void *, chip::app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum);
 typedef void (*NullableOperationalCredentialsClusterNodeOperationalCertStatusEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum> &);
+typedef void (*GroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback)(
+    void *, chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum);
+typedef void (*NullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum> &);
 typedef void (*GroupKeyManagementClusterGroupKeySecurityPolicyEnumAttributeCallback)(
     void *, chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicyEnum);
 typedef void (*NullableGroupKeyManagementClusterGroupKeySecurityPolicyEnumAttributeCallback)(
@@ -24367,6 +24371,80 @@ public:
     void OnSubscriptionEstablished();
     using MTRNullableOperationalCredentialsClusterNodeOperationalCertStatusEnumAttributeCallbackBridge::KeepAliveOnCallback;
     using MTRNullableOperationalCredentialsClusterNodeOperationalCertStatusEnumAttributeCallbackBridge::OnDone;
+
+private:
+    MTRSubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<GroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>
+{
+public:
+    MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                   ResponseHandler handler) :
+        MTRCallbackBridge<GroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>(queue, handler, OnSuccessFn){};
+
+    MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                                   MTRActionBlock action) :
+        MTRCallbackBridge<GroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>(queue, handler, action,
+                                                                                                 OnSuccessFn){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum value);
+};
+
+class MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge
+    : public MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge
+{
+public:
+    MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, MTRActionBlock action,
+        MTRSubscriptionEstablishedHandler establishedHandler) :
+        MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(queue, handler, action),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    void OnSubscriptionEstablished();
+    using MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::KeepAliveOnCallback;
+    using MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::OnDone;
+
+private:
+    MTRSubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>
+{
+public:
+    MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                           ResponseHandler handler) :
+        MTRCallbackBridge<NullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>(queue, handler,
+                                                                                                         OnSuccessFn){};
+
+    MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                           ResponseHandler handler,
+                                                                                           MTRActionBlock action) :
+        MTRCallbackBridge<NullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallback>(queue, handler, action,
+                                                                                                         OnSuccessFn){};
+
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum> & value);
+};
+
+class MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge
+    : public MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge
+{
+public:
+    MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, MTRActionBlock action,
+        MTRSubscriptionEstablishedHandler establishedHandler) :
+        MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge(queue, handler, action),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    void OnSubscriptionEstablished();
+    using MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::KeepAliveOnCallback;
+    using MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::OnDone;
 
 private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
@@ -23724,6 +23724,56 @@ void MTRNullableOperationalCredentialsClusterNodeOperationalCertStatusEnumAttrib
     }
 }
 
+void MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum value)
+{
+    NSNumber * _Nonnull objCValue;
+    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
+    DispatchSuccess(context, objCValue);
+};
+
+void MTRGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
+{
+    if (!mQueue) {
+        return;
+    }
+
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        mEstablishedHandler = nil;
+    }
+}
+
+void MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackBridge::OnSuccessFn(void * context,
+    const chip::app::DataModel::Nullable<chip::app::Clusters::GroupKeyManagement::GroupKeyMulticastPolicyEnum> & value)
+{
+    NSNumber * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
+    }
+    DispatchSuccess(context, objCValue);
+};
+
+void MTRNullableGroupKeyManagementClusterGroupKeyMulticastPolicyEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished()
+{
+    if (!mQueue) {
+        return;
+    }
+
+    if (mEstablishedHandler != nil) {
+        dispatch_async(mQueue, mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        mEstablishedHandler = nil;
+    }
+}
+
 void MTRGroupKeyManagementClusterGroupKeySecurityPolicyEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicyEnum value)
 {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -12651,6 +12651,9 @@ static void MTRClustersLogCompletion(NSString * logPrefix, id value, NSError * e
                     auto & nonNullValue_1 = request.groupKeySet.epochStartTime2.SetNonNull();
                     nonNullValue_1 = params.groupKeySet.epochStartTime2.unsignedLongLongValue;
                 }
+                request.groupKeySet.groupKeyMulticastPolicy
+                    = static_cast<std::remove_reference_t<decltype(request.groupKeySet.groupKeyMulticastPolicy)>>(
+                        params.groupKeySet.groupKeyMulticastPolicy.unsignedCharValue);
 
                 return MTRStartInvokeInteraction(typedBridge, request, exchangeManager, session, successCb, failureCb,
                     self->_endpoint, timedInvokeTimeoutMs, invokeTimeout);

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -6455,6 +6455,8 @@ NS_ASSUME_NONNULL_BEGIN
             self.groupKeySet.epochStartTime2 =
                 [NSNumber numberWithUnsignedLongLong:decodableStruct.groupKeySet.epochStartTime2.Value()];
         }
+        self.groupKeySet.groupKeyMulticastPolicy =
+            [NSNumber numberWithUnsignedChar:chip::to_underlying(decodableStruct.groupKeySet.groupKeyMulticastPolicy)];
     }
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -985,6 +985,7 @@ API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, copy) NSNumber * _Nullable epochStartTime1 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 @property (nonatomic, copy) NSData * _Nullable epochKey2 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 @property (nonatomic, copy) NSNumber * _Nullable epochStartTime2 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeyMulticastPolicy MTR_NEWLY_AVAILABLE;
 @end
 
 API_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -2818,6 +2818,8 @@ NS_ASSUME_NONNULL_BEGIN
         _epochKey2 = nil;
 
         _epochStartTime2 = nil;
+
+        _groupKeyMulticastPolicy = @(0);
     }
     return self;
 }
@@ -2834,18 +2836,19 @@ NS_ASSUME_NONNULL_BEGIN
     other.epochStartTime1 = self.epochStartTime1;
     other.epochKey2 = self.epochKey2;
     other.epochStartTime2 = self.epochStartTime2;
+    other.groupKeyMulticastPolicy = self.groupKeyMulticastPolicy;
 
     return other;
 }
 
 - (NSString *)description
 {
-    NSString * descriptionString =
-        [NSString stringWithFormat:@"<%@: groupKeySetID:%@; groupKeySecurityPolicy:%@; epochKey0:%@; epochStartTime0:%@; "
-                                   @"epochKey1:%@; epochStartTime1:%@; epochKey2:%@; epochStartTime2:%@; >",
-                  NSStringFromClass([self class]), _groupKeySetID, _groupKeySecurityPolicy,
-                  [_epochKey0 base64EncodedStringWithOptions:0], _epochStartTime0, [_epochKey1 base64EncodedStringWithOptions:0],
-                  _epochStartTime1, [_epochKey2 base64EncodedStringWithOptions:0], _epochStartTime2];
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: groupKeySetID:%@; groupKeySecurityPolicy:%@; epochKey0:%@; epochStartTime0:%@; epochKey1:%@; "
+                         @"epochStartTime1:%@; epochKey2:%@; epochStartTime2:%@; groupKeyMulticastPolicy:%@; >",
+        NSStringFromClass([self class]), _groupKeySetID, _groupKeySecurityPolicy, [_epochKey0 base64EncodedStringWithOptions:0],
+        _epochStartTime0, [_epochKey1 base64EncodedStringWithOptions:0], _epochStartTime1,
+        [_epochKey2 base64EncodedStringWithOptions:0], _epochStartTime2, _groupKeyMulticastPolicy];
     return descriptionString;
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -1224,6 +1224,18 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalCredentials:
     }
 }
 
+static auto __attribute__((unused)) EnsureKnownEnumValue(GroupKeyManagement::GroupKeyMulticastPolicyEnum val)
+{
+    using EnumType = GroupKeyManagement::GroupKeyMulticastPolicyEnum;
+    switch (val)
+    {
+    case EnumType::kPerGroupID:
+    case EnumType::kAllNodes:
+        return val;
+    default:
+        return static_cast<EnumType>(2);
+    }
+}
 static auto __attribute__((unused)) EnsureKnownEnumValue(GroupKeyManagement::GroupKeySecurityPolicyEnum val)
 {
     using EnumType = GroupKeyManagement::GroupKeySecurityPolicyEnum;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1433,6 +1433,18 @@ enum class NodeOperationalCertStatusEnum : uint8_t
 
 namespace GroupKeyManagement {
 
+// Enum for GroupKeyMulticastPolicyEnum
+enum class GroupKeyMulticastPolicyEnum : uint8_t
+{
+    kPerGroupID = 0x00,
+    kAllNodes   = 0x01,
+    // All received enum values that are not listed above will be mapped
+    // to kUnknownEnumValue. This is a helper enum value that should only
+    // be used by code to process how it handles receiving and unknown
+    // enum value. This specific should never be transmitted.
+    kUnknownEnumValue = 2,
+};
+
 // Enum for GroupKeySecurityPolicyEnum
 enum class GroupKeySecurityPolicyEnum : uint8_t
 {
@@ -1443,6 +1455,12 @@ enum class GroupKeySecurityPolicyEnum : uint8_t
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 2,
+};
+
+// Bitmap for Feature
+enum class Feature : uint32_t
+{
+    kCacheAndSync = 0x1,
 };
 } // namespace GroupKeyManagement
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -10585,6 +10585,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
     ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::ContextTag(Fields::kEpochStartTime1), epochStartTime1));
     ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::ContextTag(Fields::kEpochKey2), epochKey2));
     ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::ContextTag(Fields::kEpochStartTime2), epochStartTime2));
+    ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::ContextTag(Fields::kGroupKeyMulticastPolicy), groupKeyMulticastPolicy));
     ReturnErrorOnFailure(aWriter.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -10627,6 +10628,9 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
             break;
         case to_underlying(Fields::kEpochStartTime2):
             ReturnErrorOnFailure(DataModel::Decode(reader, epochStartTime2));
+            break;
+        case to_underlying(Fields::kGroupKeyMulticastPolicy):
+            ReturnErrorOnFailure(DataModel::Decode(reader, groupKeyMulticastPolicy));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -12977,14 +12977,15 @@ using DecodableType = Type;
 namespace GroupKeySetStruct {
 enum class Fields : uint8_t
 {
-    kGroupKeySetID          = 0,
-    kGroupKeySecurityPolicy = 1,
-    kEpochKey0              = 2,
-    kEpochStartTime0        = 3,
-    kEpochKey1              = 4,
-    kEpochStartTime1        = 5,
-    kEpochKey2              = 6,
-    kEpochStartTime2        = 7,
+    kGroupKeySetID           = 0,
+    kGroupKeySecurityPolicy  = 1,
+    kEpochKey0               = 2,
+    kEpochStartTime0         = 3,
+    kEpochKey1               = 4,
+    kEpochStartTime1         = 5,
+    kEpochKey2               = 6,
+    kEpochStartTime2         = 7,
+    kGroupKeyMulticastPolicy = 8,
 };
 
 struct Type
@@ -12998,6 +12999,7 @@ public:
     DataModel::Nullable<uint64_t> epochStartTime1;
     DataModel::Nullable<chip::ByteSpan> epochKey2;
     DataModel::Nullable<uint64_t> epochStartTime2;
+    GroupKeyMulticastPolicyEnum groupKeyMulticastPolicy = static_cast<GroupKeyMulticastPolicyEnum>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -1917,6 +1917,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
         ComplexArgumentParser::EnsureMemberExist("GroupKeySetStruct.epochKey2", "epochKey2", value.isMember("epochKey2")));
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("GroupKeySetStruct.epochStartTime2", "epochStartTime2",
                                                                   value.isMember("epochStartTime2")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist(
+        "GroupKeySetStruct.groupKeyMulticastPolicy", "groupKeyMulticastPolicy", value.isMember("groupKeyMulticastPolicy")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "groupKeySetID");
@@ -1952,6 +1954,11 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.epochStartTime2, value["epochStartTime2"]));
     valueCopy.removeMember("epochStartTime2");
 
+    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "groupKeyMulticastPolicy");
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::Setup(labelWithMember, request.groupKeyMulticastPolicy, value["groupKeyMulticastPolicy"]));
+    valueCopy.removeMember("groupKeyMulticastPolicy");
+
     return ComplexArgumentParser::EnsureNoMembersRemaining(label, valueCopy);
 }
 
@@ -1965,6 +1972,7 @@ void ComplexArgumentParser::Finalize(chip::app::Clusters::GroupKeyManagement::St
     ComplexArgumentParser::Finalize(request.epochStartTime1);
     ComplexArgumentParser::Finalize(request.epochKey2);
     ComplexArgumentParser::Finalize(request.epochStartTime2);
+    ComplexArgumentParser::Finalize(request.groupKeyMulticastPolicy);
 }
 
 CHIP_ERROR ComplexArgumentParser::Setup(const char * label,

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -1763,6 +1763,14 @@ DataModelLogger::LogValue(const char * label, size_t indent,
             return err;
         }
     }
+    {
+        CHIP_ERROR err = LogValue("GroupKeyMulticastPolicy", indent + 1, value.groupKeyMulticastPolicy);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'GroupKeyMulticastPolicy'");
+            return err;
+        }
+    }
     DataModelLogger::LogString(indent, "}");
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Add the new member, define the enum, update unit test to default to 0.

Add a featuremap bitmap.

Fixes subset of  #25642 (adds struct member and defines feature)