### PR TITLE
[matter_yamltests] Add mrpRetryActiveThreshold response key for Disco…

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -253,6 +253,11 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeDat
         value["mrpRetryIntervalActive"] = resolutionData.mrpRetryIntervalActive.Value().count();
     }
 
+    if (resolutionData.mrpRetryActiveThreshold.HasValue())
+    {
+        value["mrpRetryActiveThreshold"] = resolutionData.mrpRetryActiveThreshold.Value().count();
+    }
+
     Json::Value rootValue;
     rootValue[kValueKey] = value;
 

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
@@ -73,6 +73,7 @@ _DEFINITION = '''<?xml version="1.0"?>
         <arg name="port" type="int16u"/>
         <arg name="mrpRetryIntervalIdle" type="int32u" optional="true"/>
         <arg name="mrpRetryIntervalActive" type="int32u" optional="true"/>
+        <arg name="mrpRetryActiveThreshold" type="int16u" optional="true"/>
     </command>
 </cluster>
 </configurator>


### PR DESCRIPTION
…very Commands

#### Problem

`mrpRetryActiveThreshold` has been added to `CommonResolutionData` by https://github.com/project-chip/connectedhomeip/commit/47bd8854a18966e8f5041aa10aca223595f7c590 but it has not been added to YAML.
