### PR TITLE
Enable tracing support for python builds

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -156,7 +156,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 [[ -n "$chip_case_retry_delta" ]] && chip_case_retry_arg="chip_case_retry_delta=$chip_case_retry_delta" || chip_case_retry_arg=""
 [[ -n "$pregen_dir" ]] && pregen_dir_arg="chip_code_pre_generated_directory=\"$pregen_dir\"" || pregen_dir_arg=""
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="matter_enable_tracing_support=true chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg"
 
 function ninja_target() {
     # Print the ninja target required to build a gn label.

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -22,8 +22,7 @@ declare_args() {
   #
   # Additionally, if tracing is enabled, the main() function has to add
   # backends explicitly
-  matter_enable_tracing_support =
-      current_os == "android" || current_os == "linux"
+  matter_enable_tracing_support = current_os == "android"
 
   # Defines the trace backend. Current matter tracing splits the logic
   # into two parts:

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -22,7 +22,7 @@ declare_args() {
   #
   # Additionally, if tracing is enabled, the main() function has to add
   # backends explicitly
-  matter_enable_tracing_support = current_os == "android"
+  matter_enable_tracing_support = (current_os == "android") || (current_os == "linux")
 
   # Defines the trace backend. Current matter tracing splits the logic
   # into two parts:

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -22,7 +22,8 @@ declare_args() {
   #
   # Additionally, if tracing is enabled, the main() function has to add
   # backends explicitly
-  matter_enable_tracing_support = (current_os == "android") || (current_os == "linux")
+  matter_enable_tracing_support =
+      current_os == "android" || current_os == "linux"
 
   # Defines the trace backend. Current matter tracing splits the logic
   # into two parts:


### PR DESCRIPTION
Update new tracing macros enabling:
   - ensure python always has tracing support, this is in case python yaml scripts are needing this (and expect this to be for both linux and mac python scripting)

I had previously tried to enable tracing for all linux cases, however that does not work well as the main app also needs to enable tracing (to setup perfetto data sources) and things like tests do not like that. So for now we have python and individual linux apps enabling this.