### PR TITLE
Enable dynamic android friendly device name

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -144,6 +144,7 @@ class ExampleDeviceInstanceInfoProvider : public DeviceInstanceInfoProvider
 public:
     void Init(DeviceInstanceInfoProvider * defaultProvider) { mDefaultProvider = defaultProvider; }
 
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override { return mDefaultProvider->GetDeviceName(deviceNameSpan); }
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return mDefaultProvider->GetVendorName(buf, bufSize); }
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override { return mDefaultProvider->GetVendorId(vendorId); }
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return mDefaultProvider->GetProductName(buf, bufSize); }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -241,7 +241,9 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         CHIP_ERROR err;
         if ((err = DeviceLayer::ConfigurationMgr().GetCommissionableDeviceName(deviceNameSpan)) == CHIP_NO_ERROR)
         {
-            advertiseParameters.SetDeviceName(chip::Optional<const char *>::Value(deviceNameSpan.data()));
+            // Appending a null terminator since SetDeviceName expects a null terminated string
+            deviceName[deviceNameSpan.size()] = '\0';
+            advertiseParameters.SetDeviceName(chip::Optional<const char *>::Value(deviceName));
         }
         else
         {

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -44,6 +44,10 @@ namespace chip {
 namespace app {
 namespace {
 
+static_assert(ConfigurationManager::kMaxDeviceNameLen == Dnssd::kKeyDeviceNameMaxLength,
+              "Max device name length constants are not matching: ConfigurationManager::kMaxDeviceNameLen and "
+              "Dnssd::kKeyDeviceNameMaxLength");
+
 void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event)
 {
     switch (event->Type)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -234,8 +234,8 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         advertiseParameters.SetDeviceType(chip::Optional<uint32_t>::Value(val32));
     }
 
-    char deviceName[chip::Dnssd::kKeyDeviceNameMaxLength];
-    MutableCharSpan deviceNameSpan(deviceName);
+    char deviceName[Dnssd::kKeyDeviceNameMaxLength + 1];
+    MutableCharSpan deviceNameSpan(deviceName, Dnssd::kKeyDeviceNameMaxLength);
     if (DeviceLayer::ConfigurationMgr().IsCommissionableDeviceNameEnabled())
     {
         CHIP_ERROR err;
@@ -243,7 +243,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         {
             // Appending a null terminator since SetDeviceName expects a null terminated string
             deviceName[deviceNameSpan.size()] = '\0';
-            advertiseParameters.SetDeviceName(chip::Optional<const char *>::Value(deviceName));
+            advertiseParameters.SetDeviceName(Optional<const char *>::Value(deviceName));
         }
         else
         {

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -139,9 +139,10 @@ public:
 
     virtual void LogDeviceConfig() = 0;
 
-    virtual bool IsCommissionableDeviceTypeEnabled()                                 = 0;
-    virtual CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType)                        = 0;
-    virtual bool IsCommissionableDeviceNameEnabled()                                 = 0;
+    virtual bool IsCommissionableDeviceTypeEnabled()          = 0;
+    virtual CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) = 0;
+    virtual bool IsCommissionableDeviceNameEnabled()          = 0;
+    // deviceNameSpan gets resized to the actual size of the character data
     virtual CHIP_ERROR GetCommissionableDeviceName(MutableCharSpan & deviceNameSpan) = 0;
     virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint)                 = 0;
     virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize)      = 0;

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -64,7 +64,7 @@ public:
 
     enum
     {
-        kMaxDeviceNameLength            = 32,
+        kMaxDeviceNameLen               = 32,
         kMaxVendorNameLength            = 32,
         kMaxProductNameLength           = 32,
         kMaxLocationLength              = 2,

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -64,6 +64,7 @@ public:
 
     enum
     {
+        kMaxDeviceNameLength            = 32,
         kMaxVendorNameLength            = 32,
         kMaxProductNameLength           = 32,
         kMaxLocationLength              = 2,
@@ -138,14 +139,14 @@ public:
 
     virtual void LogDeviceConfig() = 0;
 
-    virtual bool IsCommissionableDeviceTypeEnabled()                              = 0;
-    virtual CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType)                     = 0;
-    virtual bool IsCommissionableDeviceNameEnabled()                              = 0;
-    virtual CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize)    = 0;
-    virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint)              = 0;
-    virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize)   = 0;
-    virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint)            = 0;
-    virtual CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) = 0;
+    virtual bool IsCommissionableDeviceTypeEnabled()                                 = 0;
+    virtual CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType)                        = 0;
+    virtual bool IsCommissionableDeviceNameEnabled()                                 = 0;
+    virtual CHIP_ERROR GetCommissionableDeviceName(MutableCharSpan & deviceNameSpan) = 0;
+    virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint)                 = 0;
+    virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize)      = 0;
+    virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint)               = 0;
+    virtual CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize)    = 0;
 
     virtual CHIP_ERROR GetLocationCapability(uint8_t & location);
 

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -30,6 +30,15 @@ public:
     virtual ~DeviceInstanceInfoProvider() = default;
 
     /**
+     * @brief Obtain the Device Name from the device's factory data.
+     *
+     * @param[out] deviceName Reference to location where the device name will be copied
+     * @returns CHIP_NO_ERROR on success, or another CHIP_ERROR from the underlying implementation
+     *          if access fails.
+     */
+    virtual CHIP_ERROR GetDeviceName(MutableCharSpan & deviceName) = 0;
+
+    /**
      * @brief Obtain the Vendor Name from the device's factory data.
      *
      * @param[out] buf Buffer to copy string.

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -32,7 +32,8 @@ public:
     /**
      * @brief Obtain the Device Name from the device's factory data.
      *
-     * @param[out] deviceName Reference to location where the device name will be copied
+     * @param[out] deviceName Buffer to copy the name into.  On success, will be
+                              resized to the actual size of the name.
      * @returns CHIP_NO_ERROR on success, or another CHIP_ERROR from the underlying implementation
      *          if access fails.
      */

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -85,7 +85,7 @@ public:
     bool IsCommissionableDeviceTypeEnabled() override;
     CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override;
     bool IsCommissionableDeviceNameEnabled() override;
