### PR TITLE
[Silabs] Add ICD configurations to the Silabs Light-Switch app

### DIFF
--- a/examples/light-switch-app/esp32/main/CMakeLists.txt
+++ b/examples/light-switch-app/esp32/main/CMakeLists.txt
@@ -31,6 +31,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/icd"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/access-control-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/administrator-commissioning-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic-information"
@@ -58,6 +59,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/group-key-mgmt-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/time-synchronization-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/icd-management-server"
                       PRIV_REQUIRES chip QRCode bt app_update driver nvs_flash spi_flash)
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1957,6 +1957,30 @@ server cluster UserLabel = 65 {
   readonly attribute int16u clusterRevision = 65533;
 }
 
+/** Allows servers to ensure that listed clients are notified when a server is available for communication. */
+server cluster IcdManagement = 70 {
+  bitmap Feature : BITMAP32 {
+    kCheckInProtocolSupport = 0x1;
+  }
+
+  fabric_scoped struct MonitoringRegistrationStruct {
+    fabric_sensitive node_id checkInNodeID = 1;
+    fabric_sensitive int64u monitoredSubject = 2;
+    fabric_sensitive octet_string<16> key = 3;
+    fabric_idx fabricIndex = 254;
+  }
+
+  readonly attribute int32u idleModeInterval = 0;
+  readonly attribute int32u activeModeInterval = 1;
+  readonly attribute int16u activeModeThreshold = 2;
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute event_id eventList[] = 65530;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+}
+
 /** Attributes and commands for controlling the color properties of a color-capable light. */
 client cluster ColorControl = 768 {
   enum ColorLoopAction : ENUM8 {
@@ -2578,6 +2602,14 @@ endpoint 0 {
   server cluster UserLabel {
     callback attribute labelList;
     ram      attribute featureMap default = 0;
+    ram      attribute clusterRevision default = 1;
+  }
+
+  server cluster IcdManagement {
+    callback attribute idleModeInterval default = 500;
+    callback attribute activeModeInterval default = 300;
+    callback attribute activeModeThreshold default = 300;
+    ram      attribute featureMap default = 0x0000;
     ram      attribute clusterRevision default = 1;
   }
 }

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -33,7 +33,33 @@
   ],
   "endpointTypes": [
     {
+      "id": 10,
       "name": "MA-rootdevice",
+      "deviceTypeRef": {
+        "id": 2,
+        "code": 22,
+        "profileId": 259,
+        "label": "MA-rootdevice",
+        "name": "MA-rootdevice"
+      },
+      "deviceTypes": [
+        {
+          "id": 2,
+          "code": 22,
+          "profileId": 259,
+          "label": "MA-rootdevice",
+          "name": "MA-rootdevice"
+        }
+      ],
+      "deviceTypeRefs": [
+        2
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        22
+      ],
       "deviceTypeName": "MA-rootdevice",
       "deviceTypeCode": 22,
       "deviceTypeProfileId": 259,
@@ -5808,11 +5834,291 @@
               "reportableChange": 0
             }
           ]
+        },
+        {
+          "name": "ICD Management",
+          "code": 70,
+          "mfgCode": null,
+          "define": "ICD_MANAGEMENT_CLUSTER",
+          "side": "client",
+          "enabled": 0,
+          "attributes": [
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "client",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "client",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "ICD Management",
+          "code": 70,
+          "mfgCode": null,
+          "define": "ICD_MANAGEMENT_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "RegisterClientResponse",
+              "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 1,
+              "outgoing": 0
+            }
+          ],
+          "attributes": [
+            {
+              "name": "IdleModeInterval",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int32u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "500",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ActiveModeInterval",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int32u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "300",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ActiveModeThreshold",
+              "code": 2,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "300",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "RegisteredClients",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ICDCounter",
+              "code": 4,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int32u",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClientsSupportedPerFabric",
+              "code": 5,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 0,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0x0000",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
         }
       ]
     },
     {
+      "id": 8,
       "name": "MA-onofflightswitch",
+      "deviceTypeRef": {
+        "id": 15,
+        "code": 259,
+        "profileId": 259,
+        "label": "MA-onofflightswitch",
+        "name": "MA-onofflightswitch"
+      },
+      "deviceTypes": [
+        {
+          "id": 15,
+          "code": 259,
+          "profileId": 259,
+          "label": "MA-onofflightswitch",
+          "name": "MA-onofflightswitch"
+        }
+      ],
+      "deviceTypeRefs": [
+        15
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        259
+      ],
       "deviceTypeName": "MA-onofflightswitch",
       "deviceTypeCode": 259,
       "deviceTypeProfileId": 259,
@@ -8460,7 +8766,33 @@
       ]
     },
     {
+      "id": 9,
       "name": "MA-genericswitch",
+      "deviceTypeRef": {
+        "id": 20,
+        "code": 15,
+        "profileId": 259,
+        "label": "MA-genericswitch",
+        "name": "MA-genericswitch"
+      },
+      "deviceTypes": [
+        {
+          "id": 20,
+          "code": 15,
+          "profileId": 259,
+          "label": "MA-genericswitch",
+          "name": "MA-genericswitch"
+        }
+      ],
+      "deviceTypeRefs": [
+        20
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        15
+      ],
       "deviceTypeName": "MA-genericswitch",
       "deviceTypeCode": 15,
       "deviceTypeProfileId": 259,
@@ -9757,27 +10089,21 @@
       "endpointTypeIndex": 0,
       "profileId": 259,
       "endpointId": 0,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "networkId": 0
     },
     {
       "endpointTypeName": "MA-onofflightswitch",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 259
+      "networkId": 0
     },
     {
       "endpointTypeName": "MA-genericswitch",
       "endpointTypeIndex": 2,
       "profileId": 259,
       "endpointId": 2,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 15
+      "networkId": 0
     }
   ],
   "log": []

