### PR TITLE
[Android] Remove Fabric ID negative value check 

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/ControllerParams.java
+++ b/src/controller/java/src/chip/devicecontroller/ControllerParams.java
@@ -151,9 +151,6 @@ public final class ControllerParams {
     private Builder() {}
 
     public Builder setFabricId(long fabricId) {
-      if (fabricId < 1) {
-        throw new IllegalArgumentException("fabricId must be > 0");
-      }
       this.fabricId = fabricId;
       return this;
     }


### PR DESCRIPTION
Fix #28696 

Java long variable range is -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807.
uint64_t variable range is  0 to 18,446,744,073,709,551,615.

It would be best if there was an unsigned type in Java, but since it doesn't exist, you have no choice but to use negative values when using Java in your App.

For this reason, it has been modified to remove negative checks.