-    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetCommissionableDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override;
     CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -640,11 +640,9 @@ bool GenericConfigurationManagerImpl<ConfigClass>::IsCommissionableDeviceNameEna
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCommissionableDeviceName(MutableCharSpan & deviceNameSpan)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
-    return CHIP_NO_ERROR;
+    return GetDeviceInstanceInfoProvider()->GetDeviceName(deviceNameSpan);
 }
 
 template <class ConfigClass>

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
@@ -41,6 +41,7 @@ public:
         mGenericConfigManager(configManager)
     {}
 
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
@@ -22,6 +22,18 @@ namespace DeviceLayer {
 namespace Internal {
 
 template <class ConfigClass>
+CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    constexpr char deviceName[] = CHIP_DEVICE_CONFIG_DEVICE_NAME;
+
+    ReturnErrorCodeIf(sizeof(deviceName) - 1 > deviceNameSpan.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(deviceNameSpan.data(), deviceName, sizeof(deviceName) - 1);
+    deviceNameSpan.reduce_size(sizeof(deviceName) - 1);
+
+    return CHIP_NO_ERROR;
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetVendorId(uint16_t & vendorId)
 {
     vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
@@ -26,11 +26,7 @@ CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetDeviceName(Mutable
 {
     constexpr char deviceName[] = CHIP_DEVICE_CONFIG_DEVICE_NAME;
 
-    ReturnErrorCodeIf(sizeof(deviceName) - 1 > deviceNameSpan.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
-    memcpy(deviceNameSpan.data(), deviceName, sizeof(deviceName) - 1);
-    deviceNameSpan.reduce_size(sizeof(deviceName) - 1);
-
-    return CHIP_NO_ERROR;
+    return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(deviceName), deviceNameSpan);
 }
 
 template <class ConfigClass>

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -47,6 +47,10 @@ static constexpr size_t kKeyRotatingDeviceIdMaxLength   = 100;
 static constexpr size_t kKeyPairingInstructionMaxLength = 128;
 static constexpr size_t kKeyPairingHintMaxLength        = 10;
 
+static_assert(kMaxDeviceNameLen == kKeyDeviceNameMaxLength,
+              "Max device name length constants are not matching: ConfigurationManager::kMaxDeviceNameLen and "
+              "Dnssd::kKeyDeviceNameMaxLength");
+
 enum class TxtKeyUse : uint8_t
 {
     kNone,

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -47,10 +47,6 @@ static constexpr size_t kKeyRotatingDeviceIdMaxLength   = 100;
 static constexpr size_t kKeyPairingInstructionMaxLength = 128;
 static constexpr size_t kKeyPairingHintMaxLength        = 10;
 
-static_assert(kMaxDeviceNameLen == kKeyDeviceNameMaxLength,
-              "Max device name length constants are not matching: ConfigurationManager::kMaxDeviceNameLen and "
-              "Dnssd::kKeyDeviceNameMaxLength");
-
 enum class TxtKeyUse : uint8_t
 {
     kNone,

--- a/src/platform/Ameba/FactoryDataProvider.cpp
+++ b/src/platform/Ameba/FactoryDataProvider.cpp
@@ -414,7 +414,7 @@ CHIP_ERROR FactoryDataProvider::GetSetupPasscode(uint32_t & setupPasscode)
     return err;
 }
 
-CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
+CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & deviceNameSpan)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/Ameba/FactoryDataProvider.cpp
+++ b/src/platform/Ameba/FactoryDataProvider.cpp
@@ -414,6 +414,11 @@ CHIP_ERROR FactoryDataProvider::GetSetupPasscode(uint32_t & setupPasscode)
     return err;
 }
 
+CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & deviceNameSpan)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Ameba/FactoryDataProvider.h
+++ b/src/platform/Ameba/FactoryDataProvider.h
@@ -48,6 +48,7 @@ public:
     CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
 
     // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -60,6 +60,7 @@ const char AndroidConfig::kConfigNamespace_ChipCounters[] = "chip-counters";
 
 // Keys stored in the Chip-factory namespace
 const AndroidConfig::Key AndroidConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceName         = { kConfigNamespace_ChipFactory, "device-name" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceId           = { kConfigNamespace_ChipFactory, "device-id" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceCert         = { kConfigNamespace_ChipFactory, "device-cert" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_MfrDeviceICACerts     = { kConfigNamespace_ChipFactory, "device-ca-certs" };

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -54,6 +54,7 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
+    static const Key kConfigKey_MfrDeviceName;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -87,12 +87,13 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & devic
         ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
         memcpy(deviceNameSpan.data(), androidDeviceName, deviceNameSize);
         deviceNameSpan.reduce_size(deviceNameSize);
+        return CHIP_NO_ERROR;
     }
-    else if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(CHIP_DEVICE_CONFIG_DEVICE_NAME), deviceNameSpan);
     }
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductName(char * buf, size_t bufSize)

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -78,23 +78,19 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & devic
     CHIP_ERROR err;
     size_t deviceNameSize = 0;
     char androidDeviceName[ConfigurationManager::kMaxDeviceNameLen];
-    MutableCharSpan androidDeviceNameSpan(androidDeviceName);
 
-    err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName,
-                                                      androidDeviceNameSpan.data(), androidDeviceNameSpan.size(), deviceNameSize);
+    err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName, androidDeviceName,
+                                                      sizeof(androidDeviceName), deviceNameSize);
 
     if (err == CHIP_NO_ERROR)
     {
         ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
-        memcpy(deviceNameSpan.data(), androidDeviceNameSpan.data(), deviceNameSize);
+        memcpy(deviceNameSpan.data(), androidDeviceName, deviceNameSize);
         deviceNameSpan.reduce_size(deviceNameSize);
     }
     else if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
-        ReturnErrorCodeIf(deviceNameSpan.size() < strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-        memcpy(deviceNameSpan.data(), CHIP_DEVICE_CONFIG_DEVICE_NAME, strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME));
-
-        deviceNameSpan.reduce_size(strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME));
+        return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(CHIP_DEVICE_CONFIG_DEVICE_NAME), deviceNameSpan);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & devic
     err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName,
                                                       androidDeviceNameSpan.data(), androidDeviceNameSpan.size(), deviceNameSize);
 
