### PR TITLE
[Tizen] Update Tizen SDK to the latest version

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-10 : [Telink] Update Docker image (Zephyr update)
+11 : Update Tizen SDK to the latest version after tizen-unified_20230816.124244

--- a/integrations/docker/images/stage-2/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-tizen/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 ENV TIZEN_VERSION 7.0
 ENV TIZEN_SDK_ROOT /opt/tizen-sdk
 
+# TODO(#28852): [Workflow] Make the build script used fixed version for Tizen docker
+# Fetch the version after tizen-unified_20230816.124244
 COPY tizen-sdk-installer $TIZEN_SDK_ROOT/files/installer
 RUN set -x \
     && bash $TIZEN_SDK_ROOT/files/installer/install.sh \


### PR DESCRIPTION
Tizen docker fetches the latest SDK's modification, and it effects on the example build.
ot-br-posix's dbus method change was applied in Tizen SDK 20230816 version,
https://github.com/openthread/ot-br-posix/pull/1814
And it should be applied the tizen docker image.
