### PR TITLE
[cherry-pick][esp32]add nvs size to 48k bytes for matter 1.1 (#28353)

### DIFF
--- a/examples/all-clusters-app/esp32/partitions.csv
+++ b/examples/all-clusters-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 otadata,  data, ota,     ,        0x2000,
 phy_init, data, phy,     ,        0x1000,
 ota_0,    app,  ota_0,   ,        1700K,

--- a/examples/all-clusters-minimal-app/esp32/partitions.csv
+++ b/examples/all-clusters-minimal-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 otadata,  data, ota,     ,        0x2000,
 phy_init, data, phy,     ,        0x1000,
 ota_0,    app,  ota_0,   ,        1500K,

--- a/examples/bridge-app/esp32/partitions.csv
+++ b/examples/bridge-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,

--- a/examples/chef/esp32/partitions.csv
+++ b/examples/chef/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
 factory,  app,  factory, ,        1945K,

--- a/examples/light-switch-app/esp32/partitions.csv
+++ b/examples/light-switch-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 otadata,  data, ota,     ,        0x2000,
 phy_init, data, phy,     ,        0x1000,
 ota_0,    app,  ota_0,   ,        1500K,

--- a/examples/lighting-app/esp32/partitions.csv
+++ b/examples/lighting-app/esp32/partitions.csv
@@ -1,7 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: Firmware partition offset needs to be 64K aligned, initial 36K (9 sectors) are reserved for bootloader and partition table
 esp_secure_cert,  0x3F,        ,    0xD000,     0x2000,    encrypted
-nvs,      data, nvs,     0x10000,   0x6000,
+nvs,      data, nvs,     0x10000,   0xC000,
 nvs_keys, data, nvs_keys,,          0x1000,
 otadata,  data, ota,     ,          0x2000
 phy_init, data, phy,     ,          0x1000,

--- a/examples/lighting-app/esp32/partitions_encrypted.csv
+++ b/examples/lighting-app/esp32/partitions_encrypted.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 otadata,  data, ota,     ,        0x2000, encrypted
 phy_init, data, phy,     ,        0x1000, encrypted
 ota_0,    app,  ota_0,   ,        1500K, encrypted

--- a/examples/lighting-app/esp32/partitions_h2.csv
+++ b/examples/lighting-app/esp32/partitions_h2.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,       data, nvs,     ,        0x6000,
+nvs,       data, nvs,     ,        0xC000,
 otadata,   data, ota,     ,        0x2000,
 phy_init,  data, phy,     ,        0x1000,
 ota_0,     app,  ota_0,   ,        1500K,

--- a/examples/lock-app/esp32/partitions.csv
+++ b/examples/lock-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,

--- a/examples/ota-provider-app/esp32/partitions.csv
+++ b/examples/ota-provider-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.6MB
 factory,  app,  factory, ,        1600K,

--- a/examples/ota-requestor-app/esp32/partitions.csv
+++ b/examples/ota-requestor-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 otadata,  data, ota,     ,        0x2000,
 phy_init, data, phy,     ,        0x1000,
 # OTA partitions of size 1.5M each

--- a/examples/persistent-storage/esp32/partitions.csv
+++ b/examples/persistent-storage/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,

--- a/examples/pigweed-app/esp32/partitions.csv
+++ b/examples/pigweed-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,

--- a/examples/shell/esp32/partitions.csv
+++ b/examples/shell/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,

--- a/examples/temperature-measurement-app/esp32/partitions.csv
+++ b/examples/temperature-measurement-app/esp32/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs,     ,        0x6000,
+nvs,      data, nvs,     ,        0xC000,
 phy_init, data, phy,     ,        0x1000,
 # Factory partition size about 1.9MB
-factory,  app,  factory, ,        1945K,
+factory,  app,  factory, ,        1920K,


### PR DESCRIPTION
- This branch add nvs size to 48k bytes for matter 1.1 for esp32 examples
- Cherry pick from [Add nvs size to 48k bytes in examples for matter 1.1 #28353](https://github.com/project-chip/connectedhomeip/pull/28353)

