### PR TITLE
Linux tv-casting-app: refactored Initialization

### DIFF
--- a/examples/tv-casting-app/linux/BUILD.gn
+++ b/examples/tv-casting-app/linux/BUILD.gn
@@ -19,13 +19,24 @@ import("${chip_root}/src/lib/lib.gni")
 
 assert(chip_build_tools)
 
+declare_args() {
+  chip_casting_simplified = false
+}
+
 executable("chip-tv-casting-app") {
-  sources = [
-    "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
-    "CastingUtils.cpp",
-    "CastingUtils.h",
-    "main.cpp",
-  ]
+  if (chip_casting_simplified) {
+    sources = [
+      "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
+      "simple-app.cpp",
+    ]
+  } else {
+    sources = [
+      "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
+      "CastingUtils.cpp",
+      "CastingUtils.h",
+      "main.cpp",
+    ]
+  }
 
   deps = [
     "${chip_root}/examples/common/tracing:commandline",

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -29,7 +29,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
-using namespace matter::casting::app;
+using namespace matter::casting::core;
 using namespace matter::casting::support;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
@@ -51,7 +51,7 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
 
         ChipLogError(Support,
                      "*** WARNING: Using temporary passcode %u due to no neither --passcode or --spake2p-verifier-base64 "
-                     "given on command line. This is temporary and will disappear. Please update your scripts "
+                     "given on command line. This is temporary and will be deprecated. Please update your scripts "
                      "to explicitly configure onboarding credentials. ***",
                      static_cast<unsigned>(defaultTestPasscode));
         setupPasscode.SetValue(defaultTestPasscode);
@@ -149,5 +149,6 @@ int main(int argc, char * argv[])
                         ChipLogError(AppServer, "CastingApp::Start failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+
     return 0;
 }

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -1,0 +1,153 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "core/Types.h"
+
+#include <LinuxCommissionableDataProvider.h>
+#include <Options.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
+#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/TestOnlyCommissionableDataProvider.h>
+
+using namespace matter::casting::app;
+using namespace matter::casting::support;
+
+// To hold SPAKE2+ verifier, discriminator, passcode
+LinuxCommissionableDataProvider gCommissionableDataProvider;
+
+CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, LinuxDeviceOptions & options)
+{
+    chip::Optional<uint32_t> setupPasscode;
+
+    if (options.payload.setUpPINCode != 0)
+    {
+        setupPasscode.SetValue(options.payload.setUpPINCode);
+    }
+    else if (!options.spake2pVerifier.HasValue())
+    {
+        uint32_t defaultTestPasscode = 0;
+        chip::DeviceLayer::TestOnlyCommissionableDataProvider TestOnlyCommissionableDataProvider;
+        VerifyOrDie(TestOnlyCommissionableDataProvider.GetSetupPasscode(defaultTestPasscode) == CHIP_NO_ERROR);
+
+        ChipLogError(Support,
+                     "*** WARNING: Using temporary passcode %u due to no neither --passcode or --spake2p-verifier-base64 "
+                     "given on command line. This is temporary and will disappear. Please update your scripts "
+                     "to explicitly configure onboarding credentials. ***",
+                     static_cast<unsigned>(defaultTestPasscode));
+        setupPasscode.SetValue(defaultTestPasscode);
+        options.payload.setUpPINCode = defaultTestPasscode;
+    }
+    else
+    {
+        // Passcode is 0, so will be ignored, and verifier will take over. Onboarding payload
+        // printed for debug will be invalid, but if the onboarding payload had been given
+        // properly to the commissioner later, PASE will succeed.
+    }
+
+    // Default to minimum PBKDF iterations
+    uint32_t spake2pIterationCount = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
+    if (options.spake2pIterations != 0)
+    {
+        spake2pIterationCount = options.spake2pIterations;
+    }
+    ChipLogError(Support, "PASE PBKDF iterations set to %u", static_cast<unsigned>(spake2pIterationCount));
+
+    return provider.Init(options.spake2pVerifier, options.spake2pSalt, spake2pIterationCount, setupPasscode,
+                         options.payload.discriminator.GetLongValue());
+}
+
+/**
+ * @brief Provides the unique ID that is used by the SDK to generate the Rotating Device ID.
+ */
+class RotatingDeviceIdUniqueIdProvider : public MutableByteSpanDataProvider
+{
+private:
+    chip::MutableByteSpan rotatingDeviceIdUniqueIdSpan;
+    uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+
+public:
+    RotatingDeviceIdUniqueIdProvider()
+    {
+        // generate a random Unique ID for this example app
+        for (size_t i = 0; i < sizeof(rotatingDeviceIdUniqueId); i++)
+        {
+            rotatingDeviceIdUniqueId[i] = chip::Crypto::GetRandU8();
+        }
+        rotatingDeviceIdUniqueIdSpan = chip::MutableByteSpan(rotatingDeviceIdUniqueId);
+    }
+
+    chip::MutableByteSpan * Get() { return &rotatingDeviceIdUniqueIdSpan; }
+};
+
+/**
+ * @brief Provides the ServerInitParams required to start the CastingApp, which in turn starts the Matter server
+ */
+class CommonCaseDeviceServerInitParamsProvider : public ServerInitParamsProvider
+{
+private:
+    // For this example, we'll use CommonCaseDeviceServerInitParams
+    chip::CommonCaseDeviceServerInitParams serverInitParams;
+
+public:
+    chip::ServerInitParams * Get()
+    {
+        CHIP_ERROR err = serverInitParams.InitializeStaticResourcesBeforeServerInit();
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
+                            ChipLogError(AppServer, "Initialization of ServerInitParams failed %" CHIP_ERROR_FORMAT, err.Format()));
+        return &serverInitParams;
+    }
+};
+
+int main(int argc, char * argv[])
+{
+    // Create AppParameters that need to be passed to CastingApp.Initialize()
+    AppParameters appParameters;
+    RotatingDeviceIdUniqueIdProvider rotatingDeviceIdUniqueIdProvider;
+    CommonCaseDeviceServerInitParamsProvider serverInitParamsProvider;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    err            = InitCommissionableDataProvider(gCommissionableDataProvider, LinuxDeviceOptions::GetInstance());
+    VerifyOrReturnValue(
+        err == CHIP_NO_ERROR, 0,
+        ChipLogError(AppServer, "Initialization of CommissionableDataProvider failed %" CHIP_ERROR_FORMAT, err.Format()));
+    err = appParameters.Create(&rotatingDeviceIdUniqueIdProvider, &gCommissionableDataProvider,
+                               chip::Credentials::Examples::GetExampleDACProvider(),
+                               GetDefaultDACVerifier(chip::Credentials::GetTestAttestationTrustStore()), &serverInitParamsProvider);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, 0,
+                        ChipLogError(AppServer, "Creation of AppParameters failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    // Initialize the CastingApp
+    err = CastingApp::GetInstance()->Initialize(appParameters);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, 0,
+                        ChipLogError(AppServer, "Initialization of CastingApp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    // Initialize Linux KeyValueStoreMgr
+    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
+
+    // Start the CastingApp
+    err = CastingApp::GetInstance()->Start();
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, 0,
+                        ChipLogError(AppServer, "CastingApp::Start failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    return 0;
+}

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -85,6 +85,15 @@ chip_data_model("tv-casting-common") {
     "src/TargetVideoPlayerInfo.cpp",
   ]
 
+  # Add simplified casting API files here
+  sources += [
+    "core/CastingApp.cpp",
+    "core/CastingApp.h",
+    "core/Types.h",
+    "support/AppParameters.h",
+    "support/DataProvider.h",
+  ]
+
   deps = [
     "${chip_root}/examples/common/tracing:commandline",
     "${chip_root}/src/app/tests/suites/commands/interaction_model",

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -1,0 +1,119 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CastingApp.h"
+
+#include <app/clusters/bindings/BindingManager.h>
+#include <app/server/Server.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+
+namespace matter {
+namespace casting {
+namespace app {
+
+using namespace matter::casting::support;
+
+CastingApp * CastingApp::castingApp_ = nullptr;
+
+CastingApp::CastingApp() {}
+
+CastingApp * CastingApp::GetInstance()
+{
+    if (castingApp_ == nullptr)
+    {
+        castingApp_ = new CastingApp();
+    }
+    return castingApp_;
+}
+
+CHIP_ERROR CastingApp::Initialize(const AppParameters & appParameters)
+{
+    VerifyOrReturnError(mState == UNINITIALIZED, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(appParameters.GetCommissionableDataProvider() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(appParameters.GetDeviceAttestationCredentialsProvider() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(appParameters.GetServerInitParamsProvider() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mAppParameters = &appParameters;
+
+    ReturnErrorOnFailure(chip::Platform::MemoryInit());
+    ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgr().InitChipStack());
+
+    chip::DeviceLayer::SetCommissionableDataProvider(appParameters.GetCommissionableDataProvider());
+    chip::Credentials::SetDeviceAttestationCredentialsProvider(appParameters.GetDeviceAttestationCredentialsProvider());
+    chip::Credentials::SetDeviceAttestationVerifier(appParameters.GetDeviceAttestationVerifier());
+
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    MutableByteSpanDataProvider * uniqueIdProvider = appParameters.GetRotatingDeviceIdUniqueIdProvider();
+    if (uniqueIdProvider != nullptr && uniqueIdProvider->Get() != nullptr)
+    {
+        ReturnErrorOnFailure(chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(*uniqueIdProvider->Get()));
+    }
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
+
+    mState = NOT_RUNNING; // initialization done, set state to NOT_RUNNING
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CastingApp::Start()
+{
+    VerifyOrReturnError(mState == NOT_RUNNING, CHIP_ERROR_INCORRECT_STATE);
+    auto & server = chip::Server::GetInstance();
+
+    // start Matter server
+    chip::ServerInitParams * serverInitParams = mAppParameters->GetServerInitParamsProvider()->Get();
+    VerifyOrReturnError(serverInitParams != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(server.Init(*serverInitParams));
+
+    // TBD: Set CastingApp as AppDelegate
+    // &server.GetCommissioningWindowManager().SetAppDelegate(??);
+
+    // Initialize binding handlers
+    chip::BindingManager::GetInstance().Init(
+        { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
+
+    // TBD: Set FabricDelegate
+    // chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&mPersistenceManager);
+
+    // TBD: Add DeviceEvent Handler
+    // ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(DeviceEventCallback, 0));
+
+    mState = RUNNING; // CastingApp started successfully, set state to RUNNING
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CastingApp::Stop()
+{
+    VerifyOrReturnError(mState == RUNNING, CHIP_ERROR_INCORRECT_STATE);
+
+    // TBD: add logic to capture CastingPlayers that we are currently connected to, so we can automatically reconnect with them on
+    // Start() again
+
+    // Shutdown the Matter server
+    chip::Server::GetInstance().Shutdown();
+
+    mState = NOT_RUNNING; // CastingApp started successfully, set state to RUNNING
+
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+}; // namespace app
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
@@ -1,0 +1,83 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "support/AppParameters.h"
+
+namespace matter {
+namespace casting {
+namespace app {
+
+/**
+ * @brief Represents CastingApp state.
+ *
+ */
+enum CastingAppState
+{
+    UNINITIALIZED, // Before Initialize() success
+    NOT_RUNNING,   // After Initialize() success before Start()ing, OR After stop() success
+    RUNNING,       // After Start() success
+};
+
+/**
+ * @brief CastingApp represents an app that can cast content to a Casting Player.
+ * This class is a singleton.
+ */
+class CastingApp
+{
+private:
+    CastingApp();
+
+    CastingApp(CastingApp & other) = delete;
+    void operator=(const CastingApp &) = delete;
+
+    const matter::casting::support::AppParameters * mAppParameters;
+
+    CastingAppState mState = UNINITIALIZED;
+
+public:
+    static CastingApp * castingApp_;
+    static CastingApp * GetInstance();
+
+    /**
+     * @brief Initializes the CastingApp with appParameters
+     *
+     * @param appParameters
+     * @return CHIP_ERROR
+     */
+    CHIP_ERROR Initialize(const matter::casting::support::AppParameters & appParameters);
+
+    /**
+     * @brief Starts the Matter server that the CastingApp runs on
+     *
+     * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server started successfully, specific error code otherwise.
+     */
+    CHIP_ERROR Start();
+
+    /**
+     * @brief Stops the Matter server that the CastingApp runs on
+     *
+     * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server stopped successfully, specific error code otherwise.
+     */
+    CHIP_ERROR Stop();
+};
+
+}; // namespace app
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
@@ -22,7 +22,7 @@
 
 namespace matter {
 namespace casting {
-namespace app {
+namespace core {
 
 /**
  * @brief Represents CastingApp state.
@@ -41,18 +41,7 @@ enum CastingAppState
  */
 class CastingApp
 {
-private:
-    CastingApp();
-
-    CastingApp(CastingApp & other) = delete;
-    void operator=(const CastingApp &) = delete;
-
-    const matter::casting::support::AppParameters * mAppParameters;
-
-    CastingAppState mState = UNINITIALIZED;
-
 public:
-    static CastingApp * castingApp_;
     static CastingApp * GetInstance();
 
     /**
@@ -64,11 +53,19 @@ public:
     CHIP_ERROR Initialize(const matter::casting::support::AppParameters & appParameters);
 
     /**
-     * @brief Starts the Matter server that the CastingApp runs on
+     * @brief Starts the Matter server that the CastingApp runs on and calls PostStartRegistrations() to finish starting up the
+     * CastingApp.
      *
      * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server started successfully, specific error code otherwise.
      */
     CHIP_ERROR Start();
+
+    /**
+     * @brief Perform post Matter server startup registrations
+     *
+     * @return CHIP_ERROR  - CHIP_NO_ERROR if all registrations succeeded, specific error code otherwise
+     */
+    CHIP_ERROR PostStartRegistrations();
 
     /**
      * @brief Stops the Matter server that the CastingApp runs on
@@ -76,8 +73,19 @@ public:
      * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server stopped successfully, specific error code otherwise.
      */
     CHIP_ERROR Stop();
+
+private:
+    CastingApp();
+    static CastingApp * _castingApp;
+
+    CastingApp(CastingApp & other) = delete;
+    void operator=(const CastingApp &) = delete;
+
+    const matter::casting::support::AppParameters * mAppParameters;
+
+    CastingAppState mState = UNINITIALIZED;
 };
 
-}; // namespace app
+}; // namespace core
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/Types.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Types.h
@@ -47,8 +47,7 @@ namespace support {
 
 class AppParameters;
 class ByteSpanDataProvider;
-class CommissionableDataProviderImpl;
-class DeviceAttestationCredentialsProviderImpl;
+class ServerInitParamsProvider;
 
 } // namespace support
 

--- a/examples/tv-casting-app/tv-casting-common/core/Types.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Types.h
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "core/CastingApp.h"
+#include "support/AppParameters.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace matter {
+namespace casting {
+
+namespace memory {
+
+template <typename T>
+using Weak = std::weak_ptr<T>;
+
+template <typename T>
+using Strong = std::shared_ptr<T>;
+
+} // namespace memory
+
+namespace app {
+
+class CastingApp;
+
+};
+
+namespace support {
+
+class AppParameters;
+class ByteSpanDataProvider;
+class CommissionableDataProviderImpl;
+class DeviceAttestationCredentialsProviderImpl;
+
+} // namespace support
+
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
+++ b/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "DataProvider.h"
+#include "core/Types.h"
+
+#include <app/server/Server.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <platform/CommissionableDataProvider.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+/**
+ * @brief Parameters required to Initialize() the CastingApp
+ */
+class AppParameters
+{
+private:
+    /**
+     * @brief Provides UniqueId used to generate the RotatingDeviceId advertised by the CastingApp
+     *
+     */
+    MutableByteSpanDataProvider * mRotatingDeviceIdUniqueIdProvider;
+
+    /**
+     * @brief Provides CommissionableData (such as setupPasscode, discriminator, etc) used to get the CastingApp commissioned
+     *
+     */
+    chip::DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider;
+
+    /**
+     * @brief Provides DeviceAttestationCredentials of the CastingApp during commissioning
+     *
+     */
+    chip::Credentials::DeviceAttestationCredentialsProvider * mDeviceAttestationCredentialsProvider;
+
+    /**
+     * @brief DeviceAttestationVerifier used by the CastingApp during commissioning
+     *
+     */
+    chip::Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier;
+
+    /**
+     * @brief Provides params used to initialize the Matter server run by the CastingApp
+     *
+     */
+    ServerInitParamsProvider * mServerInitParamsProvider;
+
+public:
+    AppParameters() {}
+    CHIP_ERROR Create(MutableByteSpanDataProvider * rotatingDeviceIdUniqueIdProvider,
+                      chip::DeviceLayer::CommissionableDataProvider * commissionableDataProvider,
+                      chip::Credentials::DeviceAttestationCredentialsProvider * deviceAttestationCredentialsProvider,
+                      chip::Credentials::DeviceAttestationVerifier * deviceAttestationVerifier,
+                      ServerInitParamsProvider * serverInitParamsProvider)
+    {
+        VerifyOrReturnError(commissionableDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(deviceAttestationCredentialsProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(deviceAttestationVerifier != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(serverInitParamsProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+        mRotatingDeviceIdUniqueIdProvider     = rotatingDeviceIdUniqueIdProvider;
+        mCommissionableDataProvider           = commissionableDataProvider;
+        mDeviceAttestationCredentialsProvider = deviceAttestationCredentialsProvider;
+        mDeviceAttestationVerifier            = deviceAttestationVerifier;
+        mServerInitParamsProvider             = serverInitParamsProvider;
+
+        return CHIP_NO_ERROR;
+    }
+
+    MutableByteSpanDataProvider * GetRotatingDeviceIdUniqueIdProvider() const { return mRotatingDeviceIdUniqueIdProvider; }
+
+    chip::DeviceLayer::CommissionableDataProvider * GetCommissionableDataProvider() const { return mCommissionableDataProvider; }
+
+    chip::Credentials::DeviceAttestationCredentialsProvider * GetDeviceAttestationCredentialsProvider() const
+    {
+        return mDeviceAttestationCredentialsProvider;
+    }
+
+    chip::Credentials::DeviceAttestationVerifier * GetDeviceAttestationVerifier() const { return mDeviceAttestationVerifier; }
+
+    ServerInitParamsProvider * GetServerInitParamsProvider() const { return mServerInitParamsProvider; }
+};
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
+++ b/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
@@ -35,37 +35,6 @@ namespace support {
  */
 class AppParameters
 {
-private:
-    /**
-     * @brief Provides UniqueId used to generate the RotatingDeviceId advertised by the CastingApp
-     *
-     */
-    MutableByteSpanDataProvider * mRotatingDeviceIdUniqueIdProvider;
-
-    /**
-     * @brief Provides CommissionableData (such as setupPasscode, discriminator, etc) used to get the CastingApp commissioned
-     *
-     */
-    chip::DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider;
-
-    /**
-     * @brief Provides DeviceAttestationCredentials of the CastingApp during commissioning
-     *
-     */
-    chip::Credentials::DeviceAttestationCredentialsProvider * mDeviceAttestationCredentialsProvider;
-
-    /**
-     * @brief DeviceAttestationVerifier used by the CastingApp during commissioning
-     *
-     */
-    chip::Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier;
-
-    /**
-     * @brief Provides params used to initialize the Matter server run by the CastingApp
-     *
-     */
-    ServerInitParamsProvider * mServerInitParamsProvider;
-
 public:
     AppParameters() {}
     CHIP_ERROR Create(MutableByteSpanDataProvider * rotatingDeviceIdUniqueIdProvider,
@@ -100,6 +69,37 @@ public:
     chip::Credentials::DeviceAttestationVerifier * GetDeviceAttestationVerifier() const { return mDeviceAttestationVerifier; }
 
     ServerInitParamsProvider * GetServerInitParamsProvider() const { return mServerInitParamsProvider; }
+
+private:
+    /**
+     * @brief Provides UniqueId used to generate the RotatingDeviceId advertised by the CastingApp
+     *
+     */
+    MutableByteSpanDataProvider * mRotatingDeviceIdUniqueIdProvider;
+
+    /**
+     * @brief Provides CommissionableData (such as setupPasscode, discriminator, etc) used to get the CastingApp commissioned
+     *
+     */
+    chip::DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider;
+
+    /**
+     * @brief Provides DeviceAttestationCredentials of the CastingApp during commissioning
+     *
+     */
+    chip::Credentials::DeviceAttestationCredentialsProvider * mDeviceAttestationCredentialsProvider;
+
+    /**
+     * @brief DeviceAttestationVerifier used by the CastingApp during commissioning
+     *
+     */
+    chip::Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier;
+
+    /**
+     * @brief Provides params used to initialize the Matter server run by the CastingApp
+     *
+     */
+    ServerInitParamsProvider * mServerInitParamsProvider;
 };
 
 }; // namespace support

--- a/examples/tv-casting-app/tv-casting-common/support/DataProvider.h
+++ b/examples/tv-casting-app/tv-casting-common/support/DataProvider.h
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "core/Types.h"
+
+#include <app/server/Server.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+/**
+ * @brief Generic DataProvider template that allows the implementer to provide a pointer to some data with type T
+ *
+ * @tparam T type of the data to be provided
+ */
+template <typename T>
+class DataProvider
+{
+public:
+    virtual ~DataProvider(){};
+    virtual T * Get() { return nullptr; };
+};
+
+class MutableByteSpanDataProvider : public DataProvider<chip::MutableByteSpan>
+{
+public:
+    virtual chip::MutableByteSpan * Get() { return nullptr; };
+};
+
+class ServerInitParamsProvider : public DataProvider<chip::ServerInitParams>
+{
+public:
+    virtual chip::ServerInitParams * Get() { return nullptr; };
+};
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter


### PR DESCRIPTION
The CastingServer in the tv-casting-app has grown in size and should be broken down. This PR is the first step towards doing that. It introduces a simplified version of the Initialization code and corresponding APIs.

### Change summary
1. Added a simple-app.cpp under tv-casting-app/linux that will eventually take the place of the rather large existing main.cpp. This simple-app is currently built only if the build flag `chip_casting_simplified` is set to `true` on the command line. `scripts/examples/gn_build_example.sh examples/tv-casting-app/linux/ out/tv-casting-app chip_casting_simplified=true` Otherwise, by default, we will continue to build the existing main.cpp.
2. Added a CastingApp class where we've added the Initialize(), Start() and Stop() APIs. There are some supporting classes in the "support" namespace.
3. The simple-app demonstrates how the CastingApp APIs can be used.

Some items are marked TBD - they will be addressed in following PRs, when the dependent workflows (commissioning, CASE, etc) are refactored.

### Testing
Tested by building (with the chip_casting_simplified=true flag set) and running the Linux tv-casting-app on Mac to see that it initializes and starts the Matter server.