### PR TITLE
Add a FabricTable API to get the next available fabric index.

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -2080,7 +2080,7 @@ CHIP_ERROR FabricTable::GetFabricLabel(FabricIndex fabricIndex, CharSpan & outFa
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FabricTable::GetNextFabricAdditionIndex(FabricIndex * nextIndex)
+CHIP_ERROR FabricTable::PeekFabricIndexForNextAddition(FabricIndex & outIndex)
 {
     EnsureNextAvailableFabricIndexUpdated();
     if (!mNextAvailableFabricIndex.HasValue())
@@ -2091,7 +2091,7 @@ CHIP_ERROR FabricTable::GetNextFabricAdditionIndex(FabricIndex * nextIndex)
     FabricIndex index = mNextAvailableFabricIndex.Value();
     VerifyOrReturnError(IsValidFabricIndex(index), CHIP_ERROR_INVALID_FABRIC_INDEX);
 
-    *nextIndex = index;
+    outIndex = index;
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -2080,4 +2080,19 @@ CHIP_ERROR FabricTable::GetFabricLabel(FabricIndex fabricIndex, CharSpan & outFa
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FabricTable::GetNextFabricAdditionIndex(FabricIndex * nextIndex)
+{
+    EnsureNextAvailableFabricIndexUpdated();
+    if (!mNextAvailableFabricIndex.HasValue())
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    FabricIndex index = mNextAvailableFabricIndex.Value();
+    VerifyOrReturnError(IsValidFabricIndex(index), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    *nextIndex = index;
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -971,6 +971,14 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
     }
 
+    /**
+     * Get the fabric index that will be used for the next fabric that will be
+     * added.  Returns error if no more fabrics can be added, otherwise writes
+     * the fabric index that will be used for the next addition into the
+     * outparam.
+     */
+    CHIP_ERROR GetNextFabricAdditionIndex(FabricIndex * nextIndex);
+
 private:
     enum class StateFlags : uint16_t
     {

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -977,7 +977,7 @@ public:
      * the fabric index that will be used for the next addition into the
      * outparam.
      */
-    CHIP_ERROR GetNextFabricAdditionIndex(FabricIndex * nextIndex);
+    CHIP_ERROR PeekFabricIndexForNextAddition(FabricIndex & outIndex);
 
 private:
     enum class StateFlags : uint16_t


### PR DESCRIPTION
This can be used during controller startup to map the fabric index (which is allocated to the controller partway through startup and then used immediately for storage keys) to the controller instance being started.


