### PR TITLE
[Android] Add to get DeviceTypeId, DeviceName on Android app server

### DIFF
--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -80,6 +80,8 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_UniqueId              = { kCo
 const AndroidConfig::Key AndroidConfig::kConfigKey_Spake2pIterationCount = { kConfigNamespace_ChipFactory, "iteration-count" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_Spake2pSalt           = { kConfigNamespace_ChipFactory, "salt" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_DeviceTypeId          = { kConfigNamespace_ChipFactory, "device-type-id" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_DeviceName            = { kConfigNamespace_ChipFactory, "device-name" };
 
 // Keys stored in the Chip-config namespace
 const AndroidConfig::Key AndroidConfig::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -81,6 +81,8 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
+    static const Key kConfigKey_DeviceTypeId;
+    static const Key kConfigKey_DeviceName;
 
     static CHIP_ERROR Init();
 

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -207,7 +207,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, siz
 {
     CHIP_ERROR err;
     size_t u32DeviceNameSize = 0;
-    err = ReadConfigValueStr(AndroidConfig::kConfigKey_DeviceName, buf, bufSize, u32DeviceNameSize);
+    err                      = ReadConfigValueStr(AndroidConfig::kConfigKey_DeviceName, buf, bufSize, u32DeviceNameSize);
 
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -185,6 +185,39 @@ CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
     return ReadConfigValueStr(AndroidConfig::kConfigKey_UniqueId, buf, bufSize, dateLen);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetDeviceTypeId(uint32_t & deviceType)
+{
+    CHIP_ERROR err;
+    uint32_t u32DeviceTypeId = 0;
+    err                      = ReadConfigValue(AndroidConfig::kConfigKey_DeviceTypeId, u32DeviceTypeId);
+
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        deviceType = CHIP_DEVICE_CONFIG_DEVICE_TYPE;
+    }
+    else
+    {
+        deviceType = u32DeviceTypeId;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetCommissionableDeviceName(char * buf, size_t bufSize)
+{
+    CHIP_ERROR err;
+    size_t u32DeviceNameSize = 0;
+    err = ReadConfigValueStr(AndroidConfig::kConfigKey_DeviceName, buf, bufSize, u32DeviceNameSize);
+
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 ConfigurationManager & ConfigurationMgrImpl()
 {
     return ConfigurationManagerImpl::GetDefaultInstance();

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -43,6 +43,8 @@ public:
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override;
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -46,6 +46,8 @@ public interface ConfigurationManager {
   String kConfigKey_Spake2pIterationCount = "iteration-count";
   String kConfigKey_Spake2pSalt = "salt";
   String kConfigKey_Spake2pVerifier = "verifier";
+  String kConfigKey_DeviceTypeId = "device-type-id";
+  String kConfigKey_DeviceName = "device-name";
 
   // Keys stored in the Chip-config namespace
   String kConfigKey_ServiceConfig = "service-config";


### PR DESCRIPTION
#### Problem
* For the Android App server developer
* Need to show Device type ID and Device Name on the screen

#### Change overview
* Implement to get DeviceTypeId to App
* Implement to get DeviceName to App

#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation