### PR TITLE
Get configure working again and fix the minimal build

### DIFF
--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -36,10 +36,12 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v3
-            - name: Checkout submodules & Bootstrap
-              uses: ./.github/actions/checkout-submodules-and-bootstrap
+
+            - name: Checkout submodules # but don't bootstrap!
+              uses: ./.github/actions/checkout-submodules
               with:
                 platform: linux
+
             - name: Configure and build All Clusters App
               run: |
                   CC=gcc CXX=g++ scripts/configure --project=examples/all-clusters-app/linux && ./ninja-build

--- a/scripts/configure
+++ b/scripts/configure
@@ -269,19 +269,16 @@ function finalize_build_env() {
 }
 
 function download_zap() {
-    local version platform arch
+    local version
     read -r version <"${CHIP_ROOT}/scripts/setup/zap.version"
-    case "$OSTYPE" in
-    linux*) platform=linux ;;
-    darwin*) platform=mac ;;
-    *) fail "Unable to determine zap platform for OSTYPE='$OSTYPE'" ;;
+    local platform="$(uname -sm)" flavor
+    case "$platform" in
+    Linux\ x86_64) flavor=linux-x64 ;;
+    Linux\ arm64) flavor=linux-arm64 ;;
+    Darwin\ *) flavor=mac-x64 ;; # there is no mac arm build of zap (can run x64 via Rosetta)
+    *) fail "Unable to determine zap flavor for $platform" ;;
     esac
-    case "$(uname -m)" in
-    arm64) arch=arm64 ;;
-    x86_64) arch=x64 ;;
-    *) fail "Unable to determine zap architecture for 'uname -m'='$(uname -m)'" ;;
-    esac
-    local url="https://github.com/project-chip/zap/releases/download/${version}/zap-${platform}-${arch}.zip"
+    local url="https://github.com/project-chip/zap/releases/download/${version}/zap-${flavor}.zip"
 
     progress "Installing zap-cli from $url"
     call_impl download_and_extract_zip "$url" "${BUILD_ENV_PATH}/bin" zap-cli

