### PR TITLE
[TC-DRLK] TC's 2.2, 2.3, 2.12: Make Invalid PINCode tests conditional on PICS.PIN feature

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_12.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_12.yaml
@@ -35,6 +35,7 @@ tests:
                 value: nodeId
 
     - label: "Precondition: Create new user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -55,6 +56,7 @@ tests:
                 value: 0
 
     - label: "Precondition: Read the user back and verify its fields"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetUser"
       arguments:
           values:
@@ -84,6 +86,7 @@ tests:
                 value: null
 
     - label: "Precondition: Create new PIN credential and lock/unlock user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetCredential"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -110,6 +113,7 @@ tests:
                 value: 2
 
     - label: "Precondition: Verify created PIN credential"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetCredentialStatus"
       arguments:
           values:
@@ -289,7 +293,7 @@ tests:
 
     - label:
           "Step 7: TH sends Unbolt Door Command to the DUT with Invalid PINCode"
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -301,7 +305,7 @@ tests:
 
     - label: "Step 8: TH sends Unbolt Door Command to the DUT without PINCode"
       runIf: requirePINIsTrue
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       response:
@@ -309,7 +313,7 @@ tests:
 
     - label: "Step 8: TH sends Unbolt Door Command to the DUT without PINCode"
       runIf: requirePINIsFalse
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
 
@@ -365,7 +369,7 @@ tests:
     - label:
           "Step 12a: TH sends Unbolt Door Command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -378,7 +382,7 @@ tests:
     - label:
           "Step 12b: TH sends Unbolt Door Command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -391,26 +395,13 @@ tests:
     - label:
           "Step 12c: TH sends Unbolt Door Command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
               - name: "PINCode"
                 value: "123459"
-      response:
-          error: FAILURE
-
-    - label:
-          "Step 12d: TH sends Unbolt Door Command to the DUT with invalid
-          PINCode"
-      PICS: DRLK.S.C27.Rsp
-      command: "UnboltDoor"
-      timedInteractionTimeoutMs: 1000
-      arguments:
-          values:
-              - name: "PINCode"
-                value: "123460"
       response:
           error: FAILURE
 
@@ -425,7 +416,7 @@ tests:
     - label:
           "Step 14: TH sends Unbolt Door Command to the DUT with valid PINCode
           before UserCodeTemporaryDisableTime expires"
-      PICS: DRLK.S.C27.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C27.Rsp
       command: "UnboltDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -535,6 +526,7 @@ tests:
           value: 1
 
     - label: "Cleanup the created user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "ClearUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -543,7 +535,7 @@ tests:
                 value: 1
 
     - label: "Clean the created credential"
-      PICS: DRLK.S.C26.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.F07 && DRLK.S.C26.Rsp
       command: "ClearCredential"
       timedInteractionTimeoutMs: 1000
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_2.yaml
@@ -35,6 +35,7 @@ tests:
                 value: nodeId
 
     - label: "Precondition: Create new user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -55,6 +56,7 @@ tests:
                 value: 0
 
     - label: "Precondition: Read the user back and verify its fields"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetUser"
       arguments:
           values:
@@ -84,6 +86,7 @@ tests:
                 value: null
 
     - label: "Precondition: Create new PIN credential and lock/unlock user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetCredential"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -110,6 +113,7 @@ tests:
                 value: 2
 
     - label: "Precondition: Verify created PIN credential"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetCredentialStatus"
       arguments:
           values:
@@ -289,7 +293,7 @@ tests:
 
     - label:
           "Step 7: TH sends Lock Door Command to the DUT without valid PINCode"
-      PICS: DRLK.S.C00.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C00.Rsp && DRLK.S.A0033
       command: "LockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -301,7 +305,7 @@ tests:
 
     - label: "Step 8: TH sends Lock Door Command to the DUT without PINCode"
       runIf: requirePINIsTrue
-      PICS: DRLK.S.C00.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C00.Rsp && DRLK.S.A0033
       command: "LockDoor"
       timedInteractionTimeoutMs: 1000
       response:
@@ -309,7 +313,7 @@ tests:
 
     - label: "Step 8: TH sends Lock Door Command to the DUT without PINCode"
       runIf: requirePINIsFalse
-      PICS: DRLK.S.C00.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C00.Rsp && DRLK.S.A0033
       command: "LockDoor"
       timedInteractionTimeoutMs: 1000
 
