### PR TITLE
[ReadHandler] Removed Scheduling of report from OnReadHandlerCreated 

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -882,15 +882,8 @@ void ReadHandler::SetStateFlag(ReadHandlerFlags aFlag, bool aValue)
     // If we became reportable, schedule a reporting run.
     if (!oldReportable && ShouldStartReporting())
     {
-        if (ShouldReportUnscheduled())
-        {
-            InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
-        }
-        else
-        {
-            // If we became reportable, the scheduler will schedule a run as soon as allowed
-            mObserver->OnBecameReportable(this);
-        }
+        // If we became reportable, the scheduler will schedule a run as soon as allowed
+        mObserver->OnBecameReportable(this);
     }
 }
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -604,7 +604,7 @@ void ReadHandler::MoveToState(const HandlerState aTargetState)
     //
     if (aTargetState == HandlerState::CanStartReporting)
     {
-        if (IsType(ReadHandler::InteractionType::Read) || IsPriming())
+        if (CanEmitReadReport())
         {
             InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
         }
@@ -884,7 +884,7 @@ void ReadHandler::SetStateFlag(ReadHandlerFlags aFlag, bool aValue)
     // If we became reportable, schedule a reporting run.
     if (!oldReportable && ShouldStartReporting())
     {
-        if (IsType(ReadHandler::InteractionType::Read) || IsPriming())
+        if (CanEmitReadReport())
         {
             InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
         }

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -233,7 +233,7 @@ CHIP_ERROR ReadHandler::OnStatusResponse(Messaging::ExchangeContext * apExchange
                 {
                     appCallback->OnSubscriptionEstablished(*this);
                 }
-                mObserver->OnReadHandlerSubscribed(this);
+                mObserver->OnSubscriptionEstablished(this);
             }
         }
         else
@@ -882,14 +882,14 @@ void ReadHandler::SetStateFlag(ReadHandlerFlags aFlag, bool aValue)
     // If we became reportable, schedule a reporting run.
     if (!oldReportable && ShouldStartReporting())
     {
-        if (IsActiveSubscription())
+        if (ShouldReportUnscheduled())
+        {
+            InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+        }
+        else
         {
             // If we became reportable, the scheduler will schedule a run as soon as allowed
             mObserver->OnBecameReportable(this);
-        }
-        else if (ShouldReportUnscheduled())
-        {
-            InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
         }
     }
 }

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -79,7 +79,6 @@ ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeCon
 
     VerifyOrDie(observer != nullptr);
     mObserver = observer;
-    mObserver->OnReadHandlerCreated(this);
 }
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
@@ -92,7 +91,6 @@ ReadHandler::ReadHandler(ManagementCallback & apCallback, Observer * observer) :
 
     VerifyOrDie(observer != nullptr);
     mObserver = observer;
-    mObserver->OnReadHandlerCreated(this);
 }
 
 void ReadHandler::ResumeSubscription(CASESessionManager & caseSessionManager,
@@ -235,6 +233,7 @@ CHIP_ERROR ReadHandler::OnStatusResponse(Messaging::ExchangeContext * apExchange
                 {
                     appCallback->OnSubscriptionEstablished(*this);
                 }
+                mObserver->OnReadHandlerSubscribed(this);
             }
         }
         else
@@ -246,10 +245,10 @@ CHIP_ERROR ReadHandler::OnStatusResponse(Messaging::ExchangeContext * apExchange
             return CHIP_NO_ERROR;
         }
 
-        MoveToState(HandlerState::GeneratingReports);
+        MoveToState(HandlerState::CanStartReporting);
         break;
 
-    case HandlerState::GeneratingReports:
+    case HandlerState::CanStartReporting:
     case HandlerState::Idle:
     default:
         err = CHIP_ERROR_INCORRECT_STATE;
