### PR TITLE
virtual-device-app: Add ColorControlManager for Extended Color Light

### DIFF
--- a/examples/virtual-device-app/android/BUILD.gn
+++ b/examples/virtual-device-app/android/BUILD.gn
@@ -27,6 +27,8 @@ shared_library("jni") {
     "java/AppImpl.cpp",
     "java/AppImpl.h",
     "java/ClusterChangeAttribute.cpp",
+    "java/ColorControlManager.cpp",
+    "java/ColorControlManager.h",
     "java/DeviceApp-JNI.cpp",
     "java/JNIDACProvider.cpp",
     "java/JNIDACProvider.h",
@@ -65,6 +67,7 @@ android_library("java") {
 
   sources = [
     "java/src/com/matter/virtual/device/app/Clusters.java",
+    "java/src/com/matter/virtual/device/app/ColorControlManager.java",
     "java/src/com/matter/virtual/device/app/DACProvider.java",
     "java/src/com/matter/virtual/device/app/DeviceApp.java",
     "java/src/com/matter/virtual/device/app/DeviceAppCallback.java",

--- a/examples/virtual-device-app/android/java/ClusterChangeAttribute.cpp
+++ b/examples/virtual-device-app/android/java/ClusterChangeAttribute.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include "ColorControlManager.h"
 #include "OnOffManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
@@ -38,6 +39,56 @@ static void OnOffClusterAttributeChangeCallback(const app::ConcreteAttributePath
     }
 }
 
+static void ColorControlClusterAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint16_t size,
+                                                       uint8_t * value)
+{
+    if (attributePath.mAttributeId == ColorControl::Attributes::CurrentHue::Id)
+    {
+        uint8_t currentHue = static_cast<uint8_t>(*value);
+
+        ChipLogProgress(Zcl, "Received CurrentHue command endpoint %d value = %d", static_cast<int>(attributePath.mEndpointId),
+                        currentHue);
+
+        ColorControlManager().PostCurrentHueChanged(attributePath.mEndpointId, currentHue);
+    }
+    else if (attributePath.mAttributeId == ColorControl::Attributes::CurrentSaturation::Id)
+    {
+        uint8_t currentSaturation = static_cast<uint8_t>(*value);
+
+        ChipLogProgress(Zcl, "Received CurrentSaturation command endpoint %d value = %d",
+                        static_cast<int>(attributePath.mEndpointId), currentSaturation);
+
+        ColorControlManager().PostCurrentSaturationChanged(attributePath.mEndpointId, currentSaturation);
+    }
+    else if (attributePath.mAttributeId == ColorControl::Attributes::ColorTemperatureMireds::Id)
+    {
+        int16_t colorTemperatureMireds = static_cast<int16_t>(*value);
+
+        ChipLogProgress(Zcl, "Received ColorTemperatureMireds command endpoint %d value = %d",
+                        static_cast<int>(attributePath.mEndpointId), colorTemperatureMireds);
+
+        ColorControlManager().PostColorTemperatureChanged(attributePath.mEndpointId, colorTemperatureMireds);
+    }
+    else if (attributePath.mAttributeId == ColorControl::Attributes::ColorMode::Id)
+    {
+        uint8_t colorMode = static_cast<uint8_t>(*value);
+
+        ChipLogProgress(Zcl, "Received ColorMode command endpoint %d value = %d", static_cast<int>(attributePath.mEndpointId),
+                        colorMode);
+
+        ColorControlManager().PostColorModeChanged(attributePath.mEndpointId, colorMode);
+    }
+    else if (attributePath.mAttributeId == ColorControl::Attributes::EnhancedColorMode::Id)
+    {
+        uint8_t enhancedColorMode = static_cast<uint8_t>(*value);
+
+        ChipLogProgress(Zcl, "Received EnhancedColorMode command endpoint %d value = %d",
+                        static_cast<int>(attributePath.mEndpointId), enhancedColorMode);
+
+        ColorControlManager().PostEnhancedColorModeChanged(attributePath.mEndpointId, enhancedColorMode);
+    }
+}
+
 void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
@@ -48,6 +99,9 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
     {
     case OnOff::Id:
         OnOffClusterAttributeChangeCallback(attributePath, size, value);
+        break;
+    case ColorControl::Id:
+        ColorControlClusterAttributeChangeCallback(attributePath, size, value);
         break;
 
     default:

--- a/examples/virtual-device-app/android/java/ColorControlManager.cpp
+++ b/examples/virtual-device-app/android/java/ColorControlManager.cpp
@@ -1,0 +1,269 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "ColorControlManager.h"
+#include "DeviceApp-JNI.h"
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/util/af.h>
+#include <jni.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+using namespace chip;
+
+static constexpr size_t kColorControlManagerTableSize = EMBER_AF_COLOR_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT;
+
+namespace {
+
+ColorControlManager * gColorControlManagerTable[kColorControlManagerTableSize] = { nullptr };
+static_assert(kColorControlManagerTableSize <= kEmberInvalidEndpointIndex, "gColorControlManagerTable table size error");
+
+} // namespace
+
+void emberAfColorControlClusterInitCallback(EndpointId endpoint)
+{
+    ChipLogProgress(Zcl, "Device App::ColorControl::PostClusterInit");
+    DeviceAppJNIMgr().PostClusterInit(chip::app::Clusters::ColorControl::Id, endpoint);
+}
+
+void ColorControlManager::NewManager(jint endpoint, jobject manager)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::NewManager");
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(static_cast<chip::EndpointId>(endpoint), app::Clusters::ColorControl::Id,
+                                                       EMBER_AF_COLOR_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT);
+    VerifyOrReturn(ep < kColorControlManagerTableSize,
+                   ChipLogError(Zcl, "Device App::ColorControl::NewManager: endpoint %d not found", endpoint));
+
+    VerifyOrReturn(gColorControlManagerTable[ep] == nullptr,
+                   ChipLogError(Zcl, "ST Device App::ColorControl::NewManager: endpoint %d already has a manager", endpoint));
+    ColorControlManager * mgr = new ColorControlManager();
+    CHIP_ERROR err            = mgr->InitializeWithObjects(manager);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "ST Device App::ColorControl::NewManager: failed to initialize manager for endpoint %d", endpoint);
+        delete mgr;
+    }
+    else
+    {
+        gColorControlManagerTable[ep] = mgr;
+    }
+}
+
+static ColorControlManager * GetColorControlManager(EndpointId endpoint)
+{
+    uint16_t ep = emberAfGetClusterServerEndpointIndex(endpoint, app::Clusters::ColorControl::Id,
+                                                       EMBER_AF_COLOR_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT);
+    return (ep >= kColorControlManagerTableSize ? nullptr : gColorControlManagerTable[ep]);
+}
+
+void ColorControlManager::PostCurrentHueChanged(chip::EndpointId endpoint, int value)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::PostCurrentHueChanged");
+    ColorControlManager * mgr = GetColorControlManager(endpoint);
+    VerifyOrReturn(mgr != nullptr, ChipLogError(Zcl, "ColorControlManager null"));
+
+    mgr->HandleCurrentHueChanged(value);
+}
+
+void ColorControlManager::PostCurrentSaturationChanged(chip::EndpointId endpoint, int value)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::PostCurrentSaturationChanged");
+    ColorControlManager * mgr = GetColorControlManager(endpoint);
+    VerifyOrReturn(mgr != nullptr, ChipLogError(Zcl, "ColorControlManager null"));
+
+    mgr->HandleCurrentSaturationChanged(value);
+}
+
+void ColorControlManager::PostColorTemperatureChanged(chip::EndpointId endpoint, int value)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::PostColorTemperatureChanged");
+    ColorControlManager * mgr = GetColorControlManager(endpoint);
+    VerifyOrReturn(mgr != nullptr, ChipLogError(Zcl, "ColorControlManager null"));
+
+    mgr->HandleColorTemperatureChanged(value);
+}
+
+void ColorControlManager::PostColorModeChanged(chip::EndpointId endpoint, int value)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::PostColorModeChanged");
+    ColorControlManager * mgr = GetColorControlManager(endpoint);
+    VerifyOrReturn(mgr != nullptr, ChipLogError(Zcl, "ColorControlManager null"));
+
+    mgr->HandleColorModeChanged(value);
+}
+
+void ColorControlManager::PostEnhancedColorModeChanged(chip::EndpointId endpoint, int value)
+{
+    ChipLogProgress(Zcl, "Device App: ColorControlManager::PostEnhancedColorModeChanged");
+    ColorControlManager * mgr = GetColorControlManager(endpoint);
+    VerifyOrReturn(mgr != nullptr, ChipLogError(Zcl, "ColorControlManager null"));
+
+    mgr->HandleEnhancedColorModeChanged(value);
+}
+
+CHIP_ERROR ColorControlManager::InitializeWithObjects(jobject managerObject)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    mColorControlManagerObject = env->NewGlobalRef(managerObject);
+    VerifyOrReturnLogError(mColorControlManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    jclass ColorControlManagerClass = env->GetObjectClass(managerObject);
+    VerifyOrReturnLogError(ColorControlManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mHandleCurrentHueChangedMethod = env->GetMethodID(ColorControlManagerClass, "HandleCurrentHueChanged", "(I)V");
+    if (mHandleCurrentHueChangedMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access ColorControlManager 'HandleCurrentHueChanged' method");
+        env->ExceptionClear();
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mHandleCurrentSaturationChangedMethod = env->GetMethodID(ColorControlManagerClass, "HandleCurrentSaturationChanged", "(I)V");
+    if (mHandleCurrentSaturationChangedMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access ColorControlManager 'HandleCurrentSaturationChanged' method");
+        env->ExceptionClear();
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mHandleColorTemperatureChangedMethod = env->GetMethodID(ColorControlManagerClass, "HandleColorTemperatureChanged", "(I)V");
+    if (mHandleColorTemperatureChangedMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access ColorControlManager 'HandleColorTemperatureChanged' method");
+        env->ExceptionClear();
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mHandleColorModeChangedMethod = env->GetMethodID(ColorControlManagerClass, "HandleColorModeChanged", "(I)V");
+    if (mHandleColorModeChangedMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access ColorControlManager 'HandleColorModeChanged' method");
+        env->ExceptionClear();
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mHandleEnhancedColorModeChangedMethod = env->GetMethodID(ColorControlManagerClass, "HandleEnhancedColorModeChanged", "(I)V");
+    if (mHandleEnhancedColorModeChangedMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access ColorControlManager 'HandleEnhancedColorModeChanged' method");
+        env->ExceptionClear();
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void ColorControlManager::HandleCurrentHueChanged(int value)
+{
+    ChipLogProgress(Zcl, "ColorControlManager::HandleCurrentHueChanged");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
+    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mHandleCurrentHueChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleCurrentHueChangedMethod null"));
+
+    env->ExceptionClear();
+    env->CallVoidMethod(mColorControlManagerObject, mHandleCurrentHueChangedMethod, value);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in ColorControlManager::HandleCurrentHueChanged");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+}
+
+void ColorControlManager::HandleCurrentSaturationChanged(int value)
+{
+    ChipLogProgress(Zcl, "ColorControlManager::HandleCurrentSaturationChanged");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
+    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mHandleCurrentSaturationChangedMethod != nullptr,
+                   ChipLogProgress(Zcl, "mHandleCurrentSaturationChangedMethod null"));
+
+    env->ExceptionClear();
+    env->CallVoidMethod(mColorControlManagerObject, mHandleCurrentSaturationChangedMethod, value);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in ColorControlManager::HandleCurrentSaturationChanged");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+}
+
+void ColorControlManager::HandleColorTemperatureChanged(int value)
+{
+    ChipLogProgress(Zcl, "ColorControlManager::HandleColorTemperatureChanged");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
+    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mHandleColorTemperatureChangedMethod != nullptr,
+                   ChipLogProgress(Zcl, "mHandleColorTemperatureChangedMethod null"));
+
+    env->ExceptionClear();
+    env->CallVoidMethod(mColorControlManagerObject, mHandleColorTemperatureChangedMethod, value);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in ColorControlManager::mHandleColorTemperatureChanged");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+}
+
+void ColorControlManager::HandleColorModeChanged(int value)
+{
+    ChipLogProgress(Zcl, "ColorControlManager::HandleColorModeChanged");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
+    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mHandleColorModeChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleColorModeChangedMethod null"));
+
+    env->ExceptionClear();
+    env->CallVoidMethod(mColorControlManagerObject, mHandleColorModeChangedMethod, value);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in ColorControlManager::HandleColorModeChanged");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+}
+
+void ColorControlManager::HandleEnhancedColorModeChanged(int value)
+{
+    ChipLogProgress(Zcl, "ColorControlManager::HandleEnhancedColorModeChanged");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
+    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mHandleEnhancedColorModeChangedMethod != nullptr,
+                   ChipLogProgress(Zcl, "mHandleEnhancedColorModeChangedMethod null"));
+
+    env->ExceptionClear();
+    env->CallVoidMethod(mColorControlManagerObject, mHandleEnhancedColorModeChangedMethod, value);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in ColorControlManager::HandleEnhancedColorModeChanged");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+}

--- a/examples/virtual-device-app/android/java/ColorControlManager.h
+++ b/examples/virtual-device-app/android/java/ColorControlManager.h
@@ -1,0 +1,55 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <jni.h>
+
+class ColorControlManager
+{
+public:
+    static void NewManager(jint endpoint, jobject manager);
+
+    static void PostCurrentHueChanged(chip::EndpointId endpoint, int currentHue);
+
+    static void PostCurrentSaturationChanged(chip::EndpointId endpoint, int currentSaturation);
+
+    static void PostColorTemperatureChanged(chip::EndpointId endpoint, int colorTemperature);
+
+    static void PostColorModeChanged(chip::EndpointId endpoint, int colorMode);
+
+    static void PostEnhancedColorModeChanged(chip::EndpointId endpoint, int enhancedColorMode);
+
+    void HandleCurrentHueChanged(int value);
+
+    void HandleCurrentSaturationChanged(int value);
+
+    void HandleColorTemperatureChanged(int value);
+
+    void HandleColorModeChanged(int value);
+
+    void HandleEnhancedColorModeChanged(int value);
+
+private:
+    CHIP_ERROR InitializeWithObjects(jobject managerObject);
+    jobject mColorControlManagerObject              = nullptr;
+    jmethodID mHandleCurrentHueChangedMethod        = nullptr;
+    jmethodID mHandleCurrentSaturationChangedMethod = nullptr;
+    jmethodID mHandleColorTemperatureChangedMethod  = nullptr;
+    jmethodID mHandleColorModeChangedMethod         = nullptr;
+    jmethodID mHandleEnhancedColorModeChangedMethod = nullptr;
+};

--- a/examples/virtual-device-app/android/java/DeviceApp-JNI.cpp
+++ b/examples/virtual-device-app/android/java/DeviceApp-JNI.cpp
@@ -20,6 +20,7 @@
 #include "AppImpl.h"
 #include "JNIDACProvider.h"
 
+#include "ColorControlManager.h"
 #include "OnOffManager.h"
 #include "credentials/DeviceAttestationCredsProvider.h"
 #include <app/app-platform/ContentAppPlatform.h>
@@ -156,4 +157,12 @@ JNI_METHOD(jboolean, setOnOff)(JNIEnv *, jobject, jint endpoint, jboolean value)
 {
     return DeviceLayer::SystemLayer().ScheduleLambda([endpoint, value] { OnOffManager::SetOnOff(endpoint, value); }) ==
         CHIP_NO_ERROR;
+}
+
+/*
+ * Color Control Manager
+ */
+JNI_METHOD(void, setColorControlManager)(JNIEnv *, jobject, jint endpoint, jobject manager)
+{
+    ColorControlManager::NewManager(endpoint, manager);
 }

--- a/examples/virtual-device-app/android/java/src/com/matter/virtual/device/app/ColorControlManager.java
+++ b/examples/virtual-device-app/android/java/src/com/matter/virtual/device/app/ColorControlManager.java
@@ -1,0 +1,18 @@
+package com.matter.virtual.device.app;
+
+public interface ColorControlManager {
+  /*
+   * Set up the initial value when device is powered on
+   */
+  void initAttributeValue(int endpoint);
+
+  void HandleEnhancedColorModeChanged(int value);
+
+  void HandleColorModeChanged(int value);
+
+  void HandleCurrentHueChanged(int value);
+
+  void HandleCurrentSaturationChanged(int value);
+
+  void HandleColorTemperatureChanged(int value);
+}

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -1600,6 +1600,140 @@ server cluster UserLabel = 65 {
   readonly attribute int16u clusterRevision = 65533;
 }
 
+/** Attributes and commands for controlling the color properties of a color-capable light. */
+server cluster ColorControl = 768 {
+  enum ColorLoopAction : ENUM8 {
+    kDeactivate = 0;
+    kActivateFromColorLoopStartEnhancedHue = 1;
+    kActivateFromEnhancedCurrentHue = 2;
+  }
+
+  enum ColorLoopDirection : ENUM8 {
+    kDecrementHue = 0;
+    kIncrementHue = 1;
+  }
+
+  enum ColorMode : ENUM8 {
+    kCurrentHueAndCurrentSaturation = 0;
+    kCurrentXAndCurrentY = 1;
+    kColorTemperature = 2;
+  }
+
+  enum HueDirection : ENUM8 {
+    kShortestDistance = 0;
+    kLongestDistance = 1;
+    kUp = 2;
+    kDown = 3;
+  }
+
+  enum HueMoveMode : ENUM8 {
+    kStop = 0;
+    kUp = 1;
+    kDown = 3;
+  }
+
+  enum HueStepMode : ENUM8 {
+    kUp = 1;
+    kDown = 3;
+  }
+
+  enum SaturationMoveMode : ENUM8 {
+    kStop = 0;
+    kUp = 1;
+    kDown = 3;
+  }
+
+  enum SaturationStepMode : ENUM8 {
+    kUp = 1;
+    kDown = 3;
+  }
+
+  bitmap ColorCapabilities : BITMAP16 {
+    kHueSaturationSupported = 0x1;
+    kEnhancedHueSupported = 0x2;
+    kColorLoopSupported = 0x4;
+    kXYAttributesSupported = 0x8;
+    kColorTemperatureSupported = 0x10;
+  }
+
+  bitmap ColorLoopUpdateFlags : BITMAP8 {
+    kUpdateAction = 0x1;
+    kUpdateDirection = 0x2;
+    kUpdateTime = 0x4;
+    kUpdateStartHue = 0x8;
+  }
+
+  bitmap Feature : BITMAP32 {
+    kHueAndSaturation = 0x1;
+    kEnhancedHue = 0x2;
+    kColorLoop = 0x4;
+    kXY = 0x8;
+    kColorTemperature = 0x10;
+  }
+
+  readonly attribute int8u currentHue = 0;
+  readonly attribute int8u currentSaturation = 1;
+  readonly attribute int16u remainingTime = 2;
+  readonly attribute int16u currentX = 3;
+  readonly attribute int16u currentY = 4;
+  readonly attribute int16u colorTemperatureMireds = 7;
+  readonly attribute enum8 colorMode = 8;
+  attribute bitmap8 options = 15;
+  readonly attribute nullable int8u numberOfPrimaries = 16;
+  readonly attribute enum8 enhancedColorMode = 16385;
+  readonly attribute bitmap16 colorCapabilities = 16394;
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute event_id eventList[] = 65530;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+
+  request struct MoveToHueRequest {
+    INT8U hue = 0;
+    HueDirection direction = 1;
+    INT16U transitionTime = 2;
+    BITMAP8 optionsMask = 3;
+    BITMAP8 optionsOverride = 4;
+  }
+
+  request struct MoveToSaturationRequest {
+    INT8U saturation = 0;
+    INT16U transitionTime = 1;
+    BITMAP8 optionsMask = 2;
+    BITMAP8 optionsOverride = 3;
+  }
+
+  request struct MoveToHueAndSaturationRequest {
+    INT8U hue = 0;
+    INT8U saturation = 1;
+    INT16U transitionTime = 2;
+    BITMAP8 optionsMask = 3;
+    BITMAP8 optionsOverride = 4;
+  }
+
+  request struct MoveToColorRequest {
+    INT16U colorX = 0;
+    INT16U colorY = 1;
+    INT16U transitionTime = 2;
+    BITMAP8 optionsMask = 3;
+    BITMAP8 optionsOverride = 4;
+  }
+
+  request struct MoveToColorTemperatureRequest {
+    INT16U colorTemperatureMireds = 0;
+    INT16U transitionTime = 1;
+    BITMAP8 optionsMask = 2;
+    BITMAP8 optionsOverride = 3;
+  }
+
+  command MoveToHue(MoveToHueRequest): DefaultSuccess = 0;
+  command MoveToSaturation(MoveToSaturationRequest): DefaultSuccess = 3;
+  command MoveToHueAndSaturation(MoveToHueAndSaturationRequest): DefaultSuccess = 6;
+  command MoveToColor(MoveToColorRequest): DefaultSuccess = 7;
+  command MoveToColorTemperature(MoveToColorTemperatureRequest): DefaultSuccess = 10;
+}
+
 endpoint 0 {
   device type ma_rootdevice = 22, version 1;
 
@@ -1936,6 +2070,26 @@ endpoint 1 {
     callback attribute partsList;
     ram      attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
+  }
+
+  server cluster ColorControl {
+    ram      attribute currentHue default = 0x00;
+    ram      attribute currentSaturation default = 0x00;
+    ram      attribute remainingTime default = 0x0000;
+    ram      attribute currentX default = 0x616B;
+    ram      attribute currentY default = 0x607D;
+    ram      attribute colorTemperatureMireds default = 0x00FA;
+    ram      attribute colorMode default = 0x01;
+    ram      attribute options default = 0x00;
+    ram      attribute numberOfPrimaries;
+    ram      attribute enhancedColorMode default = 0x01;
+    ram      attribute colorCapabilities default = 0x0000;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
+    ram      attribute featureMap default = 1;
+    ram      attribute clusterRevision default = 5;
   }
 }
 

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
@@ -33,7 +33,33 @@
   ],
   "endpointTypes": [
     {
+      "id": 1,
       "name": "MA-rootdevice",
+      "deviceTypeRef": {
+        "id": 2,
+        "code": 22,
+        "profileId": 259,
+        "label": "MA-rootdevice",
+        "name": "MA-rootdevice"
+      },
+      "deviceTypes": [
+        {
+          "id": 2,
+          "code": 22,
+          "profileId": 259,
+          "label": "MA-rootdevice",
+          "name": "MA-rootdevice"
+        }
+      ],
+      "deviceTypeRefs": [
+        2
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        22
+      ],
       "deviceTypeName": "MA-rootdevice",
       "deviceTypeCode": 22,
       "deviceTypeProfileId": 259,
@@ -7003,7 +7029,33 @@
       ]
     },
     {
+      "id": 2,
       "name": "MA-videoplayer",
+      "deviceTypeRef": {
+        "id": 8,
+        "code": 256,
+        "profileId": 259,
+        "label": "MA-onofflight",
+        "name": "MA-onofflight"
+      },
+      "deviceTypes": [
+        {
+          "id": 8,
+          "code": 256,
+          "profileId": 259,
+          "label": "MA-onofflight",
+          "name": "MA-onofflight"
+        }
+      ],
+      "deviceTypeRefs": [
+        8
+      ],
+      "deviceVersions": [
+        1
+      ],
+      "deviceIdentifiers": [
+        256
+      ],
       "deviceTypeName": "MA-onofflight",
       "deviceTypeCode": 256,
       "deviceTypeProfileId": 259,
@@ -12017,11 +12069,43 @@
               "outgoing": 0
             },
             {
+              "name": "MoveHue",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 0
+            },
+            {
+              "name": "StepHue",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 0
+            },
+            {
               "name": "MoveToSaturation",
               "code": 3,
               "mfgCode": null,
               "source": "client",
               "incoming": 1,
+              "outgoing": 0
+            },
+            {
+              "name": "MoveSaturation",
+              "code": 4,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 0
+            },
+            {
+              "name": "StepSaturation",
+              "code": 5,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
               "outgoing": 0
             },
             {
@@ -12046,6 +12130,14 @@
               "mfgCode": null,
               "source": "client",
               "incoming": 1,
+              "outgoing": 0
+            },
+            {
+              "name": "MoveColorTemperature",
+              "code": 75,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
               "outgoing": 0
             }
           ],
@@ -12090,7 +12182,7 @@
           "mfgCode": null,
           "define": "COLOR_CONTROL_CLUSTER",
           "side": "server",
-          "enabled": 0,
+          "enabled": 1,
           "attributes": [
             {
               "name": "CurrentHue",
@@ -12948,6 +13040,22 @@
               "type": "array",
               "included": 1,
               "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -15623,18 +15731,14 @@
       "endpointTypeIndex": 0,
       "profileId": 259,
       "endpointId": 0,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "networkId": 0
     },
     {
       "endpointTypeName": "MA-videoplayer",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
-      "networkId": 0,
-      "endpointVersion": 1,
-      "deviceIdentifier": 256
+      "networkId": 0
     }
   ],
   "log": []


### PR DESCRIPTION
### Problem
- For the Android App server developer

### Change overview
- Add ColorControlManager module to support Color Control Cluster

### Testing
- 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
- Excute Android studio and make project virtual-device-app on /examples
- Install apk file on Android phone such as Galaxy and Pixel
- SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation