### PR TITLE
[Telink] Factory reset using power on sequence

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -207,3 +207,11 @@ config CHIP_MAX_PREFERRED_SUBSCRIPTION_REPORT_INTERVAL
 	  the initiator device to detect the publisher absence reasonably fast due to not sending
 	  the reports too rarely. The current algorithm is to select bigger value from the one
 	  requested by the initiator and the one preferred by the publisher.
+
+config CHIP_ENABLE_POWER_ON_FACTORY_RESET
+	bool "Enable power on factory reset sequence"
+	default n
+	help
+	  Enable power on factory reset sequence. If device power triggered off during
+	  first 5 seconds after power on and this sequence repeated 5 times - factory
+	  reset will be involved.

--- a/examples/lighting-app/telink/include/AppTask.h
+++ b/examples/lighting-app/telink/include/AppTask.h
@@ -23,6 +23,9 @@
 class AppTask : public AppTaskCommon
 {
 public:
+#ifdef CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET
+    void PowerOnFactoryReset(void);
+#endif /* CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET */
     void SetInitiateAction(PWMDevice::Action_t aAction, int32_t aActor, uint8_t * value);
     void UpdateClusterState(void);
     PWMDevice & GetPWMDevice(void) { return mPwmRgbBlueLed; }
@@ -37,7 +40,13 @@ private:
     static void ActionCompleted(PWMDevice::Action_t aAction, int32_t aActor);
 
     static void LightingActionEventHandler(AppEvent * aEvent);
+#ifdef CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET
+    static void PowerOnFactoryResetEventHandler(AppEvent * aEvent);
+    static void PowerOnFactoryResetTimerEvent(struct k_timer * dummy);
 
+    static unsigned int sPowerOnFactoryResetTimerCnt;
+    static k_timer sPowerOnFactoryResetTimer;
+#endif /* CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET */
     PWMDevice mPwmRgbBlueLed;
 #if USE_RGB_PWM
     PWMDevice mPwmRgbGreenLed;

--- a/examples/platform/telink/common/include/AppTaskCommon.h
+++ b/examples/platform/telink/common/include/AppTaskCommon.h
@@ -63,6 +63,9 @@ constexpr uint8_t kButtonReleaseEvent   = 0;
 class AppTaskCommon
 {
 public:
+#ifdef CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET
+    void PowerOnFactoryReset(void);
+#endif /* CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET */
     CHIP_ERROR StartApp();
     void PostEvent(AppEvent * event);
 

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -222,6 +222,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_telink, SHELL_CMD(reboot, NULL, "Reboot board
 SHELL_CMD_REGISTER(telink, &sub_telink, "Telink commands", NULL);
 #endif // CONFIG_CHIP_LIB_SHELL
 
+#ifdef CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET
+void AppTaskCommon::PowerOnFactoryReset(void)
+{
+    LOG_INF("schedule factory reset");
+    chip::Server::GetInstance().ScheduleFactoryReset();
+}
+#endif /* CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET */
+
 CHIP_ERROR AppTaskCommon::StartApp(void)
 {
     CHIP_ERROR err = GetAppTask().Init();


### PR DESCRIPTION
Change overview

- The feature touches only Telink B91 platform

- Some devices do not have any physical buttons. In that case special power on
sequence is implemented to trigger factory reset:
If device power triggered off during first 5 seconds after power on
and this sequence repeated 5 times - factory reset will be involved.

- For Lightbulb implemented indication (using blinking main light) of
triggering factory reset after described sequence.

- By default feature is turned off to turn on feature add
"CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET=y" in prj.conf

Tested manually.

Steps:

1. Power On Device
2. During first 5 seconds after start power off device
3. Repeat steps 1 and 2 5 times
4. Factory reset procedure should be involved