### PR TITLE
Add functions to set Parent Endpoint and Composition Type for an Endpoint

### DIFF
--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -106,7 +106,6 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
     }
     else
     {
-        ChipLogProgress(Zcl, "MHDEBUG: Endpoint composition type is tree");
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
             {
@@ -116,8 +115,6 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
                 EndpointId parentEndpointId = emberAfParentEndpointFromIndex(index);
                 if (parentEndpointId == endpoint)
                 {
-                    ChipLogProgress(Zcl, "MHDEBUG: endpoint %d is a child of endpoint %d", emberAfEndpointFromIndex(index),
-                                    endpoint);
                     ReturnErrorOnFailure(encoder.Encode(emberAfEndpointFromIndex(index)));
                 }
             }

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
             return CHIP_NO_ERROR;
         });
     }
-    else if (emberAfEndpointCompositionTypeForEndpoint(endpoint) == EMBER_AF_ENDPOINT_COMPOSITION_FLAT)
+    else if (IsFlatCompositionForEndpoint(endpoint))
     {
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
@@ -104,7 +104,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
             return CHIP_NO_ERROR;
         });
     }
-    else
+    else if (IsTreeCompositionForEndpoint(endpoint))
     {
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             for (uint16_t index = 0; index < emberAfEndpointCount(); index++)

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -191,6 +191,16 @@ enum
   EMBER_AF_ENDPOINT_ENABLED  = 0x01,
 };
 
+#ifdef DOXYGEN_SHOULD_SKIP_THIS
+enum EmberAfEndpointCompositionType;
+#else
+typedef uint8_t EmberAfEndpointCompositionType;
+enum
+#endif
+{ EMBER_AF_ENDPOINT_COMPOSITION_FLAT = 0x00,
+  EMBER_AF_ENDPOINT_COMPOSITION_TREE = 0x01,
+};
+
 /**
  * @brief Struct that maps actual endpoint type, onto a specific endpoint.
  */
@@ -224,6 +234,11 @@ struct EmberAfDefinedEndpoint
      * Root endpoint id for composed device type.
      */
     chip::EndpointId parentEndpointId = chip::kInvalidEndpointId;
+
+    /**
+     * Endpoint's composition type
+     */
+    EmberAfEndpointCompositionType endpointCompositionType = EMBER_AF_ENDPOINT_COMPOSITION_FLAT;
 };
 
 // Cluster specific types

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -181,24 +181,11 @@ typedef struct
     uint16_t endpointSize;
 } EmberAfEndpointType;
 
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberAfEndpointBitmask;
-#else
-typedef uint8_t EmberAfEndpointBitmask;
-enum
-#endif
-{ EMBER_AF_ENDPOINT_DISABLED = 0x00,
-  EMBER_AF_ENDPOINT_ENABLED  = 0x01,
-};
-
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberAfEndpointCompositionType;
-#else
-typedef uint8_t EmberAfEndpointCompositionType;
-enum
-#endif
-{ EMBER_AF_ENDPOINT_COMPOSITION_FLAT = 0x00,
-  EMBER_AF_ENDPOINT_COMPOSITION_TREE = 0x01,
+enum class EmberAfEndpointOptions : uint8_t
+{
+    isEnabled         = 0x1,
+    isFlatComposition = 0x2,
+    isTreeComposition = 0x3,
 };
 
 /**
@@ -219,7 +206,7 @@ struct EmberAfDefinedEndpoint
     /**
      * Meta-data about the endpoint
      */
-    EmberAfEndpointBitmask bitmask = EMBER_AF_ENDPOINT_DISABLED;
+    chip::BitMask<EmberAfEndpointOptions> bitmask;
     /**
      * Endpoint type for this endpoint.
      */
@@ -234,11 +221,6 @@ struct EmberAfDefinedEndpoint
      * Root endpoint id for composed device type.
      */
     chip::EndpointId parentEndpointId = chip::kInvalidEndpointId;
-
-    /**
-     * Endpoint's composition type
-     */
-    EmberAfEndpointCompositionType endpointCompositionType = EMBER_AF_ENDPOINT_COMPOSITION_FLAT;
 };
 
 // Cluster specific types

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -130,10 +130,24 @@ extern EmberAfDefinedEndpoint emAfEndpoints[];
 #endif
 
 /**
- * @brief Returns root endpoint of a composed bridged device
+ * @brief Returns parent endpoint for a given endpoint index
  */
 chip::EndpointId emberAfParentEndpointFromIndex(uint16_t index);
 
+/**
+ * @brief Sets the parent endpoint for a given endpoint
+ */
+EmberAfStatus emberAfSetParentEndpointForEndpoint(chip::EndpointId childEndpoint, chip::EndpointId parentEndpoint);
+
+/**
+ * @brief Sets the composition type for a given endpoint
+ */
+EmberAfStatus emberAfSetEndpointComposition(chip::EndpointId endpoint, EmberAfEndpointCompositionType aEndpointCompositionType);
+
+/**
+ * @brief Returns the composition type for a given endpoint
+ */
+chip::EndpointId emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint);
 /**
  * Returns the index of a given endpoint.  Will return 0xFFFF if this is not a
  * valid endpoint id or if the endpoint is disabled.

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -306,17 +306,17 @@ private:
 /**
  * @brief Sets the parent endpoint for a given endpoint
  */
