### PR TITLE
[Android] virtual-device-app: Add LoadingFragment for commissioning establish s…

### DIFF
--- a/examples/virtual-device-app/android/App/core/common/src/main/java/com/matter/virtual/device/app/core/common/DeepLink.kt
+++ b/examples/virtual-device-app/android/App/core/common/src/main/java/com/matter/virtual/device/app/core/common/DeepLink.kt
@@ -18,4 +18,12 @@ object DeepLink {
       )
       .build()
   }
+
+  fun getDeepLinkRequestForLoadingFragment(setting: String): NavDeepLinkRequest {
+    return NavDeepLinkRequest.Builder.fromUri(
+        "android-app://com.matter.virtual.device.app.feature.main/loadingFragment/${setting}"
+          .toUri()
+      )
+      .build()
+  }
 }

--- a/examples/virtual-device-app/android/App/feature/main/src/main/java/com/matter/virtual/device/app/feature/main/LoadingFragment.kt
+++ b/examples/virtual-device-app/android/App/feature/main/src/main/java/com/matter/virtual/device/app/feature/main/LoadingFragment.kt
@@ -1,0 +1,95 @@
+package com.matter.virtual.device.app.feature.main
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.matter.virtual.device.app.core.common.MatterSettings
+import com.matter.virtual.device.app.feature.main.databinding.FragmentLoadingBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlin.math.abs
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+@AndroidEntryPoint
+class LoadingFragment : Fragment() {
+
+  private lateinit var binding: FragmentLoadingBinding
+
+  private lateinit var matterSettings: MatterSettings
+  private lateinit var onBackPressedCallback: OnBackPressedCallback
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View {
+    Timber.d("Hit")
+    binding = DataBindingUtil.inflate(inflater, R.layout.fragment_loading, container, false)
+    binding.lifecycleOwner = viewLifecycleOwner
+
+    return binding.root
+  }
+
+  @OptIn(ExperimentalSerializationApi::class)
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    Timber.d("Hit")
+    super.onViewCreated(view, savedInstanceState)
+
+    (activity as AppCompatActivity).setSupportActionBar(binding.toolbar)
+    (activity as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+    binding.appBarLayout.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
+      var ratio = 0F
+      if (abs(verticalOffset) != 0) {
+        ratio = abs(verticalOffset).toFloat() / appBarLayout.totalScrollRange.toFloat()
+      }
+
+      binding.collapseTitle.alpha = 1f - ratio * 2f + 0.1f
+      binding.toolbarTitle.alpha = (ratio - 0.5f) * 2f + 0.1f
+    }
+
+    val args: LoadingFragmentArgs by navArgs()
+    this.matterSettings = Json.decodeFromString(args.setting)
+  }
+
+  override fun onResume() {
+    Timber.d("Hit")
+    super.onResume()
+  }
+
+  override fun onAttach(context: Context) {
+    Timber.d("Hit")
+    super.onAttach(context)
+
+    onBackPressedCallback =
+      object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+          Timber.d("handleOnBackPressed()")
+          findNavController().popBackStack()
+        }
+      }
+
+    requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+  }
+
+  override fun onDetach() {
+    Timber.d("Hit")
+    super.onDetach()
+    onBackPressedCallback.remove()
+  }
+
+  override fun onDestroy() {
+    Timber.d("Hit")
+    super.onDestroy()
+  }
+}

--- a/examples/virtual-device-app/android/App/feature/main/src/main/res/layout/fragment_loading.xml
+++ b/examples/virtual-device-app/android/App/feature/main/src/main/res/layout/fragment_loading.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/appbar_layout_height"
+            android:background="@android:color/transparent"
+            android:fitsSystemWindows="true"
+            app:elevation="0dp"
+            app:expanded="false"
+            app:layout_behavior="com.matter.virtual.device.app.core.common.ui.DisableAppBarLayoutBehavior">
+
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/toolbar_layout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fitsSystemWindows="true"
+                android:theme="@style/Theme.CollapsingToolbar"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <TextView
+                    android:id="@+id/collapse_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:text="@string/title_loading"
+                    android:textAlignment="center"
+                    android:textSize="@dimen/collapse_title_text_size" />
+
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:layout_gravity="bottom"
+                    android:background="@android:color/transparent"
+                    android:contentInsetStart="0dp"
+                    android:contentInsetLeft="0dp"
+                    android:contentInsetEnd="0dp"
+                    android:contentInsetRight="0dp"
+                    android:theme="@style/Theme.CollapsingToolbar"
+                    app:contentInsetEnd="0dp"
+                    app:contentInsetLeft="0dp"
+                    app:contentInsetRight="0dp"
+                    app:contentInsetStart="0dp"
+                    app:contentInsetStartWithNavigation="0dp"
+                    app:elevation="0dp"
+                    app:layout_collapseMode="pin">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent">
+
+                        <TextView
+                            android:id="@+id/toolbar_title"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/title_loading"
+                            android:textAlignment="viewStart"
+                            android:textSize="@dimen/toolbar_title_text_size"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </androidx.appcompat.widget.Toolbar>
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/nested_scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/menu_item_side_space"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginEnd="@dimen/menu_item_side_space"
+                    android:background="@drawable/menu_item_bg">
+
+                    <com.google.android.material.progressindicator.CircularProgressIndicator
+                        android:id="@+id/loading_progress"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginEnd="20dp"
+                        android:layout_marginBottom="20dp"
+                        app:indicatorColor="@color/colorControlActivated"
+                        android:indeterminate="true"
+                        app:layout_constraintBottom_toTopOf="@+id/loading_description"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.appcompat.widget.AppCompatTextView
+                        android:id="@+id/loading_description"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginEnd="20dp"
+                        android:layout_marginBottom="20dp"
+                        android:gravity="center"
+                        android:text="@string/description_loading"
+                        android:textAlignment="center"
+                        android:textSize="17sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/loading_progress" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </FrameLayout>
+        </androidx.core.widget.NestedScrollView>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>

--- a/examples/virtual-device-app/android/App/feature/main/src/main/res/navigation/main_nav_graph.xml
+++ b/examples/virtual-device-app/android/App/feature/main/src/main/res/navigation/main_nav_graph.xml
@@ -10,4 +10,15 @@
         android:name="com.matter.virtual.device.app.feature.main.MainFragment"
         android:label="MainFragment"
         tools:layout="@layout/fragment_main" />
+
+    <fragment
+        android:id="@+id/loadingFragment"
+        android:name="com.matter.virtual.device.app.feature.main.LoadingFragment"
+        android:label="LoadingFragment"
+        tools:layout="@layout/fragment_loading">
+        <argument
+            android:name="setting"
+            app:argType="string" />
+        <deepLink app:uri="android-app://com.matter.virtual.device.app.feature.main/loadingFragment/{setting}" />
+    </fragment>
 </navigation>

--- a/examples/virtual-device-app/android/App/feature/main/src/main/res/values/strings.xml
+++ b/examples/virtual-device-app/android/App/feature/main/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_main" translatable="false">Matter Virtual Device</string>
+    <string name="title_loading" translatable="false">Loading</string>
+    <string name="description_loading">Commissioning in process.</string>
 </resources>


### PR DESCRIPTION
#### Problem
* Need to handle the commissioning establish event


#### Change overview
* Add loading fragment view and deeplink


#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation


