### PR TITLE
Add APIs for non-commissioning device attestation to Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -19,6 +19,7 @@
 
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRDefines.h>
+#import <Matter/MTRDeviceAttestationResult.h>
 
 @class MTRSetupPayload;
 @class MTRDeviceController;
@@ -112,6 +113,12 @@ typedef void (^MTRDeviceResubscriptionScheduledHandler)(NSError * error, NSNumbe
  */
 API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 typedef void (^MTRDeviceOpenCommissioningWindowHandler)(MTRSetupPayload * _Nullable payload, NSError * _Nullable error);
+
+/**
+ * Handler for verifyAttestationWithQueue.
+ */
+MTR_NEWLY_AVAILABLE
+typedef void (^MTRDeviceAttestationVerificationHandler)(MTRDeviceAttestationResult * _Nullable result, NSError * _Nullable error);
 
 extern NSString * const MTRAttributePathKey;
 extern NSString * const MTRCommandPathKey;
@@ -474,6 +481,23 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
                                            queue:(dispatch_queue_t)queue
                                       completion:(MTRDeviceOpenCommissioningWindowHandler)completion
     API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0));
+
+/**
+ * Perform device attestation on the device.
+ *
+ * If getting the various attestation information succeeds, completion will be
+ * called with an MTRDeviceAttestationResult that contains the information being
+ * verified and the verification result.  The verification will be done in the
+ * same way as for devices being commissioned.  In particular, which things are
+ * verified will depend on whether the controller has an
+ * MTROperationalCertificateIssuer, if it does on what its
+ * shouldSkipAttestationCertificateValidation property is set to.
+ *
+ * If getting the attestation information fails, so that attestation could not
+ * be checked at all, completion will be called with an NSError.
+ */
+- (void)verifyAttestationWithQueue:(dispatch_queue_t)queue
+                        completion:(MTRDeviceAttestationVerificationHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Reads events from the device.

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -490,7 +490,7 @@ API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
  * verified and the verification result.  The verification will be done in the
  * same way as for devices being commissioned.  In particular, which things are
  * verified will depend on whether the controller has an
- * MTROperationalCertificateIssuer, if it does on what its
+ * MTROperationalCertificateIssuer, and if it does on what its
  * shouldSkipAttestationCertificateValidation property is set to.
  *
  * If getting the attestation information fails, so that attestation could not

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -202,6 +202,23 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
                                       completion:(MTRDeviceOpenCommissioningWindowHandler)completion
     API_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0));
 
+/**
+ * Perform device attestation on the device.
+ *
+ * If getting the various attestation information succeeds, completion will be
+ * called with an MTRDeviceAttestationResult that contains the information being
+ * verified and the verification result.  The verification will be done in the
+ * same way as for devices being commissioned.  In particular, which things are
+ * verified will depend on whether the controller has an
+ * MTROperationalCertificateIssuer, if it does on what its
+ * shouldSkipAttestationCertificateValidation property is set to.
+ *
+ * If getting the attestation information fails, so that attestation could not
+ * be checked at all, completion will be called with an NSError.
+ */
+- (void)verifyAttestationWithQueue:(dispatch_queue_t)queue
+                        completion:(MTRDeviceAttestationVerificationHandler)completion MTR_NEWLY_AVAILABLE;
+
 @end
 
 @protocol MTRDeviceDelegate <NSObject>

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1065,6 +1065,12 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     [baseDevice openCommissioningWindowWithDiscriminator:discriminator duration:duration queue:queue completion:completion];
 }
 
+- (void)verifyAttestationWithQueue:(dispatch_queue_t)queue completion:(MTRDeviceAttestationVerificationHandler)completion
+{
+    auto * baseDevice = [self newBaseDevice];
+    [baseDevice verifyAttestationWithQueue:queue completion:completion];
+}
+
 #pragma mark - Cache management
 
 // assume lock is held

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.h
@@ -70,6 +70,24 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  */
 @property (nonatomic, copy, readonly, nullable) NSData * firmwareInfo;
 
