### PR TITLE
[Android] Support Reset API for android app server

### DIFF
--- a/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/MatterApp.kt
+++ b/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/MatterApp.kt
@@ -45,4 +45,8 @@ class MatterApp @Inject constructor() {
   fun stop() {
     chipAppServer?.stopApp()
   }
+
+  fun reset() {
+    chipAppServer?.resetApp()
+  }
 }

--- a/src/app/server/java/AndroidAppServerWrapper.cpp
+++ b/src/app/server/java/AndroidAppServerWrapper.cpp
@@ -80,3 +80,8 @@ void ChipAndroidAppShutdown(void)
     chip::Server::GetInstance().Shutdown();
     chip::Platform::MemoryShutdown();
 }
+
+void ChipAndroidAppReset(void)
+{
+    chip::Server::GetInstance().ScheduleFactoryReset();
+}

--- a/src/app/server/java/AndroidAppServerWrapper.h
+++ b/src/app/server/java/AndroidAppServerWrapper.h
@@ -25,6 +25,8 @@ CHIP_ERROR ChipAndroidAppInit(AppDelegate * appDelegate = nullptr);
 
 void ChipAndroidAppShutdown(void);
 
+void ChipAndroidAppReset(void);
+
 jint AndroidAppServerJNI_OnLoad(JavaVM * jvm, void * reserved);
 
 void AndroidAppServerJNI_OnUnload(JavaVM * jvm, void * reserved);

--- a/src/app/server/java/CHIPAppServer-JNI.cpp
+++ b/src/app/server/java/CHIPAppServer-JNI.cpp
@@ -165,6 +165,14 @@ JNI_METHOD(jboolean, stopApp)(JNIEnv * env, jobject self)
     return JNI_TRUE;
 }
 
+JNI_METHOD(jboolean, resetApp)(JNIEnv * env, jobject self)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipAndroidAppReset();
+
+    return JNI_TRUE;
+}
+
 void * IOThreadAppMain(void * arg)
 {
     JNIEnv * env;

--- a/src/app/server/java/src/chip/appserver/ChipAppServer.java
+++ b/src/app/server/java/src/chip/appserver/ChipAppServer.java
@@ -39,4 +39,6 @@ public class ChipAppServer {
   public native boolean startAppWithDelegate(ChipAppServerDelegate appDelegate);
 
   public native boolean stopApp();
+
+  public native boolean resetApp();
 }


### PR DESCRIPTION
#### Problem
* For the Android App server developer
* Need to provide Factory Reset API for cleanup


#### Change overview
* Implement resetApp function on App server for Android devices
* We added 'resetApp' api


#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation
