### PR TITLE
Bug fix for thermostat application for wifi 

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -297,7 +297,7 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
             return imcode::InvalidValue;
         if (AutoSupported)
         {
-            if (requested < OccupiedHeatingSetpoint + DeadBandTemp)
+            if (requested > OccupiedHeatingSetpoint + DeadBandTemp)
                 return imcode::InvalidValue;
         }
         return imcode::Success;
@@ -349,11 +349,11 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
         requested = static_cast<int16_t>(chip::Encoding::LittleEndian::Get16(value));
         if (!HeatSupported)
             return imcode::UnsupportedAttribute;
-        if (requested < AbsMinHeatSetpointLimit || requested < MinHeatSetpointLimit || requested > AbsMaxHeatSetpointLimit)
+        if (requested < AbsMinHeatSetpointLimit || requested < MinHeatSetpointLimit || requested < AbsMaxHeatSetpointLimit)
             return imcode::InvalidValue;
         if (AutoSupported)
         {
-            if (requested > MaxCoolSetpointLimit - DeadBandTemp)
+            if (requested < MaxCoolSetpointLimit - DeadBandTemp)
                 return imcode::InvalidValue;
         }
         return imcode::Success;


### PR DESCRIPTION
Added :
    -   added fix for OccupiedCoolingSetpoint and MaxHeatSetpointLimit write command in thermostat cluster

Issue :
    -   while trying set OccupiedCoolingSetpoint and MaxHeatSetpointLimit got CONSTRAINT_ERROR instead of SUCCESS

Tested  :
    -   manually tested on MG24 + 917 Exp 