@@ -262,7 +261,7 @@ exit:
 
 CHIP_ERROR ReadHandler::SendStatusReport(Protocols::InteractionModel::Status aStatus)
 {
-    VerifyOrReturnLogError(mState == HandlerState::GeneratingReports, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mState == HandlerState::CanStartReporting, CHIP_ERROR_INCORRECT_STATE);
     if (IsPriming() || IsChunkedReport())
     {
         mSessionHandle.Grab(mExchangeCtx->GetSessionHandle());
@@ -286,7 +285,7 @@ CHIP_ERROR ReadHandler::SendStatusReport(Protocols::InteractionModel::Status aSt
 
 CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, bool aMoreChunks)
 {
-    VerifyOrReturnLogError(mState == HandlerState::GeneratingReports, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mState == HandlerState::CanStartReporting, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrDie(!IsAwaitingReportResponse()); // Should not be reportable!
     if (IsPriming() || IsChunkedReport())
     {
@@ -456,7 +455,7 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     ReturnErrorOnFailure(readRequestParser.GetIsFabricFiltered(&isFabricFiltered));
     SetStateFlag(ReadHandlerFlags::FabricFiltered, isFabricFiltered);
     ReturnErrorOnFailure(readRequestParser.ExitContainer());
-    MoveToState(HandlerState::GeneratingReports);
+    MoveToState(HandlerState::CanStartReporting);
 
     mExchangeCtx->WillSendMessage();
 
@@ -574,8 +573,8 @@ const char * ReadHandler::GetStateStr() const
         return "Idle";
     case HandlerState::AwaitingDestruction:
         return "AwaitingDestruction";
-    case HandlerState::GeneratingReports:
-        return "GeneratingReports";
+    case HandlerState::CanStartReporting:
+        return "CanStartReporting";
 
     case HandlerState::AwaitingReportResponse:
         return "AwaitingReportResponse";
@@ -603,10 +602,17 @@ void ReadHandler::MoveToState(const HandlerState aTargetState)
     // If we just unblocked sending reports, let's go ahead and schedule the reporting
     // engine to run to kick that off.
     //
-    if (aTargetState == HandlerState::GeneratingReports)
+    if (aTargetState == HandlerState::CanStartReporting)
     {
-        // mObserver will take care of scheduling the report as soon as allowed
-        mObserver->OnBecameReportable(this);
+        if (IsType(ReadHandler::InteractionType::Read) || IsPriming())
+        {
+            InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+        }
+        else
+        {
+            // If we became reportable, the scheduler will schedule a run as soon as allowed
+            mObserver->OnBecameReportable(this);
+        }
     }
 }
 
@@ -785,7 +791,7 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     SetStateFlag(ReadHandlerFlags::FabricFiltered, isFabricFiltered);
     ReturnErrorOnFailure(Crypto::DRBG_get_bytes(reinterpret_cast<uint8_t *>(&mSubscriptionId), sizeof(mSubscriptionId)));
     ReturnErrorOnFailure(subscribeRequestParser.ExitContainer());
-    MoveToState(HandlerState::GeneratingReports);
+    MoveToState(HandlerState::CanStartReporting);
 
     mExchangeCtx->WillSendMessage();
 
@@ -872,14 +878,21 @@ void ReadHandler::ForceDirtyState()
 
 void ReadHandler::SetStateFlag(ReadHandlerFlags aFlag, bool aValue)
 {
-    bool oldReportable = IsReportable();
+    bool oldReportable = ShouldStartReporting();
     mFlags.Set(aFlag, aValue);
 
     // If we became reportable, schedule a reporting run.
-    if (!oldReportable && IsReportable())
+    if (!oldReportable && ShouldStartReporting())
     {
-        // If we became reportable, the scheduler will schedule a run as soon as allowed
-        mObserver->OnBecameReportable(this);
+        if (IsType(ReadHandler::InteractionType::Read) || IsPriming())
+        {
+            InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+        }
+        else
+        {
+            // If we became reportable, the scheduler will schedule a run as soon as allowed
+            mObserver->OnBecameReportable(this);
+        }
     }
 }
 
@@ -895,7 +908,7 @@ void ReadHandler::HandleDeviceConnected(void * context, Messaging::ExchangeManag
 
     _this->mSessionHandle.Grab(sessionHandle);
 
-    _this->MoveToState(HandlerState::GeneratingReports);
+    _this->MoveToState(HandlerState::CanStartReporting);
 
     ObjectList<AttributePathParams> * attributePath = _this->mpAttributePathList;
     while (attributePath)

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -166,8 +166,8 @@ public:
     public:
         virtual ~Observer() = default;
 
-        /// @brief Callback invoked to notify a ReadHandler was created and can be registered
-        /// @param[in] apReadHandler  ReadHandler getting added
+        /// @brief Callback invoked to notify a subscription was successfully established for a read handler
+        /// @param[in] apReadHandler  ReadHandler that completed its subscription
         virtual void OnReadHandlerSubscribed(ReadHandler * apReadHandler) = 0;
 
         /// @brief Callback invoked when a ReadHandler went from a non reportable state to a reportable state. Indicates to the
@@ -335,10 +335,11 @@ private:
     bool ShouldStartReporting() const
     {
         // Important: Anything that changes ShouldStartReporting() from false to true
-        // (which can only happen for subscriptions) must call 
+        // (which can only happen for subscriptions) must call
         // mObserver->OnBecameReportable(this).
-        return mState == HandlerState::CanStartReporting && IsDirty();
+        return mState == HandlerState::CanStartReporting && (CanEmitReadReport() || IsDirty());
     }
+    bool CanEmitReadReport() const { return IsType(ReadHandler::InteractionType::Read) || IsPriming(); }
     bool CanStartReporting() const { return mState == HandlerState::CanStartReporting; }
     bool IsAwaitingReportResponse() const { return mState == HandlerState::AwaitingReportResponse; }
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -175,6 +175,7 @@ public:
         ///
         /// This will only be invoked for subscribe-type ReadHandler objects, and only after
         /// OnSubscriptionEstablished has been called.
+        ///
         /// @param[in] apReadHandler  ReadHandler that became dirty and in HandlerState::CanStartReporting state
         virtual void OnBecameReportable(ReadHandler * apReadHandler) = 0;
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -349,7 +349,7 @@ private:
     /// without consulting the report scheduler.
     bool ShouldReportUnscheduled() const
     {
-        return CanStartReporting() && (IsType(ReadHandler::InteractionType::Read) || IsPriming()) && !IsActiveSubscription();
+        return CanStartReporting() && (IsType(ReadHandler::InteractionType::Read) || IsPriming());
     }
     bool IsAwaitingReportResponse() const { return mState == HandlerState::AwaitingReportResponse; }
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -171,7 +171,7 @@ public:
         virtual void OnReadHandlerSubscribed(ReadHandler * apReadHandler) = 0;
 
         /// @brief Callback invoked when a ReadHandler went from a non reportable state to a reportable state. Indicates to the
-        /// observer that a report should be emitted if the min interval allows it.
+        /// observer that a report should be emitted when the min interval allows it.
         /// @param[in] apReadHandler  ReadHandler that became dirty and in HandlerState::CanStartReporting state
         virtual void OnBecameReportable(ReadHandler * apReadHandler) = 0;
 
@@ -334,9 +334,9 @@ private:
     /// @brief Returns whether the ReadHandler is in a state where it can send a report and there is data to report.
     bool ShouldStartReporting() const
     {
-        // Important: Anything that changes the state ShouldStartReporting() must either call mObserver->OnBecameReportable(this)
-        // for active subscription or InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun() for read request and
-        // priming subscription.
+        // Important: Anything that changes ShouldStartReporting() from false to true
+        // (which can only happen for subscriptions) must call 
+        // mObserver->OnBecameReportable(this).
         return mState == HandlerState::CanStartReporting && IsDirty();
     }
     bool CanStartReporting() const { return mState == HandlerState::CanStartReporting; }

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -166,12 +166,15 @@ public:
     public:
         virtual ~Observer() = default;
 
-        /// @brief Callback invoked to notify a subscription was successfully established for a read handler
+        /// @brief Callback invoked to notify a subscription was successfully established for the ReadHandler
         /// @param[in] apReadHandler  ReadHandler that completed its subscription
-        virtual void OnReadHandlerSubscribed(ReadHandler * apReadHandler) = 0;
+        virtual void OnSubscriptionEstablished(ReadHandler * apReadHandler) = 0;
 
         /// @brief Callback invoked when a ReadHandler went from a non reportable state to a reportable state. Indicates to the
         /// observer that a report should be emitted when the min interval allows it.
+        ///
+        /// This will only be invoked for subscribe-type ReadHandler objects, and only after
+        /// OnSubscriptionEstablished has been called.
         /// @param[in] apReadHandler  ReadHandler that became dirty and in HandlerState::CanStartReporting state
         virtual void OnBecameReportable(ReadHandler * apReadHandler) = 0;
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -636,7 +636,7 @@ void Engine::Run()
         ReadHandler * readHandler = imEngine->ActiveHandlerAt(mCurReadHandlerIdx % (uint32_t) imEngine->mReadHandlers.Allocated());
         VerifyOrDie(readHandler != nullptr);
 
-        if (readHandler->CanEmitReadReport() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
+        if (readHandler->ShouldReportUnscheduled() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -636,8 +636,7 @@ void Engine::Run()
         ReadHandler * readHandler = imEngine->ActiveHandlerAt(mCurReadHandlerIdx % (uint32_t) imEngine->mReadHandlers.Allocated());
         VerifyOrDie(readHandler != nullptr);
 
-        if (readHandler->IsType(ReadHandler::InteractionType::Read) || readHandler->IsPriming() ||
-            imEngine->GetReportScheduler()->IsReportableNow(readHandler))
+        if (readHandler->CanEmitReadReport() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -636,7 +636,8 @@ void Engine::Run()
         ReadHandler * readHandler = imEngine->ActiveHandlerAt(mCurReadHandlerIdx % (uint32_t) imEngine->mReadHandlers.Allocated());
         VerifyOrDie(readHandler != nullptr);
 
-        if (imEngine->GetReportScheduler()->IsReportableNow(readHandler))
+        if (readHandler->IsType(ReadHandler::InteractionType::Read) || readHandler->IsPriming() ||
+            imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);
@@ -829,7 +830,7 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
             // We call AttributePathIsDirty for both read interactions and subscribe interactions, since we may send inconsistent
             // attribute data between two chunks. AttributePathIsDirty will not schedule a new run for read handlers which are
             // waiting for a response to the last message chunk for read interactions.
-            if (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse())
+            if (handler->CanStartReporting() || handler->IsAwaitingReportResponse())
             {
                 for (auto object = handler->GetAttributePathList(); object != nullptr; object = object->mpNext)
                 {

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -82,7 +82,7 @@ public:
         {
             Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
-            return (mReadHandler->IsGeneratingReports() &&
+            return (mReadHandler->CanStartReporting() &&
                     (now >= mMinTimestamp && (mReadHandler->IsDirty() || now >= mMaxTimestamp || now >= mSyncTimestamp)));
         }
 
@@ -139,9 +139,13 @@ public:
 
     /// @brief Check whether a ReadHandler is reportable right now, taking into account its minimum and maximum intervals.
     /// @param aReadHandler read handler to check
-    bool IsReportableNow(ReadHandler * aReadHandler) { return FindReadHandlerNode(aReadHandler)->IsReportableNow(); }
+    bool IsReportableNow(ReadHandler * aReadHandler)
+    {
+        ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);
+        return (nullptr != node) ? node->IsReportableNow() : false;
+    }
     /// @brief Check if a ReadHandler is reportable without considering the timing
-    bool IsReadHandlerReportable(ReadHandler * aReadHandler) const { return aReadHandler->IsReportable(); }
+    bool IsReadHandlerReportable(ReadHandler * aReadHandler) const { return aReadHandler->ShouldStartReporting(); }
     /// @brief Sets the ForceDirty flag of a ReadHandler
     void HandlerForceDirtyState(ReadHandler * aReadHandler) { aReadHandler->ForceDirtyState(); }
 

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -55,7 +55,7 @@ void ReportSchedulerImpl::OnEnterActiveMode()
 }
 
 /// @brief When a ReadHandler is added, register it, which will schedule an engine run
-void ReportSchedulerImpl::OnReadHandlerCreated(ReadHandler * aReadHandler)
+void ReportSchedulerImpl::OnReadHandlerSubscribed(ReadHandler * aReadHandler)
 {
     ReadHandlerNode * newNode = FindReadHandlerNode(aReadHandler);
     // Handler must not be registered yet; it's just being constructed.

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -57,7 +57,7 @@ void ReportSchedulerImpl::OnEnterActiveMode()
 /// @brief When a ReadHandler is added, register it in the scheduler node pool. Scheduling the report here is un-necessary since the
 /// ReadHandler will call MoveToState(HandlerState::CanStartReporting);, which will call OnBecameReportable() and schedule the
 /// report.
-void ReportSchedulerImpl::OnReadHandlerSubscribed(ReadHandler * aReadHandler)
+void ReportSchedulerImpl::OnSubscriptionEstablished(ReadHandler * aReadHandler)
 {
     ReadHandlerNode * newNode = FindReadHandlerNode(aReadHandler);
     // Handler must not be registered yet; it's just being constructed.

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -68,6 +68,10 @@ void ReportSchedulerImpl::OnReadHandlerSubscribed(ReadHandler * aReadHandler)
                     "Registered a ReadHandler that will schedule a report between system Timestamp: %" PRIu64
                     " and system Timestamp %" PRIu64 ".",
                     newNode->GetMinTimestamp().count(), newNode->GetMaxTimestamp().count());
+
+    Milliseconds32 newTimeout;
+    CalculateNextReportTimeout(newTimeout, newNode);
+    ScheduleReport(newTimeout, newNode);
 }
 
 /// @brief When a ReadHandler becomes reportable, schedule, recalculate and reschedule the report.

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -54,7 +54,9 @@ void ReportSchedulerImpl::OnEnterActiveMode()
 #endif
 }
 
-/// @brief When a ReadHandler is added, register it, which will schedule an engine run
+/// @brief When a ReadHandler is added, register it in the scheduler node pool. Scheduling the report here is un-necessary since the
+/// ReadHandler will call MoveToState(HandlerState::CanStartReporting);, which will call OnBecameReportable() and schedule the
+/// report.
 void ReportSchedulerImpl::OnReadHandlerSubscribed(ReadHandler * aReadHandler)
 {
     ReadHandlerNode * newNode = FindReadHandlerNode(aReadHandler);
@@ -68,10 +70,6 @@ void ReportSchedulerImpl::OnReadHandlerSubscribed(ReadHandler * aReadHandler)
                     "Registered a ReadHandler that will schedule a report between system Timestamp: %" PRIu64
                     " and system Timestamp %" PRIu64 ".",
                     newNode->GetMinTimestamp().count(), newNode->GetMaxTimestamp().count());
-
-    Milliseconds32 newTimeout;
-    CalculateNextReportTimeout(newTimeout, newNode);
-    ScheduleReport(newTimeout, newNode);
 }
 
 /// @brief When a ReadHandler becomes reportable, schedule, recalculate and reschedule the report.
@@ -84,7 +82,7 @@ void ReportSchedulerImpl::OnBecameReportable(ReadHandler * aReadHandler)
     ScheduleReport(newTimeout, node);
 }
 
-void ReportSchedulerImpl::OnSubscriptionAction(ReadHandler * aReadHandler)
+void ReportSchedulerImpl::OnSubscriptionReportSent(ReadHandler * aReadHandler)
 {
     ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);
     VerifyOrReturn(nullptr != node);

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -68,11 +68,6 @@ void ReportSchedulerImpl::OnReadHandlerCreated(ReadHandler * aReadHandler)
                     "Registered a ReadHandler that will schedule a report between system Timestamp: %" PRIu64
                     " and system Timestamp %" PRIu64 ".",
                     newNode->GetMinTimestamp().count(), newNode->GetMaxTimestamp().count());
-
-    Milliseconds32 newTimeout;
-    // No need to check for error here, since the node is already in the list otherwise we would have Died
-    CalculateNextReportTimeout(newTimeout, newNode);
-    ScheduleReport(newTimeout, newNode);
 }
 
 /// @brief When a ReadHandler becomes reportable, schedule, recalculate and reschedule the report.

--- a/src/app/reporting/ReportSchedulerImpl.h
+++ b/src/app/reporting/ReportSchedulerImpl.h
@@ -36,7 +36,7 @@ public:
     void OnEnterActiveMode() override;
 
     // ReadHandlerObserver
-    void OnReadHandlerCreated(ReadHandler * aReadHandler) final;
+    void OnReadHandlerSubscribed(ReadHandler * aReadHandler) final;
     void OnBecameReportable(ReadHandler * aReadHandler) final;
     void OnSubscriptionAction(ReadHandler * aReadHandler) final;
     void OnReadHandlerDestroyed(ReadHandler * aReadHandler) override;

--- a/src/app/reporting/ReportSchedulerImpl.h
+++ b/src/app/reporting/ReportSchedulerImpl.h
@@ -38,7 +38,7 @@ public:
     // ReadHandlerObserver
     void OnReadHandlerSubscribed(ReadHandler * aReadHandler) final;
     void OnBecameReportable(ReadHandler * aReadHandler) final;
-    void OnSubscriptionAction(ReadHandler * aReadHandler) final;
+    void OnSubscriptionReportSent(ReadHandler * aReadHandler) final;
     void OnReadHandlerDestroyed(ReadHandler * aReadHandler) override;
 
     bool IsReportScheduled(ReadHandler * aReadHandler);

--- a/src/app/reporting/ReportSchedulerImpl.h
+++ b/src/app/reporting/ReportSchedulerImpl.h
@@ -36,7 +36,7 @@ public:
     void OnEnterActiveMode() override;
 
     // ReadHandlerObserver
-    void OnReadHandlerSubscribed(ReadHandler * aReadHandler) final;
+    void OnSubscriptionEstablished(ReadHandler * aReadHandler) final;
     void OnBecameReportable(ReadHandler * aReadHandler) final;
     void OnSubscriptionReportSent(ReadHandler * aReadHandler) final;
     void OnReadHandlerDestroyed(ReadHandler * aReadHandler) override;

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2225,7 +2225,7 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
                        reportScheduler->GetMinTimestampForHandler(delegate.mpReadHandler) <
                            System::SystemClock().GetMonotonicTimestamp());
         NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !delegate.mpReadHandler->ShouldStartReporting());
 
         // And the non-urgent one should not have changed state either, since
         // it's waiting for the max-interval.
@@ -2236,7 +2236,7 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
                        reportScheduler->GetMaxTimestampForHandler(nonUrgentDelegate.mpReadHandler) >
                            System::SystemClock().GetMonotonicTimestamp());
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->ShouldStartReporting());
 
         // There should be no reporting run scheduled.  This is very important;
         // otherwise we can get a false-positive pass below because the run was
