### PR TITLE
[ESP32] Fix the parentheses and ifdefs during ble deinit

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -62,43 +62,48 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
 
     case DeviceEventType::kCHIPoBLEConnectionClosed:
         ESP_LOGI(TAG, "CHIPoBLE disconnected");
-#if CONFIG_BT_ENABLED
-#if CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
 
+#if CONFIG_BT_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() > 0)
         {
             esp_err_t err = ESP_OK;
+
 #if CONFIG_BT_NIMBLE_ENABLED
-            if (ble_hs_is_enabled())
+            if (!ble_hs_is_enabled())
             {
-                int ret = nimble_port_stop();
-                if (ret == 0)
-                {
-                    nimble_port_deinit();
+                ESP_LOGI(TAG, "BLE already deinited");
+                break;
+            }
+            if (nimble_port_stop() != 0)
+            {
+                ESP_LOGE(TAG, "nimble_port_stop() failed");
+                break;
+            }
+            vTaskDelay(100);
+            nimble_port_deinit();
+
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-                    err = esp_nimble_hci_and_controller_deinit();
-#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-#endif // CONFIG_BT_NIMBLE_ENABLED
+            err = esp_nimble_hci_and_controller_deinit();
+#endif
+#endif /* CONFIG_BT_NIMBLE_ENABLED */
 
 #if CONFIG_IDF_TARGET_ESP32
-                    err += esp_bt_mem_release(ESP_BT_MODE_BTDM);
+            err |= esp_bt_mem_release(ESP_BT_MODE_BTDM);
 #elif CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32H2
-            err += esp_bt_mem_release(ESP_BT_MODE_BLE);
+            err |= esp_bt_mem_release(ESP_BT_MODE_BLE);
 #endif
-                    if (err == ESP_OK)
-                    {
-                        ESP_LOGI(TAG, "BLE deinit successful and memory reclaimed");
-                    }
-                }
-                else
-                {
-                    ESP_LOGW(TAG, "nimble_port_stop() failed");
-                }
+
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "BLE deinit failed");
             }
-            else { ESP_LOGI(TAG, "BLE already deinited"); }
+            else
+            {
+                ESP_LOGI(TAG, "BLE deinit successful and memory reclaimed");
+            }
         }
-#endif // CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
-#endif // CONFIG_BT_ENABLED
+#endif /* CONFIG_BT_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING */
+
         break;
 
     case DeviceEventType::kDnssdInitialized:

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -211,7 +211,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
 #endif
     SuccessOrExit(err);
 
-    memset(mCons, 0, sizeof(mCons));
+    memset(reinterpret_cast<void *>(mCons), 0, sizeof(mCons));
     mServiceMode          = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     mAppIf                = ESP_GATT_IF_NONE;
     mServiceAttrHandle    = 0;


### PR DESCRIPTION
This would have broke when using bluedroid host.

- Tested building for nimble.
- Tested building for bluedroid host, compilation successful and raised an issue for linker errors https://github.com/project-chip/connectedhomeip/issues/28627