### PR TITLE
Fix cancellation of subscriptions to work correctly. (1.1 cherrypick of #28569)

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -453,14 +453,14 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
             // Walk through all existing subscriptions and shut down those whose subscriber matches
             // that which just came in.
             //
-            mReadHandlers.ForEachActiveObject([this, apExchangeContext](ReadHandler * handler) {
+            mReadHandlers.ForEachActiveObject([apExchangeContext](ReadHandler * handler) {
                 if (handler->IsFromSubscriber(*apExchangeContext))
                 {
                     ChipLogProgress(InteractionModel,
                                     "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
                                     ChipLogValueX64(apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId()),
                                     apExchangeContext->GetSessionHandle()->GetFabricIndex());
-                    mReadHandlers.ReleaseObject(handler);
+                    handler->Close();
                 }
 
                 return Loop::Continue;


### PR DESCRIPTION
* Fix cancellation of subscriptions to work correctly.

When a subscription came in with KeepSubscriptions set to false, we would just directly delete the ReadHandlers for the subscriptions not being kept, instead of calling Close().

That meant we skipped deleting subscription persistence data, and also failed to correcly update the reporting engine's round-robin reporting state, which could lead to subscriptions not being serviced fairly.

The fix is to just call Close() just like we do for out-of-resource eviction, instead of manually deleting the object.

* Fix build issue.
