### PR TITLE
Validate if the Current Group = RemovedGroup before invalidating scene

### DIFF
--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -511,18 +511,18 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     VerifyOrReturn(nullptr != sceneTable);
 
     chip::GroupId currentGroup;
-    Attributes::CurrentGroup::Get(aEndpointId,&currentGroup);
+    Attributes::CurrentGroup::Get(aEndpointId, &currentGroup);
 
     chip::SceneId currentScene;
-    Attributes::CurrentScene::Get(aEndpointId,&currentScene);
+    Attributes::CurrentScene::Get(aEndpointId, &currentScene);
 
-    //Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
+    // Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
     SceneTableEntry entry;
-    if(aGroupId == currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(currentScene,currentGroup),entry) == CHIP_NO_ERROR)
+    if (aGroupId == currentGroup ||
+        sceneTable->GetSceneTableEntry(aFabricIx, SceneStorageId(currentScene, currentGroup), entry) == CHIP_NO_ERROR)
     {
         MakeSceneInvalid(aEndpointId);
     }
-
 
     VerifyOrReturn(nullptr != mGroupProvider);
     if (0 != aGroupId && !mGroupProvider->HasEndpoint(aFabricIx, aGroupId, aEndpointId))

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -516,10 +516,9 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     chip::SceneId currentScene;
     Attributes::CurrentScene::Get(aEndpointId, &currentScene);
 
-    // Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
+    // Validate if the Current Group = RemovedGroup before invalidating the scene.
     SceneTableEntry entry;
-    if (aGroupId == currentGroup ||
-        sceneTable->GetSceneTableEntry(aFabricIx, SceneStorageId(currentScene, currentGroup), entry) == CHIP_NO_ERROR)
+    if (aGroupId == currentGroup)
     {
         MakeSceneInvalid(aEndpointId);
     }

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -518,7 +518,7 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
 
     //Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
     SceneTableEntry entry;
-    if(aGroupId == *currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(*currentScene,*currentGroup),entry) == CHIP_NO_ERROR)
+    if(aGroupId == *currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(currentScene,currentGroup),entry) == CHIP_NO_ERROR)
     {
         MakeSceneInvalid(aEndpointId);
     }

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -510,7 +510,19 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     SceneTable * sceneTable = scenes::GetSceneTableImpl(aEndpointId);
     VerifyOrReturn(nullptr != sceneTable);
 
-    MakeSceneInvalid(aEndpointId);
+    chip::GroupId * currentGroup;
+    Attributes::CurrentGroup::Get(aEndpointId, currentGroup);
+
+    chip::SceneId * currentScene;
+    Attributes::CurrentScene::Get(aEndpointId,currentScene);
+
+    //Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
+    SceneTableEntry entry;
+    if(aGroupId == *currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(*currentScene,*currentGroup),entry) == CHIP_NO_ERROR)
+    {
+        MakeSceneInvalid(aEndpointId);
+    }
+
 
     VerifyOrReturn(nullptr != mGroupProvider);
     if (0 != aGroupId && !mGroupProvider->HasEndpoint(aFabricIx, aGroupId, aEndpointId))

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -513,11 +513,7 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     chip::GroupId currentGroup;
     Attributes::CurrentGroup::Get(aEndpointId, &currentGroup);
 
-    chip::SceneId currentScene;
-    Attributes::CurrentScene::Get(aEndpointId, &currentScene);
-
     // Validate if the Current Group = RemovedGroup before invalidating the scene.
-    SceneTableEntry entry;
     if (aGroupId == currentGroup)
     {
         MakeSceneInvalid(aEndpointId);

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -513,7 +513,8 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     chip::GroupId currentGroup;
     Attributes::CurrentGroup::Get(aEndpointId, &currentGroup);
 
-    // Validate if the Current Group = RemovedGroup before invalidating the scene.
+    // If currentGroup is what is being removed, we can't possibly still have a valid scene,
+    // because the scene we have (if any) will also be removed.
     if (aGroupId == currentGroup)
     {
         MakeSceneInvalid(aEndpointId);

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -510,11 +510,11 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     SceneTable * sceneTable = scenes::GetSceneTableImpl(aEndpointId);
     VerifyOrReturn(nullptr != sceneTable);
 
-    chip::GroupId * currentGroup;
-    Attributes::CurrentGroup::Get(aEndpointId, currentGroup);
+    chip::GroupId currentGroup;
+    Attributes::CurrentGroup::Get(aEndpointId,&currentGroup);
 
-    chip::SceneId * currentScene;
-    Attributes::CurrentScene::Get(aEndpointId,currentScene);
+    chip::SceneId currentScene;
+    Attributes::CurrentScene::Get(aEndpointId,&currentScene);
 
     //Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
     SceneTableEntry entry;

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -518,7 +518,7 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
 
     //Validate if the Current Group = RemovedGroup or check if CurrentScene is in RemovedGroup before invalidating the scene.
     SceneTableEntry entry;
-    if(aGroupId == *currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(currentScene,currentGroup),entry) == CHIP_NO_ERROR)
+    if(aGroupId == currentGroup || sceneTable->GetSceneTableEntry(aFabricIx,SceneStorageId(currentScene,currentGroup),entry) == CHIP_NO_ERROR)
     {
         MakeSceneInvalid(aEndpointId);
     }


### PR DESCRIPTION
Validate if the Current Group = RemovedGroup ~~or check if CurrentScene is in RemovedGroup~~ before invalidating the scene.

Fixes : https://github.com/project-chip/connectedhomeip/issues/26884

