### PR TITLE
Improve size calculation for our packets.

### DIFF
--- a/src/app/StatusResponse.h
+++ b/src/app/StatusResponse.h
@@ -22,10 +22,11 @@
 #include <messaging/ExchangeContext.h>
 #include <protocols/interaction_model/Constants.h>
 #include <system/TLVPacketBufferBackingStore.h>
+#include <transport/raw/MessageHeader.h>
 
 namespace chip {
 namespace app {
-static constexpr size_t kMaxSecureSduLengthBytes = 1024;
+static constexpr size_t kMaxSecureSduLengthBytes = kMaxAppMessageLen + kMaxTagLen;
 
 class StatusResponse
 {

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -67,6 +67,9 @@ chip::EndpointId kInvalidTestEndpointId = 3;
 chip::DataVersion kTestDataVersion1     = 3;
 chip::DataVersion kTestDataVersion2     = 5;
 
+// Number of items in the list for MockAttributeId(4).
+constexpr int kMockAttribute4ListLength = 6;
+
 static chip::System::Clock::Internal::MockClock gMockClock;
 static chip::System::Clock::ClockBase * gRealClock;
 
@@ -1214,7 +1217,8 @@ void TestReadInteraction::TestReadChunking(nlTestSuite * apSuite, void * apConte
     NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
 
     chip::app::AttributePathParams attributePathParams[1];
-    // Mock Attribute 4 is a big attribute, with 6 large OCTET_STRING
+    // Mock Attribute 4 is a big attribute, with kMockAttribute4ListLength large
+    // OCTET_STRING elements.
     attributePathParams[0].mEndpointId  = Test::kMockEndpoint3;
     attributePathParams[0].mClusterId   = Test::MockClusterId(2);
     attributePathParams[0].mAttributeId = Test::MockAttributeId(4);
@@ -1234,8 +1238,10 @@ void TestReadInteraction::TestReadChunking(nlTestSuite * apSuite, void * apConte
 
         ctx.DrainAndServiceIO();
 
-        // We get one chunk with 3 array elements, and then one chunk per element.
-        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 4);
+        // We get one chunk with 4 array elements, and then one chunk per
+        // element, and the total size of the array is
+        // kMockAttribute4ListLength.
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1 + (kMockAttribute4ListLength - 4));
         NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 6);
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
@@ -1380,13 +1386,16 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
 
         ctx.DrainAndServiceIO();
 
-        // We should receive another (3 + 1) = 4 attribute reports represeting 6
-        // array items, since the underlying path iterator should be reset to
-        // the beginning of the cluster it is currently iterating.
+        // Our list has length kMockAttribute4ListLength.  Since the underlying
+        // path iterator should be reset to the beginning of the cluster it is
+        // currently iterating, we expect to get another value for our
+        // attribute.  The way the packet boundaries happen to fall, that value
+        // will encode 4 items in the first IB and then one IB per item.
+        const int expectedIBs = 1 + (kMockAttribute4ListLength - 4);
         ChipLogError(DataManagement, "OLD: %d\n", currentAttributeResponsesWhenSetDirty);
         ChipLogError(DataManagement, "NEW: %d\n", delegate.mNumAttributeResponse);
-        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == currentAttributeResponsesWhenSetDirty + 4);
-        NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == currentArrayItemsWhenSetDirty + 6);
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == currentAttributeResponsesWhenSetDirty + expectedIBs);
+        NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == currentArrayItemsWhenSetDirty + kMockAttribute4ListLength);
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
         // By now we should have closed all exchanges and sent all pending acks, so
@@ -2341,7 +2350,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
         // paths, for a total of 58 attributes.
         //
         // Attribute 0xFFFC::0xFFF1'FC02::0xFFF1'0004 (kMockEndpoint3::MockClusterId(2)::MockAttributeId(4))
-        // is a list of 6 elements of size 256 bytes each, which cannot fit in a single
+        // is a list of kMockAttribute4ListLength elements of size 256 bytes each, which cannot fit in a single
         // packet, so gets list chunking applied to it.
         //
         // Because delegate.mNumAttributeResponse counts AttributeDataIB instances, not attributes,
@@ -2350,21 +2359,16 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
         // in the response, there will be one AttributeDataIB for the start of the list (which will include
         // some number of 256-byte elements), then one AttributeDataIB for each of the remaining elements.
         //
-        // When EventList is enabled, for the first report for the list attribute we receive two
-        // of its items in the initial list, then 4 additional items.  For the second report we
-        // receive 3 items in the initial list followed by 3 additional items.
-        //
-        // Thus we should receive 29*2 + 4 + 3 = 65 attribute data in total.
-        constexpr size_t kExpectedAttributeResponse = 65;
+        // When EventList is enabled, for the first report for the list attribute we receive three
+        // of its items in the initial list, then the remaining items.  For the second report we
+        // receive 2 items in the initial list followed by the remaining items.
+        constexpr size_t kExpectedAttributeResponse = 29 * 2 + (kMockAttribute4ListLength - 3) + (kMockAttribute4ListLength - 2);
 #else
         // When EventList is not enabled, the packet boundaries shift and for the first
