### PR TITLE
Add support for controllers not advertising their operational identities.

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -152,6 +152,11 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 
     for (const FabricInfo & fabricInfo : *mFabricTable)
     {
+        if (!fabricInfo.ShouldAdvertiseIdentity())
+        {
+            continue;
+        }
+
         uint8_t macBuffer[DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength];
         MutableByteSpan mac(macBuffer);
         if (chip::DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac) != CHIP_NO_ERROR)

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -252,6 +252,7 @@ private:
     void PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params);
     CHIP_ERROR InitSystemState(FactoryInitParams params);
     CHIP_ERROR InitSystemState();
+    void ControllerInitialized(const DeviceController & controller);
 
     uint16_t mListenPort;
     DeviceControllerSystemState * mSystemState                          = nullptr;

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -78,12 +78,13 @@ CHIP_ERROR FabricInfo::Init(const FabricInfo::InitParams & initParams)
 
     Reset();
 
-    mNodeId             = initParams.nodeId;
-    mFabricId           = initParams.fabricId;
-    mFabricIndex        = initParams.fabricIndex;
-    mCompressedFabricId = initParams.compressedFabricId;
-    mRootPublicKey      = initParams.rootPublicKey;
-    mVendorId           = static_cast<VendorId>(initParams.vendorId);
+    mNodeId                  = initParams.nodeId;
+    mFabricId                = initParams.fabricId;
+    mFabricIndex             = initParams.fabricIndex;
+    mCompressedFabricId      = initParams.compressedFabricId;
+    mRootPublicKey           = initParams.rootPublicKey;
+    mVendorId                = static_cast<VendorId>(initParams.vendorId);
+    mShouldAdvertiseIdentity = initParams.advertiseIdentity;
 
     // Deal with externally injected keys
     if (initParams.operationalKeypair != nullptr)
@@ -105,12 +106,13 @@ void FabricInfo::operator=(FabricInfo && other)
 {
     Reset();
 
-    mNodeId             = other.mNodeId;
-    mFabricId           = other.mFabricId;
-    mFabricIndex        = other.mFabricIndex;
-    mCompressedFabricId = other.mCompressedFabricId;
-    mRootPublicKey      = other.mRootPublicKey;
-    mVendorId           = other.mVendorId;
+    mNodeId                  = other.mNodeId;
+    mFabricId                = other.mFabricId;
+    mFabricIndex             = other.mFabricIndex;
+    mCompressedFabricId      = other.mCompressedFabricId;
+    mRootPublicKey           = other.mRootPublicKey;
+    mVendorId                = other.mVendorId;
+    mShouldAdvertiseIdentity = other.mShouldAdvertiseIdentity;
 
     SetFabricLabel(other.GetFabricLabel());
 
@@ -768,7 +770,7 @@ CHIP_ERROR FabricTable::NotifyFabricCommitted(FabricIndex fabricIndex)
 
 CHIP_ERROR
 FabricTable::AddOrUpdateInner(FabricIndex fabricIndex, bool isAddition, Crypto::P256Keypair * existingOpKey,
-                              bool isExistingOpKeyExternallyOwned, uint16_t vendorId)
+                              bool isExistingOpKeyExternallyOwned, uint16_t vendorId, AdvertiseIdentity advertiseIdentity)
 {
     // All parameters pre-validated before we get here
 
@@ -866,6 +868,8 @@ FabricTable::AddOrUpdateInner(FabricIndex fabricIndex, bool isAddition, Crypto::
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
+
+    newFabricInfo.advertiseIdentity = (advertiseIdentity == AdvertiseIdentity::Yes);
 
     // Update local copy of fabric data. For add it's a new entry, for update, it's `mPendingFabric` shadow entry.
     ReturnErrorOnFailure(fabricEntry->Init(newFabricInfo));
@@ -1642,7 +1646,7 @@ CHIP_ERROR FabricTable::FindExistingFabricByNocChaining(FabricIndex pendingFabri
 
 CHIP_ERROR FabricTable::AddNewPendingFabricCommon(const ByteSpan & noc, const ByteSpan & icac, uint16_t vendorId,
                                                   Crypto::P256Keypair * existingOpKey, bool isExistingOpKeyExternallyOwned,
-                                                  FabricIndex * outNewFabricIndex)
+                                                  AdvertiseIdentity advertiseIdentity, FabricIndex * outNewFabricIndex)
 {
     VerifyOrReturnError(mOpCertStore != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(outNewFabricIndex != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -1692,8 +1696,8 @@ CHIP_ERROR FabricTable::AddNewPendingFabricCommon(const ByteSpan & noc, const By
     ReturnErrorOnFailure(mOpCertStore->AddNewOpCertsForFabric(fabricIndexToUse, noc, icac));
     VerifyOrReturnError(SetPendingDataFabricIndex(fabricIndexToUse), CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err =
-        AddOrUpdateInner(fabricIndexToUse, /* isAddition = */ true, existingOpKey, isExistingOpKeyExternallyOwned, vendorId);
+    CHIP_ERROR err = AddOrUpdateInner(fabricIndexToUse, /* isAddition = */ true, existingOpKey, isExistingOpKeyExternallyOwned,
+                                      vendorId, advertiseIdentity);
     if (err != CHIP_NO_ERROR)
     {
         // Revert partial state added on error
@@ -1712,7 +1716,8 @@ CHIP_ERROR FabricTable::AddNewPendingFabricCommon(const ByteSpan & noc, const By
 }
 
 CHIP_ERROR FabricTable::UpdatePendingFabricCommon(FabricIndex fabricIndex, const ByteSpan & noc, const ByteSpan & icac,
-                                                  Crypto::P256Keypair * existingOpKey, bool isExistingOpKeyExternallyOwned)
+                                                  Crypto::P256Keypair * existingOpKey, bool isExistingOpKeyExternallyOwned,
+                                                  AdvertiseIdentity advertiseIdentity)
 {
     VerifyOrReturnError(mOpCertStore != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_ARGUMENT);
@@ -1751,7 +1756,7 @@ CHIP_ERROR FabricTable::UpdatePendingFabricCommon(FabricIndex fabricIndex, const
     VerifyOrReturnError(SetPendingDataFabricIndex(fabricIndex), CHIP_ERROR_INCORRECT_STATE);
 
     CHIP_ERROR err = AddOrUpdateInner(fabricIndex, /* isAddition = */ false, existingOpKey, isExistingOpKeyExternallyOwned,
-                                      fabricInfo->GetVendorId());
+                                      fabricInfo->GetVendorId(), advertiseIdentity);
     if (err != CHIP_NO_ERROR)
     {
         // Revert partial state added on error


### PR DESCRIPTION
If multiple controllers are running, and some want to enable server interactions while others do not, the ones not enabling server interactions should not advertise.

Fixes https://github.com/project-chip/connectedhomeip/issues/28279
