### PR TITLE
[shell] Add commands for resource usage statistics

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -134,6 +134,7 @@ matter_add_gn_arg_bool  ("chip_detail_logging"                    CONFIG_MATTER_
 matter_add_gn_arg_bool  ("chip_automation_logging"                FALSE)
 matter_add_gn_arg_bool  ("chip_malloc_sys_heap"                   CONFIG_CHIP_MALLOC_SYS_HEAP)
 matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_WIFI_NRF700X)
+matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 
 if (CONFIG_CHIP_FACTORY_DATA)
     matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider" FALSE)

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -282,6 +282,12 @@ config CHIP_PERSISTENT_SUBSCRIPTIONS
 	  subscriptions instead of waiting for the subscriber node to realize that
 	  the publisher is alive again.
 
+config CHIP_STATISTICS
+	bool "Resource usage statistics"
+	help
+	  Enables tracking the current and the top usage of critical resources used
+	  by the Matter stack, such as packet buffers, timers or exchange contexts.
+
 config CHIP_LIB_SHELL
 	bool "Matter shell commands"
 	default n

--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -361,3 +361,32 @@ DNS resolve for 000000014A77CBB3-0000000000BC5C01 succeeded:
    IP address: fd08:b65e:db8e:f9c7:8052:1a8e:4dd4:e1f3
    Port: 5540
 ```
+
+### `stat` command group
+
+Handles a group of commands that are used to get and reset the peak usage of
+critical system resources used by Matter. These commands are only available when
+the `CONFIG_CHIP_STATISTICS=y` Kconfig option is set.
+
+#### `peak` subcommand
+
+Prints the peak usage of system resources.
+
+```shell
+uart:~$ matter stat peak
+Packet Buffers: 1
+Timers: 2
+TCP endpoints: 0
+UDP endpoints: 1
+Exchange contexts: 0
+Unsolicited message handlers: 5
+Platform events: 2
+```
+
+#### `reset` subcommand
+
+Resets the peak usage of system resources.
+
+```shell
+uart:~$ matter stat reset
+```

--- a/src/lib/shell/Commands.h
+++ b/src/lib/shell/Commands.h
@@ -57,6 +57,12 @@ void RegisterDeviceCommands();
 void RegisterOtaCommands();
 
 /**
+ * This function registers the resource usage statistics commands.
+ *
+ */
+void RegisterStatCommands();
+
+/**
  * This function registers the device onboarding codes commands.
  *
  */

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -125,6 +125,9 @@ void Engine::RegisterDefaultCommands()
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     RegisterOtaCommands();
 #endif
+#if CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
+    RegisterStatCommands();
+#endif
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/BUILD.gn
+++ b/src/lib/shell/commands/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${chip_root}/src/system/system.gni")
 
 source_set("commands") {
   sources = [
@@ -64,6 +65,10 @@ source_set("commands") {
 
     configs +=
         [ "${chip_root}/src/controller/data_model:data_model_zapgen_config" ]
+  }
+
+  if (chip_system_config_provide_statistics) {
+    sources += [ "Stat.cpp" ]
   }
 
   if (chip_device_platform != "none") {

--- a/src/lib/shell/commands/Stat.cpp
+++ b/src/lib/shell/commands/Stat.cpp
@@ -1,0 +1,93 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/DiagnosticDataProvider.h>
+#include <system/SystemStats.h>
+
+using namespace chip;
+
+namespace chip {
+namespace Shell {
+namespace {
+
+Shell::Engine sSubShell;
+
+CHIP_ERROR StatPeakHandler(int argc, char ** argv)
+{
+    auto labels     = System::Stats::GetStrings();
+    auto watermarks = System::Stats::GetHighWatermarks();
+
+    for (int i = 0; i < System::Stats::kNumEntries; i++)
+    {
+        streamer_printf(streamer_get(), "%s: %i\r\n", labels[i], static_cast<int>(watermarks[i]));
+    }
+
+    if (DeviceLayer::GetDiagnosticDataProvider().SupportsWatermarks())
+    {
+        uint64_t heapWatermark;
+        ReturnErrorOnFailure(DeviceLayer::GetDiagnosticDataProvider().GetCurrentHeapHighWatermark(heapWatermark));
+        streamer_printf(streamer_get(), "Heap allocated bytes: %u\r\n", static_cast<unsigned>(heapWatermark));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StatResetHandler(int argc, char ** argv)
+{
+    auto current    = System::Stats::GetResourcesInUse();
+    auto watermarks = System::Stats::GetHighWatermarks();
+
+    for (int i = 0; i < System::Stats::kNumEntries; i++)
+    {
+        watermarks[i] = current[i];
+    }
+
+    if (DeviceLayer::GetDiagnosticDataProvider().SupportsWatermarks())
+    {
+        ReturnErrorOnFailure(DeviceLayer::GetDiagnosticDataProvider().ResetWatermarks());
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StatHandler(int argc, char ** argv)
+{
+    return sSubShell.ExecCommand(argc, argv);
+}
+} // namespace
+
+void RegisterStatCommands()
+{
+    // Register subcommands of the `stat` commands.
+    static const shell_command_t subCommands[] = {
+        { &StatPeakHandler, "peak", "Print peak usage of system resources. Usage: stat peak" },
+        { &StatResetHandler, "reset", "Reset peak usage of system resources. Usage: stat reset" },
+    };
+
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+
+    // Register the root `stat` command in the top-level shell.
+    static const shell_command_t statCommand = { &StatHandler, "stat", "Statistics commands" };
+
+    Engine::Root().RegisterCommands(&statCommand, 1);
+}
+
+} // namespace Shell
+} // namespace chip

--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -43,16 +43,17 @@ static const Label sStatsStrings[chip::System::Stats::kNumEntries] = {
 #include "lwippools.h"
 #undef LWIP_PBUF_MEMPOOL
 #else
-    "SystemLayer_NumPacketBufs",
+    "Packet Buffers",
 #endif
-    "SystemLayer_NumTimersInUse",
+    "Timers",
 #if INET_CONFIG_NUM_TCP_ENDPOINTS
-    "InetLayer_NumTCPEpsInUse",
+    "TCP endpoints",
 #endif
 #if INET_CONFIG_NUM_UDP_ENDPOINTS
-    "InetLayer_NumUDPEpsInUse",
+    "UDP endpoints",
 #endif
-    "ExchangeMgr_NumContextsInUse", "ExchangeMgr_NumUMHandlersInUse", "ExchangeMgr_NumBindings", "MessageLayer_NumConnectionsInUse",
+    "Exchange contexts",
+    "Unsolicited message handlers",
 };
 
 count_t sResourcesInUse[kNumEntries];

--- a/src/system/SystemStats.h
+++ b/src/system/SystemStats.h
@@ -68,8 +68,6 @@ enum
 #endif
     kExchangeMgr_NumContexts,
     kExchangeMgr_NumUMHandlers,
-    kExchangeMgr_NumBindings,
-    kMessageLayer_NumConnections,
     kNumEntries
 };
 

--- a/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
@@ -38,7 +38,7 @@ def binaryPath(request, rootDir):
 
 SHELL_COMMAND_NAME = ["base64", "exit", "help", "version",
                       "config", "device", "onboardingcodes", "dns",
-                      "echo", "log", "rand"]
+                      "echo", "log", "rand", "stat"]
 
 
 def parse_config_response(response):

--- a/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
@@ -86,7 +86,7 @@ def test_commissioning(device, controller):
 
 SHELL_MAIN_COMMANDS_NAME = ["base64", "exit", "help", "version",
                             "config", "device", "onboardingcodes", "dns",
-                            "app"]
+                            "app", "stat"]
 
 SHELL_APP_COMMANDS_NAME = ["help", "add", "remove", "setpin",
                            "add-admin-vendor"]


### PR DESCRIPTION
1. Add shell commands for printing and resetting the peak resource usage statistics. If the heap usage watermark is supported, the peak heap usage is printed as well.
2. Add `CONFIG_CHIP_STATISTICS` Kconfig to enable system statistics on nRF Connect platform.
3. Replace the current system stat labels with more user-friendly ones so that they can be used in a shell command output. Also, remove two unused statistics.