-EmberAfStatus SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint);
+CHIP_ERROR SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint);
 
 /**
  * @brief Sets an Endpoint to use Flat Composition
  */
-EmberAfStatus SetFlatCompositionForEndpoint(EndpointId endpoint);
+CHIP_ERROR SetFlatCompositionForEndpoint(EndpointId endpoint);
 
 /**
  * @brief Sets an Endpoint to use Tree Composition
  */
-EmberAfStatus SetTreeCompositionForEndpoint(EndpointId endpoint);
+CHIP_ERROR SetTreeCompositionForEndpoint(EndpointId endpoint);
 
 /**
  * @brief Returns true is an Endpoint has flat composition

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -135,20 +135,6 @@ extern EmberAfDefinedEndpoint emAfEndpoints[];
 chip::EndpointId emberAfParentEndpointFromIndex(uint16_t index);
 
 /**
- * @brief Sets the parent endpoint for a given endpoint
- */
-EmberAfStatus emberAfSetParentEndpointForEndpoint(chip::EndpointId childEndpoint, chip::EndpointId parentEndpoint);
-
-/**
- * @brief Sets the composition type for a given endpoint
- */
-EmberAfStatus emberAfSetEndpointComposition(chip::EndpointId endpoint, EmberAfEndpointCompositionType aEndpointCompositionType);
-
-/**
- * @brief Returns the composition type for a given endpoint
- */
-EmberAfEndpointCompositionType emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint);
-/**
  * Returns the index of a given endpoint.  Will return 0xFFFF if this is not a
  * valid endpoint id or if the endpoint is disabled.
  */
@@ -316,6 +302,31 @@ private:
     uint16_t mEndpointCount = emberAfEndpointCount();
     ClusterId mClusterId;
 };
+
+/**
+ * @brief Sets the parent endpoint for a given endpoint
+ */
+EmberAfStatus SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint);
+
+/**
+ * @brief Sets an Endpoint to use Flat Composition
+ */
+EmberAfStatus SetFlatCompositionForEndpoint(EndpointId endpoint);
+
+/**
+ * @brief Sets an Endpoint to use Tree Composition
+ */
+EmberAfStatus SetTreeCompositionForEndpoint(EndpointId endpoint);
+
+/**
+ * @brief Returns true is an Endpoint has flat composition
+ */
+bool IsFlatCompositionForEndpoint(EndpointId endpoint);
+
+/**
+ * @brief Returns true is an Endpoint has tree composition
+ */
+bool IsTreeCompositionForEndpoint(EndpointId endpoint);
 
 } // namespace app
 } // namespace chip

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -147,7 +147,7 @@ EmberAfStatus emberAfSetEndpointComposition(chip::EndpointId endpoint, EmberAfEn
 /**
  * @brief Returns the composition type for a given endpoint
  */
-chip::EndpointId emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint);
+EmberAfEndpointCompositionType emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint);
 /**
  * Returns the index of a given endpoint.  Will return 0xFFFF if this is not a
  * valid endpoint id or if the endpoint is disabled.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -371,8 +371,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     // Casting and calling a function pointer on the same line results in ignoring the return
     // of the call on gcc-arm-none-eabi-9-2019-q4-major
-    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback) (emberAfFindClusterFunction(
-        cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
+        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
     if (f != nullptr)
     {
         status = f(attributePath, attributeType, size, value);

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -373,8 +373,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     // Casting and calling a function pointer on the same line results in ignoring the return
     // of the call on gcc-arm-none-eabi-9-2019-q4-major
-    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
-        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback) (emberAfFindClusterFunction(
+        cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
     if (f != nullptr)
     {
         status = f(attributePath, attributeType, size, value);
@@ -1424,41 +1424,41 @@ app::AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId
     return nullptr;
 }
 
-EmberAfStatus SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint)
+CHIP_ERROR SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint)
 {
     uint16_t childIndex  = emberAfIndexFromEndpoint(childEndpoint);
     uint16_t parentIndex = emberAfIndexFromEndpoint(parentEndpoint);
 
     if (childIndex == kEmberInvalidEndpointIndex || parentIndex == kEmberInvalidEndpointIndex)
     {
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     emAfEndpoints[childIndex].parentEndpointId = parentEndpoint;
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return CHIP_NO_ERROR;
 }
 
-EmberAfStatus SetFlatCompositionForEndpoint(EndpointId endpoint)
+CHIP_ERROR SetFlatCompositionForEndpoint(EndpointId endpoint)
 {
     uint16_t index = emberAfIndexFromEndpoint(endpoint);
     if (index == kEmberInvalidEndpointIndex)
     {
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     emAfEndpoints[index].bitmask.Clear(EmberAfEndpointOptions::isTreeComposition);
     emAfEndpoints[index].bitmask.Set(EmberAfEndpointOptions::isFlatComposition);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return CHIP_NO_ERROR;
 }
 
-EmberAfStatus SetTreeCompositionForEndpoint(EndpointId endpoint)
+CHIP_ERROR SetTreeCompositionForEndpoint(EndpointId endpoint)
 {
     uint16_t index = emberAfIndexFromEndpoint(endpoint);
     if (index == kEmberInvalidEndpointIndex)
     {
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     emAfEndpoints[index].bitmask.Clear(EmberAfEndpointOptions::isFlatComposition);
     emAfEndpoints[index].bitmask.Set(EmberAfEndpointOptions::isTreeComposition);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return CHIP_NO_ERROR;
 }
 
 bool IsFlatCompositionForEndpoint(EndpointId endpoint)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -373,8 +373,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     // Casting and calling a function pointer on the same line results in ignoring the return
     // of the call on gcc-arm-none-eabi-9-2019-q4-major
-    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback) (emberAfFindClusterFunction(
-        cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
+        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
     if (f != nullptr)
     {
         status = f(attributePath, attributeType, size, value);

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -375,8 +375,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     // Casting and calling a function pointer on the same line results in ignoring the return
     // of the call on gcc-arm-none-eabi-9-2019-q4-major
-    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback) (emberAfFindClusterFunction(
-        cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
+        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
     if (f != nullptr)
     {
         status = f(attributePath, attributeType, size, value);

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -375,8 +375,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     // Casting and calling a function pointer on the same line results in ignoring the return
     // of the call on gcc-arm-none-eabi-9-2019-q4-major
-    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
-        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback) (emberAfFindClusterFunction(
+        cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
     if (f != nullptr)
     {
         status = f(attributePath, attributeType, size, value);
@@ -1021,7 +1021,7 @@ EmberAfStatus emberAfSetEndpointComposition(chip::EndpointId endpoint, EmberAfEn
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EndpointId emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint)
+EmberAfEndpointCompositionType emberAfEndpointCompositionTypeForEndpoint(chip::EndpointId endpoint)
 {
     uint16_t index = emberAfIndexFromEndpoint(endpoint);
     return emAfEndpoints[index].endpointCompositionType;

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -159,12 +159,10 @@ void UnregisterMatchingAttributeAccessInterfaces(F shouldUnregister)
 // Initial configuration
 void emberAfEndpointConfigure()
 {
-    ChipLogProgress(DataManagement, "MHDEBUG: emberAfEndpointConfigure");
     uint16_t ep;
 
     static_assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<decltype(ep)>::max(),
                   "FIXED_ENDPOINT_COUNT must not exceed the size of the endpoint data type");
-    ChipLogProgress(DataManagement, "MHDEBUG: FIXED_ENDPOINT_COUNT: %d", FIXED_ENDPOINT_COUNT);
 
 #if !defined(EMBER_SCRIPTED_TEST)
     uint16_t fixedEndpoints[]             = FIXED_ENDPOINT_ARRAY;
@@ -199,8 +197,6 @@ void emberAfEndpointConfigure()
         // Increment currentDataVersions by 1 (slot) for every server cluster
         // this endpoint has.
         currentDataVersions += emberAfClusterCountByIndex(ep, /* server = */ true);
