### PR TITLE
[cloudbuild] switch to v2 of our build images.

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -85,7 +85,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 2700s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -27,7 +27,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -43,7 +43,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -64,7 +64,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -139,7 +139,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:1"
+    - name: "ghcr.io/project-chip/chip-build-vscode:2"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
This is required because esp32 switch to IDF 5.1 is only available in v2 of the images.