+/**
+ * The vendor ID value from the device's Basic Information cluster that was used
+ * for device attestation.  If attestation succeeds, this must match the vendor
+ * ID from the certification declaration.
+ */
+@property (nonatomic, readonly) NSNumber * basicInformationVendorID MTR_NEWLY_AVAILABLE;
+
+/**
+ * The product ID value from the device's Basic Information cluster that was
+ * used for device attestation.  If attestation succeeds, this must match one of
+ * the product IDs from the certification declaration.
+ */
+@property (nonatomic, readonly) NSNumber * basicInformationProductID MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initializer without basicInformationVendorID and basicInformationProductID.
+ * Will set those properties to @(0).
+ */
 - (instancetype)initWithDeviceAttestationChallenge:(NSData *)challenge
                                              nonce:(NSData *)nonce
                                        elementsTLV:(MTRTLVBytes)elementsTLV
@@ -77,8 +95,19 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
                       deviceAttestationCertificate:(MTRCertificateDERBytes)deviceAttestationCertificate
          productAttestationIntermediateCertificate:(MTRCertificateDERBytes)processAttestationIntermediateCertificate
                           certificationDeclaration:(NSData *)certificationDeclaration
-                                      firmwareInfo:(NSData *)firmwareInfo;
+                                      firmwareInfo:(NSData *)firmwareInfo
+    MTR_NEWLY_DEPRECATED("Please use the version with basicInformationVendorID and basicInformationProductID");
 
