### PR TITLE
Looking to remove dependencies from `requirements.all.txt`

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -10,4 +10,4 @@ runs:
   steps:
     - name: Bootstrap
       shell: bash
-      run: bash scripts/bootstrap.sh -p ${{ inputs.platform }}
+      run: bash scripts/bootstrap.sh -p all,${{ inputs.platform }}

--- a/scripts/py_matter_yamltests/setup.cfg
+++ b/scripts/py_matter_yamltests/setup.cfg
@@ -22,5 +22,6 @@ description = Parse matter yaml tests files
 packages = find:
 zip_safe = False
 install_requires=
-   websockets
+   diskcache
    lark
+   websockets

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -8,13 +8,9 @@ virtualenv
 -c constraints.esp32.txt
 -r requirements.esp32.txt
 
--r requirements.mbed.txt
--r requirements.openiotsdk.txt
--r requirements.infineon.txt
 -r requirements.zephyr.txt
 -r requirements.cirque.txt
 -r requirements.memory.txt
--r requirements.yaml_tests.txt
 
 # device controller wheel package
 wheel; sys_platform == 'linux'

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -9,10 +9,8 @@ virtualenv
 -r requirements.esp32.txt
 
 -r requirements.mbed.txt
--r requirements.bouffalolab.txt
 -r requirements.openiotsdk.txt
 -r requirements.infineon.txt
--r requirements.ti.txt
 -r requirements.zephyr.txt
 -r requirements.cirque.txt
 -r requirements.memory.txt

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -19,6 +19,14 @@ pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'
 pyobjc-framework-corebluetooth; sys_platform == 'darwin'
 
+# python unit tests run directly without installing
+# built venv
+#
+# TODO: this should change in the Future
+diskcache
+lark
+websockets
+
 # mobly tests
 portpicker
 mobly

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -13,7 +13,6 @@ virtualenv
 -r requirements.openiotsdk.txt
 -r requirements.infineon.txt
 -r requirements.ti.txt
--r requirements.telink.txt
 -r requirements.zephyr.txt
 -r requirements.cirque.txt
 -r requirements.memory.txt

--- a/scripts/setup/requirements.yaml_tests.txt
+++ b/scripts/setup/requirements.yaml_tests.txt
@@ -1,2 +1,0 @@
-diskcache
-websockets


### PR DESCRIPTION
Looking to see what breaks when we try to trim down dependencies. Manual testing showed that at least ti, telink and boufallolab dependencies are not needed, so remove a bunch and let CI figure it out.