### PR TITLE
[docker] Use gcc 10 in chip build

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -216,7 +216,7 @@ RUN case ${TARGETPLATFORM} in \
     && export CCACHE_DISABLE=1 PYTHONDONTWRITEBYTECODE=1 \
     && GLIB_VERSION=$(pkg-config --modversion glib-2.0) \
     && git clone --depth=1 --branch=$GLIB_VERSION https://github.com/GNOME/glib.git \
-    && CFLAGS="-O2 -g -fsanitize=thread" meson glib/build glib \
+    && CFLAGS="-O2 -g -fsanitize=thread" meson glib/build glib -Dtests=false \
     && DESTDIR=../build-image ninja -C glib/build install \
     && mv glib/build-image/usr/local/lib/x86_64-linux-gnu/lib* $LD_LIBRARY_PATH_TSAN \
     && rm -rf glib \

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -41,7 +41,7 @@ RUN set -x \
     clang-tidy \
     curl \
     flex \
-    g++ \
+    g++-10 \
     git \
     git-lfs \
     gperf \
@@ -96,6 +96,16 @@ RUN set -x \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/ \
     && git lfs install \
+    && : # last line
+
+# Set gcc 10 as a default compiler to work with TSAN
+RUN set -x \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \
+    && update-alternatives --set cc /usr/bin/gcc \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 \
+    && update-alternatives --set c++ /usr/bin/g++ \
     && : # last line
 
 # Cmake v3.23.1

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-2 : Update esp-idf to v5.1 and remove few pinned package version
+3 : Update to gcc-10


### PR DESCRIPTION
Without this, it looks like the tsan build of glib-2 fails. 
From what I can tell this is because https://packages.ubuntu.com/focal/libtsan0  is for gcc10 instead of gcc9 and https://packages.ubuntu.com/focal/gcc is gcc9.

I am unsure why it worked before, however it does seem like they need to be compatible.

Failure for existing case example: https://github.com/project-chip/connectedhomeip/actions/runs/5735918812/job/15564760900?pr=28431

```
...
meson.build:1:0: ERROR: Compiler ccache cc can not compile programs.
```

and manually I saw:

```
...
Sanity check compiler command line: ccache cc /glib/build/meson-private/sanitycheckc.c -o /glib/build/meson-private/sanitycheckc.exe -O2 -g -fsanitize=thread -pipe -D_FILE_OFFSET_BITS=64
Sanity check compile stdout:

-----
Sanity check compile stderr:
/usr/bin/ld: cannot find libtsan_preinit.o: No such file or directory
collect2: error: ld returned 1 exit status
```