### PR TITLE
Added method in python runner to get eventNumber for TC-SMOKECO tests

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/SafeInt.h>
 #include <lib/support/jsontlv/TlvJson.h>
 
+constexpr const char * kEventNumberKey    = "eventNumber";
 constexpr const char * kDataVersionKey    = "dataVersion";
 constexpr const char * kClusterIdKey      = "clusterId";
 constexpr const char * kEndpointIdKey     = "endpointId";
@@ -129,9 +130,10 @@ CHIP_ERROR LogEventAsJSON(const chip::app::EventHeader & header, chip::TLV::TLVR
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     Json::Value value;
-    value[kClusterIdKey]  = header.mPath.mClusterId;
-    value[kEndpointIdKey] = header.mPath.mEndpointId;
-    value[kEventIdKey]    = header.mPath.mEventId;
+    value[kClusterIdKey]   = header.mPath.mClusterId;
+    value[kEndpointIdKey]  = header.mPath.mEndpointId;
+    value[kEventIdKey]     = header.mPath.mEventId;
+    value[kEventNumberKey] = header.mEventNumber;
 
     chip::TLV::TLVReader reader;
     reader.Init(*data);

--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -35,6 +35,7 @@ _ERROR = 'error'
 _CLUSTER_ERROR = 'clusterError'
 _VALUE = 'value'
 _DATA_VERSION = 'dataVersion'
+_EVENT_NUMBER = 'eventNumber'
 
 # FabricIndex is a special case where the field is added as a struct field by the SDK
 # if needed but is not part of the XML definition of the struct.
@@ -89,7 +90,7 @@ class Decoder:
                 elif key == _EVENT_ID:
                     key = _EVENT
                     value = specs.get_event_name(payload[_CLUSTER_ID], value)
-                elif key == _VALUE or key == _ERROR or key == _CLUSTER_ERROR or key == _DATA_VERSION:
+                elif key == _VALUE or key == _ERROR or key == _CLUSTER_ERROR or key == _DATA_VERSION or key == _EVENT_NUMBER:
                     pass
                 else:
                     # Raise an error since the other fields probably needs to be translated too.

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -207,6 +207,7 @@ class _TestStepWithPlaceholders:
         self.busy_wait_ms = _value_or_none(test, 'busyWaitMs')
         self.wait_for = _value_or_none(test, 'wait')
         self.event_number = _value_or_none(test, 'eventNumber')
+        self.is_last_event_number = _value_or_none(test, 'isLastEventNumber')
         self.run_if = _value_or_none(test, 'runIf')
         self.save_response_as = _value_or_none(test, 'saveResponseAs')
 
@@ -578,6 +579,8 @@ class TestStep:
                 self._test.run_if)
             self._test.event_number = self._config_variable_substitution(
                 self._test.event_number)
+            self._test.is_last_event_number = self._config_variable_substitution(
+                self._test.is_last_event_number)
             self._test.cluster = self._config_variable_substitution(
                 self._test.cluster)
             self._test.command = self._config_variable_substitution(
@@ -682,6 +685,14 @@ class TestStep:
     @property
     def event_number(self):
         return self._test.event_number
+
+    @event_number.setter
+    def event_number(self, value):
+        self._test.event_number = value
+
+    @property
+    def is_last_event_number(self):
+        return self._test.is_last_event_number
 
     @property
     def pics(self):

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -207,7 +207,6 @@ class _TestStepWithPlaceholders:
         self.busy_wait_ms = _value_or_none(test, 'busyWaitMs')
         self.wait_for = _value_or_none(test, 'wait')
         self.event_number = _value_or_none(test, 'eventNumber')
-        self.is_last_event_number = _value_or_none(test, 'isLastEventNumber')
         self.run_if = _value_or_none(test, 'runIf')
         self.save_response_as = _value_or_none(test, 'saveResponseAs')
 
@@ -579,8 +578,6 @@ class TestStep:
                 self._test.run_if)
             self._test.event_number = self._config_variable_substitution(
                 self._test.event_number)
