### PR TITLE
Fix warning Classes that contain only a companion object should be re…

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/Verhoeff.kt
+++ b/src/controller/java/src/chip/onboardingpayload/Verhoeff.kt
@@ -17,29 +17,27 @@
 
 package chip.onboardingpayload
 
-class Verhoeff {
-  companion object {
-    fun dihedralMultiply(x: Int, y: Int, n: Int): Int {
-      val n2 = n * 2
-      var newX = x % n2
-      var newY = y % n2
-      if (newX < n) {
-        if (newY < n) return (newX + newY) % n
-        return ((newX + (newY - n)) % n) + n
-      }
-      if (newY < n) return ((n + (newX - n) - newY) % n) + n
-      return (n + (newX - n) - (newY - n)) % n
+object Verhoeff {
+  fun dihedralMultiply(x: Int, y: Int, n: Int): Int {
+    val n2 = n * 2
+    var newX = x % n2
+    var newY = y % n2
+    if (newX < n) {
+      if (newY < n) return (newX + newY) % n
+      return ((newX + (newY - n)) % n) + n
     }
+    if (newY < n) return ((n + (newX - n) - newY) % n) + n
+    return (n + (newX - n) - (newY - n)) % n
+  }
 
-    fun dihedralInvert(value: Int, n: Int): Int {
-      if (value > 0 && value < n) return n - value
-      return value
-    }
+  fun dihedralInvert(value: Int, n: Int): Int {
+    if (value > 0 && value < n) return n - value
+    return value
+  }
 
-    fun permute(value: Int, permTable: ByteArray, permTableLen: Int, iterCount: Int): Int {
-      var newValue = value % permTableLen
-      if (iterCount == 0) return newValue
-      return permute(permTable[newValue].toInt(), permTable, permTableLen, iterCount - 1)
-    }
+  fun permute(value: Int, permTable: ByteArray, permTableLen: Int, iterCount: Int): Int {
+    var newValue = value % permTableLen
+    if (iterCount == 0) return newValue
+    return permute(permTable[newValue].toInt(), permTable, permTableLen, iterCount - 1)
   }
 }


### PR DESCRIPTION
…placed with a named object declaration

`third_party/connectedhomeip/next/src/controller/java/src/chip/onboardingpayload/Verhoeff.kt:20: Error: Classes that contain only a companion object should be replaced with a named object declaration (see https://kotlinlang.org/docs/object-declarations.html#object-declarations-overview) [ClassShouldBeObject]
`
