### PR TITLE
Skip building python modules as part of Matter.framework build.

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -96,6 +96,7 @@ declare -a args=(
     'chip_build_tools=false'
     'chip_build_tests=false'
     'chip_enable_wifi=false'
+    'chip_enable_python_modules=false'
     'chip_log_message_max_size=4096' # might as well allow nice long log messages
     'chip_disable_platform_kvs=true'
     'enable_fuzz_test_targets=false'


### PR DESCRIPTION
We don't need them there, but also they unconditionally pull in perfetto bits, which is also undesirable.