-    if (err = CHIP_NO_ERROR)
+    if (err == CHIP_NO_ERROR)
     {
         ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
         memcpy(deviceNameSpan.data(), androidDeviceNameSpan.data(), deviceNameSize);

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -77,7 +77,7 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & devic
 {
     CHIP_ERROR err;
     size_t deviceNameSize = 0;
-    char androidDeviceName[ConfigurationManager::kMaxDeviceNameLength];
+    char androidDeviceName[ConfigurationManager::kMaxDeviceNameLen];
     MutableCharSpan androidDeviceNameSpan(androidDeviceName);
 
     err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName,

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -73,6 +73,29 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductLabel(char * buf, size_t bu
     return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);
 }
 
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    CHIP_ERROR err;
+    size_t deviceNameSize = 0;
+    char androidDeviceName[ConfigurationManager::kMaxDeviceNameLength];
+    MutableCharSpan androidDeviceNameSpan(androidDeviceName);
+
+    err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName,
+                                                      androidDeviceNameSpan.data(), androidDeviceNameSpan.size(), deviceNameSize);
+    ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(deviceNameSpan.data(), androidDeviceNameSpan.data(), deviceNameSize);
+    deviceNameSpan.data()[deviceNameSize] = '\0';
+    deviceNameSpan.reduce_size(deviceNameSize + 1);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(deviceNameSpan.size() < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        memcpy(deviceNameSpan.data(), CHIP_DEVICE_CONFIG_DEVICE_NAME, sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME));
+
+        deviceNameSpan.reduce_size(sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME));
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductName(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -82,16 +82,19 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetDeviceName(MutableCharSpan & devic
 
     err = Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_MfrDeviceName,
                                                       androidDeviceNameSpan.data(), androidDeviceNameSpan.size(), deviceNameSize);
-    ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
-    memcpy(deviceNameSpan.data(), androidDeviceNameSpan.data(), deviceNameSize);
-    deviceNameSpan.data()[deviceNameSize] = '\0';
-    deviceNameSpan.reduce_size(deviceNameSize + 1);
-    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        ReturnErrorCodeIf(deviceNameSpan.size() < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-        memcpy(deviceNameSpan.data(), CHIP_DEVICE_CONFIG_DEVICE_NAME, sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME));
 
-        deviceNameSpan.reduce_size(sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME));
+    if (err = CHIP_NO_ERROR)
+    {
+        ReturnErrorCodeIf(deviceNameSpan.size() < deviceNameSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+        memcpy(deviceNameSpan.data(), androidDeviceNameSpan.data(), deviceNameSize);
+        deviceNameSpan.reduce_size(deviceNameSize);
+    }
+    else if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(deviceNameSpan.size() < strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        memcpy(deviceNameSpan.data(), CHIP_DEVICE_CONFIG_DEVICE_NAME, strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME));
+
+        deviceNameSpan.reduce_size(strlen(CHIP_DEVICE_CONFIG_DEVICE_NAME));
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.h
@@ -27,6 +27,7 @@ namespace DeviceLayer {
 class DeviceInstanceInfoProviderImpl : public Internal::GenericDeviceInstanceInfoProvider<Internal::AndroidConfig>
 {
 public:
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -26,6 +26,7 @@ public interface ConfigurationManager {
 
   // Keys stored in the Chip-factory namespace
   String kConfigKey_SerialNum = "serial-num";
+  String kConfigKey_MfrDeviceName = "device-name";
   String kConfigKey_MfrDeviceId = "device-id";
   String kConfigKey_MfrDeviceCert = "device-cert";
   String kConfigKey_MfrDeviceICACerts = "device-ca-certs";

--- a/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
@@ -103,6 +103,14 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
 
     switch (key) {
         /**
+         * Human readable name of the device name.
+         *
+         * <p>return a different value than src/include/platform/CHIPDeviceConfig.h for debug
+         */
+      case kConfigNamespace_ChipFactory + ":" + kConfigKey_MfrDeviceName:
+        return "TEST_ANDROID_DEVICE_NAME";
+
+        /**
          * Human readable name of the device model. return a different value than
          * src/include/platform/CHIPDeviceConfig.h for debug
          */

--- a/src/platform/bouffalolab/common/FactoryDataProvider.cpp
+++ b/src/platform/bouffalolab/common/FactoryDataProvider.cpp
@@ -398,6 +398,11 @@ CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR FactoryDataProvider::GetVendorName(char * buf, size_t bufSize)
 {
 #if CONFIG_BOUFFALOLAB_FACTORY_DATA_ENABLE

--- a/src/platform/bouffalolab/common/FactoryDataProvider.h
+++ b/src/platform/bouffalolab/common/FactoryDataProvider.h
@@ -50,6 +50,7 @@ public:
     CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
 
     // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -67,7 +67,7 @@ private:
     bool IsCommissionableDeviceTypeEnabled() override { return false; }
     CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     bool IsCommissionableDeviceNameEnabled() override { return false; }
-    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetCommissionableDeviceName(MutableCharSpan & deviceNameSpan) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -240,6 +240,12 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::SetSetupPasscode(uint32_t setu
 }
 
 template <class FlashFactoryData>
+CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetVendorName(char * buf, size_t bufSize)
 {
     return GetFactoryDataString(mFactoryData.vendor_name, buf, bufSize);

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -127,6 +127,7 @@ public:
     CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
 
     // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/nxp/k32w/common/FactoryDataProvider.cpp
+++ b/src/platform/nxp/k32w/common/FactoryDataProvider.cpp
@@ -57,6 +57,7 @@ FactoryDataProvider::FactoryDataProvider()
     maxLengths[FactoryDataId::kVidId]                = sizeof(uint16_t);
     maxLengths[FactoryDataId::kPidId]                = sizeof(uint16_t);
     maxLengths[FactoryDataId::kCertDeclarationId]    = Credentials::kMaxCMSSignedCDMessage;
+    maxLengths[FactoryDataId::kDeviceName]           = ConfigurationManager::kMaxDeviceNameLength;
     maxLengths[FactoryDataId::kVendorNameId]         = ConfigurationManager::kMaxVendorNameLength;
     maxLengths[FactoryDataId::kProductNameId]        = ConfigurationManager::kMaxProductNameLength;
     maxLengths[FactoryDataId::kSerialNumberId]       = ConfigurationManager::kMaxSerialNumberLength;
@@ -218,6 +219,11 @@ CHIP_ERROR FactoryDataProvider::GetSetupPasscode(uint32_t & setupPasscode)
 }
 
 CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & deviceNameSpan)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/nxp/k32w/common/FactoryDataProvider.cpp
+++ b/src/platform/nxp/k32w/common/FactoryDataProvider.cpp
@@ -57,7 +57,7 @@ FactoryDataProvider::FactoryDataProvider()
     maxLengths[FactoryDataId::kVidId]                = sizeof(uint16_t);
     maxLengths[FactoryDataId::kPidId]                = sizeof(uint16_t);
     maxLengths[FactoryDataId::kCertDeclarationId]    = Credentials::kMaxCMSSignedCDMessage;
-    maxLengths[FactoryDataId::kDeviceName]           = ConfigurationManager::kMaxDeviceNameLength;
+    maxLengths[FactoryDataId::kDeviceName]           = ConfigurationManager::kMaxDeviceNameLen;
     maxLengths[FactoryDataId::kVendorNameId]         = ConfigurationManager::kMaxVendorNameLength;
     maxLengths[FactoryDataId::kProductNameId]        = ConfigurationManager::kMaxProductNameLength;
     maxLengths[FactoryDataId::kSerialNumberId]       = ConfigurationManager::kMaxSerialNumberLength;

--- a/src/platform/nxp/k32w/common/FactoryDataProvider.h
+++ b/src/platform/nxp/k32w/common/FactoryDataProvider.h
@@ -78,6 +78,7 @@ public:
         kVidId,
         kPidId,
         kCertDeclarationId,
+        kDeviceNameId,
         kVendorNameId,
         kProductNameId,
         kSerialNumberId,
@@ -130,6 +131,7 @@ public:
     CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & messageToSign, MutableByteSpan & outSignBuffer) override;
 
     // ===== Members functions that implement the GenericDeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/nxp/mw320/FactoryDataProvider.cpp
+++ b/src/platform/nxp/mw320/FactoryDataProvider.cpp
@@ -267,6 +267,11 @@ CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
+CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & devicenameSpan)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR FactoryDataProvider::GetVendorName(char * buf, size_t bufSize)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nxp/mw320/FactoryDataProvider.h
+++ b/src/platform/nxp/mw320/FactoryDataProvider.h
@@ -62,6 +62,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
     // ===== Members functions that implement the GenericDeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/qpg/FactoryDataProvider.cpp
+++ b/src/platform/qpg/FactoryDataProvider.cpp
@@ -240,6 +240,11 @@ CHIP_ERROR FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+CHIP_ERROR FactoryDataProvider::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR FactoryDataProvider::GetVendorName(char * buf, size_t bufSize)
 {
     qvStatus_t status;

--- a/src/platform/qpg/FactoryDataProvider.h
+++ b/src/platform/qpg/FactoryDataProvider.h
@@ -50,6 +50,7 @@ public:
     CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
 
     // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;

--- a/src/platform/telink/FactoryDataProvider.cpp
+++ b/src/platform/telink/FactoryDataProvider.cpp
@@ -239,6 +239,12 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::SetSetupPasscode(uint32_t setu
 }
 
 template <class FlashFactoryData>
+CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetDeviceName(MutableCharSpan & deviceNameSpan)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetVendorName(char * buf, size_t bufSize)
 {
     return GetFactoryDataString(mFactoryData.vendor_name, buf, bufSize);

--- a/src/platform/telink/FactoryDataProvider.h
+++ b/src/platform/telink/FactoryDataProvider.h
@@ -91,6 +91,7 @@ public:
     CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
 
     // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetDeviceName(MutableCharSpan & deviceNameSpan) override;
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;


### PR DESCRIPTION

**Problem**

Device name can be set by setting the CHIP_DEVICE_CONFIG_DEVICE_NAME key at compile time, but there is no way to set it at runtime.

**Solution**

This PR adds a way to set the device name at runtime in the SDK.
