### PR TITLE
Helper script for DA-1.4 and DA-1.8

### DIFF
--- a/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
+++ b/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S python3 -B
 #
-#    Copyright (c) 2022 Project CHIP Authors
+#    Copyright (c) 2023 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,13 +51,22 @@ def main(app: str, chip_tool: str, out_dir: str, test_case: str, manual: bool):
     success_tc = test_case == '1.8'
     cert_path = os.path.abspath(os.path.join(CHIP_ROOT, 'credentials/development/commissioner_dut'))
 
-    # struct_cd_version_number_wrong - excluded because this is a DCL test not covered by cert
-    # struct_cd_cert_id_mismatch - excluded because this is a DCL test not covered by cert
-    exclude_cases = ['struct_cd_version_number_wrong', 'struct_cd_cert_id_mismatch']
+    # The following test vectors are success conditions for an SDK commissioner for the following reasons:
+    # struct_cd_device_type_id_mismatch - requires DCL access, which the SDK does not have and is not required
+    # struct_cd_security_info_wrong - while devices are required to set this to 0, commissioners are required to ignore it
+    #                                 (see 6.3.1)
+    #                                 hence this is marked as a failure for devices, but should be a success case for
+    #                                 commissioners
+    # struct_cd_security_level_wrong - as with security info, commissioners are required to ignore this value (see 6.3.1)
+    # struct_cd_version_number_wrong - this value is not meant to be interpreted by commissioners, so errors here should be
+    #                                  ignored (6.3.1)
+    # struct_cd_cert_id_mismatch - requires DCL access, which the SDK does not have and is not required.
+    exclude_cases = ['struct_cd_device_type_id_mismatch', 'struct_cd_security_info_wrong',
+                     'struct_cd_security_level_wrong', 'struct_cd_version_number_wrong', 'struct_cd_cert_id_mismatch']
 
     subprocess.call(f'mkdir -p {out_dir}', shell=True)
     results = {}
-    for p in os.listdir(cert_path):
+    for p in sorted(os.listdir(cert_path)):
         if str(p) in exclude_cases:
             continue
 
@@ -82,7 +91,7 @@ def main(app: str, chip_tool: str, out_dir: str, test_case: str, manual: bool):
             if manual:
                 input_done = False
                 while not input_done:
-                    resp = input('Please commissiong the DUT. Please input Y if the commissioning is successful, N if it is unsuccessful')
+                    resp = input('Please commission the DUT. Please input Y if the commissioning is successful, N if it is unsuccessful')
                     if resp == 'y' or resp == "Y":
                         commissioning_ok = True
                         input_done = True
@@ -106,8 +115,10 @@ def main(app: str, chip_tool: str, out_dir: str, test_case: str, manual: bool):
 
     summary_file_name = f'{out_dir}/summary_{test_case}.log'
 
-    print(results)
+    test_passed = all(results.values())
+    print(f"\n Test passed? {test_passed}\n")
     with open(summary_file_name, 'w') as summary_file:
+        summary_file.write(f"Test passed? {test_passed}\n\n")
         for k, v in results.items():
             passed = "PASSED" if v is True else "FAILED"
             summary_file.write(f'{k}:{passed}\n')

--- a/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
+++ b/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
@@ -18,11 +18,12 @@
 #    This script is intended for QA use only and does not automatically
 #    verify the results of the commissioning process. Please use with caution.
 
-import click
 import json
 import os
 import signal
 import subprocess
