### PR TITLE
Factor out CheckFabricInfo test helper into a separate header.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
@@ -19,52 +19,12 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
+#import "MTRFabricInfoChecker.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
 static uint16_t kTestVendorId1 = 0xFFF1u;
 static uint16_t kTestVendorId2 = 0xFFF2u;
-
-void CheckFabricInfo(NSArray<MTRFabricInfo *> * fabricInfoList, NSMutableSet<NSDictionary *> * expectedSet)
-{
-    XCTAssertEqual([fabricInfoList count], [expectedSet count]);
-    for (size_t i = 0; i < [fabricInfoList count]; ++i) {
-        __auto_type * info = fabricInfoList[i];
-        NSSet<NSDictionary *> * expectedInfoForIndex = [expectedSet objectsPassingTest:^(NSDictionary * obj, BOOL * stop) {
-            return [info.fabricIndex isEqual:obj[@"fabricIndex"]];
-        }];
-        XCTAssertEqual([expectedInfoForIndex count], 1);
-        __auto_type * expected = [expectedInfoForIndex anyObject];
-        XCTAssertEqualObjects(info.rootPublicKey, expected[@"rootPublicKey"]);
-        XCTAssertEqualObjects(info.vendorID, expected[@"vendorID"]);
-        XCTAssertEqualObjects(info.fabricID, expected[@"fabricID"]);
-        XCTAssertEqualObjects(info.nodeID, expected[@"nodeID"]);
-        XCTAssertEqualObjects(info.label, expected[@"label"]);
-        XCTAssertNotNil(info.rootCertificate);
-        XCTAssertNotNil(info.rootCertificateTLV);
-        XCTAssertEqualObjects([MTRCertificates convertX509Certificate:info.rootCertificate], info.rootCertificateTLV);
-        XCTAssertEqualObjects([MTRCertificates convertMatterCertificate:info.rootCertificateTLV], info.rootCertificate);
-        XCTAssertEqual((info.intermediateCertificate == nil), (info.intermediateCertificateTLV == nil));
-        XCTAssertEqualObjects(@(info.intermediateCertificate != nil), expected[@"hasIntermediateCertificate"]);
-        if (info.intermediateCertificate != nil) {
-            XCTAssertEqualObjects(
-                [MTRCertificates convertX509Certificate:info.intermediateCertificate], info.intermediateCertificateTLV);
-            XCTAssertEqualObjects(
-                [MTRCertificates convertMatterCertificate:info.intermediateCertificateTLV], info.intermediateCertificate);
-        }
-        XCTAssertNotNil(info.operationalCertificate);
-        XCTAssertNotNil(info.operationalCertificateTLV);
-        XCTAssertEqualObjects([MTRCertificates convertX509Certificate:info.operationalCertificate], info.operationalCertificateTLV);
-        XCTAssertEqualObjects(
-            [MTRCertificates convertMatterCertificate:info.operationalCertificateTLV], info.operationalCertificate);
-        __auto_type * certInfo = [[MTRCertificateInfo alloc] initWithTLVBytes:info.operationalCertificateTLV];
-        XCTAssertNotNil(certInfo);
-        XCTAssertEqualObjects(certInfo.subject.nodeID, info.nodeID);
-        XCTAssertEqualObjects(certInfo.subject.fabricID, info.fabricID);
-        XCTAssertEqualObjects(info.fabricIndex, expected[@"fabricIndex"]);
-        [expectedSet removeObject:expected];
-    }
-}
 
 @interface MTRFabricInfoTests : XCTestCase
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRFabricInfoChecker.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRFabricInfoChecker.h
@@ -1,0 +1,24 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void CheckFabricInfo(NSArray<MTRFabricInfo *> * fabricInfoList, NSMutableSet<NSDictionary *> * expectedSet);
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRFabricInfoChecker.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRFabricInfoChecker.m
@@ -1,0 +1,59 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRFabricInfoChecker.h"
+#import <XCTest/XCTest.h>
+
+void CheckFabricInfo(NSArray<MTRFabricInfo *> * fabricInfoList, NSMutableSet<NSDictionary *> * expectedSet)
+{
+    XCTAssertEqual([fabricInfoList count], [expectedSet count]);
+    for (size_t i = 0; i < [fabricInfoList count]; ++i) {
+        __auto_type * info = fabricInfoList[i];
+        NSSet<NSDictionary *> * expectedInfoForIndex = [expectedSet objectsPassingTest:^(NSDictionary * obj, BOOL * stop) {
+            return [info.fabricIndex isEqual:obj[@"fabricIndex"]];
+        }];
+        XCTAssertEqual([expectedInfoForIndex count], 1);
+        __auto_type * expected = [expectedInfoForIndex anyObject];
+        XCTAssertEqualObjects(info.rootPublicKey, expected[@"rootPublicKey"]);
+        XCTAssertEqualObjects(info.vendorID, expected[@"vendorID"]);
+        XCTAssertEqualObjects(info.fabricID, expected[@"fabricID"]);
+        XCTAssertEqualObjects(info.nodeID, expected[@"nodeID"]);
+        XCTAssertEqualObjects(info.label, expected[@"label"]);
+        XCTAssertNotNil(info.rootCertificate);
+        XCTAssertNotNil(info.rootCertificateTLV);
+        XCTAssertEqualObjects([MTRCertificates convertX509Certificate:info.rootCertificate], info.rootCertificateTLV);
+        XCTAssertEqualObjects([MTRCertificates convertMatterCertificate:info.rootCertificateTLV], info.rootCertificate);
+        XCTAssertEqual((info.intermediateCertificate == nil), (info.intermediateCertificateTLV == nil));
+        XCTAssertEqualObjects(@(info.intermediateCertificate != nil), expected[@"hasIntermediateCertificate"]);
+        if (info.intermediateCertificate != nil) {
+            XCTAssertEqualObjects(
+                [MTRCertificates convertX509Certificate:info.intermediateCertificate], info.intermediateCertificateTLV);
+            XCTAssertEqualObjects(
+                [MTRCertificates convertMatterCertificate:info.intermediateCertificateTLV], info.intermediateCertificate);
+        }
+        XCTAssertNotNil(info.operationalCertificate);
+        XCTAssertNotNil(info.operationalCertificateTLV);
+        XCTAssertEqualObjects([MTRCertificates convertX509Certificate:info.operationalCertificate], info.operationalCertificateTLV);
+        XCTAssertEqualObjects(
+            [MTRCertificates convertMatterCertificate:info.operationalCertificateTLV], info.operationalCertificate);
+        __auto_type * certInfo = [[MTRCertificateInfo alloc] initWithTLVBytes:info.operationalCertificateTLV];
+        XCTAssertNotNil(certInfo);
+        XCTAssertEqualObjects(certInfo.subject.nodeID, info.nodeID);
+        XCTAssertEqualObjects(certInfo.subject.fabricID, info.fabricID);
+        XCTAssertEqualObjects(info.fabricIndex, expected[@"fabricIndex"]);
+        [expectedSet removeObject:expected];
+    }
+}

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		51B22C262740CB32008D5055 /* MTRStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* MTRStructsObjc.mm */; };
 		51B22C2A2740CB47008D5055 /* MTRCommandPayloadsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C292740CB47008D5055 /* MTRCommandPayloadsObjc.mm */; };
 		51C8E3F82825CDB600D47D00 /* MTRTestKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */; };
