### PR TITLE
[Silabs] Attestation credentials auto-detect.

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -102,11 +102,6 @@ source_set("siwx917-matter-shell") {
 
 config("attestation-credentials-config") {
   include_dirs = [ "${chip_root}" ]
-
-  defines = [
-    # Set to 1 to enable SI917 attestation credentials
-    "SILABS_ATTESTATION_CREDENTIALS",
-  ]
 }
 
 source_set("siwx917-attestation-credentials") {
@@ -275,9 +270,7 @@ source_set("siwx917-common") {
   }
 
   # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    deps += [ ":siwx917-attestation-credentials" ]
-  }
+  deps += [ ":siwx917-attestation-credentials" ]
 
   # Factory Data Provider
   if (use_efr32_factory_data_provider) {

--- a/examples/platform/silabs/SilabsDeviceAttestationCreds.cpp
+++ b/examples/platform/silabs/SilabsDeviceAttestationCreds.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 #include "SilabsDeviceAttestationCreds.h"
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
@@ -27,9 +28,6 @@
 using namespace chip::DeviceLayer::Internal;
 
 using chip::DeviceLayer::Internal::SilabsConfig;
-
-extern uint8_t linker_nvm_end[];
-static uint8_t * _credentials_address = (uint8_t *) linker_nvm_end;
 
 namespace chip {
 namespace Credentials {
@@ -46,8 +44,17 @@ class DeviceAttestationCredsSilabs : public DeviceAttestationCredentialsProvider
 public:
     CHIP_ERROR GetCertificationDeclaration(MutableByteSpan & out_span) override
     {
-        return GetFile("GetCertificationDeclaration", SilabsConfig::kConfigKey_Creds_CD_Offset, SILABS_CREDENTIALS_CD_OFFSET,
-                       SilabsConfig::kConfigKey_Creds_CD_Size, SILABS_CREDENTIALS_CD_SIZE, out_span);
+        if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_Base_Addr))
+        {
+            // Provisioned CD
+            return GetFile("GetCertificationDeclaration", SilabsConfig::kConfigKey_Creds_CD_Offset, SILABS_CREDENTIALS_CD_OFFSET,
+                           SilabsConfig::kConfigKey_Creds_CD_Size, SILABS_CREDENTIALS_CD_SIZE, out_span);
+        }
+        else
+        {
+            // Example CD
+            return Examples::GetExampleDACProvider()->GetCertificationDeclaration(out_span);
+        }
     }
 
     CHIP_ERROR GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer) override
@@ -59,68 +66,83 @@ public:
 
     CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan & out_span) override
     {
-        return GetFile("GetDeviceAttestationCert", SilabsConfig::kConfigKey_Creds_DAC_Offset, SILABS_CREDENTIALS_DAC_OFFSET,
-                       SilabsConfig::kConfigKey_Creds_DAC_Size, SILABS_CREDENTIALS_DAC_SIZE, out_span);
+        if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_Base_Addr))
+        {
+            // Provisioned DAC
+            return GetFile("GetDeviceAttestationCert", SilabsConfig::kConfigKey_Creds_DAC_Offset, SILABS_CREDENTIALS_DAC_OFFSET,
+                           SilabsConfig::kConfigKey_Creds_DAC_Size, SILABS_CREDENTIALS_DAC_SIZE, out_span);
+        }
+        else
+        {
+            // Example DAC
+            return Examples::GetExampleDACProvider()->GetDeviceAttestationCert(out_span);
+        }
     }
 
     CHIP_ERROR GetProductAttestationIntermediateCert(MutableByteSpan & out_span) override
     {
-        return GetFile("GetProductAttestationIntermediateCert", SilabsConfig::kConfigKey_Creds_PAI_Offset,
-                       SILABS_CREDENTIALS_PAI_OFFSET, SilabsConfig::kConfigKey_Creds_PAI_Size, SILABS_CREDENTIALS_PAI_SIZE,
-                       out_span);
+        if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_Base_Addr))
+        {
+            // Provisioned PAI
+            return GetFile("GetProductAttestationIntermediateCert", SilabsConfig::kConfigKey_Creds_PAI_Offset,
+                           SILABS_CREDENTIALS_PAI_OFFSET, SilabsConfig::kConfigKey_Creds_PAI_Size, SILABS_CREDENTIALS_PAI_SIZE,
+                           out_span);
+        }
+        else
+        {
+            // Example PAI
+            return Examples::GetExampleDACProvider()->GetProductAttestationIntermediateCert(out_span);
+        }
     }
 
     CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & message_to_sign, MutableByteSpan & out_span) override
     {
-        uint32_t key_id       = SILABS_CREDENTIALS_DAC_KEY_ID;
-        uint8_t signature[64] = { 0 };
-        size_t signature_size = sizeof(signature);
-
         if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_KeyId))
         {
+            // Provisioned DAC key
+            uint32_t key_id       = SILABS_CREDENTIALS_DAC_KEY_ID;
+            uint8_t signature[64] = { 0 };
+            size_t signature_size = sizeof(signature);
+
             ReturnErrorOnFailure(SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_Creds_KeyId, key_id));