@@ -365,7 +369,7 @@ tests:
           [1659013993.893344][25432:25437] CHIP:TOO: Error: IM Error 0x00000501: General error: 0x01 (FAILURE)
       cluster: "LogCommands"
       command: "UserPrompt"
-      PICS: PICS_USER_PROMPT && DRLK.S.A0030
+      PICS: PICS_USER_PROMPT && DRLK.S.F00 && DRLK.S.A0030
       arguments:
           values:
               - name: "message"
@@ -398,7 +402,7 @@ tests:
           [1659517923.876495][33902:33907] CHIP:TOO: Error: IM Error 0x00000501: General error: 0x01 (FAILURE)
       cluster: "LogCommands"
       command: "UserPrompt"
-      PICS: PICS_USER_PROMPT && DRLK.S.A0030
+      PICS: PICS_USER_PROMPT && DRLK.S.F00 && DRLK.S.A0030
       arguments:
           values:
               - name: "message"
@@ -501,6 +505,7 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Clean the created user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "ClearUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -509,7 +514,7 @@ tests:
                 value: 1
 
     - label: "Cleanup the created credential"
-      PICS: DRLK.S.C26.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.F07 && DRLK.S.C26.Rsp
       command: "ClearCredential"
       timedInteractionTimeoutMs: 1000
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_3.yaml
@@ -36,6 +36,7 @@ tests:
                 value: nodeId
 
     - label: "Precondition: Create new user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -56,6 +57,7 @@ tests:
                 value: 0
 
     - label: "Precondition: Read the user back and verify its fields"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetUser"
       arguments:
           values:
@@ -85,6 +87,7 @@ tests:
                 value: null
 
     - label: "Precondition: Create new PIN credential and lock/unlock user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "SetCredential"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -111,6 +114,7 @@ tests:
                 value: 2
 
     - label: "Precondition: Verify created PIN credential"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "GetCredentialStatus"
       arguments:
           values:
@@ -295,7 +299,7 @@ tests:
     - label:
           "Step 7: TH sends the unlock Door command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C01.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp && DRLK.S.A0033
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -308,7 +312,7 @@ tests:
     - label:
           "Step 8: TH sends the unlock Door command to the DUT without PINCode"
       runIf: requirePINIsTrue
-      PICS: DRLK.S.C01.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp && DRLK.S.A0033
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       response:
@@ -317,7 +321,7 @@ tests:
     - label:
           "Step 8: TH sends the unlock Door command to the DUT without PINCode"
       runIf: requirePINIsFalse
-      PICS: DRLK.S.C01.Rsp && DRLK.S.A0033
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp && DRLK.S.A0033
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
 
@@ -375,7 +379,7 @@ tests:
     - label:
           "Step 12a: TH sends the unlock Door command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C01.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -388,7 +392,7 @@ tests:
     - label:
           "Step 12b: TH sends the unlock Door command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C01.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -401,20 +405,7 @@ tests:
     - label:
           "Step 12c: TH sends the unlock Door command to the DUT with invalid
           PINCode"
-      PICS: DRLK.S.C01.Rsp
-      command: "UnlockDoor"
-      timedInteractionTimeoutMs: 1000
-      arguments:
-          values:
-              - name: "PINCode"
-                value: "1234568"
-      response:
-          error: FAILURE
-
-    - label:
-          "Step 12d: TH sends the unlock Door command to the DUT with invalid
-          PINCode"
-      PICS: DRLK.S.C01.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -435,7 +426,7 @@ tests:
     - label:
           "Step 14: TH sends the unlock Door command to the DUT with valid
           PINCode"
-      PICS: DRLK.S.C01.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.C01.Rsp
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -545,6 +536,7 @@ tests:
           value: 1
 
     - label: "Cleanup the created user"
+      PICS: DRLK.S.F00 && DRLK.S.F07
       command: "ClearUser"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -553,7 +545,7 @@ tests:
                 value: 1
 
     - label: "Clean the created credential"
-      PICS: DRLK.S.C26.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.F07 && DRLK.S.C26.Rsp
       command: "ClearCredential"
       timedInteractionTimeoutMs: 1000
       arguments:


### PR DESCRIPTION
[TC-DRLK] TC's 2.2, 2.3, 2.12:
- Make Invalid PINCode tests conditional on PICS.PIN feature
- Fix WrongCodeEntryLimit tests to repeat the correct total number of times

Fixes https://github.com/CHIP-Specifications/chip-test-plans/issues/3309