@@ -2248,12 +2248,12 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
         // Urgent read handler should now be dirty, and reportable.
         NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, delegate.mpReadHandler->ShouldStartReporting());
         NL_TEST_ASSERT(apSuite, reportScheduler->IsReadHandlerReportable(delegate.mpReadHandler));
 
         // Non-urgent read handler should not be reportable.
         NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsDirty());
-        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->IsReportable());
+        NL_TEST_ASSERT(apSuite, !nonUrgentDelegate.mpReadHandler->ShouldStartReporting());
 
         // Still no reporting should have happened.
         NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);

--- a/src/app/tests/TestReportScheduler.cpp
+++ b/src/app/tests/TestReportScheduler.cpp
@@ -351,8 +351,9 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMaxReportingInterval(2));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMinReportingIntervalForTests(1));
         sScheduler.OnReadHandlerSubscribed(readHandler1);
-        readHandler1->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
+        readHandler1->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+
         readHandler1->ForceDirtyState();
 
         // Clean read handler, will be triggered at max interval
@@ -362,8 +363,8 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMaxReportingInterval(3));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMinReportingIntervalForTests(0));
         sScheduler.OnReadHandlerSubscribed(readHandler2);
-        readHandler2->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
+        readHandler2->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
 
         // Clean read handler, will be triggered at max interval, but will be cancelled before
         ReadHandler * readHandler3 =
