### PR TITLE
Stop using controllerID for internal XPC bookkeeping.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
@@ -179,7 +179,7 @@ static void SetupXPCQueue(void)
 
     dispatch_async(_workQueue, ^{
         dispatch_group_t group = dispatch_group_create();
-        if (!self.controllerID) {
+        if (!self.controllerXPCID) {
             dispatch_group_enter(group);
             [self.xpcConnection getProxyHandleWithCompletion:^(
                 dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
@@ -188,7 +188,7 @@ static void SetupXPCQueue(void)
                         if (error) {
                             MTR_LOG_ERROR("Failed to fetch any shared remote controller");
                         } else {
-                            self.controllerID = controller;
+                            self.controllerXPCID = controller;
                             handleRetainer = handle;
                         }
                         dispatch_group_leave(group);
@@ -200,8 +200,8 @@ static void SetupXPCQueue(void)
             }];
         }
         dispatch_group_notify(group, queue, ^{
-            if (self.controllerID) {
-                completion(self.controllerID, handleRetainer, nil);
+            if (self.controllerXPCID) {
+                completion(self.controllerXPCID, handleRetainer, nil);
             } else {
                 completion(nil, nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             }
@@ -234,7 +234,7 @@ static void SetupXPCQueue(void)
                            workQueue:(dispatch_queue_t)queue
                        xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
-    _controllerID = controllerID;
+    _controllerXPCID = controllerID;
     _workQueue = queue;
     _xpcConnection = xpcConnection;
     return self;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -25,7 +25,7 @@ typedef void (^MTRFetchControllerIDCompletion)(
 
 @interface MTRDeviceControllerOverXPC ()
 
-@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerID;
+@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerXPCID;
 @property (nonatomic, readonly, strong) dispatch_queue_t workQueue;
 @property (nonatomic, readonly, strong) MTRDeviceControllerXPCConnection * xpcConnection;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -46,7 +46,7 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
                                  deviceID:(NSNumber *)deviceID
                             xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
-    _controllerID = controllerOverXPC.controllerID;
+    _controllerID = controllerOverXPC.controllerXPCID;
     _controller = controllerOverXPC;
     _nodeID = deviceID;
     _xpcConnection = xpcConnection;


### PR DESCRIPTION
We want to use controllerID for client-assigned controller IDs.