+		51C984622A61CE2A00B0AD9A /* MTRFabricInfoChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */; };
 		51D10D2E2808E2CA00E8CA3D /* MTRTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */; };
 		51E0310027EA20D20083DC9C /* MTRControllerAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E030FE27EA20D20083DC9C /* MTRControllerAccessControl.h */; };
 		51E0310127EA20D20083DC9C /* MTRControllerAccessControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E030FF27EA20D20083DC9C /* MTRControllerAccessControl.mm */; };
@@ -477,6 +478,8 @@
 		51B22C252740CB32008D5055 /* MTRStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRStructsObjc.mm; sourceTree = "<group>"; };
 		51B22C292740CB47008D5055 /* MTRCommandPayloadsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommandPayloadsObjc.mm; sourceTree = "<group>"; };
 		51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestKeys.m; sourceTree = "<group>"; };
+		51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRFabricInfoChecker.m; sourceTree = "<group>"; };
+		51C984612A61CE2A00B0AD9A /* MTRFabricInfoChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRFabricInfoChecker.h; sourceTree = "<group>"; };
 		51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestStorage.m; sourceTree = "<group>"; };
 		51E030FE27EA20D20083DC9C /* MTRControllerAccessControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerAccessControl.h; sourceTree = "<group>"; };
 		51E030FF27EA20D20083DC9C /* MTRControllerAccessControl.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRControllerAccessControl.mm; sourceTree = "<group>"; };
@@ -947,6 +950,8 @@
 				1E748B3828941A44008A1BE8 /* MTRTestOTAProvider.m */,
 				51742B4829CB5F45009974FE /* MTRTestResetCommissioneeHelper.h */,
 				51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */,
+				51C984612A61CE2A00B0AD9A /* MTRFabricInfoChecker.h */,
+				51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -1536,6 +1541,7 @@
 				7596A8512878709F004DAE0E /* MTRAsyncCallbackQueueTests.m in Sources */,
 				997DED1A26955D0200975E97 /* MTRThreadOperationalDatasetTests.mm in Sources */,
 				51C8E3F82825CDB600D47D00 /* MTRTestKeys.m in Sources */,
+				51C984622A61CE2A00B0AD9A /* MTRFabricInfoChecker.m in Sources */,
 				99C65E10267282F1003402F6 /* MTRControllerTests.m in Sources */,
 				1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* MTRXPCProtocolTests.m in Sources */,


### PR DESCRIPTION
This way we can use it from multiple test files if needed.