@@ -371,8 +372,8 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMaxReportingInterval(3));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMinReportingIntervalForTests(0));
         sScheduler.OnReadHandlerSubscribed(readHandler3);
-        readHandler3->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         readHandler3->MoveToState(ReadHandler::HandlerState::CanStartReporting);
+        readHandler3->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
 
         // Confirms that none of the ReadHandlers are currently reportable
         NL_TEST_ASSERT(aSuite, !sScheduler.IsReportableNow(readHandler1));
@@ -428,8 +429,8 @@ public:
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler->SetMaxReportingInterval(2));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler->SetMinReportingIntervalForTests(1));
-
         sScheduler.OnReadHandlerSubscribed(readHandler);
+        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
 
         // Verifies OnReadHandlerSubscribed registered the ReadHandler in the scheduler
@@ -444,8 +445,6 @@ public:
         NL_TEST_ASSERT(aSuite, node->GetMinTimestamp().count() == 1000);
         NL_TEST_ASSERT(aSuite, node->GetMaxTimestamp().count() == 2000);
 
-        // Do those manually to avoid scheduling an engine run
-        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         NL_TEST_ASSERT(aSuite, sScheduler.IsReportScheduled(readHandler));
 
         NL_TEST_ASSERT(aSuite, nullptr != node);
