### PR TITLE
Add `__test__ = False` to hooks

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/hooks.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/hooks.py
@@ -18,6 +18,8 @@ from .parser import TestStep
 
 
 class TestParserHooks():
+    __test__ = False
+
     def start(self, count: int):
         """
         This method is called when the parser starts parsing a set of files.
@@ -77,6 +79,8 @@ class TestParserHooks():
 
 
 class TestRunnerHooks():
+    __test__ = False
+
     def start(self, count: int):
         """
         This method is called when the runner starts running a set of tests.


### PR DESCRIPTION
The runner uses some hooks classes that start with "Test", so they get picked up as unit test classes. I added `__test__ = False` to these classes to avoid that.
