### PR TITLE
Fix complains about an unused output

### DIFF
--- a/src/controller/java/tests/chip/onboardingpayload/ManualCodeTest.kt
+++ b/src/controller/java/tests/chip/onboardingpayload/ManualCodeTest.kt
@@ -483,13 +483,13 @@ class ManualCodeTest {
     decimalString = representationWithoutCheckDigit + checkDigit
 
     outReprensation = ManualOnboardingPayloadParser.checkDecimalStringValidity(decimalString)
-    assertThat(outReprensation == representationWithoutCheckDigit)
+    assertThat(outReprensation).isEqualTo(representationWithoutCheckDigit)
 
     representationWithoutCheckDigit = "0000"
     checkDigit = Verhoeff10.computeCheckChar(representationWithoutCheckDigit)
     decimalString = representationWithoutCheckDigit + checkDigit
     outReprensation = ManualOnboardingPayloadParser.checkDecimalStringValidity(decimalString)
-    assertThat(outReprensation == representationWithoutCheckDigit)
+    assertThat(outReprensation).isEqualTo(representationWithoutCheckDigit)
   }
 
   /*


### PR DESCRIPTION
assertThat(outReprensation == representationWithoutCheckDigit) will construct an unused Boolean object, it needs to be replaced with assertThat(outReprensation).isEqualTo(representationWithoutCheckDigit)

