### PR TITLE
[CI] Add keepSubscriptions supports to matter_yamltests

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -284,6 +284,8 @@ class Encoder:
             arguments, request.min_interval, "min-interval")
         arguments = self.__maybe_add(
             arguments, request.max_interval, "max-interval")
+        arguments = self.__maybe_add(
+            arguments, request.keep_subscriptions, "keepSubscriptions")
         arguments = self.__maybe_add(arguments, request.timed_interaction_timeout_ms,
                                      "timedInteractionTimeoutMs")
         arguments = self.__maybe_add(

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -199,6 +199,7 @@ class _TestStepWithPlaceholders:
         self.fabric_filtered = _value_or_none(test, 'fabricFiltered')
         self.min_interval = _value_or_none(test, 'minInterval')
         self.max_interval = _value_or_none(test, 'maxInterval')
+        self.keep_subscriptions = _value_or_none(test, 'keepSubscriptions')
         self.timed_interaction_timeout_ms = _value_or_none(
             test, 'timedInteractionTimeoutMs')
         self.timeout = _value_or_none(test, 'timeout')
@@ -658,6 +659,10 @@ class TestStep:
     @property
     def max_interval(self):
         return self._test.max_interval
+
+    @property
+    def keep_subscriptions(self):
+        return self._test.keep_subscriptions
 
     @property
     def timed_interaction_timeout_ms(self):

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -106,6 +106,7 @@ class YamlLoader:
             'saveResponseAs': str,
             'minInterval': int,
             'maxInterval': int,
+            'keepSubscriptions': bool,
             'timeout': int,
             'timedInteractionTimeoutMs': int,
             'dataVersion': (list, int, str),  # Can be a variable


### PR DESCRIPTION
#### Problem

The `matter_yanltests` package does not support the `keepSubscriptions` key while it used to be supported by the codegen version.