+- (instancetype)initWithDeviceAttestationChallenge:(NSData *)challenge
+                                             nonce:(NSData *)nonce
+                                       elementsTLV:(MTRTLVBytes)elementsTLV
+                                 elementsSignature:(NSData *)elementsSignature
+                      deviceAttestationCertificate:(MTRCertificateDERBytes)deviceAttestationCertificate
+         productAttestationIntermediateCertificate:(MTRCertificateDERBytes)processAttestationIntermediateCertificate
+                          certificationDeclaration:(NSData *)certificationDeclaration
+                                      firmwareInfo:(NSData *)firmwareInfo
+                          basicInformationVendorID:(NSNumber *)basicInformationVendorID
+                         basicInformationProductID:(NSNumber *)basicInformationProductID MTR_NEWLY_AVAILABLE;
 @end
 
 MTR_DEPRECATED("Please use MTRDeviceAttestationInfo", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.h
@@ -72,7 +72,7 @@ API_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
 
 /**
  * The vendor ID value from the device's Basic Information cluster that was used
- * for device attestation.  If attestation succeeds, this must match the vendor
+ * for device attestation.  For attestation to succeed, this must match the vendor
  * ID from the certification declaration.
  */
 @property (nonatomic, readonly) NSNumber * basicInformationVendorID MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.mm
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
          productAttestationIntermediateCertificate:(MTRCertificateDERBytes)productAttestationIntermediateCertificate
                           certificationDeclaration:(NSData *)certificationDeclaration
                                       firmwareInfo:(NSData *)firmwareInfo
+                          basicInformationVendorID:(NSNumber *)basicInformationVendorID
+                         basicInformationProductID:(NSNumber *)basicInformationProductID
 {
     if (self = [super init]) {
         _challenge = challenge;
@@ -39,8 +41,31 @@ NS_ASSUME_NONNULL_BEGIN
         _productAttestationIntermediateCertificate = productAttestationIntermediateCertificate;
         _certificationDeclaration = certificationDeclaration;
         _firmwareInfo = firmwareInfo;
+        _basicInformationVendorID = basicInformationVendorID;
+        _basicInformationProductID = basicInformationProductID;
     }
     return self;
+}
+
+- (instancetype)initWithDeviceAttestationChallenge:(NSData *)challenge
+                                             nonce:(NSData *)nonce
+                                       elementsTLV:(MTRTLVBytes)elementsTLV
+                                 elementsSignature:(NSData *)elementsSignature
+                      deviceAttestationCertificate:(MTRCertificateDERBytes)deviceAttestationCertificate
+         productAttestationIntermediateCertificate:(MTRCertificateDERBytes)productAttestationIntermediateCertificate
+                          certificationDeclaration:(NSData *)certificationDeclaration
+                                      firmwareInfo:(NSData *)firmwareInfo
+{
+    return [self initWithDeviceAttestationChallenge:challenge
+                                              nonce:nonce
+                                        elementsTLV:elementsTLV
+                                  elementsSignature:elementsSignature
+                       deviceAttestationCertificate:deviceAttestationCertificate
+          productAttestationIntermediateCertificate:productAttestationIntermediateCertificate
+                           certificationDeclaration:certificationDeclaration
+                                       firmwareInfo:firmwareInfo
+                           basicInformationVendorID:@(0)
+                          basicInformationProductID:@(0)];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationResult.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationResult.h
@@ -1,0 +1,41 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <Matter/MTRDefines.h>
+#import <Matter/MTRDeviceAttestationInfo.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Represents the result of a device attestation operation.
+ */
+MTR_NEWLY_AVAILABLE
+@interface MTRDeviceAttestationResult : NSObject
+
+/**
+ * The attestation info that was used to perform attestation verification.
+ */
+@property (nonatomic, strong) MTRDeviceAttestationInfo * attestationInfo;
+
+/**
+ * Whether attestation verification succeeded.
+ */
+@property (nonatomic, assign) BOOL attestationSucceded;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationResult.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationResult.mm
@@ -1,0 +1,21 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDeviceAttestationResult.h>
+
+@implementation MTRDeviceAttestationResult
+@end

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -177,7 +177,9 @@ CHIP_ERROR MTROperationalCredentialsDelegate::ExternalGenerateNOCChain(const chi
                      deviceAttestationCertificate:AsData(DAC)
         productAttestationIntermediateCertificate:AsData(PAI)
                          certificationDeclaration:AsData(certificationDeclarationSpan)
-                                     firmwareInfo:firmwareInfo];
+                                     firmwareInfo:firmwareInfo
+                         basicInformationVendorID:@(commissioningParameters.Value().GetRemoteVendorId().Value())
+                        basicInformationProductID:@(commissioningParameters.Value().GetRemoteProductId().Value())];
 
     MTRDeviceController * __weak weakController = mWeakController;
     dispatch_async(mOperationalCertificateIssuerQueue, ^{

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -36,6 +36,7 @@
 #import <Matter/MTRDevice.h>
 #import <Matter/MTRDeviceAttestationDelegate.h>
 #import <Matter/MTRDeviceAttestationInfo.h>
+#import <Matter/MTRDeviceAttestationResult.h>
 #import <Matter/MTRDeviceController+XPC.h>
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDeviceControllerDelegate.h>

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -2382,6 +2382,26 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
 }
 
+- (void)test027_DeviceAttestation
+{
+    __auto_type * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Perform device attestation on the device"];
+
+    [device verifyAttestationWithQueue:queue
+                            completion:^(MTRDeviceAttestationResult * _Nullable result, NSError * _Nullable error) {
+                                XCTAssertNil(error);
+                                XCTAssertNotNil(result);
+                                XCTAssertTrue(result.attestationSucceded);
+                                XCTAssertEqualObjects(result.attestationInfo.basicInformationVendorID, @(0xFFF1));
+                                XCTAssertEqualObjects(result.attestationInfo.basicInformationProductID, @(0x8001));
+                                [expectation fulfill];
+                            }];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
 - (void)test900_SubscribeAllAttributes
 {
     MTRBaseDevice * device = GetConnectedDevice();

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		51565CAE2A79D42100469F18 /* MTRConversion.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51565CAD2A79D42100469F18 /* MTRConversion.mm */; };
 		515C1C6F284F9FFB00A48F0C /* MTRFramework.mm in Sources */ = {isa = PBXBuildFile; fileRef = 515C1C6D284F9FFB00A48F0C /* MTRFramework.mm */; };
 		515C1C70284F9FFB00A48F0C /* MTRFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 515C1C6E284F9FFB00A48F0C /* MTRFramework.h */; };
+		516122182A82CF6700D15825 /* MTRDeviceAttestationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 516122172A82CF6700D15825 /* MTRDeviceAttestationResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5161221A2A82D46000D15825 /* MTRDeviceAttestationResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 516122192A82D46000D15825 /* MTRDeviceAttestationResult.mm */; };
 		51669AF02913204400F4AA36 /* MTRBackwardsCompatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51669AEF2913204400F4AA36 /* MTRBackwardsCompatTests.m */; };
 		5173A47529C0E2ED00F67F48 /* MTRFabricInfo_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5173A47229C0E2ED00F67F48 /* MTRFabricInfo_Internal.h */; };
 		5173A47629C0E2ED00F67F48 /* MTRFabricInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5173A47329C0E2ED00F67F48 /* MTRFabricInfo.mm */; };
