### PR TITLE
[TC-DT-1.1] Fix Wild card read if thread diagnostic attributes on wifi devices.

### DIFF
--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -23,7 +23,7 @@
  */
 
 #pragma once
-
+#include <app-common/zap-generated/ids/Attributes.h>
 #include <app/AttributeAccessInterface.h>
 
 namespace chip {
@@ -120,9 +120,96 @@ template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(
     AttributeId attributeId, app::AttributeValueEncoder & encoder)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
+    // If we get here the Thread Network Diagnostic cluster is enabled on the device but doesn't run thread.
+    // Encode Null or default values for all attributes of the cluster.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    switch (attributeId)
+    {
+    // Encode EmptyList
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RouteTable::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::NeighborTable::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::Id:
+        err = encoder.EncodeEmptyList();
+        break;
+    // Encode Null
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Channel::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RoutingRole::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::NetworkName::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PanId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Weighting::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::DataVersion::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRouterId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Delay::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ChannelPage0Mask::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::SecurityPolicy::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::Id:
+        err = encoder.EncodeNull();
+        break;
+    // Encode UINT64_T 0
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::OverrunCount::Id:
+        err = encoder.Encode(static_cast<uint64_t>(0));
+        break;
+    // Encode UINT16_T 0
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ChildRoleCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ParentChangeCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    // Encode UINT32_T 0
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxUnicastCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataPollCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxOtherCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxUnicastCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxOtherCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    default:
+        err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        break;
+    }
 
+    return err;
+}
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
Issue:
 TC-DT-1.1 wild card read would fail on our wifi platform running the doorlock app using the common data model config (.zap and .matter files). Other WiFi platforms probably encounter the same failure if they use common data models of the examples.

Fix:
In the case of non-thread devices that would have the ThreadDiagnostic Cluster enabled, we  encode null (for nullable attributes) or the default values of the attributes instead of erroring the read command with `CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE`