-        // report for the list attribute we receive two of its items in the initial list,
-        // then 4 additional items.  For the second report we receive 3 items in
-        // the initial list followed by 3 additional items.
-        //
-        // Thus we should receive 29*2 + 4 + 3 = 65 attribute data when the eventlist
-        // attribute is not available.
-        constexpr size_t kExpectedAttributeResponse = 65;
+        // report for the list attribute we receive four of its items in the initial list,
+        // then additional items.  For the second report we receive 4 items in
+        // the initial list followed by additional items.
+        constexpr size_t kExpectedAttributeResponse = 29 * 2 + (kMockAttribute4ListLength - 4) + (kMockAttribute4ListLength - 4);
 #endif
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == kExpectedAttributeResponse);
         NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 12);
@@ -3460,9 +3464,10 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReport(nlTestSuite * ap
             gMockClock.AdvanceMonotonic(System::Clock::Milliseconds32(10));
         }
     }
-    // Two chunked reports carry 4 attributeDataIB: 1 with a list of 3 items,
-    // and then one per remaining item.
-    NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 4);
+    // We get one chunk with 4 array elements, and then one chunk per
+    // element, and the total size of the array is
+    // kMockAttribute4ListLength.
+    NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1 + (kMockAttribute4ListLength - 4));
     NL_TEST_ASSERT(apSuite, delegate.mNumArrayItems == 6);
 
     NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -579,8 +579,9 @@ void TestWriteInteraction::TestWriteHandlerReceiveInvalidMessage(nlTestSuite * a
     err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable(), app::reporting::GetDefaultReportScheduler());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    // Reserve all except the last 128 bytes, so that we make sure to chunk.
     app::WriteClient writeClient(&ctx.GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(900) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
 
     ByteSpan list[5];
 
@@ -647,8 +648,9 @@ void TestWriteInteraction::TestWriteHandlerInvalidateFabric(nlTestSuite * apSuit
     err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable(), app::reporting::GetDefaultReportScheduler());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    // Reserve all except the last 128 bytes, so that we make sure to chunk.
     app::WriteClient writeClient(&ctx.GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(900) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
 
     ByteSpan list[5];
 

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -293,23 +293,17 @@
 #endif // CHIP_SYSTEM_CONFIG_ZEPHYR_LOCKING && CHIP_SYSTEM_CONFIG_NO_LOCKING
 
 /**
- *  @def CHIP_SYSTEM_HEADER_RESERVE_SIZE
+ *  @def CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE
  *
  *  @brief
  *      The number of bytes to reserve in a network packet buffer to contain
- *      the CHIP message and exchange headers.
+ *      the Matter crypto headers.
  *
- *      This number was calculated as follows:
- *
- *      CHIP Crypto Header:
- *
- *          4 -- Length of encrypted block
- *          4 -- Reserve
- *          8 -- Initialization Vector
- *          8 -- Encryption Tag
+ *      This is 0, because Matter does not have any crypto headers.  This define
+ *      is still here only for backwards compatibility.
  */
 #ifndef CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE
-#define CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE 24
+#define CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE 0
 #endif
 
 /**
@@ -317,31 +311,39 @@
  *
  *  @brief
  *      The number of bytes to reserve in a network packet buffer to contain
- *      the CHIP message and exchange headers.
+ *      the CHIP message and payload headers.
  *
  *      This number was calculated as follows:
  *
- *      CHIP Message Header:
+ *      Matter Message Header:
  *
  *          2 -- Frame Length
- *          2 -- Message Header
- *          4 -- Message Id
- *          8 -- Source Node Id
- *          8 -- Destination Node Id
- *          2 -- Key Id
+ *          1 -- Message Flags
+ *          2 -- Session ID
+ *          1 -- Security Flags
+ *          4 -- Message Counter
+ *          8 -- Source Node ID
+ *          8 -- Destination Node ID
  *
- *      CHIP Exchange Header:
+ *      Total: 26 bytes.
  *
- *          1 -- Application Version
- *          1 -- Message Type
- *          2 -- Exchange Id
- *          4 -- Profile Id
- *          4 -- Acknowledged Message Id
+ *      Matter Payload Header:
  *
- *    @note A number of these fields are optional or not presently used. So most headers will be considerably smaller than this.
+ *          1 -- Exhange Flags
+ *          1 -- Protocol Opcode
+ *          2 -- Exchange ID
+ *          2 -- Protocol Vendor ID
+ *          2 -- Protocol ID
+ *          4 -- Acknowledged MEssage Counter
+ *
+ *      Total: 12 bytes.
+ *
+ *    @note A number of these fields are optional or not presently used. So most
+ *          headers will be considerably smaller than this.
+ *    @note This calculation assumes ther are no Message Extensions or Secured Extensions.
  */
 #ifndef CHIP_SYSTEM_HEADER_RESERVE_SIZE
-#define CHIP_SYSTEM_HEADER_RESERVE_SIZE (38 + CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE)
+#define CHIP_SYSTEM_HEADER_RESERVE_SIZE (26 + 12 + CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE)
 #endif /* CHIP_SYSTEM_HEADER_RESERVE_SIZE */
 
 /**

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -44,32 +44,33 @@ namespace chip {
 
 namespace detail {
 // Figure out the max size of a packet we can allocate, including all headers.
-static constexpr size_t kMaxIPPacketSizeBytes     = 1280;
-static constexpr size_t kMaxPacketBufferSizeBytes = System::PacketBuffer::kMaxSizeWithoutReserve;
-static constexpr size_t kMaxPacketSizeBytes       = min(kMaxIPPacketSizeBytes, kMaxPacketBufferSizeBytes);
+static constexpr size_t kMaxIPPacketSizeBytes       = 1280;
+static constexpr size_t kMaxUDPAndIPHeaderSizeBytes = 48;
 
-// Figure out the max size of our headers.
-// System::PacketBuffer::kDefaultHeaderReserve may or may not include space for
-// UDP headers, depending on the situation.  Make sure we always have enough
-// space for UDP headers plus Matter headers.
-static constexpr size_t kMaxUDPHeaderSizeBytes          = 48;
-static constexpr size_t kMaxPacketbufferHeaderSizeBytes = System::PacketBuffer::kDefaultHeaderReserve;
-static constexpr size_t kMaxHeaderSizeBytes =
-    max(kMaxUDPHeaderSizeBytes + CHIP_SYSTEM_HEADER_RESERVE_SIZE, kMaxPacketbufferHeaderSizeBytes);
+static_assert(kMaxIPPacketSizeBytes >= kMaxUDPAndIPHeaderSizeBytes + CHIP_SYSTEM_HEADER_RESERVE_SIZE,
+              "Matter headers and IP headers must fit in an MTU.");
 
-static_assert(kMaxPacketSizeBytes > kMaxHeaderSizeBytes, "Need to be able to fit our headers in a packet.");
+// Max space we have for our Application Payload and MIC, per spec.
+static constexpr size_t kMaxPerSpecApplicationPayloadAndMICSizeBytes =
+    kMaxIPPacketSizeBytes - kMaxUDPAndIPHeaderSizeBytes - CHIP_SYSTEM_HEADER_RESERVE_SIZE;
 
-static constexpr size_t kMaxMessageSizeBytes = detail::kMaxPacketSizeBytes - detail::kMaxHeaderSizeBytes;
+// Max space we have for our Application Payload and MIC in our actual packet
+// buffers.  This is the size _excluding_ the header reserve.
+static constexpr size_t kMaxPacketBufferApplicationPayloadAndMICSizeBytes = System::PacketBuffer::kMaxSize;
+
+static constexpr size_t kMaxApplicationPayloadAndMICSizeBytes =
+    min(kMaxPerSpecApplicationPayloadAndMICSizeBytes, kMaxPacketBufferApplicationPayloadAndMICSizeBytes);
+
 } // namespace detail
 
 static constexpr size_t kMaxTagLen = 16;
 
-static_assert(detail::kMaxMessageSizeBytes > kMaxTagLen, "Need to be able to fit our tag in a message");
+static_assert(detail::kMaxApplicationPayloadAndMICSizeBytes > kMaxTagLen, "Need to be able to fit our tag in a message");
 
 // This is somewhat of an under-estimate, because in practice any time we have a
 // tag we will not have source/destination node IDs, but above we are including
-// those in the header size.
-static constexpr size_t kMaxAppMessageLen = detail::kMaxMessageSizeBytes - kMaxTagLen;
+// those in the header sizes.
+static constexpr size_t kMaxAppMessageLen = detail::kMaxApplicationPayloadAndMICSizeBytes - kMaxTagLen;
 
 static constexpr uint16_t kMsgUnicastSessionIdUnsecured = 0x0000;
 


### PR DESCRIPTION
We were hardcoding kMaxAppMessageLen and kMaxSecureSduLengthBytes, but those defines were not even consistent with each other, and both were overly conservative.  Specific changes:

1. Fix computation of CHIP_SYSTEM_HEADER_RESERVE_SIZE: we don't have any "crypto headers".
2. Fix computation of kMaxAppMessageLen to use our actual packet buffer sizes and defined header sizes.
3. Fix kMaxSecureSduLengthBytes to be consistent with kMaxAppMessageLen.

