### PR TITLE
Fix selector for status update on CHIPToolDeviceControllerDelegate.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.h
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.h
@@ -28,6 +28,7 @@
 @property MTRDeviceController * commissioner;
 @property MTRCommissioningParameters * params;
 
+- (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status;
 - (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error;
 - (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error;
 

--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
@@ -23,7 +23,7 @@
 @end
 
 @implementation CHIPToolDeviceControllerDelegate
-- (void)onStatusUpdate:(MTRCommissioningStatus)status
+- (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
 {
     NSLog(@"Pairing Status Update: %tu", status);
     switch (status) {


### PR DESCRIPTION
This did not get correctly updated in
https://github.com/project-chip/connectedhomeip/pull/23665, so it was not getting the status update callbacks.