### PR TITLE
[ESP32] Add matter IP events for Ethernet

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -167,6 +167,12 @@ private:
     void OnStationIPv6AddressAvailable(const ip_event_got_ip6_t & got_ip);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    void OnEthernetIPv4AddressAvailable(const ip_event_got_ip_t & got_ip);
+    void OnEthernetIPv4AddressLost(void);
+    void OnEthernetIPv6AddressAvailable(const ip_event_got_ip6_t & got_ip);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
     // ===== Members for internal use by the following friends.
 
     friend ConnectivityManager & ConnectivityMgr(void);

--- a/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
@@ -57,8 +57,8 @@ CHIP_ERROR ConnectivityManagerImpl::InitEthernet()
 
 void ConnectivityManagerImpl::OnEthernetIPv4AddressAvailable(const ip_event_got_ip_t & got_ip)
 {
-    ChipLogProgress(DeviceLayer, "IPv4 address available on Ethernet interface: " IPSTR "/" IPSTR " gateway " IPSTR, IP2STR(&got_ip.ip_info.ip), IP2STR(&got_ip.ip_info.netmask),
-                    IP2STR(&got_ip.ip_info.gw));
+    ChipLogProgress(DeviceLayer, "IPv4 address available on Ethernet interface: " IPSTR "/" IPSTR " gateway " IPSTR,
+                    IP2STR(&got_ip.ip_info.ip), IP2STR(&got_ip.ip_info.netmask), IP2STR(&got_ip.ip_info.gw));
 
     ChipDeviceEvent event;
     event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
@@ -78,8 +78,7 @@ void ConnectivityManagerImpl::OnEthernetIPv4AddressLost(void)
 
 void ConnectivityManagerImpl::OnEthernetIPv6AddressAvailable(const ip_event_got_ip6_t & got_ip)
 {
-    ChipLogProgress(DeviceLayer, "IPv6 address available on Ethernet interface: " IPV6STR,
-                    IPV62STR(got_ip.ip6_info.ip));
+    ChipLogProgress(DeviceLayer, "IPv6 address available on Ethernet interface: " IPV6STR, IPV62STR(got_ip.ip6_info.ip));
 
     ChipDeviceEvent event;
     event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;

--- a/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
@@ -55,15 +55,53 @@ CHIP_ERROR ConnectivityManagerImpl::InitEthernet()
     return CHIP_NO_ERROR;
 }
 
+void ConnectivityManagerImpl::OnEthernetIPv4AddressAvailable(const ip_event_got_ip_t & got_ip)
+{
+    ChipLogProgress(DeviceLayer, "IPv4 address available on Ethernet interface: " IPSTR "/" IPSTR " gateway " IPSTR, IP2STR(&got_ip.ip_info.ip), IP2STR(&got_ip.ip_info.netmask),
+                    IP2STR(&got_ip.ip_info.gw));
+
+    ChipDeviceEvent event;
+    event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
+    event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV4_Assigned;
+    PlatformMgr().PostEventOrDie(&event);
+}
+
+void ConnectivityManagerImpl::OnEthernetIPv4AddressLost(void)
+{
+    ChipLogProgress(DeviceLayer, "IPv4 address lost on Ethernet interface");
+
+    ChipDeviceEvent event;
+    event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
+    event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV4_Lost;
+    PlatformMgr().PostEventOrDie(&event);
+}
+
+void ConnectivityManagerImpl::OnEthernetIPv6AddressAvailable(const ip_event_got_ip6_t & got_ip)
+{
+    ChipLogProgress(DeviceLayer, "IPv6 address available on Ethernet interface: " IPV6STR,
+                    IPV62STR(got_ip.ip6_info.ip));
+
+    ChipDeviceEvent event;
+    event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
+    event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV6_Assigned;
+    PlatformMgr().PostEventOrDie(&event);
+}
+
 void ConnectivityManagerImpl::OnEthernetPlatformEvent(const ChipDeviceEvent * event)
 {
     switch (event->Platform.ESPSystemEvent.Id)
     {
     case IP_EVENT_ETH_GOT_IP:
-        ChipLogProgress(DeviceLayer, "Ethernet Link Up");
+        OnEthernetIPv4AddressAvailable(event->Platform.ESPSystemEvent.Data.IpGotIp);
         break;
     case IP_EVENT_ETH_LOST_IP:
-        ChipLogProgress(DeviceLayer, "Ethernet Link Down");
+        OnEthernetIPv4AddressLost();
+        break;
+    case IP_EVENT_GOT_IP6:
+        if (strcmp(esp_netif_get_ifkey(event->Platform.ESPSystemEvent.Data.IpGotIp6.esp_netif), "ETH_DEF") == 0)
+        {
+            OnEthernetIPv6AddressAvailable(event->Platform.ESPSystemEvent.Data.IpGotIp6);
+        }
         break;
     case ETHERNET_EVENT_START:
         ChipLogProgress(DeviceLayer, "Ethernet Started");


### PR DESCRIPTION
- Dnsserver Initialisation should be done whenever the IP address is changed for ethernet
- This PR has changes to trigger the matter IP events and Initialise the Dnssd server

##TESTING
- Tested commissioning and control

