### PR TITLE
[Docker][K32W1] Add support for K32W1 SDK

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-5 : Use west to download the K32W0 SDK
+6 : Add support for K32W1 SDK

--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -22,8 +22,15 @@ RUN set -x \
     && cp -R examples/* core/boards && rm -rf examples \
     && : # last line
 
+RUN set -x \
+    && mkdir -p k32w1
+    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_12_5_K32W148-EVK.zip \
+    && unzip SDK_2_12_5_K32W148-EVK.zip -d k32w1 \
+    && rm -rf SDK_2_12_5_K32W148-EVK.zip \
+
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
 COPY --from=build /opt/sdk/ /opt/sdk/
 
 ENV NXP_K32W0_SDK_ROOT=/opt/sdk/core
+ENV NXP_K32W1_SDK_ROOT=/opt/sdk/k32w1

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=crosscompile /opt/ubuntu-22.04.1-aarch64-sysroot /opt/ubuntu-22.04.1
 
 COPY --from=ameba /opt/ameba /opt/ameba
 
-COPY --from=k32w /opt/sdk /opt/k32w_sdk
+COPY --from=k32w /opt/sdk /opt/k32w
 
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
 
@@ -104,7 +104,8 @@ ENV IDF_TOOLS_PATH=/opt/espressif/tools
 ENV IMX_SDK_ROOT=/opt/fsl-imx-xwayland/6.1-langdale
 ENV JAVA_PATH=/usr/lib/jvm/java-8-openjdk-amd64
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
-ENV NXP_K32W0_SDK_ROOT=/opt/k32w_sdk
+ENV NXP_K32W0_SDK_ROOT=/opt/k32w/core
+ENV NXP_K32W1_SDK_ROOT=/opt/k32w/k32w1
 ENV OPENOCD_PATH=/opt/openocd/
 ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV QEMU_ESP32=/opt/espressif/qemu/xtensa-softmmu/qemu-system-xtensa


### PR DESCRIPTION
Latest release for K32W1 SDK is public under an URL.
This is a prerequisite for an upcoming PR that will enable support for K32W1 platform.

