### PR TITLE
Fix bootstrap on M1/M2 mac.

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -1,8 +1,13 @@
 name: Bootstrap
 description: Bootstrap
+inputs:
+  platform:
+    description: "Platform name"
+    required: false
+    default: none
 runs:
   using: "composite"
   steps:
     - name: Bootstrap
       shell: bash
-      run: bash scripts/bootstrap.sh
+      run: bash scripts/bootstrap.sh -p ${{ inputs.platform }}

--- a/.github/actions/checkout-submodules-and-bootstrap/action.yaml
+++ b/.github/actions/checkout-submodules-and-bootstrap/action.yaml
@@ -24,6 +24,8 @@ runs:
       uses: ./.github/actions/bootstrap-cache
     - name: Bootstrap
       uses: ./.github/actions/bootstrap
+      with:
+        platform: ${{ inputs.platform }}
     - name: Upload Bootstrap Logs
       uses: ./.github/actions/upload-bootstrap-logs
       with:

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -9,7 +9,6 @@ virtualenv
 -r requirements.esp32.txt
 
 -r requirements.mbed.txt
--r requirements.bouffalolab.txt
 -r requirements.openiotsdk.txt
 -r requirements.infineon.txt
 -r requirements.ti.txt


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/28146 added bitarray to requirements.bouffalolab.txt, but that package requires native compilation during bootstrap.  And bootstrap ends up using the pigweed-provided clang for that, but that clang is broken on M1/M2 mac.

For now, stop pulling requirements.bouffalolab.txt into the general requirements.all.txt, so that bootstrap works for all the people not actively developing for bouffalolab.  If it's re-added there later, it should be split up to make sure the bitarray bits are not pulled in.