@@ -460,6 +462,8 @@
 		51565CAD2A79D42100469F18 /* MTRConversion.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRConversion.mm; sourceTree = "<group>"; };
 		515C1C6D284F9FFB00A48F0C /* MTRFramework.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRFramework.mm; sourceTree = "<group>"; };
 		515C1C6E284F9FFB00A48F0C /* MTRFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRFramework.h; sourceTree = "<group>"; };
+		516122172A82CF6700D15825 /* MTRDeviceAttestationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceAttestationResult.h; sourceTree = "<group>"; };
+		516122192A82D46000D15825 /* MTRDeviceAttestationResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceAttestationResult.mm; sourceTree = "<group>"; };
 		51669AEF2913204400F4AA36 /* MTRBackwardsCompatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRBackwardsCompatTests.m; sourceTree = "<group>"; };
 		5173A47229C0E2ED00F67F48 /* MTRFabricInfo_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRFabricInfo_Internal.h; sourceTree = "<group>"; };
 		5173A47329C0E2ED00F67F48 /* MTRFabricInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRFabricInfo.mm; sourceTree = "<group>"; };
@@ -1037,6 +1041,8 @@
 				7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */,
 				88EBF8CD27FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.h */,
 				88EBF8CC27FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.mm */,
+				516122172A82CF6700D15825 /* MTRDeviceAttestationResult.h */,
+				516122192A82D46000D15825 /* MTRDeviceAttestationResult.mm */,
 				2C5EEEF4268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h */,
 				2C5EEEF5268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm */,
 				991DC0822475F45400C13860 /* MTRDeviceController.h */,
@@ -1198,6 +1204,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				516122182A82CF6700D15825 /* MTRDeviceAttestationResult.h in Headers */,
 				510A07492A685D3900A9241C /* Matter.apinotes in Headers */,
 				51EF279F2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h in Headers */,
 				5173A47729C0E2ED00F67F48 /* MTRFabricInfo.h in Headers */,
@@ -1502,6 +1509,7 @@
 				51E51FC1282AD37A00FC978D /* MTRDeviceControllerStartupParams.mm in Sources */,
 				51565CAE2A79D42100469F18 /* MTRConversion.mm in Sources */,
 				1ED276E026C57CF000547A89 /* MTRCallbackBridge.mm in Sources */,
+				5161221A2A82D46000D15825 /* MTRDeviceAttestationResult.mm in Sources */,
 				517BF3F1282B62B800A8B7DB /* MTRCertificates.mm in Sources */,
 				5A6FEC9627B5983000F25F42 /* MTRDeviceControllerXPCConnection.mm in Sources */,
 				511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */,


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/24709
