### PR TITLE
Adding interface to handle manual step execution.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/hooks.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/hooks.py
@@ -207,6 +207,12 @@ class TestRunnerHooks():
         """
         pass
 
+    async def step_manual(self):
+        """
+        This method is called when the step is executed manually.
+        """
+        pass
+
 
 class WebSocketRunnerHooks():
     def connecting(self, url: str):

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/pseudo_clusters.py
@@ -31,6 +31,10 @@ class PseudoClusters:
     def supports(self, request) -> bool:
         return False if self.__get_command(request) is None else True
 
+    def is_manual_step(self, request):
+        return (request.cluster == LogCommands().name and
+                request.command == "UserPrompt")
+
     def add(self, cluster: PseudoCluster):
         self.clusters.append(cluster)
 

--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -182,6 +182,10 @@ class TestRunner(TestRunnerBase):
                     hooks.step_start(request)
                     hooks.step_unknown()
                     continue
+                elif config.pseudo_clusters.is_manual_step(request):
+                    hooks.step_start(request)
+                    await hooks.step_manual()
+                    continue
                 else:
                     hooks.step_start(request)
 


### PR DESCRIPTION
Manual step execution are meant to be executed outside runner domain. 
E.g Collecting user feedback through prompt.

The goal of this change is to provide support  for executing semi-automated tests as well as simulated tests that still needs user interaction (manual command execution)

The step result depends only on the user response ( Based on the prompt options). 

PASS
FAIL
NOT APPLICABLE

**Related Issue in TH**
---
CHIP-Specifications/chip-certification-tool#884


**General Discussion**
---

Is there a policy related to plugin versioning?
Changes in interface shouldn't increase plugin version?
The change related to this PR is already in place as a patch on TestHarness. 
