### PR TITLE
enable android platform configuration

### DIFF
--- a/src/platform/android/SystemPlatformConfig.h
+++ b/src/platform/android/SystemPlatformConfig.h
@@ -41,4 +41,5 @@ struct ChipDeviceEvent;
 
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
 
+#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1
 // ========== Platform-specific Configuration Overrides =========


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/28450

-- Enable android platform configuration
-- Use heap for pool