### PR TITLE
[ReadHandler] Unification of serial "now" timestamp

### DIFF
--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -141,9 +141,9 @@ public:
     bool IsReportableNow(ReadHandler * aReadHandler)
     {
         // Update the now timestamp to ensure external calls to IsReportableNow are always comparing to the current time
-        mNow                   = mTimerDelegate->GetCurrentMonotonicTimestamp();
+        Timestamp now          = mTimerDelegate->GetCurrentMonotonicTimestamp();
         ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);
-        return (nullptr != node) ? node->IsReportableNow(mNow) : false;
+        return (nullptr != node) ? node->IsReportableNow(now) : false;
     }
 
     /// @brief Check if a ReadHandler is reportable without considering the timing
@@ -190,11 +190,6 @@ protected:
 
     ObjectPool<ReadHandlerNode, CHIP_IM_MAX_NUM_READS + CHIP_IM_MAX_NUM_SUBSCRIPTIONS> mNodesPool;
     TimerDelegate * mTimerDelegate;
-
-    // This represents the current time to be used for scheduling the next report, or to compare against Timestamps to determine
-    // reportability based on time. This timestamp needs to be updated upon each callback that will do scheduling or check the
-    // reportability state.
-    Timestamp mNow = System::Clock::Milliseconds64(0);
 };
 }; // namespace reporting
 }; // namespace app

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -87,7 +87,7 @@ public:
         void SetEngineRunScheduled(bool aEngineRunScheduled) { mEngineRunScheduled = aEngineRunScheduled; }
 
         /// @brief Set the interval timestamps for the node based on the read handler reporting intervals
-        /// @param aReadHandler
+        /// @param aReadHandler read handler to get the intervals from
         /// @param now current time to calculate the mMin and mMax timestamps, user must ensure to provide a valid time for this to
         /// be reliable
         void SetIntervalTimeStamps(ReadHandler * aReadHandler, const Timestamp & now)

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -63,7 +63,6 @@ void ReportSchedulerImpl::OnSubscriptionEstablished(ReadHandler * aReadHandler)
     // Handler must not be registered yet; it's just being constructed.
     VerifyOrDie(nullptr == newNode);
 
-    // Update the now timestamp to the current time to determine the min and max timestamps
     Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
     // The NodePool is the same size as the ReadHandler pool from the IM Engine, so we don't need a check for size here since if a
@@ -82,7 +81,6 @@ void ReportSchedulerImpl::OnBecameReportable(ReadHandler * aReadHandler)
     ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);
     VerifyOrReturn(nullptr != node);
 
-    // Update the now timestamp to the current time to calculate the next report timeout
     Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
     Milliseconds32 newTimeout;
@@ -95,7 +93,6 @@ void ReportSchedulerImpl::OnSubscriptionReportSent(ReadHandler * aReadHandler)
     ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);
     VerifyOrReturn(nullptr != node);
 
-    // Update the now timestamp to the current time to update the node's interval timestamps and calculate the next report timeout
     Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
     node->SetIntervalTimeStamps(aReadHandler, now);

--- a/src/app/reporting/ReportSchedulerImpl.h
+++ b/src/app/reporting/ReportSchedulerImpl.h
@@ -46,14 +46,14 @@ public:
     void ReportTimerCallback() override;
 
 protected:
-    virtual CHIP_ERROR ScheduleReport(Timeout timeout, ReadHandlerNode * node);
+    virtual CHIP_ERROR ScheduleReport(Timeout timeout, ReadHandlerNode * node, const Timestamp & now);
     void CancelReport(ReadHandler * aReadHandler);
     virtual void UnregisterAllHandlers();
 
 private:
     friend class chip::app::reporting::TestReportScheduler;
 
-    virtual CHIP_ERROR CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aNode);
+    virtual CHIP_ERROR CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aNode, const Timestamp & now);
 };
 
 } // namespace reporting

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -44,7 +44,7 @@ void SynchronizedReportSchedulerImpl::OnReadHandlerDestroyed(ReadHandler * aRead
     }
 }
 
