### PR TITLE
[ESP32] encrypted_ota: Call abort API when aborting OTA and some refactoring

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -12,6 +12,7 @@ dependencies:
             - if: "idf_version >=4.3"
 
     espressif/esp_encrypted_img:
-        version: "2.0.3"
+        version: "2.1.0"
+        require: public
         rules:
             - if: "idf_version >=4.4"

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -168,7 +168,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
 void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
 {
     DeviceLayer::OtaState otaState = DeviceLayer::kOtaDownloadFailed;
-    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    auto * imageProcessor          = reinterpret_cast<OTAImageProcessorImpl *>(context);
     VerifyOrReturn(imageProcessor, ChipLogError(SoftwareUpdate, "ImageProcessor context is null"));
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -58,20 +58,6 @@ void PostOTAStateChangeEvent(DeviceLayer::OtaState newState)
 
 } // namespace
 
-#if CONFIG_ENABLE_ENCRYPTED_OTA
-void OTAImageProcessorImpl::EndDecryption()
-{
-    VerifyOrReturn(mEncryptedOTAEnabled);
-
-    esp_err_t err = esp_encrypted_img_decrypt_end(mOTADecryptionHandle);
-    if (err != ESP_OK)
-    {
-        ChipLogError(SoftwareUpdate, "Failed to end pre encrypted OTA esp_err:%d", err);
-    }
-    mOTADecryptionHandle = nullptr;
-}
-#endif // CONFIG_ENABLE_ENCRYPTED_OTA
-
 bool OTAImageProcessorImpl::IsFirstImageRun()
 {
     OTARequestorInterface * requestor = GetRequestorInstance();
@@ -165,26 +151,11 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     }
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    if (imageProcessor->mEncryptedOTAEnabled == false)
+    CHIP_ERROR chipError = imageProcessor->DecryptStart();
+    if (chipError != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Encrypted OTA is not initialized");
-        imageProcessor->mDownloader->OnPreparedForDownload(ESP32Utils::MapError(err));
-        return;
-    }
-
-    // This struct takes in private key but arguments are named as pub_key
-    // This is the issue in the esp_encrypted_img component
-    // https://github.com/espressif/idf-extra-components/blob/791d506/esp_encrypted_img/include/esp_encrypted_img.h#L47
-    const esp_decrypt_cfg_t decryptionConfig = {
-        .rsa_pub_key     = imageProcessor->mKey.data(),
-        .rsa_pub_key_len = imageProcessor->mKey.size(),
-    };
-
-    imageProcessor->mOTADecryptionHandle = esp_encrypted_img_decrypt_start(&decryptionConfig);
-    if (imageProcessor->mOTADecryptionHandle == nullptr)
-    {
-        ChipLogError(SoftwareUpdate, "Failed to initialize encrypted OTA");
-        imageProcessor->mDownloader->OnPreparedForDownload(ESP32Utils::MapError(ESP_FAIL));
+        ChipLogError(SoftwareUpdate, "Failed to start decryption process, err:%" CHIP_ERROR_FORMAT, chipError.Format());
+        imageProcessor->mDownloader->OnPreparedForDownload(chipError);
         return;
     }
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
@@ -204,7 +175,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     }
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    imageProcessor->EndDecryption();
+    imageProcessor->DecryptEnd();
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
 
     esp_err_t err = esp_ota_end(imageProcessor->mOTAUpdateHandle);
@@ -236,7 +207,7 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
     }
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    imageProcessor->EndDecryption();
+    imageProcessor->DecryptAbort();
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
 
     if (esp_ota_abort(imageProcessor->mOTAUpdateHandle) != ESP_OK)
@@ -276,53 +247,20 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
     ByteSpan blockToWrite = block;
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    if (imageProcessor->mEncryptedOTAEnabled == false)
-    {
-        ChipLogError(SoftwareUpdate, "Encrypted OTA is not initialized");
-        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INCORRECT_STATE);
-        PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
-        return;
-    }
-
-    if (imageProcessor->mOTADecryptionHandle == nullptr)
-    {
-        ChipLogError(SoftwareUpdate, "OTA decryption handle is nullptr");
-        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INCORRECT_STATE);
-        PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
-        return;
-    }
-
-    pre_enc_decrypt_arg_t preEncOtaDecryptArgs = {
-        .data_in      = reinterpret_cast<const char *>(block.data()),
-        .data_in_len  = block.size(),
-        .data_out     = nullptr,
-        .data_out_len = 0,
-    };
-
-    err = esp_encrypted_img_decrypt_data(imageProcessor->mOTADecryptionHandle, &preEncOtaDecryptArgs);
-    if (err != ESP_OK && err != ESP_ERR_NOT_FINISHED)
+    error = imageProcessor->DecryptBlock(block, blockToWrite);
+    if (error != CHIP_NO_ERROR)
     {
         ChipLogError(SoftwareUpdate, "esp_encrypted_img_decrypt_data failed err:%d", err);
         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
         PostOTAStateChangeEvent(DeviceLayer::kOtaDownloadFailed);
         return;
     }
