### PR TITLE
[ICD]Add unit tests for the ICD Manager operational states

### DIFF
--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -75,9 +75,12 @@ void ICDManager::Shutdown()
 
 bool ICDManager::SupportsCheckInProtocol()
 {
-    bool success;
-    uint32_t featureMap;
+    bool success        = false;
+    uint32_t featureMap = 0;
+    // Can't use attribute accessors/Attributes::FeatureMap::Get in unit tests
+#ifndef CONFIG_BUILD_FOR_HOST_UNIT_TEST
     success = (Attributes::FeatureMap::Get(kRootEndpointId, &featureMap) == EMBER_ZCL_STATUS_SUCCESS);
+#endif
     return success ? ((featureMap & to_underlying(Feature::kCheckInProtocolSupport)) != 0) : false;
 }
 

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -26,6 +26,10 @@
 namespace chip {
 namespace app {
 
+// Forward declaration of TestICDManager to allow it to be friend with ICDManager
+// Used in unit tests
+class TestICDManager;
+
 /**
  * @brief ICD Manager is responsible of processing the events and triggering the correct action for an ICD
  */
@@ -67,6 +71,8 @@ public:
     static System::Clock::Milliseconds32 GetFastPollingInterval() { return kFastPollingInterval; }
 
 protected:
+    friend class TestICDManager;
+
     static void OnIdleModeDone(System::Layer * aLayer, void * appState);
     static void OnActiveModeDone(System::Layer * aLayer, void * appState);
 

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -195,9 +195,9 @@ static const nlTest sTests[] =
 // clang-format on
 
 // clang-format off
-nlTestSuite cmSuite = 
-{ 
-    "TestICDManager", 
+nlTestSuite cmSuite =
+{
+    "TestICDManager",
     &sTests[0],
     TestContext::Initialize,
     TestContext::Finalize

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -15,17 +15,204 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <app/EventManagement.h>
+#include <app/tests/AppTestContext.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <lib/support/UnitTestContext.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>
+#include <system/SystemLayerImpl.h>
 
-int TestICDManager()
+#include <app/icd/ICDManager.h>
+#include <app/icd/ICDStateObserver.h>
+#include <app/icd/IcdManagementServer.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::System;
+
+namespace {
+
+class TestICDStateObserver : public app::ICDStateObserver
 {
-    static nlTest sTests[] = { NL_TEST_SENTINEL() };
+public:
+    void OnEnterActiveMode() {}
+};
 
-    nlTestSuite cmSuite = { "TestICDManager", &sTests[0], nullptr, nullptr };
+TestICDStateObserver mICDStateObserver;
+static Clock::Internal::MockClock gMockClock;
+static Clock::ClockBase * gRealClock;
 
-    nlTestRunner(&cmSuite, nullptr);
-    return (nlTestRunnerStats(&cmSuite));
+class TestContext : public Test::AppContext
+{
+public:
+    static int Initialize(void * context)
+    {
+        gRealClock = &SystemClock();
+        Clock::Internal::SetSystemClockForTesting(&gMockClock);
+
+        if (chip::DeviceLayer::PlatformMgr().InitChipStack() != CHIP_NO_ERROR)
+            return FAILURE;
+
+        if (AppContext::Initialize(context) != SUCCESS)
+            return FAILURE;
+
+        auto * ctx = static_cast<TestContext *>(context);
+
+        if (ctx->mEventCounter.Init(0) != CHIP_NO_ERROR)
+        {
+            return FAILURE;
+        }
+
+        ctx->mICDManager.Init(&ctx->testStorage, &ctx->GetFabricTable(), &mICDStateObserver);
+        return SUCCESS;
+    }
+
+    static int Finalize(void * context)
+    {
+        auto * ctx = static_cast<TestContext *>(context);
+        ctx->mICDManager.Shutdown();
+        app::EventManagement::DestroyEventManagement();
+        chip::System::Clock::Internal::SetSystemClockForTesting(gRealClock);
+
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        if (AppContext::Finalize(context) != SUCCESS)
+            return FAILURE;
+
+        return SUCCESS;
+    }
+
+    app::ICDManager mICDManager;
+
+private:
+    TestPersistentStorageDelegate testStorage;
+    MonotonicallyIncreasingCounter<EventNumber> mEventCounter;
+};
+
+} // namespace
+
+namespace chip {
+namespace app {
+class TestICDManager
+{
+public:
+    /*
+     * Advance the test Mock clock time by the amout passed in argument
+     * and then force the SystemLayer Timer event loop. It will check for any expired timer,
+     * and invoke their callbacks if there are any.
+     *
+     * @param time_ms: Value in milliseconds.
+     */
+    static void AdvanceClockAndRunEventLoop(uint32_t time_ms)
+    {
+        LayerSocketsLoop & layer = static_cast<LayerSocketsLoop &>(DeviceLayer::SystemLayer());
+        gMockClock.AdvanceMonotonic(System::Clock::Timeout(time_ms));
+
+        layer.PrepareEvents();
+        layer.WaitForEvents();
+        layer.HandleEvents();
+    }
+
+    static void TestICDModeIntervals(nlTestSuite * aSuite, void * aContext)
+    {
+        TestContext * ctx                   = static_cast<TestContext *>(aContext);
+        Clock::ClockBase * const savedClock = &SystemClock();
+
+        // After the init we should be in active mode
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval() + 1);
+
+        // Active mode interval expired, ICDManager transitioned to the IdleMode.
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetIdleModeInterval() + 1);
+        // Idle mode interval expired, ICDManager transitioned to the ActiveMode.
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Events updating the Operation to Active mode can extend the current active mode time by 1 Active mode threshold.
+        // Kick an active Threshold just before the end of the Active interval and validate that the active mode is extended.
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval() - 1);
+        ctx->mICDManager.UpdateOperationState(ICDManager::OperationalState::ActiveMode);
+
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeThreshold() / 2);
+        ctx->mICDManager.UpdateOperationState(ICDManager::OperationalState::ActiveMode);
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeThreshold());
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        Clock::Internal::SetSystemClockForTesting(savedClock);
+    }
+
+    static void TestKeepActivemodeRequests(nlTestSuite * aSuite, void * aContext)
+    {
+        TestContext * ctx = static_cast<TestContext *>(aContext);
+
+        Clock::ClockBase * const savedClock = &SystemClock();
+        // Setting a requirement will transition the ICD to active mode.
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kCommissioningWindowOpen, true);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+        // Advance time so active mode interval expires.
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval());
+        // Requirement flag still set. We stay in active mode
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Remove requirement. we should directly transition to idle mode.
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kCommissioningWindowOpen, false);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kFailSafeArmed, true);
+        // Requirement will transition us to active mode.
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Advance time, but by less than the active mode interval and remove the requirement.
+        // We should stay in active mode.
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval() / 2);
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kFailSafeArmed, false);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Advance time again, The activemode interval is completed.
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval());
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Set two requirements
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kExpectingMsgResponse, true);
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kAwaitingMsgAck, true);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+        // advance time so the active mode interval expires.
+        AdvanceClockAndRunEventLoop(IcdManagementServer::GetInstance().GetActiveModeInterval());
+        // A requirement flag is still set. We stay in active mode.
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // remove 1 requirement. Active mode is maintained
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kExpectingMsgResponse, false);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+        // remove the last requirement
+        ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kAwaitingMsgAck, false);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        Clock::Internal::SetSystemClockForTesting(savedClock);
+    }
+};
+
+} // namespace app
+} // namespace chip
+
+namespace {
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestICDModeIntervals",         TestICDManager::TestICDModeIntervals),
+    NL_TEST_DEF("TestKeepActivemodeRequests",   TestICDManager::TestKeepActivemodeRequests),
+    NL_TEST_SENTINEL()
+};
+
+nlTestSuite cmSuite = { "TestICDManager", &sTests[0], TestContext::Initialize, TestContext::Finalize };
+} // namespace
+
+int TestSuiteICDManager()
+{
+    return ExecuteTestsWithContext<TestContext>(&cmSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestICDManager)
+CHIP_REGISTER_TEST_SUITE(TestSuiteICDManager)

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -109,8 +109,7 @@ public:
 
     static void TestICDModeIntervals(nlTestSuite * aSuite, void * aContext)
     {
-        TestContext * ctx                   = static_cast<TestContext *>(aContext);
-        Clock::ClockBase * const savedClock = &SystemClock();
+        TestContext * ctx = static_cast<TestContext *>(aContext);
 
         // After the init we should be in active mode
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
@@ -129,15 +128,12 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         AdvanceClockAndRunEventLoop(ctx, IcdManagementServer::GetInstance().GetActiveModeThreshold());
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
-
-        Clock::Internal::SetSystemClockForTesting(savedClock);
     }
 
     static void TestKeepActivemodeRequests(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
 
-        Clock::ClockBase * const savedClock = &SystemClock();
         // Setting a requirement will transition the ICD to active mode.
         ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kCommissioningWindowOpen, true);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
@@ -179,8 +175,6 @@ public:
         // remove the last requirement
         ctx->mICDManager.SetKeepActiveModeRequirements(ICDManager::KeepActiveFlags::kAwaitingMsgAck, false);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
-
-        Clock::Internal::SetSystemClockForTesting(savedClock);
     }
 };
 


### PR DESCRIPTION
Add tests for ICD Manager

1.  Base operational state flows for the idle and active intervals.
2. Test KeepActiveModeRequirements