+
+            ChipLogProgress(DeviceLayer, "SignWithDeviceAttestationKey, key:%lu", key_id);
+
+            psa_status_t err =
+                psa_sign_message(static_cast<psa_key_id_t>(key_id), PSA_ALG_ECDSA(PSA_ALG_SHA_256), message_to_sign.data(),
+                                 message_to_sign.size(), signature, signature_size, &signature_size);
+            VerifyOrReturnError(!err, CHIP_ERROR_INTERNAL);
+
+            return CopySpanToMutableSpan(ByteSpan(signature, signature_size), out_span);
         }
-
-        ChipLogProgress(DeviceLayer, "SignWithDeviceAttestationKey, key:%lu", key_id);
-
-        psa_status_t err =
-            psa_sign_message(static_cast<psa_key_id_t>(key_id), PSA_ALG_ECDSA(PSA_ALG_SHA_256), message_to_sign.data(),
-                             message_to_sign.size(), signature, signature_size, &signature_size);
-        VerifyOrReturnError(!err, CHIP_ERROR_INTERNAL);
-
-        return CopySpanToMutableSpan(ByteSpan(signature, signature_size), out_span);
+        else
+        {
+            // Example DAC key
+            return Examples::GetExampleDACProvider()->SignWithDeviceAttestationKey(message_to_sign, out_span);
+        }
     }
 
 private:
     CHIP_ERROR GetFile(const char * description, uint32_t offset_key, uint32_t offset_default, uint32_t size_key,
                        uint32_t size_default, MutableByteSpan & out_span)
     {
-        uint8_t * address = nullptr;
-        uint32_t offset   = offset_default;
+        uint32_t base_addr = 0;
+        uint8_t * address  = nullptr;
+        uint32_t offset    = offset_default;
+        uint32_t size      = size_default;
+
+        ReturnErrorOnFailure(SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_Creds_Base_Addr, base_addr));
+        address = (uint8_t *) (base_addr + offset);
+
+        // Offset
         if (SilabsConfig::ConfigValueExists(offset_key))
         {
-            // NVM-provided offset
             ReturnErrorOnFailure(SilabsConfig::ReadConfigValue(offset_key, offset));
         }
 
-        if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_Base_Addr))
-        {
-            // NVM-provided location
-            uint32_t base_addr = 0;
-            ReturnErrorOnFailure(SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_Creds_Base_Addr, base_addr));
-            address = (uint8_t *) (base_addr + offset);
-        }
-        else
-        {
-            // Default location
-            address = _credentials_address + offset;
-        }
-
         // Size
-        uint32_t size = size_default;
         if (SilabsConfig::ConfigValueExists(size_key))
         {
-            // NVM-provided size
             ReturnErrorOnFailure(SilabsConfig::ReadConfigValue(size_key, size));
         }
 

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -133,11 +133,6 @@ source_set("efr-matter-shell") {
 
 config("attestation-credentials-config") {
   include_dirs = [ "${chip_root}" ]
-
-  defines = [
-    # Set to 1 to enable EFR32 attestation credentials
-    "SILABS_ATTESTATION_CREDENTIALS",
-  ]
 }
 
 source_set("efr32-attestation-credentials") {
@@ -310,9 +305,7 @@ source_set("efr32-common") {
   }
 
   # Attestation Credentials
-  if (chip_build_platform_attestation_credentials_provider) {
-    public_deps += [ ":efr32-attestation-credentials" ]
-  }
+  public_deps += [ ":efr32-attestation-credentials" ]
 
   # Factory Data Provider
   if (use_efr32_factory_data_provider) {

--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -25,11 +25,7 @@
 #include <MatterConfig.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
-#ifdef SILABS_ATTESTATION_CREDENTIALS
 #include <examples/platform/silabs/SilabsDeviceAttestationCreds.h>
-#else
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-#endif
 
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
@@ -86,11 +82,7 @@ void application_start(void * unused)
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
-#ifdef SILABS_ATTESTATION_CREDENTIALS
     SetDeviceAttestationCredentialsProvider(Credentials::Silabs::GetSilabsDacProvider());
-#else
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     SILABS_LOG("Starting App Task");

--- a/src/platform/silabs/MigrationManager.cpp
+++ b/src/platform/silabs/MigrationManager.cpp
@@ -37,10 +37,7 @@ typedef struct
 
 #define COUNT_OF(A) (sizeof(A) / sizeof((A)[0]))
 static migrationData_t migrationTable[] = {
-    { .migrationGroup = 1, .migrationFunc = MigrateKvsMap },
-#ifdef SILABS_ATTESTATION_CREDENTIALS
-    { .migrationGroup = 2, .migrationFunc = MigrateDacProvider },
-#endif
+    { .migrationGroup = 1, .migrationFunc = MigrateKvsMap }, { .migrationGroup = 2, .migrationFunc = MigrateDacProvider },
     // add any additional migration neccesary. migrationGroup should stay equal if done in the same commit or increment by 1 for
     // each new entry.
 };

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -98,6 +98,9 @@ silabs_executable("efr32_device_tests") {
     ]
   }
 
+  # Attestation Credentials
+  deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+
   # Factory Data Provider
   if (use_efr32_factory_data_provider) {
     deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]


### PR DESCRIPTION
Allows runtime detection of the provisioned credentials. If credentials are not present, default example credentials are used instead.
Tested on EFR32MG12 and EFR32MG24.