### PR TITLE
[Java] Fix crash on 32bit Android phone when eventing is enabled

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -364,9 +364,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     readerForJavaTLV.Init(*apData);
     readerForJson.Init(*apData);
 
-    jlong eventNumber   = static_cast<jlong>(aEventHeader.mEventNumber);
+    jlong eventNumber  = static_cast<jlong>(aEventHeader.mEventNumber);
     jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
-    jlong timestamp     = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
+    jlong timestamp    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
     jobject value = nullptr;
 #if USE_JAVA_TLV_ENCODE_DECODE

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -364,10 +364,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     readerForJavaTLV.Init(*apData);
     readerForJson.Init(*apData);
 
-    jlong eventNumber   = static_cast<jlong>(aEventHeader.mEventNumber);
+    jlong eventNumber  = static_cast<jlong>(aEventHeader.mEventNumber);
     jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
-    jlong timestamp     = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
-
+    jlong timestamp    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
     // Create TLV byte array to pass to Java layer
     size_t bufferLen                  = readerForJavaTLV.GetRemainingLength() + readerForJavaTLV.GetLengthRead();

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -365,23 +365,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     readerForJson.Init(*apData);
 
     jlong eventNumber   = static_cast<jlong>(aEventHeader.mEventNumber);
-    jlong priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
+    jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
     jlong timestamp     = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
-    jobject value = nullptr;
-#if USE_JAVA_TLV_ENCODE_DECODE
-    TLV::TLVReader readerForJavaObject;
-    readerForJavaObject.Init(*apData);
-    value = DecodeEventValue(aEventHeader.mPath, readerForJavaObject, &err);
-    // If we don't know this event, just skip it.
-    if (err == CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB)
-    {
-        err = CHIP_NO_ERROR;
-    }
-    VerifyOrReturn(err == CHIP_NO_ERROR, ReportError(nullptr, eventPathObj, err));
-    VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe(),
-                   ReportError(nullptr, eventPathObj, CHIP_JNI_ERROR_EXCEPTION_THROWN));
-#endif
 
     // Create TLV byte array to pass to Java layer
     size_t bufferLen                  = readerForJavaTLV.GetRemainingLength() + readerForJavaTLV.GetLengthRead();
@@ -412,7 +398,7 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     chip::JniClass eventStateJniCls(eventStateCls);
     jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", "(JIJLjava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(eventStateCtor != nullptr, ChipLogError(Controller, "Could not find EventState constructor"));
-    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestamp, value,
+    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestamp, nullptr,
                                            jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(eventStateObj != nullptr, ChipLogError(Controller, "Could not create EventState object"));
 


### PR DESCRIPTION
```
08-03 13:49:17.045 5459 7132 F [gle.android.gm](http://gle.android.gm/): runtime.cc:655] native: #16 pc 00421535 /apex/com.android.art/lib/libart.so (art::JNI<false>::NewObjectV(_JNIEnv*, _jclass*, _jmethodID*, char*)+885)
_JNIEnv::NewObject(_jclass*, _jmethodID*, ...) at AndroidCallbacks.cpp:0
chip::Controller::ReportCallback::OnEventData(chip::app::EventHeader const&, chip::TLV::TLVReader*, chip::app::StatusIB const*) at AndroidCallbacks.cpp:0
chip::app::ClusterStateCache::OnEventData(chip::app::EventHeader const&, chip::TLV::TLVReader*, chip::app::StatusIB const*) at ClusterStateCache.cpp:0
chip::app::BufferedReadCallback::OnEventData(chip::app::EventHeader const&, chip::TLV::TLVReader*, chip::app::StatusIB const*) at BufferedReadCallback.cpp:0
chip::app::ReadClient::ProcessEventReportIBs(chip::TLV::TLVReader&) at ReadClient.cpp:0
chip::app::ReadClient::ProcessReportData(chip::System::PacketBufferHandle&&) at ReadClient.cpp:0
chip::app::ReadClient::OnMessageReceived(chip::Messaging::ExchangeContext*, chip::PayloadHeader const&, chip::System::PacketBufferHandle&&) at ReadClient.cpp:0
[2:06](https://csamembers.slack.com/archives/D0155443H6G/p1691183188056909)
```
The root cause of the issue is that the wrong data type was used to pass the priorityLevel parameter to the JNI call.
which lead to incorrect interpretation of the value when passed to the JNI call on 32bit platform