@@ -511,18 +510,18 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMaxReportingInterval(2));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMinReportingIntervalForTests(0));
         syncScheduler.OnReadHandlerSubscribed(readHandler1);
+        readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler1->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         ReadHandlerNode * node1 = syncScheduler.FindReadHandlerNode(readHandler1);
-        readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
 
         ReadHandler * readHandler2 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &syncScheduler);
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMaxReportingInterval(3));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMinReportingIntervalForTests(1));
         syncScheduler.OnReadHandlerSubscribed(readHandler2);
+        readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler2->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         ReadHandlerNode * node2 = syncScheduler.FindReadHandlerNode(readHandler2);
-        readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
 
         // Confirm all handler are currently registered in the scheduler
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 2);
@@ -626,9 +625,9 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMaxReportingInterval(3));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMinReportingIntervalForTests(2));
         syncScheduler.OnReadHandlerSubscribed(readHandler3);
+        readHandler3->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler3->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         ReadHandlerNode * node3 = syncScheduler.FindReadHandlerNode(readHandler3);
-        readHandler3->MoveToState(ReadHandler::HandlerState::CanStartReporting);
 
         // Confirm all handler are currently registered in the scheduler
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 3);
@@ -684,9 +683,9 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler4->SetMaxReportingInterval(1));
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler4->SetMinReportingIntervalForTests(0));
         syncScheduler.OnReadHandlerSubscribed(readHandler4);
