### PR TITLE
[Silabs] Remove ICDM cluster from lighting app

### DIFF
--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -1914,53 +1914,6 @@ server cluster UserLabel = 65 {
   readonly attribute int16u clusterRevision = 65533;
 }
 
-/** Allows servers to ensure that listed clients are notified when a server is available for communication. */
-server cluster IcdManagement = 70 {
-  bitmap Feature : BITMAP32 {
-    kCheckInProtocolSupport = 0x1;
-  }
-
-  fabric_scoped struct MonitoringRegistrationStruct {
-    fabric_sensitive node_id checkInNodeID = 1;
-    fabric_sensitive int64u monitoredSubject = 2;
-    fabric_sensitive octet_string<16> key = 3;
-    fabric_idx fabricIndex = 254;
-  }
-
-  readonly attribute int32u idleModeInterval = 0;
-  readonly attribute int32u activeModeInterval = 1;
-  readonly attribute int16u activeModeThreshold = 2;
-  readonly attribute access(read: administer) MonitoringRegistrationStruct registeredClients[] = 3;
-  readonly attribute access(read: administer) int32u ICDCounter = 4;
-  readonly attribute int16u clientsSupportedPerFabric = 5;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute event_id eventList[] = 65530;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  request struct RegisterClientRequest {
-    node_id checkInNodeID = 0;
-    INT64U monitoredSubject = 1;
-    OCTET_STRING<16> key = 2;
-    optional OCTET_STRING<16> verificationKey = 3;
-  }
-
-  request struct UnregisterClientRequest {
-    node_id checkInNodeID = 0;
-    optional OCTET_STRING<16> verificationKey = 1;
-  }
-
-  response struct RegisterClientResponse = 1 {
-    INT32U ICDCounter = 0;
-  }
-
-  fabric command access(invoke: manage) RegisterClient(RegisterClientRequest): RegisterClientResponse = 0;
-  fabric command access(invoke: manage) UnregisterClient(UnregisterClientRequest): DefaultSuccess = 2;
-  command access(invoke: manage) StayActiveRequest(): DefaultSuccess = 3;
-}
-
 /** Attributes and commands for controlling the color properties of a color-capable light. */
 server cluster ColorControl = 768 {
   enum ColorLoopAction : ENUM8 {
@@ -2461,20 +2414,6 @@ endpoint 0 {
   server cluster UserLabel {
     callback attribute labelList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
-  }
-
-  server cluster IcdManagement {
-    callback attribute idleModeInterval default = 500;
-    callback attribute activeModeInterval default = 300;
-    callback attribute activeModeThreshold default = 300;
-    callback attribute registeredClients;
-    callback attribute ICDCounter;
-    callback attribute clientsSupportedPerFabric default = 1;
-    callback attribute generatedCommandList;
-    callback attribute acceptedCommandList;
-    callback attribute attributeList;
-    ram      attribute featureMap default = 1;
     ram      attribute clusterRevision default = 1;
   }
 }

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -33,7 +33,33 @@
   ],
   "endpointTypes": [
     {
+      "id": 1,
       "name": "MA-rootdevice",
+      "deviceTypeRef": {
+        "id": 2,
+        "code": 22,
+        "profileId": 259,
+        "label": "MA-rootdevice",
+        "name": "MA-rootdevice"
+      },
+      "deviceTypes": [
+        {
+          "id": 2,
+          "code": 22,
+          "profileId": 259,
+          "label": "MA-rootdevice",
+          "name": "MA-rootdevice"
+        }
+      ],
+      "deviceTypeRefs": [
+        2
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        22
+      ],
       "deviceTypeName": "MA-rootdevice",
       "deviceTypeCode": 22,
       "deviceTypeProfileId": 259,
@@ -5555,7 +5581,7 @@
           "mfgCode": null,
           "define": "ICD_MANAGEMENT_CLUSTER",
           "side": "server",
-          "enabled": 1,
+          "enabled": 0,
           "commands": [
             {
               "name": "RegisterClientResponse",
@@ -5764,7 +5790,33 @@
       ]
     },
     {
+      "id": 2,
       "name": "MA-dimmablelight",
+      "deviceTypeRef": {
+        "id": 9,
+        "code": 257,
+        "profileId": 259,
+        "label": "MA-dimmablelight",
+        "name": "MA-dimmablelight"
+      },
+      "deviceTypes": [
+        {
+          "id": 9,
+          "code": 257,
+          "profileId": 259,
+          "label": "MA-dimmablelight",
+          "name": "MA-dimmablelight"
+        }
+      ],
+      "deviceTypeRefs": [
+        9
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        257
+      ],
       "deviceTypeName": "MA-dimmablelight",
       "deviceTypeCode": 257,
       "deviceTypeProfileId": 259,
@@ -9103,18 +9155,14 @@
       "endpointTypeIndex": 0,
       "profileId": 259,
       "endpointId": 0,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "networkId": 0
     },
     {
       "endpointTypeName": "MA-dimmablelight",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 257
+      "networkId": 0
     }
   ],
   "log": []


### PR DESCRIPTION
#### Description
ICDM cluster was enabled on the lighting to simplify development. Now that the cluster is enabled on the lock-app, we don't need it to be enabled on the lighting app.

Remove ICDM cluster from the Silabs lighting app.