+
+import click
 
 CHIP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 DEFAULT_APP = os.path.abspath(os.path.join(CHIP_ROOT, 'out',

--- a/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
+++ b/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
@@ -55,8 +55,6 @@ def main(app: str, chip_tool: str, out_dir: str, test_case: str, manual: bool):
     # struct_cd_cert_id_mismatch - excluded because this is a DCL test not covered by cert
     exclude_cases = ['struct_cd_version_number_wrong', 'struct_cd_cert_id_mismatch']
 
-    passes = []
-
     subprocess.call(f'mkdir -p {out_dir}', shell=True)
     results = {}
     for p in os.listdir(cert_path):

--- a/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
+++ b/src/python_testing/QA_TC_DA_1_4_1_8_helper.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S python3 -B
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    This script is intended for QA use only and does not automatically
+#    verify the results of the commissioning process. Please use with caution.
+
+import click
+import json
+import os
+import signal
+import subprocess
+
+CHIP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+DEFAULT_APP = os.path.abspath(os.path.join(CHIP_ROOT, 'out',
+                                           'linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test', 'chip-all-clusters-app'))
+DEFAULT_CHIP_TOOL = os.path.abspath(os.path.join(CHIP_ROOT, 'out', 'debug', 'standalone', 'chip-tool'))
+
+
+def get_pid(dirname: str) -> int:
+    if 'fallback_encoding' in dirname:
+        return 177
+    return 32768
+
+# 1.4 is all the failure cases, 1.8 is all the success cases
+
+
+@click.command()
+@click.option('--app', type=click.Path(exists=True), default=DEFAULT_APP,
+              help='Path to local application to use')
+@click.option('--chip-tool', type=click.Path(exists=True), default=DEFAULT_CHIP_TOOL,
+              help='Path to local chip tool if automated testing is requested')
+@click.option('--out-dir', type=click.Path(), default='test_results')
+@click.option('--test-case',
+              type=click.Choice(['1.4', '1.8'], case_sensitive=False))
+@click.option('--manual', is_flag=True, show_default=True, default=False, help="Run the tests manually from a different TH and enter the results by hand")
+def main(app: str, chip_tool: str, out_dir: str, test_case: str, manual: bool):
+    success_tc = test_case == '1.8'
+    cert_path = os.path.abspath(os.path.join(CHIP_ROOT, 'credentials/development/commissioner_dut'))
+
+    # struct_cd_version_number_wrong - excluded because this is a DCL test not covered by cert
+    # struct_cd_cert_id_mismatch - excluded because this is a DCL test not covered by cert
+    exclude_cases = ['struct_cd_version_number_wrong', 'struct_cd_cert_id_mismatch']
+
+    passes = []
+
+    subprocess.call(f'mkdir -p {out_dir}', shell=True)
+    results = {}
+    for p in os.listdir(cert_path):
+        if str(p) in exclude_cases:
+            continue
+
+        path = str(os.path.join(cert_path, p, 'test_case_vector.json'))
+        with open(path, 'r') as f:
+            j = json.loads(f.read())
+            success_expected = j['is_success_case'].lower() == 'true'
+
+        if (success_expected != success_tc):
+            continue
+
+        pid = get_pid(p)
+        # Start the chip tool running, as for manual verification
+        subprocess.call("rm -f tmpkvs", shell=True)
+        app_args = f'--trace_decode 1 --dac_provider {path} --product-id {pid}  --KVS tmpkvs'
+        app_log_file_name = f'{out_dir}/{str(p)}_app.log'
+        commission_log_file_name = f'{out_dir}/{str(p)}_commissioner.log'
+        app_cmd = app + ' ' + app_args
+        with open(app_log_file_name, 'w') as app_log_file:
+            print(f'Starting all clusters app with certs from {p}')
+            app_process = subprocess.Popen(app_cmd.split(), stdout=app_log_file, stderr=app_log_file)
+            if manual:
+                input_done = False
+                while not input_done:
+                    resp = input('Please commissiong the DUT. Please input Y if the commissioning is successful, N if it is unsuccessful')
+                    if resp == 'y' or resp == "Y":
+                        commissioning_ok = True
+                        input_done = True
+                    elif resp == 'n' or resp == 'N':
+                        commissioning_ok = False
+                        input_done = True
+                    else:
+                        print('Unknown key entered, please try again')
+            else:
+                # Commission the dut from another process and auto-record the result
+                chip_tool_cmd = chip_tool + ' pairing onnetwork-long 0x12344321 20202021 3840'
+                with open(commission_log_file_name, 'w') as commissioner_log_file:
+                    commissioning_result = subprocess.run(chip_tool_cmd.split(
+                    ), stdout=commissioner_log_file, stderr=commissioner_log_file)
+                    print(commissioning_result)
+                    commissioning_ok = commissioning_result.returncode == 0
+                    print(f'Commissioning successful? {commissioning_ok}')
+            app_process.send_signal(signal.SIGINT.value)
+            app_process.wait()
+        results[p] = commissioning_ok == success_tc
+
+    summary_file_name = f'{out_dir}/summary_{test_case}.log'
+
+    print(results)
+    with open(summary_file_name, 'w') as summary_file:
+        for k, v in results.items():
+            passed = "PASSED" if v is True else "FAILED"
+            summary_file.write(f'{k}:{passed}\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This does the setup of the all clusters app for the various scenarios required for DA-1.4 and DA-1.8. It has both a manual mode for testing against an external commissioner, and an automatic mode for QA.