### PR TITLE
Fix crash when an error happens during a BLE scan on darwin.

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -181,8 +181,10 @@ namespace DeviceLayer {
 
                 [ble stop];
                 ble = [[BleConnection alloc] initWithDelegate:delegate queue:bleWorkQueue];
-                ble.onConnectionComplete = OnConnectionComplete;
-                ble.onConnectionError = OnConnectionError;
+                // Do _not_ set onConnectionComplete and onConnectionError
+                // here.  The connection callbacks we have expect an appState
+                // that we do not have here, and in any case connection
+                // complete/error make no sense for a scan.
                 ble.centralManager = [ble.centralManager initWithDelegate:ble queue:bleWorkQueue];
             });
         }


### PR DESCRIPTION
If we happened to do a BLE scan after doing a BLE connect, and then during the BLE scan one of two things happens:

1. Bluetooth is shut down (e.g. by just turning it off via the menubar).
2. The scan is a delegate-less scan and times out.

then we would try to use the error handler that expects a SetUpCodePairer but without an actual non-null SetUpCodePairer to pass it.  And then that would crash.

The fix is to not call an error handler that we're not supposed to be calling; scans do not call the _connection_ error handler.
