### PR TITLE
[Silabs] Fix build with Silabs crendential provider

### DIFF
--- a/examples/platform/silabs/SilabsDeviceAttestationCreds.h
+++ b/examples/platform/silabs/SilabsDeviceAttestationCreds.h
@@ -16,9 +16,6 @@
  */
 #pragma once
 
-// The "sl_token_manager.h" include belongs to the .cpp file, but the formatter change the order
-// of the headers, causing a compilation error, so the include had to be added here instead
-#include "sl_token_manager.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 
 namespace chip {


### PR DESCRIPTION
sl tokens aren't used and are not part of the project anymore. remove the include.
