### PR TITLE
python: Set urgent before early returns

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1019,10 +1019,7 @@ class ChipDeviceControllerBase():
                     event = pathTuple[1]
                 else:
                     raise ValueError("Unsupported Attribute Path")
-                if len(pathTuple) > 2:
-                    urgent = pathTuple[-1]
-                else:
-                    urgent = 0
+                urgent = bool(pathTuple[-1]) if len(pathTuple) > 2 else False
         return ClusterAttribute.EventPath(
             EndpointId=endpoint, Cluster=cluster, Event=event, Urgent=urgent)
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1019,7 +1019,10 @@ class ChipDeviceControllerBase():
                     event = pathTuple[1]
                 else:
                     raise ValueError("Unsupported Attribute Path")
-                urgent = pathTuple[-1]
+                if len(pathTuple) > 2:
+                    urgent = pathTuple[-1]
+                else:
+                    urgent = 0
         return ClusterAttribute.EventPath(
             EndpointId=endpoint, Cluster=cluster, Event=event, Urgent=urgent)
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -173,6 +173,7 @@ class EventPath:
 
     def __init__(self, EndpointId: int = None, Cluster=None, Event=None, ClusterId=None, EventId=None, Urgent=None):
         self.EndpointId = EndpointId
+        self.Urgent = Urgent
         if Cluster is not None:
             # Wildcard read for a specific cluster
             if (Event is not None) or (ClusterId is not None) or (EventId is not None):
@@ -189,7 +190,6 @@ class EventPath:
             return
         self.ClusterId = ClusterId
         self.EventId = EventId
-        self.Urgent = Urgent
 
     def __str__(self) -> str:
         return f"{self.EndpointId}/{self.ClusterId}/{self.EventId}/{self.Urgent}"


### PR DESCRIPTION
Properly set isUrgent on python generated event subscriptions. 

test: subscribed with isUrgent, can now see it being set

Fixes: #28567

