### PR TITLE
[Java] Add support for Timestamp type in EventState

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -226,7 +226,7 @@ class WildcardFragment : Fragment() {
             stringBuilder.append("\t\teventNumber: ${event.eventNumber}\n")
             stringBuilder.append("\t\tpriorityLevel: ${event.priorityLevel}\n")
             stringBuilder.append("\t\ttimestampType: ${event.timestampType}\n")
-            stringBuilder.append("\t\tsystemTimeStamp: ${event.systemTimeStamp}\n")
+            stringBuilder.append("\t\ttimestampValue: ${event.timestampValue}\n")
 
             val eventName = ChipIdLookup.eventIdToName(clusterId, eventId)
             stringBuilder.append("\t\t$eventName: ${event.value}\n")

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -225,6 +225,7 @@ class WildcardFragment : Fragment() {
           for (event in events) {
             stringBuilder.append("\t\teventNumber: ${event.eventNumber}\n")
             stringBuilder.append("\t\tpriorityLevel: ${event.priorityLevel}\n")
+            stringBuilder.append("\t\ttimestampType: ${event.timestampType}\n")            
             stringBuilder.append("\t\tsystemTimeStamp: ${event.systemTimeStamp}\n")
 
             val eventName = ChipIdLookup.eventIdToName(clusterId, eventId)

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -225,7 +225,7 @@ class WildcardFragment : Fragment() {
           for (event in events) {
             stringBuilder.append("\t\teventNumber: ${event.eventNumber}\n")
             stringBuilder.append("\t\tpriorityLevel: ${event.priorityLevel}\n")
-            stringBuilder.append("\t\ttimestampType: ${event.timestampType}\n")            
+            stringBuilder.append("\t\ttimestampType: ${event.timestampType}\n")
             stringBuilder.append("\t\tsystemTimeStamp: ${event.systemTimeStamp}\n")
 
             val eventName = ChipIdLookup.eventIdToName(clusterId, eventId)

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -368,9 +368,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     readerForJavaTLV.Init(*apData);
     readerForJson.Init(*apData);
 
-    jlong eventNumber  = static_cast<jlong>(aEventHeader.mEventNumber);
-    jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
-    jlong timestampValue    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
+    jlong eventNumber    = static_cast<jlong>(aEventHeader.mEventNumber);
+    jint priorityLevel   = static_cast<jint>(aEventHeader.mPriorityLevel);
+    jlong timestampValue = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
     jint timestampType = 0;
     if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem)

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -370,7 +370,7 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
 
     jlong eventNumber  = static_cast<jlong>(aEventHeader.mEventNumber);
     jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
-    jlong timestamp    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
+    jlong timestampValue    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
     jint timestampType = 0;
     if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem)
@@ -432,7 +432,7 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     chip::JniClass eventStateJniCls(eventStateCls);
     jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", "(JIIJLjava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(eventStateCtor != nullptr, ChipLogError(Controller, "Could not find EventState constructor"));
-    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestampType, timestamp,
+    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestampType, timestampValue,
                                            value, jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(eventStateObj != nullptr, ChipLogError(Controller, "Could not create EventState object"));
 

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -374,9 +374,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
 
     jint timestampType = 0;
     if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem) {
-       timestampType = static_cast<jint>(MILLIS_SINCE_BOOT);  
+       timestampType = static_cast<jint>(MILLIS_SINCE_BOOT);
     } else if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kEpoch) {
-       timestampType = static_cast<jint>(MILLIS_SINCE_EPOCH);  
+       timestampType = static_cast<jint>(MILLIS_SINCE_EPOCH);
     } else {
         ChipLogError(Controller, "Unsupported event timestamp type");
         ReportError(nullptr, eventPathObj, CHIP_ERROR_INVALID_ARGUMENT);
@@ -425,7 +425,7 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find EventState class"));
     VerifyOrReturn(eventStateCls != nullptr, ChipLogError(Controller, "Could not find EventState class"));
     chip::JniClass eventStateJniCls(eventStateCls);
-    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", 
+    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>",
                                                 "(JIIJLjava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(eventStateCtor != nullptr, ChipLogError(Controller, "Could not find EventState constructor"));
     jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel,

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -22,6 +22,7 @@
 #include <controller/java/CHIPEventTLVValueDecoder.h>
 #endif
 #include <jni.h>
+#include <app/EventLoggingTypes.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ErrorStr.h>
@@ -34,6 +35,9 @@
 
 namespace chip {
 namespace Controller {
+
+static const int MILLIS_SINCE_BOOT = 0;
+static const int MILLIS_SINCE_EPOCH = 1;
 
 GetConnectedDeviceCallback::GetConnectedDeviceCallback(jobject wrapperCallback, jobject javaCallback) :
     mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnDeviceConnectionFailureFn, this)
@@ -368,6 +372,17 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     jint priorityLevel = static_cast<jint>(aEventHeader.mPriorityLevel);
     jlong timestamp    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
+    jint timestampType = 0;
+    if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem) {
+       timestampType = static_cast<jint>(MILLIS_SINCE_BOOT);  
+    } else if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kEpoch) {
+       timestampType = static_cast<jint>(MILLIS_SINCE_EPOCH);  
+    } else {
+        ChipLogError(Controller, "Unsupported event timestamp type");
+        ReportError(nullptr, eventPathObj, CHIP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     jobject value = nullptr;
 #if USE_JAVA_TLV_ENCODE_DECODE
     TLV::TLVReader readerForJavaObject;
@@ -407,12 +422,14 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     // Create EventState object
     jclass eventStateCls;
     err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/model/EventState", eventStateCls);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find EventState class"));
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find EventState class"));
     VerifyOrReturn(eventStateCls != nullptr, ChipLogError(Controller, "Could not find EventState class"));
     chip::JniClass eventStateJniCls(eventStateCls);
-    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", "(JIJLjava/lang/Object;[BLjava/lang/String;)V");
+    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", 
+                                                "(JIIJLjava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(eventStateCtor != nullptr, ChipLogError(Controller, "Could not find EventState constructor"));
-    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestamp, value,
+    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel,
+                                           timestampType, timestamp, value,
                                            jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(eventStateObj != nullptr, ChipLogError(Controller, "Could not create EventState object"));
 

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -21,8 +21,8 @@
 #include <controller/java/CHIPAttributeTLVValueDecoder.h>
 #include <controller/java/CHIPEventTLVValueDecoder.h>
 #endif
-#include <jni.h>
 #include <app/EventLoggingTypes.h>
+#include <jni.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ErrorStr.h>
@@ -36,7 +36,7 @@
 namespace chip {
 namespace Controller {
 
-static const int MILLIS_SINCE_BOOT = 0;
+static const int MILLIS_SINCE_BOOT  = 0;
 static const int MILLIS_SINCE_EPOCH = 1;
 
 GetConnectedDeviceCallback::GetConnectedDeviceCallback(jobject wrapperCallback, jobject javaCallback) :
@@ -373,11 +373,16 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     jlong timestamp    = static_cast<jlong>(aEventHeader.mTimestamp.mValue);
 
     jint timestampType = 0;
-    if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem) {
-       timestampType = static_cast<jint>(MILLIS_SINCE_BOOT);
-    } else if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kEpoch) {
-       timestampType = static_cast<jint>(MILLIS_SINCE_EPOCH);
-    } else {
+    if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kSystem)
+    {
+        timestampType = static_cast<jint>(MILLIS_SINCE_BOOT);
+    }
+    else if (aEventHeader.mTimestamp.mType == app::Timestamp::Type::kEpoch)
+    {
+        timestampType = static_cast<jint>(MILLIS_SINCE_EPOCH);
+    }
+    else
+    {
         ChipLogError(Controller, "Unsupported event timestamp type");
         ReportError(nullptr, eventPathObj, CHIP_ERROR_INVALID_ARGUMENT);
         return;
@@ -425,12 +430,10 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find EventState class"));
     VerifyOrReturn(eventStateCls != nullptr, ChipLogError(Controller, "Could not find EventState class"));
     chip::JniClass eventStateJniCls(eventStateCls);
-    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>",
-                                                "(JIIJLjava/lang/Object;[BLjava/lang/String;)V");
+    jmethodID eventStateCtor = env->GetMethodID(eventStateCls, "<init>", "(JIIJLjava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(eventStateCtor != nullptr, ChipLogError(Controller, "Could not find EventState constructor"));
-    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel,
-                                           timestampType, timestamp, value,
-                                           jniByteArray.jniValue(), jsonString.jniValue());
+    jobject eventStateObj = env->NewObject(eventStateCls, eventStateCtor, eventNumber, priorityLevel, timestampType, timestamp,
+                                           value, jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(eventStateObj != nullptr, ChipLogError(Controller, "Could not create EventState object"));
 
     // Add EventState to NodeState

--- a/src/controller/java/src/chip/devicecontroller/model/EventState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/EventState.java
@@ -23,10 +23,13 @@ import org.json.JSONObject;
 
 /** Represents the reported value of an attribute in object form, TLV and JSON. */
 public final class EventState {
+  public static final int MILLIS_SINCE_BOOT = 0;
+  public static final int MILLIS_SINCE_EPOCH = 1;  
   private static final String TAG = "EventState";
 
   private long eventNumber;
   private int priorityLevel;
+  private int timestampType;  
   private long systemTimeStamp;
 
   private Object valueObject;
@@ -36,12 +39,14 @@ public final class EventState {
   public EventState(
       long eventNumber,
       int priorityLevel,
+      int timestampType,      
       long systemTimeStamp,
       Object valueObject,
       byte[] tlv,
       String jsonString) {
     this.eventNumber = eventNumber;
     this.priorityLevel = priorityLevel;
+    this.timestampType = timestampType;
     this.systemTimeStamp = systemTimeStamp;
 
     this.valueObject = valueObject;
@@ -60,6 +65,10 @@ public final class EventState {
   public int getPriorityLevel() {
     return priorityLevel;
   }
+
+  public int getTimestampType() {
+    return timestampType;
+  }  
 
   public long getSystemTimeStamp() {
     return systemTimeStamp;

--- a/src/controller/java/src/chip/devicecontroller/model/EventState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/EventState.java
@@ -24,12 +24,12 @@ import org.json.JSONObject;
 /** Represents the reported value of an attribute in object form, TLV and JSON. */
 public final class EventState {
   public static final int MILLIS_SINCE_BOOT = 0;
-  public static final int MILLIS_SINCE_EPOCH = 1;  
+  public static final int MILLIS_SINCE_EPOCH = 1;
   private static final String TAG = "EventState";
 
   private long eventNumber;
   private int priorityLevel;
-  private int timestampType;  
+  private int timestampType;
   private long systemTimeStamp;
 
   private Object valueObject;
@@ -39,7 +39,7 @@ public final class EventState {
   public EventState(
       long eventNumber,
       int priorityLevel,
-      int timestampType,      
+      int timestampType,
       long systemTimeStamp,
       Object valueObject,
       byte[] tlv,
@@ -68,7 +68,7 @@ public final class EventState {
 
   public int getTimestampType() {
     return timestampType;
-  }  
+  }
 
   public long getSystemTimeStamp() {
     return systemTimeStamp;

--- a/src/controller/java/src/chip/devicecontroller/model/EventState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/EventState.java
@@ -30,7 +30,7 @@ public final class EventState {
   private long eventNumber;
   private int priorityLevel;
   private int timestampType;
-  private long systemTimeStamp;
+  private long timestampValue;
 
   private Object valueObject;
   private byte[] tlv;
@@ -47,7 +47,7 @@ public final class EventState {
     this.eventNumber = eventNumber;
     this.priorityLevel = priorityLevel;
     this.timestampType = timestampType;
-    this.systemTimeStamp = systemTimeStamp;
+    this.timestampValue = timestampValue;
 
     this.valueObject = valueObject;
     this.tlv = tlv;
@@ -70,8 +70,8 @@ public final class EventState {
     return timestampType;
   }
 
-  public long getSystemTimeStamp() {
-    return systemTimeStamp;
+  public long getTimestampValue() {
+    return timestampValue;
   }
 
   public Object getValue() {


### PR DESCRIPTION
Currently, we only have timestamp value in milliseconds in EventState, we can't tell this is time since device boot or Unix Epoch.
Add support for Timestamp type in EventState.

Fixes [20595](https://github.com/project-chip/connectedhomeip/issues/20595)

Testing:

Trigger an event in commissioned device and confirm the correct timestampType is logged in Android ChipTool.

```
08-05 10:35:45.906 18190 18245 I WildcardFragment: Received wildcard report
08-05 10:35:45.908 18190 18245 I WildcardFragment: Endpoint 0: {
08-05 10:35:45.908 18190 18245 I WildcardFragment: 	SwitchCluster: {
08-05 10:35:45.908 18190 18245 I WildcardFragment: 		eventNumber: 8
08-05 10:35:45.908 18190 18245 I WildcardFragment: 		priorityLevel: 1
08-05 10:35:45.908 18190 18245 I WildcardFragment: 		timestampType: 1
08-05 10:35:45.908 18190 18245 I WildcardFragment: 		systemTimeStamp: 1691256938651
08-05 10:35:45.908 18190 18245 I WildcardFragment: 		SwitchLatched: SwitchClusterSwitchLatchedEvent {
08-05 10:35:45.908 18190 18245 I WildcardFragment: 	newPosition: 3
08-05 10:35:45.908 18190 18245 I WildcardFragment: }
08-05 10:35:45.908 18190 18245 I WildcardFragment: 
```