-            self._test.is_last_event_number = self._config_variable_substitution(
-                self._test.is_last_event_number)
             self._test.cluster = self._config_variable_substitution(
                 self._test.cluster)
             self._test.command = self._config_variable_substitution(
@@ -689,10 +686,6 @@ class TestStep:
     @event_number.setter
     def event_number(self, value):
         self._test.event_number = value
-
-    @property
-    def is_last_event_number(self):
-        return self._test.is_last_event_number
 
     @property
     def pics(self):

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -201,7 +201,6 @@ class TestRunner(TestRunnerBase):
                 duration = round((time.time() - start) * 1000, 2)
                 test_duration += duration
 
-
                 if request.is_event:
                     received_event_number = responses[-1].get('eventNumber')
                     if received_event_number and self.last_event_number < received_event_number:

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -180,7 +180,7 @@ class TestRunner(TestRunnerBase):
 
             test_duration = 0
             for idx, request in enumerate(parser.tests):
-                if request.is_event and request.is_last_event_number:
+                if request.is_event and request.event_number == 'newEventsOnly':
                     request.event_number = self.last_event_number + 1
 
                 if not request.is_pics_enabled:

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import asyncio
-import re
 import time
 from abc import ABC, abstractmethod
 from asyncio import CancelledError
@@ -127,7 +126,6 @@ class TestRunner(TestRunnerBase):
     TestRunner is a default runner implementation.
     """
 
-    pattern = re.compile(r'EventNumber = (0x[0-9a-f]+)')
     last_event_number = 0
 
     async def start(self):
@@ -180,8 +178,8 @@ class TestRunner(TestRunnerBase):
 
             test_duration = 0
             for idx, request in enumerate(parser.tests):
-                if request.is_last_event_number:
-                    request.event_number = self.last_event_number
+                if request.is_event and request.is_last_event_number:
+                    request.event_number = self.last_event_number + 1
 
                 if not request.is_pics_enabled:
                     hooks.step_skipped(request.label, request.pics)
@@ -203,14 +201,11 @@ class TestRunner(TestRunnerBase):
                 duration = round((time.time() - start) * 1000, 2)
                 test_duration += duration
 
-                # TODO: To get the event number, the method could be improved
-                for log in reversed(logs):
-                    match = self.pattern.search(log.message)
-                    if match:
-                        received_event_number = int(match.group(1), 16) + 1
-                        if self.last_event_number < received_event_number:
-                            self.last_event_number = received_event_number
-                        break
+
+                if request.is_event:
+                    received_event_number = responses[-1].get('eventNumber')
+                    if received_event_number and self.last_event_number < received_event_number:
+                        self.last_event_number = received_event_number
 
                 logger = request.post_process_response(responses)
 

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -124,9 +124,11 @@ class TestRunnerBase(ABC):
 class TestRunner(TestRunnerBase):
     """
     TestRunner is a default runner implementation.
+
+    last_event_number: The latest event number value after the readEvent command.
     """
 
-    last_event_number = 0
+    last_event_number: int = 0
 
     async def start(self):
         return
@@ -202,9 +204,11 @@ class TestRunner(TestRunnerBase):
                 test_duration += duration
 
                 if request.is_event:
-                    received_event_number = responses[-1].get('eventNumber')
-                    if received_event_number and self.last_event_number < received_event_number:
-                        self.last_event_number = received_event_number
+                    last_event = responses[-1]
+                    if isinstance(last_event, dict):
+                        received_event_number = last_event.get('eventNumber')
+                        if isinstance(received_event_number, int) and self.last_event_number < received_event_number:
+                            self.last_event_number = received_event_number
 
                 logger = request.post_process_response(responses)
 

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -97,7 +97,6 @@ class YamlLoader:
             'command': str,
             'event': str,
             'eventNumber': (int, str),  # Can be a variable.
-            'isLastEventNumber': bool,  # Can be a variable.
             'disabled': bool,
             'fabricFiltered': bool,
             'verification': str,

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -97,6 +97,7 @@ class YamlLoader:
             'command': str,
             'event': str,
             'eventNumber': (int, str),  # Can be a variable.
+            'isLastEventNumber': bool,  # Can be a variable.
             'disabled': bool,
             'fabricFiltered': bool,
             'verification': str,

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -135,25 +135,16 @@ def _GetInDevelopmentTests() -> Set[str]:
         "Test_TC_PSCFG_1_1.yaml",  # Power source configuration cluster is deprecated and removed from all-clusters
         "Test_TC_PSCFG_2_1.yaml",  # Power source configuration cluster is deprecated and removed from all-clusters
         "Test_TC_PSCFG_2_2.yaml",  # Power source configuration cluster is deprecated and removed from all-clusters
-        "Test_TC_SMOKECO_2_6.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
-                                             # TestEventTriggersEnabled is true, which it's not in CI. Also, test
-                                             # has wrong key for eventNumber: because using the right key leads to
-                                             # codegen that does not compile.
         "Test_TC_SMOKECO_2_2.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
-                                             # TestEventTriggersEnabled is true, which it's not in CI. Also, test
-                                             # has wrong key for eventNumber: because using the right key leads to
-                                             # codegen that does not compile.
+                                             # TestEventTriggersEnabled is true, which it's not in CI.
         "Test_TC_SMOKECO_2_3.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
-                                             # TestEventTriggersEnabled is true, which it's not in CI. Also, test
-                                             # has wrong key for eventNumber: because using the right key leads to
-                                             # codegen that does not compile.
+                                             # TestEventTriggersEnabled is true, which it's not in CI.
         "Test_TC_SMOKECO_2_4.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
-                                             # TestEventTriggersEnabled is true, which it's not in CI. Also, test
-                                             # has wrong key for eventNumber: because using the right key leads to
-                                             # codegen that does not compile.
-        "Test_TC_SMOKECO_2_5.yaml",          # chip-repl does not support local timeout (07/20/2023) and test uses unknown
-                                             # keepSubscriptions key in the YAML. Also, test has wrong key for eventNumber:
-                                             # because using the right key leads to codegen that does not compile.
+                                             # TestEventTriggersEnabled is true, which it's not in CI.
+        "Test_TC_SMOKECO_2_5.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
+                                             # TestEventTriggersEnabled is true, which it's not in CI.
+        "Test_TC_SMOKECO_2_6.yaml",          # chip-repl does not support local timeout (07/20/2023) and test assumes
+                                             # TestEventTriggersEnabled is true, which it's not in CI.
     }
 
 

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -36,9 +36,6 @@ config:
     TEST_EVENT_TRIGGER_SMOKE_ALARM_CLEAR:
         type: int64u
         defaultValue: "0xffffffff000000a0"
-    EVENT_NUMBER:
-        type: int64u
-        defaultValue: 0
 
 tests:
     - label: "Commission DUT to TH"
@@ -68,6 +65,11 @@ tests:
           value: 0
           constraints:
               type: enum8
+
+    - label: "TH gets last event number from DUT"
+      PICS: SMOKECO.S.E0a
+      command: "readEvent"
+      event: "AllClear"
 
     - label:
           "TH reads TestEventTriggersEnabled attribute from General Diagnostics
@@ -121,7 +123,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -201,7 +203,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -246,6 +248,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      isLastEventNumber: true
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -123,7 +123,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -203,7 +203,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -248,6 +248,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -122,7 +122,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -202,7 +202,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -247,6 +247,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -35,9 +35,6 @@ config:
     TEST_EVENT_TRIGGER_CO_ALARM_CLEAR:
         type: int64u
         defaultValue: "0xffffffff000000a1"
-    EVENT_NUMBER:
-        type: int64u
-        defaultValue: 0
 
 tests:
     - label: "Commission DUT to TH"
@@ -67,6 +64,11 @@ tests:
           value: 0
           constraints:
               type: enum8
+
+    - label: "TH gets last event number from DUT"
+      PICS: SMOKECO.S.E0a
+      command: "readEvent"
+      event: "AllClear"
 
     - label:
           "TH reads TestEventTriggersEnabled attribute from General Diagnostics
@@ -120,7 +122,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -200,7 +202,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -245,6 +247,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      isLastEventNumber: true
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -48,9 +48,6 @@ config:
     TEST_EVENT_TRIGGER_END_OF_SERVICE_ALERT_CLEAR:
         type: int64u
         defaultValue: "0xffffffff000000aa"
-    EVENT_NUMBER:
-        type: int64u
-        defaultValue: 0
 
 tests:
     - label: "Commission DUT to TH"
@@ -80,6 +77,11 @@ tests:
           value: 0
           constraints:
               type: enum8
+
+    - label: "TH gets last event number from DUT"
+      PICS: SMOKECO.S.E0a
+      command: "readEvent"
+      event: "AllClear"
 
     - label:
           "TH reads TestEventTriggersEnabled attribute from General Diagnostics
@@ -133,7 +135,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -178,7 +180,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -223,7 +225,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -279,7 +281,7 @@ tests:
       PICS: SMOKECO.S.E03
       command: "readEvent"
       event: "HardwareFault"
-      EVENT_NUMBER: EVENT_NUMBER + 4
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -325,7 +327,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 5
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -381,7 +383,7 @@ tests:
       PICS: SMOKECO.S.E04
       command: "readEvent"
       event: "EndOfService"
-      EVENT_NUMBER: EVENT_NUMBER + 6
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -427,7 +429,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 7
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -499,7 +501,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      EVENT_NUMBER: EVENT_NUMBER + 8
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -516,7 +518,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 9
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -561,7 +563,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      EVENT_NUMBER: EVENT_NUMBER + 10
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -578,6 +580,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 11
+      isLastEventNumber: true
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -135,7 +135,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -180,7 +180,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -225,7 +225,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -281,7 +281,7 @@ tests:
       PICS: SMOKECO.S.E03
       command: "readEvent"
       event: "HardwareFault"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -327,7 +327,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -383,7 +383,7 @@ tests:
       PICS: SMOKECO.S.E04
       command: "readEvent"
       event: "EndOfService"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -429,7 +429,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -501,7 +501,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -518,7 +518,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -563,7 +563,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -580,6 +580,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -162,7 +162,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E08
       command: "readEvent"
       event: "InterconnectSmokeAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: interconnectSmokeAlarmSeverityLevel }
 
@@ -217,7 +217,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -275,7 +275,7 @@ tests:
       PICS: SMOKECO.S.A0009 && SMOKECO.S.E09
       command: "readEvent"
       event: "InterconnectCOAlarm"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: { AlarmSeverityLevel: interconnectCOAlarmSeverityLevel }
 
@@ -330,7 +330,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -681,7 +681,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -718,7 +718,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -893,7 +893,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 
@@ -930,7 +930,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      isLastEventNumber: true
+      eventNumber: "newEventsOnly"
       response:
           value: {}
 

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -81,9 +81,6 @@ config:
     TTEST_EVENT_TRIGGER_SENSITIVITY_LEVEL_CLEAR:
         type: int64u
         defaultValue: "0xffffffff000000a8"
-    EVENT_NUMBER:
-        type: int64u
-        defaultValue: 0
 
 tests:
     - label: "Commission DUT to TH"
@@ -113,6 +110,11 @@ tests:
           value: 0
           constraints:
               type: enum8
+
+    - label: "TH gets last event number from DUT"
+      PICS: SMOKECO.S.E0a
+      command: "readEvent"
+      event: "AllClear"
 
     - label:
           "TH reads TestEventTriggersEnabled attribute from General Diagnostics
@@ -160,7 +162,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E08
       command: "readEvent"
       event: "InterconnectSmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: interconnectSmokeAlarmSeverityLevel }
 
@@ -215,7 +217,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -273,7 +275,7 @@ tests:
       PICS: SMOKECO.S.A0009 && SMOKECO.S.E09
       command: "readEvent"
       event: "InterconnectCOAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      isLastEventNumber: true
       response:
           value: { AlarmSeverityLevel: interconnectCOAlarmSeverityLevel }
 
@@ -328,7 +330,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 4
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -679,7 +681,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      EVENT_NUMBER: EVENT_NUMBER + 5
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -716,7 +718,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      EVENT_NUMBER: EVENT_NUMBER + 6
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -891,7 +893,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      EVENT_NUMBER: EVENT_NUMBER + 7
+      isLastEventNumber: true
       response:
           value: {}
 
@@ -928,7 +930,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      EVENT_NUMBER: EVENT_NUMBER + 8
+      isLastEventNumber: true
       response:
           value: {}
 


### PR DESCRIPTION
Proposing the method to fixes #27539

- This PR tried to -

Adding a method in Python runner to get eventNumber in order to get the TC-SMOKECO test to work, I understand this could not be a good implementation and may need improvement/use another alternative. 

- The problem was -

The `readEvent` command from eventTest returns a list of events. But in yaml, the value I expect needs to match the value actually returned. And the eventNumber parameter in yaml acts as a filter that allows me to accomplish this. 
If I know the event number before a readEvent step, I can get the latest one located and read the event generated after this eventNumber to pass the test plan, which also makes it easier for automation.

- Why such command is essential -
In the testing of the smoke and CO Test plan, we will verify a series of new events that are received. The EventNumber is used to distinguish whether an event is the most recent one. However, the issue lies in the fact that the EventNumber provided in the testEvents currently relies on an initial eventNumber in a configuration file. (I have set it to 0 in the config, which results in retrieving all records.)
Since I didn't find certain commands only returned the latest event sequence number. I can't do the effective update to flag the new starting point with the EventNumber to search event. 
The readEvent returns a list of all corresponding events found. Due to the fact that the test plan will test multiple times for different scenarios triggering the same event, this leads to the continuous growth of the returned list... Consequently, if testing persists, the returned records will become unpredictable and lead to test failure.

Example test Ymal:
```
config:
......
    EVENT_NUMBER:
        type: int64u
        defaultValue: 0

label: "TH reads LowBattery event from DUT"
      PICS: SMOKECO.S.E02
      command: "readEvent"
      event: "LowBattery"
      EVENT_NUMBER: EVENT_NUMBER + 1
      response:
          value: { AlarmSeverityLevel: 1 }
....
label: "TH reads LowBattery event from DUT"
      PICS: SMOKECO.S.E02
      command: "readEvent"
      event: "LowBattery"
      EVENT_NUMBER: EVENT_NUMBER + 2
      response:
          value: { AlarmSeverityLevel: 2 } //Here could have two values returned. 
```

Until then, I've tried to modify EVENT_NUMBER at config and letting testers enter it manually.
But there are some issues with using the eventNumber parameter in TC-SMOKECO:

1. The TH currently only accepts the endpoint parameter, setting EVENT_NUMBER manually may fail/not take effect. Even if it works, it can be troublesome for testing. Such manual operation requires finding the value manually first before executing each TC, and then needing to modify the config value after each TC. So they will have a relatively clean list from the readEvent for individual TC, which will make the tester very inconvenient and also not guarantee some accidentally generated event will not interfere with the readEvent verification.
2. EVENT_NUMBER +1 in each readEvent step, if any test item is skipped due to PICS, it will also cause failure at the test.

- To make TC work -

So this would need a new method to get the latest event automatically.
My logic for the change is to 

1. Add the `last_event_number` variable to the python runner to record the latest event number of the readEvent.
2. At the beginning of each yaml, add a `readEvent` with no response to let the last_event_number have a value.
3. In the subsequent readEvent step, if the `isLastEventNumber` parameter is true, the eventNumber parameter is set to last_event_number. 

This will make a method for tracking the last event number. By running tests, this method worked with the PR proposed here.
