### PR TITLE
SystemLayerImplSelect: libev: avoid timers firing early (#28434)

### DIFF
--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -195,8 +195,10 @@ CHIP_ERROR LayerImplSelect::StartTimer(Clock::Timeout delay, TimerCompleteCallba
     // Note: libev uses the time when events started processing as the "now" reference for relative timers,
     //   for efficiency reasons. This point in time is represented by ev_now().
     //   The real time is represented by ev_time().
-    //   As some chip code relies on timers to fire NEVER even only a bit early, we must increase the
-    //   relative value passed to ev_timer_set().
+    //   Without correction, this leads to timers firing a bit too early relative to the time StartTimer()
+    //   is called. So the relative value passed to ev_timer_set() is adjusted (increased) here.
+    // Note: Still, slightly early (and of course, late) firing timers are something the caller MUST be prepared for,
+    //   because edge cases like system clock adjustments may cause them even with the correction applied here.
     ev_timer_set(&timer->mLibEvTimer, (static_cast<double>(t) / 1E3) + ev_time() - ev_now(mLibEvLoopP), 0.);
     (void) mTimerList.Add(timer);
     ev_timer_start(mLibEvLoopP, &timer->mLibEvTimer);

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -146,7 +146,9 @@ protected:
     int mSelectResult;
 
     ObjectLifeCycle mLayerState;
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
     WakeEvent mWakeEvent;
+#endif
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     std::atomic<pthread_t> mHandleSelectThread;

--- a/src/system/WakeEvent.cpp
+++ b/src/system/WakeEvent.cpp
@@ -23,7 +23,7 @@
 
 #include <system/SystemConfig.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
 #include <system/WakeEvent.h>
 
@@ -207,4 +207,4 @@ CHIP_ERROR WakeEvent::Notify() const
 } // namespace System
 } // namespace chip
 
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV

--- a/src/system/WakeEvent.h
+++ b/src/system/WakeEvent.h
@@ -25,7 +25,7 @@
 // Include configuration headers
 #include <system/SystemConfig.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
 #include <lib/core/CHIPError.h>
 #include <system/SocketEvents.h>
@@ -67,4 +67,4 @@ private:
 } // namespace System
 } // namespace chip
 
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV


### PR DESCRIPTION
Fixes #28434

This fixes a ReportEngine problem that was caused by libev-based timers firing slightly (in the range of 20mS) too early, because libev by default uses the time when events started processing as the "now" reference for relative timers for efficiency reasons.

To ensure timers cannot fire early, timer setup must compensate for any difference between ev_now() which is the time events started processing and ev_time(), which is the actual current time (but is a bit less efficient to obtain).

The PR also avoids and warns about useless (but harmless) calls to Signal() in libev case.