-CHIP_ERROR SynchronizedReportSchedulerImpl::ScheduleReport(Timeout timeout, ReadHandlerNode * node)
+CHIP_ERROR SynchronizedReportSchedulerImpl::ScheduleReport(Timeout timeout, ReadHandlerNode * node, const Timestamp & now)
 {
     // Cancel Report if it is currently scheduled
     mTimerDelegate->CancelTimer(this);
@@ -54,7 +54,7 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::ScheduleReport(Timeout timeout, Read
         return CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(mTimerDelegate->StartTimer(this, timeout));
-    mTestNextReportTimestamp = mNow + timeout;
+    mTestNextReportTimestamp = now + timeout;
 
     return CHIP_NO_ERROR;
 }
@@ -73,13 +73,13 @@ bool SynchronizedReportSchedulerImpl::IsReportScheduled()
 
 /// @brief Find the smallest maximum interval possible and set it as the common maximum
 /// @return NO_ERROR if the smallest maximum interval was found, error otherwise, INVALID LIST LENGTH if the list is empty
-CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMaxInterval()
+CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMaxInterval(const Timestamp & now)
 {
     VerifyOrReturnError(mNodesPool.Allocated(), CHIP_ERROR_INVALID_LIST_LENGTH);
-    System::Clock::Timestamp earliest = mNow + Seconds16::max();
+    System::Clock::Timestamp earliest = now + Seconds16::max();
 
-    mNodesPool.ForEachActiveObject([&earliest, this](ReadHandlerNode * node) {
-        if (node->GetMaxTimestamp() < earliest && node->GetMaxTimestamp() > this->mNow)
+    mNodesPool.ForEachActiveObject([&earliest, now](ReadHandlerNode * node) {
+        if (node->GetMaxTimestamp() < earliest && node->GetMaxTimestamp() > now)
         {
             earliest = node->GetMaxTimestamp();
         }
@@ -96,10 +96,10 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMaxInterval()
 /// minimum. If the max timestamp has not been updated and is in the past, or if no min timestamp is lower than the current max
 /// timestamp, this will set now as the common minimum timestamp, thus allowing the report to be sent immediately.
 /// @return NO_ERROR if the highest minimum timestamp was found, error otherwise, INVALID LIST LENGTH if the list is empty
-CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMinInterval()
+CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMinInterval(const Timestamp & now)
 {
     VerifyOrReturnError(mNodesPool.Allocated(), CHIP_ERROR_INVALID_LIST_LENGTH);
-    System::Clock::Timestamp latest = mNow;
+    System::Clock::Timestamp latest = now;
 
     mNodesPool.ForEachActiveObject([&latest, this](ReadHandlerNode * node) {
         if (node->GetMinTimestamp() > latest && this->IsReadHandlerReportable(node->GetReadHandler()) &&
@@ -117,18 +117,19 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMinInterval()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aNode)
+CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aNode,
+                                                                       const Timestamp & now)
 {
     VerifyOrReturnError(nullptr != FindReadHandlerNode(aNode->GetReadHandler()), CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorOnFailure(FindNextMaxInterval());
-    ReturnErrorOnFailure(FindNextMinInterval());
+    ReturnErrorOnFailure(FindNextMaxInterval(now));
+    ReturnErrorOnFailure(FindNextMinInterval(now));
     bool reportableNow   = false;
     bool reportableAtMin = false;
 
-    mNodesPool.ForEachActiveObject([&reportableNow, &reportableAtMin, this](ReadHandlerNode * node) {
+    mNodesPool.ForEachActiveObject([&reportableNow, &reportableAtMin, this, now](ReadHandlerNode * node) {
         if (!node->IsEngineRunScheduled())
         {
-            if (node->IsReportableNow(mNow))
+            if (node->IsReportableNow(now))
             {
                 reportableNow = true;
                 return Loop::Break;
@@ -151,21 +152,21 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout &
     }
     else if (reportableAtMin)
     {
-        timeout = mNextMinTimestamp - mNow;
+        timeout = mNextMinTimestamp - now;
     }
     else
     {
         // Schedule report at next max otherwise
-        timeout = mNextMaxTimestamp - mNow;
+        timeout = mNextMaxTimestamp - now;
     }
 
     // Updates the synching time of each handler
-    mNodesPool.ForEachActiveObject([this, timeout](ReadHandlerNode * node) {
+    mNodesPool.ForEachActiveObject([now, timeout](ReadHandlerNode * node) {
         // Prevent modifying the sync if the handler is currently reportable, sync's purpose is to allow handler to become
         // reportable earlier than their max interval
-        if (!node->IsReportableNow(this->mNow))
+        if (!node->IsReportableNow(now))
         {
-            node->SetSyncTimestamp(Milliseconds64(this->mNow + timeout));
+            node->SetSyncTimestamp(Milliseconds64(now + timeout));
         }
 
         return Loop::Continue;
@@ -179,12 +180,12 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout &
 void SynchronizedReportSchedulerImpl::TimerFired()
 {
     // Update the current time to validate reportability upon current time
-    mNow = mTimerDelegate->GetCurrentMonotonicTimestamp();
+    Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
 
-    mNodesPool.ForEachActiveObject([this](ReadHandlerNode * node) {
-        if (node->IsReportableNow(this->mNow))
+    mNodesPool.ForEachActiveObject([now](ReadHandlerNode * node) {
+        if (node->IsReportableNow(now))
         {
             node->SetEngineRunScheduled(true);
             ChipLogProgress(DataManagement, "Handler: %p with min: %" PRIu64 " and max: %" PRIu64 " and sync: %" PRIu64, (node),

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -179,7 +179,6 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout &
 /// the engine already verifies that read handlers are reportable before sending a report
 void SynchronizedReportSchedulerImpl::TimerFired()
 {
-    // Update the current time to validate reportability upon current time
     Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -43,15 +43,15 @@ public:
     void TimerFired() override;
 
 protected:
-    CHIP_ERROR ScheduleReport(System::Clock::Timeout timeout, ReadHandlerNode * node) override;
+    CHIP_ERROR ScheduleReport(System::Clock::Timeout timeout, ReadHandlerNode * node, const Timestamp & now) override;
     void CancelReport();
 
 private:
     friend class chip::app::reporting::TestReportScheduler;
 
-    CHIP_ERROR FindNextMinInterval();
-    CHIP_ERROR FindNextMaxInterval();
-    CHIP_ERROR CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aReadHandlerNode) override;
+    CHIP_ERROR FindNextMinInterval(const Timestamp & now);
+    CHIP_ERROR FindNextMaxInterval(const Timestamp & now);
+    CHIP_ERROR CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aReadHandlerNode, const Timestamp & now) override;
 
     Timestamp mNextMaxTimestamp = Milliseconds64(0);
     Timestamp mNextMinTimestamp = Milliseconds64(0);


### PR DESCRIPTION
Centralized the "now" timestamp used to schedule reports and validate reportability to a value held in the Report Scheduler that is called at start of each callbacks needing to schedule reports or assess reportability.