+        readHandler4->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler4->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
         ReadHandlerNode * node4 = syncScheduler.FindReadHandlerNode(readHandler4);
-        readHandler4->MoveToState(ReadHandler::HandlerState::CanStartReporting);
 
         // Confirm all handler are currently registered in the scheduler
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 4);

--- a/src/app/tests/TestReportScheduler.cpp
+++ b/src/app/tests/TestReportScheduler.cpp
@@ -246,6 +246,23 @@ SynchronizedReportSchedulerImpl syncScheduler(&sTestTimerSynchronizedDelegate);
 class TestReportScheduler
 {
 public:
+    /// @brief Mimicks the various operations that happen on a subscription transaction after a read handler was created so that
+    /// readhandlers are in the expected state for further tests.
+    /// @param readHandler
+    /// @param scheduler
+    static CHIP_ERROR MockReadHandlerSubscriptionTransation(ReadHandler * readHandler, ReportScheduler * scheduler,
+                                                            uint8_t min_interval_seconds, uint8_t max_interval_seconds)
+    {
+        ReturnErrorOnFailure(readHandler->SetMaxReportingInterval(max_interval_seconds));
+        ReturnErrorOnFailure(readHandler->SetMinReportingIntervalForTests(min_interval_seconds));
+        scheduler->OnReadHandlerSubscribed(readHandler);
+        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription);
+        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
+        readHandler->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+
+        return CHIP_NO_ERROR;
+    }
+
     static ReadHandler * GetReadHandlerFromPool(ReportScheduler * scheduler, uint32_t target)
     {
         uint32_t i        = 0;
@@ -347,33 +364,18 @@ public:
         // Test OnReadHandler created
         ReadHandler * readHandler1 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
-
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMaxReportingInterval(2));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMinReportingIntervalForTests(1));
-        sScheduler.OnReadHandlerSubscribed(readHandler1);
-        readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler1->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
-
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler1, &sScheduler, 1, 2));
         readHandler1->ForceDirtyState();
 
         // Clean read handler, will be triggered at max interval
         ReadHandler * readHandler2 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
-
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMaxReportingInterval(3));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMinReportingIntervalForTests(0));
-        sScheduler.OnReadHandlerSubscribed(readHandler2);
-        readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler2->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler2, &sScheduler, 0, 3));
 
         // Clean read handler, will be triggered at max interval, but will be cancelled before
         ReadHandler * readHandler3 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMaxReportingInterval(3));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMinReportingIntervalForTests(0));
-        sScheduler.OnReadHandlerSubscribed(readHandler3);
-        readHandler3->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler3->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler3, &sScheduler, 0, 3));
 
         // Confirms that none of the ReadHandlers are currently reportable
         NL_TEST_ASSERT(aSuite, !sScheduler.IsReportableNow(readHandler1));
@@ -427,11 +429,7 @@ public:
 
         ReadHandler * readHandler =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler->SetMaxReportingInterval(2));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler->SetMinReportingIntervalForTests(1));
-        sScheduler.OnReadHandlerSubscribed(readHandler);
-        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler, &sScheduler, 1, 2));
 
         // Verifies OnReadHandlerSubscribed registered the ReadHandler in the scheduler
         NL_TEST_ASSERT(aSuite, nullptr != sScheduler.FindReadHandlerNode(readHandler));
@@ -461,9 +459,9 @@ public:
         // Check that no report is scheduled since the min interval has expired, the timer should now be stopped
         NL_TEST_ASSERT(aSuite, !sScheduler.IsReportScheduled(readHandler));
 
-        // Test OnSubscriptionAction
+        // Test OnSubscriptionReportSent
         readHandler->ClearForceDirtyFlag();
-        readHandler->mObserver->OnSubscriptionAction(readHandler);
+        readHandler->mObserver->OnSubscriptionReportSent(readHandler);
         // Should have changed the scheduled timeout to the handlers max interval, to check, we wait for the min interval to
         // confirm it is not expired yet so the report should still be scheduled
 
@@ -507,20 +505,12 @@ public:
 
         ReadHandler * readHandler1 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &syncScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMaxReportingInterval(2));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMinReportingIntervalForTests(0));