--- a/examples/light-switch-app/silabs/openthread.gn
+++ b/examples/light-switch-app/silabs/openthread.gn
@@ -23,7 +23,7 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "freertos"
-  chip_openthread_ftd = true
+  chip_openthread_ftd = false
 
   import("//openthread.gni")
 }

--- a/examples/light-switch-app/silabs/openthread.gni
+++ b/examples/light-switch-app/silabs/openthread.gni
@@ -24,3 +24,17 @@ chip_enable_openthread = true
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
+
+# ICD Default configurations
+chip_enable_icd_server = true
+chip_subscription_timeout_resumption = false
+sl_use_subscription_synching = true
+
+# Openthread Configuration flags
+sl_ot_idle_interval_ms   = 30000    # 30s Idle Intervals
+sl_ot_active_interval_ms = 500      # 500ms Active Intervals
+
+# ICD Matter Configuration flags
+sl_idle_mode_interval_ms    = 3600000   # 60min Idle Mode Interval
+sl_active_mode_interval_ms  = 60000     # 60s Active Mode Interval
+sl_active_mode_threshold_ms = 1000      # 1s Active Mode Threshold

--- a/examples/light-switch-app/silabs/openthread.gni
+++ b/examples/light-switch-app/silabs/openthread.gni
@@ -31,10 +31,10 @@ chip_subscription_timeout_resumption = false
 sl_use_subscription_synching = true
 
 # Openthread Configuration flags
-sl_ot_idle_interval_ms   = 30000    # 30s Idle Intervals
-sl_ot_active_interval_ms = 500      # 500ms Active Intervals
+sl_ot_idle_interval_ms = 30000  # 30s Idle Intervals
+sl_ot_active_interval_ms = 500  # 500ms Active Intervals
 
 # ICD Matter Configuration flags
-sl_idle_mode_interval_ms    = 3600000   # 60min Idle Mode Interval
-sl_active_mode_interval_ms  = 60000     # 60s Active Mode Interval
-sl_active_mode_threshold_ms = 1000      # 1s Active Mode Threshold
+sl_idle_mode_interval_ms = 3600000  # 60min Idle Mode Interval
+sl_active_mode_interval_ms = 60000  # 60s Active Mode Interval
+sl_active_mode_threshold_ms = 1000  # 1s Active Mode Threshold


### PR DESCRIPTION
#### Description
Enables SIT ICD device types on the silabs light-switch example app

* Add ICDM cluster on light-switch common
* Enable ICD behavior by default on light-switch app