--- a/scripts/configure
+++ b/scripts/configure
@@ -226,8 +226,21 @@ function check_build_env() {
 
 function configure_python_env() {
     progress "Setting up Python venv"
-    "$PYTHON" -m venv --clear "$BUILD_ENV_PATH"
+    # Debian and Ubuntu ship python3 with a broken venv module unless the
+    # python3-venv package is installed (https://bugs.launchpad.net/bugs/1290847)
+    local withoutpip=() pip="${BUILD_ENV_PATH}/bin/pip"
+    if ! "$PYTHON" -m ensurepip --version >/dev/null 2>&1; then
+        withoutpip=(--without-pip) pip="${pip}.pyz" # bootstrapped below
+    fi
+    "$PYTHON" -m venv --clear "${withoutpip[@]}" "$BUILD_ENV_PATH"
     info "$BUILD_ENV_PATH"
+
+    # Download a standalone pip.pyz from pypa.io if necessary
+    if [[ -n "$withoutpip" ]]; then
+        progress "Bootstrapping pip via pypa.io (venv module is missing ensurepip dependency)"
+        call_impl download https://bootstrap.pypa.io/pip/pip.pyz "$pip"
+        info "ok"
+    fi
 
     # Install our auto-loading venvactivate module so that running scripts via
     # the venv python has the side-effect of fully activating the environment.
@@ -236,7 +249,9 @@ function configure_python_env() {
     cp "${CHIP_ROOT}/scripts/configure.venv/venvactivate".{pth,py} "${sitepkgs}/"
 
     progress "Installing Python build dependencies"
-    "${BUILD_ENV_PATH}/bin/pip" install --require-virtualenv --quiet --upgrade pip wheel
+    # Ensure pip and wheel are up to date first (using pip.pyz if necessary)
+    "${BUILD_ENV_PATH}/bin/python3" "$pip" install --require-virtualenv --quiet --upgrade pip wheel
+
     "${BUILD_ENV_PATH}/bin/pip" install --require-virtualenv --quiet \
         -r "${CHIP_ROOT}/scripts/setup/requirements.build.txt" \
         -c "${CHIP_ROOT}/scripts/setup/constraints.txt"

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -24,6 +24,10 @@ import urllib.request
 import zipfile
 
 
+def download(url, dest):
+    urllib.request.urlretrieve(url, dest)
+
+
 def download_and_extract_zip(url, dest_dir, *member_names):
     file, *_ = urllib.request.urlretrieve(url)
     with zipfile.ZipFile(file) as zip:
@@ -84,7 +88,8 @@ class ProjectArgProcessor:
         value = os.environ.get(envvar, default)
         if not value:
             return
-        if not (type := self.gn_args.get(arg, None)):
+        type = self.gn_args.get(arg, None)
+        if not type:
             info("Warning: Not propagating %s, project has no build arg '%s'" % (envvar, arg))
             return
         self.args[arg] = json.dumps(value if type != '[' else value.split() if list else [value])
@@ -94,7 +99,8 @@ class ProjectArgProcessor:
         arg = name.translate(str.maketrans('-', '_'))
         candidates = [p + arg for p in (('',) + prefixes) if (p + arg) in self.gn_args]
         preferred = [c for c in candidates if self.gn_args[c] == type] if type else []
-        if not (match := next(iter(preferred + candidates), None)):
+        match = next(iter(preferred + candidates), None)
+        if not match:
             info("Warning: Project has no build arg '%s'" % arg)
         return match
 
@@ -109,7 +115,8 @@ class ProjectArgProcessor:
         self.add_arg(prefix + 'os', triplet[1 if len(triplet) == 2 else 2])
 
     def process_enable_parameter(self, name, value):
-        if not (arg := self.gn_arg(name[len('enable-'):], self.BOOL_ARG_PREFIXES, 'b')):
+        arg = self.gn_arg(name[len('enable-'):], self.BOOL_ARG_PREFIXES, 'b')
+        if not arg:
             return
         if self.gn_args[arg] != 'b':
             fail("Project build arg '%s' is not a boolean" % arg)
@@ -118,7 +125,8 @@ class ProjectArgProcessor:
         self.add_arg(arg, value is None)
 
     def process_generic_parameter(self, name, value):
-        if not (arg := self.gn_arg(name, self.GENERIC_ARG_PREFIXES)):
+        arg = self.gn_arg(name, self.GENERIC_ARG_PREFIXES)
+        if not arg:
             return
         if self.gn_args[arg] == 'b':
             fail("Project build arg '%s' is a boolean, use --enable-..." % arg)
@@ -137,9 +145,10 @@ class ProjectArgProcessor:
     def process_parameters(self, args):
         """Process GNU-style configure command line parameters"""
         for arg in args:
-            if not (m := re.fullmatch(r'--([a-z][a-z0-9-]*)(?:=(.*))?', arg)):
+            match = re.fullmatch(r'--([a-z][a-z0-9-]*)(?:=(.*))?', arg)
+            if not match:
                 fail("Invalid argument: '%s'" % arg)
-            self.process_parameter(m.group(1), m.group(2))
+            self.process_parameter(match.group(1), match.group(2))
 
 
 def info(message):

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -48,8 +48,10 @@ def process_project_args(gn_args_json_file, *params):
 
 class ProjectArgProcessor:
     # Prefixes to try when mapping parameters to GN arguments
-    BOOL_ARG_PREFIXES = ('is_', 'enable_', 'use_', 'chip_', 'chip_enable', 'chip_use_', 'chip_config_')
-    GENERIC_ARG_PREFIXES = ('chip_', 'chip_config_')
+    BOOL_ARG_PREFIXES = ('is_', 'enable_', 'use_',
+                         'chip_', 'chip_enable_', 'chip_use_', 'chip_config_',
+                         'matter_', 'matter_enable_', 'matter_use_', 'matter_config_')
+    GENERIC_ARG_PREFIXES = ('chip_', 'chip_config_', 'matter_', 'matter_config_')
 
     gn_args = {}  # GN arg -> type ('s'tring, 'b'ool, 'i'integer, '[' list, '{' struct)
     args = collections.OrderedDict()  # collected arguments


### PR DESCRIPTION
- The minimal build workflow is not a proper test currently because it picked up a PW bootstrap step when workflows were bulk refactored a few months back. Remove the bootstrap step.
- Use the x64 build of zap on Mac for all architectures, there are no packaged arm releases.
- Work around the partially-working venv module that the `python3` package installs on Debian / Ubuntu
- Revert pigweed to 0889de6~1 to avoid https://issues.pigweed.dev/issues/294886611