-
-    ChipLogDetail(SoftwareUpdate, "data_in_len:%u, data_out_len:%u", preEncOtaDecryptArgs.data_in_len,
-                  preEncOtaDecryptArgs.data_out_len);
-
-    if (preEncOtaDecryptArgs.data_out == nullptr || preEncOtaDecryptArgs.data_out_len <= 0)
-    {
-        ChipLogProgress(SoftwareUpdate, "Decrypted data is null or out len is zero");
-    }
-
-    blockToWrite = ByteSpan(reinterpret_cast<const uint8_t *>(preEncOtaDecryptArgs.data_out), preEncOtaDecryptArgs.data_out_len);
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
 
     err = esp_ota_write(imageProcessor->mOTAUpdateHandle, blockToWrite.data(), blockToWrite.size());
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    free(preEncOtaDecryptArgs.data_out);
+    free((void *) (blockToWrite.data()));
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA
 
     if (err != ESP_OK)
@@ -425,6 +363,75 @@ CHIP_ERROR OTAImageProcessorImpl::InitEncryptedOTA(const CharSpan & key)
 
     mKey                 = key;
     mEncryptedOTAEnabled = true;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::DecryptStart()
+{
+    VerifyOrReturnError(mEncryptedOTAEnabled, CHIP_ERROR_INCORRECT_STATE);
+
+    const esp_decrypt_cfg_t decryptionConfig = {
+        .rsa_priv_key     = mKey.data(),
+        .rsa_priv_key_len = mKey.size(),
+    };
+
+    mOTADecryptionHandle = esp_encrypted_img_decrypt_start(&decryptionConfig);
+    VerifyOrReturnError(mOTADecryptionHandle, CHIP_ERROR_INCORRECT_STATE);
+    return CHIP_NO_ERROR;
+}
+
+void OTAImageProcessorImpl::DecryptEnd()
+{
+    VerifyOrReturn(mEncryptedOTAEnabled);
+
+    esp_err_t err = esp_encrypted_img_decrypt_end(mOTADecryptionHandle);
+    if (err != ESP_OK)
+    {
+        ChipLogError(SoftwareUpdate, "Failed to end pre encrypted OTA esp_err:%d", err);
+    }
+    mOTADecryptionHandle = nullptr;
+}
+
+void OTAImageProcessorImpl::DecryptAbort()
+{
+    VerifyOrReturn(mEncryptedOTAEnabled);
+
+    esp_err_t err = esp_encrypted_img_decrypt_abort(mOTADecryptionHandle);
+    if (err != ESP_OK)
+    {
+        ChipLogError(SoftwareUpdate, "Failed to abort pre encrypted OTA esp_err:%d", err);
+    }
+    mOTADecryptionHandle = nullptr;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::DecryptBlock(const ByteSpan & blockToDecrypt, ByteSpan & decryptedBlock)
+{
+    VerifyOrReturnError(mEncryptedOTAEnabled, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mOTADecryptionHandle, CHIP_ERROR_INCORRECT_STATE);
+
+    pre_enc_decrypt_arg_t preEncOtaDecryptArgs = {
+        .data_in      = reinterpret_cast<const char *>(blockToDecrypt.data()),
+        .data_in_len  = blockToDecrypt.size(),
+        .data_out     = nullptr,
+        .data_out_len = 0,
+    };
+
+    esp_err_t err = esp_encrypted_img_decrypt_data(mOTADecryptionHandle, &preEncOtaDecryptArgs);
+    if (err != ESP_OK && err != ESP_ERR_NOT_FINISHED)
+    {
+        ChipLogError(SoftwareUpdate, "esp_encrypted_img_decrypt_data failed err:%d", err);
+        return ESP32Utils::MapError(err);
+    }
+
+    ChipLogDetail(SoftwareUpdate, "esp_encrypted_img_decrypt_data data_in_len:%u, data_out_len:%u",
+                  preEncOtaDecryptArgs.data_in_len, preEncOtaDecryptArgs.data_out_len);
+
+    if (preEncOtaDecryptArgs.data_out == nullptr || preEncOtaDecryptArgs.data_out_len <= 0)
+    {
+        ChipLogProgress(SoftwareUpdate, "Decrypted data is null or out len is zero");
+    }
+
+    decryptedBlock = ByteSpan(reinterpret_cast<const uint8_t *>(preEncOtaDecryptArgs.data_out), preEncOtaDecryptArgs.data_out_len);
     return CHIP_NO_ERROR;
 }
 #endif // CONFIG_ENABLE_ENCRYPTED_OTA

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -68,7 +68,7 @@ private:
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
     CHIP_ERROR DecryptStart();
-    void DecryptEnd();
+    CHIP_ERROR DecryptEnd();
     void DecryptAbort();
 
     // This API decrypts the blockToDecrypt, dynamically allocates the memory for storing the

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -67,7 +67,14 @@ private:
     OTAImageHeaderParser mHeaderParser;
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA
-    void EndDecryption();
+    CHIP_ERROR DecryptStart();
+    void DecryptEnd();
+    void DecryptAbort();
+
+    // This API decrypts the blockToDecrypt, dynamically allocates the memory for storing the
+    // plain text, and return that in decryptedBlock.
+    // Caller shall free the memory after use by calling free() on decryptedBlock.data()
+    CHIP_ERROR DecryptBlock(const ByteSpan & blockToDecrypt, ByteSpan & decryptedBlock);
 
     CharSpan mKey;
     bool mEncryptedOTAEnabled                 = false;


### PR DESCRIPTION
#### Problem and change overview
`esp_encrypted_img_decrypt_abort()` API is recently added to the encrypted ota component, so using it when aborting the OTA process.

Also, refactored out the decryption bits into routines.

#### Tests
- Manually tested the encrypted OTA image.
- Manually tested the abort bits by quitting the linux ota provider in the middle of trasfer.