-
-        ChipLogProgress(DataManagement, "MHDEBUG: emAfEndpoints[%d].endpoint: %d", ep, emAfEndpoints[ep].endpoint);
     }
 
 #if CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT
@@ -1005,7 +1001,6 @@ EmberAfStatus emberAfSetParentEndpointForEndpoint(chip::EndpointId childEndpoint
     {
         return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
     }
-    ChipLogProgress(Zcl, "MHDEBUG: Setting parent endpoint for endpoint %d to %d", childEndpoint, parentEndpoint);
     emAfEndpoints[childIndex].parentEndpointId = parentEndpoint;
     return EMBER_ZCL_STATUS_SUCCESS;
 }


### PR DESCRIPTION
### Background

Some of the new devices being added in the Fall 2023 release require device composition using the Parts List. 

This is not currently achievable via Zap Tool and the while the Endpoint data structure in `attribute-storage.cpp` _has_ a `parentEndpointId` member, it is only settable by the `emberAfSetDynamicEndpoint` which is not useful to a zap configured device.

### Description

I have added three functions in `attribute-storage.cpp`:

1. `emberAfSetParentEndpointForEndpoint`
2. `emberAfSetEndpointComposition`
3. `emberAfEndpointCompositionTypeForEndpoint`

These can be used by the application to configure it's device's composition. 

My hope is that in the future, Zap Tool can provide this additional data that can be parsed by the initial `emberAfEndpointConfigure` function when the Chip App is being brought up.  

### Testing

Manually tested via `rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45` chef device using the following `ApplicationInit` function:

```
void ApplicationInit()
{
    emberAfSetEndpointComposition(1, EMBER_AF_ENDPOINT_COMPOSITION_TREE);
    emberAfSetParentEndpointForEndpoint(2, 1);
    emberAfSetParentEndpointForEndpoint(3, 1);
    emberAfSetParentEndpointForEndpoint(4, 1);
    emberAfSetParentEndpointForEndpoint(5, 1);
}
```