-        syncScheduler.OnReadHandlerSubscribed(readHandler1);
-        readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler1->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler1, &syncScheduler, 0, 2));
         ReadHandlerNode * node1 = syncScheduler.FindReadHandlerNode(readHandler1);
 
         ReadHandler * readHandler2 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &syncScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMaxReportingInterval(3));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMinReportingIntervalForTests(1));
-        syncScheduler.OnReadHandlerSubscribed(readHandler2);
-        readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler2->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler2, &syncScheduler, 1, 3));
         ReadHandlerNode * node2 = syncScheduler.FindReadHandlerNode(readHandler2);
 
         // Confirm all handler are currently registered in the scheduler
@@ -548,9 +538,9 @@ public:
         NL_TEST_ASSERT(aSuite, !sScheduler.IsReportScheduled(readHandler2));
 
         // Simulate a report emission for readHandler1
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
         // Simulate a report emission for readHandler2
-        readHandler2->mObserver->OnSubscriptionAction(readHandler2);
+        readHandler2->mObserver->OnSubscriptionReportSent(readHandler2);
 
         // Validate that the max timestamp for both readhandlers got updated and that the next report emission is scheduled on
         //  the new max timestamp for readhandler1
@@ -576,13 +566,13 @@ public:
         NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node2->GetMinTimestamp());
 
         // Simulate a report emission for readHandler1
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
 
         // ReadHandler 2 should still be reportable since it hasn't emitted a report yet
         NL_TEST_ASSERT(aSuite, syncScheduler.IsReportableNow(readHandler2));
         readHandler2->ClearForceDirtyFlag();
-        readHandler2->mObserver->OnSubscriptionAction(readHandler2);
+        readHandler2->mObserver->OnSubscriptionReportSent(readHandler2);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
         // Validate next report scheduled on the max timestamp of readHandler1
@@ -598,7 +588,7 @@ public:
 
         // Simulate a report emission for readHandler1
         readHandler1->ClearForceDirtyFlag();
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
@@ -609,8 +599,8 @@ public:
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(2000));
         NL_TEST_ASSERT(aSuite, syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, syncScheduler.IsReportableNow(readHandler2));
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
-        readHandler2->mObserver->OnSubscriptionAction(readHandler2);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
+        readHandler2->mObserver->OnSubscriptionReportSent(readHandler2);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
@@ -622,11 +612,7 @@ public:
 
         ReadHandler * readHandler3 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &syncScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMaxReportingInterval(3));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler3->SetMinReportingIntervalForTests(2));
-        syncScheduler.OnReadHandlerSubscribed(readHandler3);
-        readHandler3->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler3->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler3, &syncScheduler, 2, 3));
         ReadHandlerNode * node3 = syncScheduler.FindReadHandlerNode(readHandler3);
 
         // Confirm all handler are currently registered in the scheduler
@@ -648,8 +634,8 @@ public:
         readHandler2->mObserver->OnBecameReportable(readHandler2);
 
         // Simulate a report emission for readHandler1 and readHandler2
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
-        readHandler1->mObserver->OnSubscriptionAction(readHandler2);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler2);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
@@ -667,9 +653,9 @@ public:
         readHandler2->mObserver->OnBecameReportable(readHandler2);
         readHandler3->mObserver->OnBecameReportable(readHandler3);
         // Engine run should happen here and send all reports
-        readHandler1->mObserver->OnSubscriptionAction(readHandler1);
-        readHandler2->mObserver->OnSubscriptionAction(readHandler2);
-        readHandler3->mObserver->OnSubscriptionAction(readHandler3);
+        readHandler1->mObserver->OnSubscriptionReportSent(readHandler1);
+        readHandler2->mObserver->OnSubscriptionReportSent(readHandler2);
+        readHandler3->mObserver->OnSubscriptionReportSent(readHandler3);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler3));
@@ -680,11 +666,7 @@ public:
         // Now simulate a new readHandler being added with a max forcing a conflict
         ReadHandler * readHandler4 =
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &syncScheduler);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler4->SetMaxReportingInterval(1));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler4->SetMinReportingIntervalForTests(0));
-        syncScheduler.OnReadHandlerSubscribed(readHandler4);
-        readHandler4->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        readHandler4->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler4, &syncScheduler, 0, 1));
         ReadHandlerNode * node4 = syncScheduler.FindReadHandlerNode(readHandler4);
 
         // Confirm all handler are currently registered in the scheduler
@@ -710,9 +692,9 @@ public:
         readHandler4->mObserver->OnBecameReportable(readHandler1);
         readHandler4->mObserver->OnBecameReportable(readHandler2);
         readHandler4->mObserver->OnBecameReportable(readHandler4);
-        readHandler4->mObserver->OnSubscriptionAction(readHandler1);
-        readHandler4->mObserver->OnSubscriptionAction(readHandler2);
-        readHandler4->mObserver->OnSubscriptionAction(readHandler4);
+        readHandler4->mObserver->OnSubscriptionReportSent(readHandler1);
+        readHandler4->mObserver->OnSubscriptionReportSent(readHandler2);
+        readHandler4->mObserver->OnSubscriptionReportSent(readHandler4);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler4));
@@ -728,10 +710,10 @@ public:
         syncScheduler.OnBecameReportable(readHandler2);
         syncScheduler.OnBecameReportable(readHandler3);
         syncScheduler.OnBecameReportable(readHandler4);
