### PR TITLE
inet: ScopedLwIPLock for better safety and added locks at necessary places

### DIFF
--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -178,12 +178,15 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
     }
 
+    CHIP_ERROR res = CHIP_NO_ERROR;
+    err_t lwipErr  = ERR_VAL;
+
     // Adding a scope here to unlock the LwIP core when the lock is no longer required.
     {
         ScopedLwIPLock lwipLock;
 
         // Make sure we have the appropriate type of PCB based on the destination address.
-        CHIP_ERROR res = GetPCB(destAddr.Type());
+        res = GetPCB(destAddr.Type());
         if (res != CHIP_NO_ERROR)
         {
             return res;
@@ -195,7 +198,6 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
         // If a source address has been specified, temporarily override the local_ip of the PCB.
         // This results in LwIP using the given address being as the source address for the generated
         // packet, as if the PCB had been bound to that address.
-        err_t lwipErr              = ERR_VAL;
         const IPAddress & srcAddr  = pktInfo->SrcAddress;
         const uint16_t & destPort  = pktInfo->DestPort;
         const InterfaceId & intfId = pktInfo->Interface;

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -40,7 +40,6 @@
 #include <lwip/udp.h>
 
 static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
-static_assert(LWIP_TCPIP_CORE_LOCKING, "CHIP requires config LWIP_TCPIP_CORE_LOCKING enabled");
 
 #if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
     !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)


### PR DESCRIPTION
Related: https://github.com/project-chip/connectedhomeip/issues/28590

Almost every platform other than ESP32 enables the config `LWIP_TCPIP_CORE_LOCKING` which ensures that the thread safety in the LwIP.

I enabled the same option on ESP32 platform along with one more, [`CONFIG_LWIP_CHECK_THREAD_SAFETY=y`](https://github.com/espressif/esp-idf/blob/master/components/lwip/Kconfig#L29-L36) which asserts when LwIP code runs from non-LwIP task and added the lock/unlock which were missing in following APIs:
- GetBoundInterface()
- IPv4JoinLeaveMulticastGroupImpl()
- IPv6JoinLeaveMulticastGroupImpl()

Added the RAII locking for LwIP core.

#### How was this tested
- Enabled the configs `LWIP_TCPIP_CORE_LOCKING` and `CONFIG_LWIP_CHECK_THREAD_SAFETY` for ESP32C3.
- Server side: `lighting-app/esp32` and verified commissioning/cluster-control, read/write/wildcard-subscribe works.
- Client side: `light-switch-app/esp32` and verified commissioning, read/write/wildcard-subscribe works.
- Installed the access control on server and bindings on client and verified those bits works as expected.

NOTE: I had to add lock in [`esp_route_hook_init()`](https://github.com/project-chip/connectedhomeip/blob/master/src/platform/ESP32/route_hook/ESP32RouteHook.c#L150) which consumes LwIP APIs.

Follow up PR: Default the `LWIP_TCPIP_CORE_LOCKING` and `CONFIG_LWIP_CHECK_THREAD_SAFETY` on ESP32.