### PR TITLE
[matteridl] use looping struct for getting device types

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -6063,7 +6063,8 @@ server cluster FaultInjection = 4294048774 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Identify {
@@ -6440,7 +6441,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type onofflight = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
   binding cluster OnOff;
 
   server cluster Identify {
@@ -7449,7 +7451,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type onofflight = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
 
   server cluster Groups {
     ram      attribute nameSupport;
@@ -7497,7 +7500,8 @@ endpoint 2 {
   }
 }
 endpoint 65534 {
-  device type anonymousEndpointType = 61442, version 1;
+  device type ma_secondary_network_commissioning = 61442, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -3960,7 +3960,8 @@ server cluster UnitTesting = 4294048773 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Identify {
@@ -4200,7 +4201,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type onofflight = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;
@@ -4616,7 +4618,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type onofflight = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
 
   server cluster Groups {
     ram      attribute nameSupport;
@@ -4657,7 +4660,8 @@ endpoint 2 {
   }
 }
 endpoint 65534 {
-  device type anonymousEndpointType = 61442, version 1;
+  device type ma_secondary_network_commissioning = 61442, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -1641,7 +1641,8 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 endpoint 0 {
-  device type bridge = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster AccessControl;
 
   server cluster Descriptor {
@@ -1939,7 +1940,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 14, version 1;
+  device type ma_aggregator = 14, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {
@@ -1977,7 +1979,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type dimmablelight = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
 
   server cluster OnOff {
     ram      attribute onOff default = 0x00;

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1501,7 +1501,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1757,7 +1758,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
   binding cluster Binding;
   binding cluster OccupancySensing;
 

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -1753,7 +1753,8 @@ server cluster RadonConcentrationMeasurement = 1071 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1876,7 +1877,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 45, version 1;
+  device type ma_air_purifier = 45, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -1960,7 +1962,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type anonymousEndpointType = 44, version 1;
+  device type ma_air_quality_sensor = 44, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -2187,7 +2190,8 @@ endpoint 2 {
   }
 }
 endpoint 3 {
-  device type anonymousEndpointType = 770, version 1;
+  device type ma_tempsensor = 770, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -2226,7 +2230,8 @@ endpoint 3 {
   }
 }
 endpoint 4 {
-  device type anonymousEndpointType = 775, version 1;
+  device type ma_humiditysensor = 775, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -2265,7 +2270,8 @@ endpoint 4 {
   }
 }
 endpoint 5 {
-  device type anonymousEndpointType = 769, version 1;
+  device type ma_thermostat = 769, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
+++ b/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
@@ -1463,7 +1463,8 @@ server cluster AudioOutput = 1291 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1629,7 +1630,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 40, version 1;
+  device type ma_basic_videoplayer = 40, version 1;
+
 
   server cluster OnOff {
     ram      attribute onOff default = 0;

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -1534,7 +1534,8 @@ server cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1679,7 +1680,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 268, version 1;
+  device type ma_colortemperaturelight = 268, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -1191,7 +1191,8 @@ server cluster BooleanState = 69 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1357,7 +1358,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 21, version 1;
+  device type ma_contactsensor = 21, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1365,7 +1365,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1533,7 +1534,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
   binding cluster Binding;
   binding cluster OccupancySensing;
 

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -1663,7 +1663,8 @@ server cluster DoorLock = 257 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1829,7 +1830,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 10, version 1;
+  device type ma_doorlock = 10, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -1594,7 +1594,8 @@ server cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1760,7 +1761,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 269, version 1;
+  device type ma_extendedcolorlight = 269, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
@@ -1233,7 +1233,8 @@ server cluster FanControl = 514 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1400,7 +1401,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 43, version 1;
+  device type ma_fan = 43, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -1196,7 +1196,8 @@ server cluster FlowMeasurement = 1028 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1362,7 +1363,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 774, version 1;
+  device type ma_flowsensor = 774, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -1543,7 +1543,8 @@ server cluster FanControl = 514 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1709,7 +1710,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 768, version 1;
+  device type ma_heatcool = 768, version 1;
+
   binding cluster Binding;
   binding cluster Thermostat;
 

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -1196,7 +1196,8 @@ server cluster RelativeHumidityMeasurement = 1029 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1362,7 +1363,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 775, version 1;
+  device type ma_humiditysensor = 775, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -1201,7 +1201,8 @@ server cluster IlluminanceMeasurement = 1024 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1367,7 +1368,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 262, version 1;
+  device type ma_lightsensor = 262, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -1212,7 +1212,8 @@ server cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1378,7 +1379,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 263, version 1;
+  device type ma_occupancysensor = 263, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -1326,7 +1326,8 @@ server cluster FixedLabel = 64 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1492,7 +1493,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -1290,7 +1290,8 @@ server cluster FixedLabel = 64 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1456,7 +1457,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 259, version 1;
+  device type ma_onofflightswitch = 259, version 1;
+
   binding cluster OnOff;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -1225,7 +1225,8 @@ server cluster FixedLabel = 64 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1391,7 +1392,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 266, version 1;
+  device type ma_onoffpluginunit = 266, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -1215,7 +1215,8 @@ server cluster PressureMeasurement = 1027 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1387,7 +1388,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 773, version 1;
+  device type ma_pressuresensor = 773, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_pump_a811bb33a0.matter
+++ b/examples/chef/devices/rootnode_pump_a811bb33a0.matter
@@ -1016,7 +1016,8 @@ server cluster PumpConfigurationAndControl = 512 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1168,7 +1169,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 771, version 1;
+  device type ma_pump = 771, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -1193,7 +1193,8 @@ server cluster RvcOperationalState = 97 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1316,7 +1317,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 116, version 1;
+  device type ma_robotic_vacuum_cleaner = 116, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
+++ b/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
@@ -1122,7 +1122,8 @@ server cluster ThermostatUserInterfaceConfiguration = 516 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1245,7 +1246,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 114, version 1;
+  device type ma_room_airconditioner = 114, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -1251,7 +1251,8 @@ server cluster FixedLabel = 64 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1417,7 +1418,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 34, version 1;
+  device type ma_speaker = 34, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -1195,7 +1195,8 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1361,7 +1362,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 770, version 1;
+  device type ma_tempsensor = 770, version 1;
+
   binding cluster Groups;
   binding cluster Binding;
 

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -1444,7 +1444,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1610,7 +1611,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 769, version 1;
+  device type ma_thermostat = 769, version 1;
+
   binding cluster Binding;
   binding cluster FanControl;
   binding cluster TemperatureMeasurement;

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -1320,7 +1320,8 @@ server cluster WindowCovering = 258 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1486,7 +1487,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 514, version 1;
+  device type ma_windowcovering = 514, version 1;
+
   binding cluster Binding;
 
   server cluster Identify {

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -1500,7 +1500,8 @@ server cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Groups {
@@ -1781,7 +1782,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 21, version 1;
+  device type ma_contactsensor = 21, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
@@ -1102,7 +1102,8 @@ server cluster OperationalState = 96 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;
@@ -1309,7 +1310,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 117, version 1;
+  device type ma_dishwasher = 117, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -2276,7 +2276,8 @@ client cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2582,7 +2583,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type onofflightswitch = 259, version 1;
+  device type ma_onofflightswitch = 259, version 1;
+
   binding cluster Identify;
   binding cluster Scenes;
   binding cluster OnOff;
@@ -2619,7 +2621,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type genericswitch = 15, version 1;
+  device type ma_genericswitch = 15, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
@@ -1879,7 +1879,8 @@ server cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Groups {
@@ -2135,7 +2136,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type extendedcolorlight = 269, version 1;
+  device type ma_extendedcolorlight = 269, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -1789,7 +1789,8 @@ server cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Groups {
@@ -1997,7 +1998,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type extendedcolorlight = 269, version 1;
+  device type ma_extendedcolorlight = 269, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -2120,7 +2120,8 @@ server cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2406,7 +2407,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/nxp/zap/lighting-on-off.matter
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.matter
@@ -1356,7 +1356,8 @@ server cluster GroupKeyManagement = 63 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1547,7 +1548,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/qpg/zap/light.matter
+++ b/examples/lighting-app/qpg/zap/light.matter
@@ -1741,7 +1741,8 @@ server cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2010,7 +2011,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 269, version 1;
+  device type ma_extendedcolorlight = 269, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -2183,7 +2183,8 @@ server cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2418,7 +2419,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -2072,7 +2072,8 @@ server cluster ColorControl = 768 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2257,7 +2258,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type dimmablelight = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -2278,7 +2278,8 @@ server cluster DoorLock = 257 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2575,7 +2576,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type doorlock = 10, version 1;
+  device type ma_doorlock = 10, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/lock-app/nxp/zap/lock-app.matter
+++ b/examples/lock-app/nxp/zap/lock-app.matter
@@ -1444,7 +1444,8 @@ server cluster DoorLock = 257 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1622,7 +1623,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 10, version 1;
+  device type ma_doorlock = 10, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -1775,7 +1775,8 @@ server cluster DoorLock = 257 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2044,7 +2045,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type doorlock = 10, version 1;
+  device type ma_doorlock = 10, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -498,7 +498,8 @@ server cluster OperationalCredentials = 62 {
 }
 
 endpoint 0 {
-  device type anonymousEndpointType = 0, version 1;
+  device type ma_all_clusters_app = 0, version 1;
+
   binding cluster DiagnosticLogs;
 
   server cluster AccessControl {

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -988,7 +988,8 @@ server cluster UserLabel = 65 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster AccessControl;
 
   server cluster Descriptor {

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -1171,7 +1171,8 @@ server cluster UserLabel = 65 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1329,7 +1330,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 259, version 1;
+  device type ma_onofflightswitch = 259, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -1367,7 +1369,8 @@ endpoint 1 {
   }
 }
 endpoint 65534 {
-  device type anonymousEndpointType = 61442, version 1;
+  device type ma_secondary_network_commissioning = 61442, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -6438,7 +6438,8 @@ server cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster GeneralCommissioning;
   binding cluster ThreadNetworkDiagnostics;
   binding cluster Switch;
@@ -7085,7 +7086,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
   binding cluster Identify;
   binding cluster OnOff;
   binding cluster LevelControl;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -6397,7 +6397,8 @@ server cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster GeneralCommissioning;
   binding cluster ThreadNetworkDiagnostics;
   binding cluster Switch;
@@ -7063,7 +7064,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 257, version 1;
+  device type ma_dimmablelight = 257, version 1;
+
   binding cluster Identify;
   binding cluster OnOff;
   binding cluster LevelControl;

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -1426,7 +1426,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type pump = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1603,7 +1604,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type pump = 771, version 1;
+  device type ma_pump = 771, version 1;
+
   binding cluster OccupancySensing;
 
   server cluster Identify {

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -1426,7 +1426,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type pump = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1603,7 +1604,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type pump = 771, version 1;
+  device type ma_pump = 771, version 1;
+
   binding cluster OccupancySensing;
 
   server cluster Identify {

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -1426,7 +1426,8 @@ client cluster OccupancySensing = 1030 {
 }
 
 endpoint 0 {
-  device type pump = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1603,7 +1604,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type pump = 771, version 1;
+  device type ma_pump = 771, version 1;
+
   binding cluster OccupancySensing;
 
   server cluster Identify {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -1312,7 +1312,8 @@ client cluster FlowMeasurement = 1028 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1489,7 +1490,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type pumpcontroller = 772, version 1;
+  device type ma_pumpcontroller = 772, version 1;
+
   binding cluster OnOff;
   binding cluster PumpConfigurationAndControl;
   binding cluster TemperatureMeasurement;

--- a/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
+++ b/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
@@ -1666,7 +1666,8 @@ server cluster FanControl = 514 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Groups {
@@ -1957,7 +1958,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 43, version 1;
+  device type ma_fan = 43, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -1730,7 +1730,8 @@ server cluster SmokeCoAlarm = 92 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -1975,7 +1976,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type anonymousEndpointType = 118, version 1;
+  device type ma_smokecoalarm = 118, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
@@ -1052,7 +1052,8 @@ server cluster TemperatureMeasurement = 1026 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1249,7 +1250,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type tempsensor = 770, version 1;
+  device type ma_tempsensor = 770, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -1767,7 +1767,8 @@ server cluster ThermostatUserInterfaceConfiguration = 516 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Identify {
@@ -2060,7 +2061,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type thermostat = 769, version 1;
+  device type ma_thermostat = 769, version 1;
+
   binding cluster Identify;
 
   server cluster Identify {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2449,7 +2449,8 @@ server cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster Binding;
   binding cluster GeneralCommissioning;
   binding cluster NetworkCommissioning;
@@ -2743,7 +2744,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type videoplayer = 35, version 1;
+  device type ma_casting_videoplayer = 35, version 1;
+
 
   server cluster OnOff {
     ram      attribute onOff default = 0x00;
@@ -2838,7 +2840,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type speaker = 34, version 1;
+  device type ma_speaker = 34, version 1;
+
 
   server cluster OnOff {
     ram      attribute onOff default = 0x00;
@@ -2875,7 +2878,8 @@ endpoint 2 {
   }
 }
 endpoint 3 {
-  device type contentapplication = 36, version 1;
+  device type ma_contentapp = 36, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -2006,7 +2006,8 @@ client cluster AccountLogin = 1294 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -2195,7 +2196,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type videoplayer = 41, version 1;
+  device type ma_casting_videoclient = 41, version 1;
+
   binding cluster OnOff;
   binding cluster LevelControl;
   binding cluster Descriptor;

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -1597,7 +1597,8 @@ server cluster UserLabel = 65 {
 }
 
 endpoint 0 {
-  device type rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
 
   server cluster Descriptor {
     callback attribute deviceTypeList;
@@ -1880,7 +1881,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type videoplayer = 256, version 1;
+  device type ma_onofflight = 256, version 1;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1935,7 +1935,8 @@ server cluster WindowCovering = 258 {
 }
 
 endpoint 0 {
-  device type windowcovering = 22, version 1;
+  device type ma_rootdevice = 22, version 1;
+
   binding cluster OtaSoftwareUpdateProvider;
 
   server cluster Descriptor {
@@ -2260,7 +2261,8 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type windowcovering = 514, version 2;
+  device type ma_windowcovering = 514, version 2;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;
@@ -2337,7 +2339,8 @@ endpoint 1 {
   }
 }
 endpoint 2 {
-  device type windowcovering = 514, version 2;
+  device type ma_windowcovering = 514, version 2;
+
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/src/app/zap-templates/templates/app/MatterIDL_Server.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL_Server.zapt
@@ -16,9 +16,13 @@
 {{/all_user_clusters}}
 {{#user_endpoints}}
 endpoint {{endpointId}} {
-  {{#if deviceIdentifier}}
-  device type {{chip_friendly_endpoint_type_name}} = {{deviceIdentifier}}, version {{endpointVersion}};
-  {{/if~}}
+  {{#user_device_types}}
+  device type 
+    {{~#zcl_device_types}}
+      {{~#if (is_num_equal id ../deviceTypeRef)}} {{as_underscore_lowercase name}} {{/if~}}
+    {{/zcl_device_types~}}
+    = {{deviceIdentifier}}, version {{deviceVersion}};
+  {{/user_device_types}}
 
   {{#user_clusters}}
     {{#if enabled}}


### PR DESCRIPTION
The friendly name is still awkward - could only get it with a "ma-" prefix (which is pointless as all these are always matter). Zap to fix this as a followup.

For now names are human-readable, we seem to have gotten more names that are usable and we will support multiple types per endpoint as a result.