### PR TITLE
Added checking for CancelledError in YAML runner

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -16,6 +16,7 @@
 import asyncio
 import time
 from abc import ABC, abstractmethod
+from asyncio import CancelledError
 from dataclasses import dataclass, field
 
 from .adapter import TestAdapter
@@ -144,7 +145,7 @@ class TestRunner(TestRunnerBase):
                 continue
 
             result = await self._run_with_timeout(parser, runner_config)
-            if isinstance(result, Exception):
+            if isinstance(result, Exception) or isinstance(result, CancelledError):
                 raise (result)
             elif not result:
                 return False
@@ -160,7 +161,7 @@ class TestRunner(TestRunnerBase):
         try:
             await self.start()
             status = await asyncio.wait_for(self._run(parser, config), parser.timeout)
-        except Exception as exception:
+        except (Exception, CancelledError) as exception:
             status = exception
         finally:
             await self.stop()


### PR DESCRIPTION
Capture and raise CancelledError in YAML Runner.
TH expects that TAML runner raises `CancelledError` when cancelling a Task. Currently the code is not checking the `CancelledError`. 
