### PR TITLE
[CI] Replace EVENT_NUMBER key by eventNumber in certification/TEST_TC…

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -121,7 +121,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      eventNumber: EVENT_NUMBER + 1
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -201,7 +201,7 @@ tests:
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      eventNumber: EVENT_NUMBER + 2
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -246,6 +246,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      eventNumber: EVENT_NUMBER + 3
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -120,7 +120,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      eventNumber: EVENT_NUMBER + 1
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -200,7 +200,7 @@ tests:
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      eventNumber: EVENT_NUMBER + 2
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -245,6 +245,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      eventNumber: EVENT_NUMBER + 3
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -133,7 +133,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      eventNumber: EVENT_NUMBER + 1
       response:
           value: { AlarmSeverityLevel: 1 }
 
@@ -178,7 +178,7 @@ tests:
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      eventNumber: EVENT_NUMBER + 2
       response:
           value: { AlarmSeverityLevel: 2 }
 
@@ -223,7 +223,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      eventNumber: EVENT_NUMBER + 3
       response:
           value: {}
 
@@ -279,7 +279,7 @@ tests:
       PICS: SMOKECO.S.E03
       command: "readEvent"
       event: "HardwareFault"
-      EVENT_NUMBER: EVENT_NUMBER + 4
+      eventNumber: EVENT_NUMBER + 4
       response:
           value: {}
 
@@ -325,7 +325,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 5
+      eventNumber: EVENT_NUMBER + 5
       response:
           value: {}
 
@@ -381,7 +381,7 @@ tests:
       PICS: SMOKECO.S.E04
       command: "readEvent"
       event: "EndOfService"
-      EVENT_NUMBER: EVENT_NUMBER + 6
+      eventNumber: EVENT_NUMBER + 6
       response:
           value: {}
 
@@ -427,7 +427,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 7
+      eventNumber: EVENT_NUMBER + 7
       response:
           value: {}
 
@@ -499,7 +499,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      EVENT_NUMBER: EVENT_NUMBER + 8
+      eventNumber: EVENT_NUMBER + 8
       response:
           value: {}
 
@@ -516,7 +516,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 9
+      eventNumber: EVENT_NUMBER + 9
       response:
           value: {}
 
@@ -561,7 +561,7 @@ tests:
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
-      EVENT_NUMBER: EVENT_NUMBER + 10
+      eventNumber: EVENT_NUMBER + 10
       response:
           value: {}
 
@@ -578,6 +578,6 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 11
+      eventNumber: EVENT_NUMBER + 11
       response:
           value: {}

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -160,7 +160,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E08
       command: "readEvent"
       event: "InterconnectSmokeAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 1
+      eventNumber: EVENT_NUMBER + 1
       response:
           value: { AlarmSeverityLevel: interconnectSmokeAlarmSeverityLevel }
 
@@ -215,7 +215,7 @@ tests:
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 2
+      eventNumber: EVENT_NUMBER + 2
       response:
           value: {}
 
@@ -273,7 +273,7 @@ tests:
       PICS: SMOKECO.S.A0009 && SMOKECO.S.E09
       command: "readEvent"
       event: "InterconnectCOAlarm"
-      EVENT_NUMBER: EVENT_NUMBER + 3
+      eventNumber: EVENT_NUMBER + 3
       response:
           value: { AlarmSeverityLevel: interconnectCOAlarmSeverityLevel }
 
@@ -328,7 +328,7 @@ tests:
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
-      EVENT_NUMBER: EVENT_NUMBER + 4
+      eventNumber: EVENT_NUMBER + 4
       response:
           value: {}
 
@@ -679,7 +679,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      EVENT_NUMBER: EVENT_NUMBER + 5
+      eventNumber: EVENT_NUMBER + 5
       response:
           value: {}
 
@@ -716,7 +716,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      EVENT_NUMBER: EVENT_NUMBER + 6
+      eventNumber: EVENT_NUMBER + 6
       response:
           value: {}
 
@@ -891,7 +891,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
-      EVENT_NUMBER: EVENT_NUMBER + 7
+      eventNumber: EVENT_NUMBER + 7
       response:
           value: {}
 
@@ -928,7 +928,7 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
-      EVENT_NUMBER: EVENT_NUMBER + 8
+      eventNumber: EVENT_NUMBER + 8
       response:
           value: {}
 


### PR DESCRIPTION
…_SMOKECO_2_X.yaml

#### Problem

There are a typos in the different `Test_TC_SMOKECO_2_*.yaml` tests where the `EVENT_NUMBER` key should be `eventNumber`.