-        syncScheduler.OnSubscriptionAction(readHandler1);
-        syncScheduler.OnSubscriptionAction(readHandler2);
-        syncScheduler.OnSubscriptionAction(readHandler3);
-        syncScheduler.OnSubscriptionAction(readHandler4);
+        syncScheduler.OnSubscriptionReportSent(readHandler1);
+        syncScheduler.OnSubscriptionReportSent(readHandler2);
+        syncScheduler.OnSubscriptionReportSent(readHandler3);
+        syncScheduler.OnSubscriptionReportSent(readHandler4);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler3));
@@ -765,19 +747,14 @@ public:
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 0);
 
         readHandler1->MoveToState(ReadHandler::HandlerState::Idle);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMaxReportingInterval(2));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler1->SetMinReportingIntervalForTests(0));
-        readHandler1->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        syncScheduler.OnReadHandlerSubscribed(readHandler1);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler1, &syncScheduler, 0, 2));
+
         // Forcing the dirty flag to make the scheduler call Engine::ScheduleRun() immediately
         readHandler1->ForceDirtyState();
         NL_TEST_ASSERT(aSuite, syncScheduler.IsReportableNow(readHandler1));
 
         readHandler2->MoveToState(ReadHandler::HandlerState::Idle);
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMaxReportingInterval(4));
-        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == readHandler2->SetMinReportingIntervalForTests(3));
-        readHandler2->MoveToState(ReadHandler::HandlerState::CanStartReporting);
-        syncScheduler.OnReadHandlerSubscribed(readHandler2);
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler2, &syncScheduler, 3, 4));
         readHandler2->ForceDirtyState();
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
@@ -785,7 +762,7 @@ public:
         node2 = syncScheduler.FindReadHandlerNode(readHandler2);
 
         readHandler1->ClearForceDirtyFlag(); // report got emited so clear dirty flag
-        syncScheduler.OnSubscriptionAction(readHandler1);
+        syncScheduler.OnSubscriptionReportSent(readHandler1);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
@@ -801,7 +778,7 @@ public:
         syncScheduler.OnBecameReportable(readHandler1);
 
         // simulate run with only readhandler1 reportable
-        syncScheduler.OnSubscriptionAction(readHandler1);
+        syncScheduler.OnSubscriptionReportSent(readHandler1);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node2->GetMinTimestamp());
@@ -812,8 +789,8 @@ public:
         NL_TEST_ASSERT(aSuite, syncScheduler.IsReportableNow(readHandler2));
 
         readHandler2->ClearForceDirtyFlag();
-        syncScheduler.OnSubscriptionAction(readHandler1);
-        syncScheduler.OnSubscriptionAction(readHandler2);
+        syncScheduler.OnSubscriptionReportSent(readHandler1);
+        syncScheduler.OnSubscriptionReportSent(readHandler2);
 
         NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
         NL_TEST_ASSERT(aSuite, node2->GetSyncTimestamp() == node2->GetMaxTimestamp());

--- a/src/app/tests/TestReportScheduler.cpp
+++ b/src/app/tests/TestReportScheduler.cpp
@@ -255,10 +255,10 @@ public:
     {
         ReturnErrorOnFailure(readHandler->SetMaxReportingInterval(max_interval_seconds));
         ReturnErrorOnFailure(readHandler->SetMinReportingIntervalForTests(min_interval_seconds));
-        scheduler->OnReadHandlerSubscribed(readHandler);
-        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription);
-        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
         readHandler->ClearStateFlag(ReadHandler::ReadHandlerFlags::PrimingReports);
+        readHandler->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription);
+        scheduler->OnSubscriptionEstablished(readHandler);
+        readHandler->MoveToState(ReadHandler::HandlerState::CanStartReporting);
 
         return CHIP_NO_ERROR;
     }
@@ -299,7 +299,7 @@ public:
         {
             ReadHandler * readHandler =
                 readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
-            sScheduler.OnReadHandlerSubscribed(readHandler);
+            sScheduler.OnSubscriptionEstablished(readHandler);
             NL_TEST_ASSERT(aSuite, nullptr != readHandler);
             VerifyOrReturn(nullptr != readHandler);
             NL_TEST_ASSERT(aSuite, nullptr != sScheduler.FindReadHandlerNode(readHandler));
@@ -431,7 +431,7 @@ public:
             readHandlerPool.CreateObject(nullCallback, exchangeCtx, ReadHandler::InteractionType::Subscribe, &sScheduler);
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == MockReadHandlerSubscriptionTransation(readHandler, &sScheduler, 1, 2));
 
-        // Verifies OnReadHandlerSubscribed registered the ReadHandler in the scheduler
+        // Verifies OnSubscriptionEstablished registered the ReadHandler in the scheduler
         NL_TEST_ASSERT(aSuite, nullptr != sScheduler.FindReadHandlerNode(readHandler));
 
         // Should have registered the read handler in the scheduler and scheduled a report


### PR DESCRIPTION
The Scheduling in OnReadHandlerCreated method triggered the immediate scheduling before the intervals are negotiated.

This might be the root cause of the issue: https://github.com/project-chip/connectedhomeip/issues/28434


