### PR TITLE
Allow setting device name at runtime

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -113,6 +113,7 @@ class ExampleDeviceInstanceInfoProvider : public DeviceInstanceInfoProvider
 public:
     void Init(DeviceInstanceInfoProvider * defaultProvider) { mDefaultProvider = defaultProvider; }
 
+    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override { return mDefaultProvider->GetDeviceName(buf, bufSize); }
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return mDefaultProvider->GetVendorName(buf, bufSize); }
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override { return mDefaultProvider->GetVendorId(vendorId); }
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return mDefaultProvider->GetProductName(buf, bufSize); }

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -30,6 +30,19 @@ public:
     virtual ~DeviceInstanceInfoProvider() = default;
 
     /**
+     * @brief Obtain the Device Name from the device's factory data.
+     *
+     * @param[out] buf Buffer to copy string.
+     *                 On CHIP_NO_ERROR return from this function this buffer will be null-terminated.
+     *                 On error CHIP_ERROR_BUFFER_TOO_SMALL there is no guarantee that buffer will be null-terminated.
+     * @param[in] bufSize Size of data, including the null terminator, that can be written to buf.
+     *                    This size should be +1 higher than maximum possible string.
+     * @returns CHIP_NO_ERROR on success, or another CHIP_ERROR from the underlying implementation
+     *          if access fails.
+     */
+    virtual CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) = 0;
+
+    /**
      * @brief Obtain the Vendor Name from the device's factory data.
      *
      * @param[out] buf Buffer to copy string.

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -635,9 +635,7 @@ bool GenericConfigurationManagerImpl<ConfigClass>::IsCommissionableDeviceNameEna
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
-    return CHIP_NO_ERROR;
+    return GetDeviceInstanceInfoProvider()->GetDeviceName(buf, bufSize);
 }
 
 template <class ConfigClass>

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
@@ -41,6 +41,7 @@ public:
         mGenericConfigManager(configManager)
     {}
 
+    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
@@ -22,6 +22,15 @@ namespace DeviceLayer {
 namespace Internal {
 
 template <class ConfigClass>
+CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetDeviceName(char * buf, size_t bufSize)
+{
+    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+
+    return CHIP_NO_ERROR;
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetVendorId(uint16_t & vendorId)
 {
     vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -60,6 +60,7 @@ const char AndroidConfig::kConfigNamespace_ChipCounters[] = "chip-counters";
 
 // Keys stored in the Chip-factory namespace
 const AndroidConfig::Key AndroidConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceName         = { kConfigNamespace_ChipFactory, "device-name" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceId           = { kConfigNamespace_ChipFactory, "device-id" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceCert         = { kConfigNamespace_ChipFactory, "device-cert" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceICACerts     = { kConfigNamespace_ChipFactory, "device-ca-certs" };

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -54,6 +54,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_MfrDeviceName;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -73,6 +73,20 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductLabel(char * buf, size_t bu
     return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);
 }
 
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(char * buf, size_t bufSize)
+{
+    CHIP_ERROR err;
+    size_t deviceNameSize = 0; // without counting null-terminator
+    err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName, buf, bufSize,
+                                                      deviceNameSize);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductName(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.h
@@ -27,6 +27,7 @@ namespace DeviceLayer {
 class DeviceInstanceInfoProviderImpl : public Internal::GenericDeviceInstanceInfoProvider<Internal::AndroidConfig>
 {
 public:
+    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -26,6 +26,7 @@ public interface ConfigurationManager {
 
   // Keys stored in the Chip-factory namespace
   String kConfigKey_SerialNum = "serial-num";
+  String kConfigKey_MfrDeviceName = "device-name";
   String kConfigKey_MfrDeviceId = "device-id";
   String kConfigKey_MfrDeviceCert = "device-cert";
   String kConfigKey_MfrDeviceICACerts = "device-ca-certs";


### PR DESCRIPTION
### Problem
Device name can be set by setting the CHIP_DEVICE_CONFIG_DEVICE_NAME key at compile time, but there is no way to set it at runtime.

### Solution
This PR adds a way to set the device name at runtime in the SDK.