### PR TITLE
[ESP32]: Add way to configure BLE scan response.

### DIFF
--- a/docs/guides/esp32/README.md
+++ b/docs/guides/esp32/README.md
@@ -17,4 +17,4 @@ example on ESP32 series of SoCs
 -   [RPC Console and Device Tracing](rpc_console.md)
 -   [Matter OTA](ota.md)
 -   [Generating and Using ESP Secure Cert Partition](secure_cert_partition.md)
--   [BLE](ble.md)
+-   [BLE Settings](ble_settings.md)

--- a/docs/guides/esp32/README.md
+++ b/docs/guides/esp32/README.md
@@ -17,3 +17,4 @@ example on ESP32 series of SoCs
 -   [RPC Console and Device Tracing](rpc_console.md)
 -   [Matter OTA](ota.md)
 -   [Generating and Using ESP Secure Cert Partition](secure_cert_partition.md)
+-   [BLE](ble.md)

--- a/docs/guides/esp32/ble.md
+++ b/docs/guides/esp32/ble.md
@@ -2,14 +2,15 @@
 
 # Nimble: scan response
 
-The `ConfigureScanResponseData` API is used to configure the
-scan response data for advertising in a Bluetooth Low Energy (BLE) application
-based on the NimBLE BLE stack. Scan response data is additional data that a BLE
-peripheral device can include in its advertising packets to provide more
-information about itself. This API allows you to set the scan response data that
-will be included in the advertising packets.
+The `ConfigureScanResponseData` API is used to configure the scan response data
+for advertising in a Bluetooth Low Energy (BLE) application based on the NimBLE
+BLE stack. Scan response data is additional data that a BLE peripheral device
+can include in its advertising packets to provide more information about itself.
+This API allows you to set the scan response data that will be included in the
+advertising packets.
 
 ## Usage
+
 ```
 uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
 
@@ -24,4 +25,5 @@ uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureScanResponseData(data);
 }
 ```
+
 Note: ScanResponse should be configure before device starts advertisement.

--- a/docs/guides/esp32/ble.md
+++ b/docs/guides/esp32/ble.md
@@ -1,0 +1,27 @@
+# Bluetooth Low Energy (BLE)
+
+# Nimble: scan response
+
+The `ConfigureScanResponseData` API is used to configure the
+scan response data for advertising in a Bluetooth Low Energy (BLE) application
+based on the NimBLE BLE stack. Scan response data is additional data that a BLE
+peripheral device can include in its advertising packets to provide more
+information about itself. This API allows you to set the scan response data that
+will be included in the advertising packets.
+
+## Usage
+```
+uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
+
+{
+    scanResponse[0] = 0x05;
+    scanResponse[1] = 0x09;
+    scanResponse[2] = 0x61;
+    scanResponse[3] = 0x62;
+    scanResponse[4] = 0x63;
+    scanResponse[5] = 0x64;
+    chip::ByteSpan data();
+    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureScanResponseData(data);
+}
+```
+Note: ScanResponse should be configure before device starts advertisement.

--- a/docs/guides/esp32/ble_settings.md
+++ b/docs/guides/esp32/ble_settings.md
@@ -1,6 +1,6 @@
 # Bluetooth Low Energy (BLE)
 
-# Nimble: scan response
+## Nimble: scan response
 
 The `ConfigureScanResponseData` API is used to configure the scan response data
 for advertising in a Bluetooth Low Energy (BLE) application based on the NimBLE
@@ -9,21 +9,24 @@ can include in its advertising packets to provide more information about itself.
 This API allows you to set the scan response data that will be included in the
 advertising packets.
 
-## Usage
+### Usage
 
 ```
-uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
-
 {
+    uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
     scanResponse[0] = 0x05;
     scanResponse[1] = 0x09;
     scanResponse[2] = 0x61;
     scanResponse[3] = 0x62;
     scanResponse[4] = 0x63;
     scanResponse[5] = 0x64;
-    chip::ByteSpan data();
-    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureScanResponseData(data);
+    chip::ByteSpan data(scanResponse);
+    CHIP_ERROR err = chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureScanResponseData(data);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to configure scan response, err:%" CHIP_ERROR_FORMAT, err.Format());
+    }
 }
 ```
 
-Note: ScanResponse should be configure before device starts advertisement.
+Note: Scan response should be configure before `InitServer`.

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -71,6 +71,8 @@ struct ble_gatt_char_context
 #include <platform/ESP32/ChipDeviceScanner.h>
 #endif
 
+#define MAX_SCAN_RSP_DATA_LEN 31
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -132,6 +134,7 @@ class BLEManagerImpl final : public BLEManager,
 #endif
 {
 public:
+    uint8_t scanResponseBuffer[MAX_SCAN_RSP_DATA_LEN];
     BLEManagerImpl() {}
 #if CONFIG_ENABLE_ESP32_BLE_CONTROLLER
     CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
@@ -140,10 +143,11 @@ public:
 #endif
 #endif
 
-    void ConfigureScanResponseData(ByteSpan data);
+    CHIP_ERROR ConfigureScanResponseData(ByteSpan data);
+    void ClearScanResponseData(void);
 
 private:
-    chip::Optional<chip::ByteSpan> scanResponse;
+    chip::Optional<chip::ByteSpan> mScanResponse;
 
     // Allow the BLEManager interface class to delegate method calls to
     // the implementation methods provided by this class.

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -140,7 +140,11 @@ public:
 #endif
 #endif
 
+    void ConfigureScanResponseData(ByteSpan data);
+
 private:
+    chip::Optional<chip::ByteSpan> scanResponse;
+
     // Allow the BLEManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend BLEManager;


### PR DESCRIPTION
- Problem
> There was no way to configure scan response for esp32.

- Changes
> Added API to configure scan response with docs.

- Testing
> Tested scan response using nrf-connect android app.