### PR TITLE
[ESP32] Enable LWIP_TCPIP_CORE_LOCKING by default and added static assert for the same

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -194,7 +194,7 @@ menu "CHIP Core"
             help
                 CHIP SDK performs LwIP core locking before calling an LwIP API.
                 To make the calls thread safe we have to enable LWIP_TCPIP_CORE_LOCKING.
-                Here, we are also enabling LWIP_CHECK_THREAD_SAFETY which will asser when
+                Here, we are also enabling LWIP_CHECK_THREAD_SAFETY which will assert when
                 LwIP code gets called from any other context or without holding the LwIP lock.
 
     endmenu # "Networking Options"

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -186,6 +186,17 @@ menu "CHIP Core"
             help
                 Enable this option to use LwIP default IPv6 route hook for Route Information Option(RIO) feature.
 
+        config ENABLE_LWIP_THREAD_SAFETY
+            bool "Enable LwIP Thread safety options"
+            default y
+            select LWIP_TCPIP_CORE_LOCKING
+            select LWIP_CHECK_THREAD_SAFETY
+            help
+                CHIP SDK performs LwIP core locking before calling an LwIP API.
+                To make the calls thread safe we have to enable LWIP_TCPIP_CORE_LOCKING.
+                Here, we are also enabling LWIP_CHECK_THREAD_SAFETY which will asser when
+                LwIP code gets called from any other context or without holding the LwIP lock.
+
     endmenu # "Networking Options"
 
     menu "System Options"

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -41,6 +41,11 @@
 
 static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
 
+#if !(CHIP_DEVICE_LAYER_TARGET_BL602 || CHIP_DEVICE_LAYER_TARGET_BL702 || CHIP_DEVICE_LAYER_TARGET_BL702L ||                       \
+      CHIP_DEVICE_LAYER_TARGET_ASR)
+static_assert(LWIP_TCPIP_CORE_LOCKING, "CHIP requires config LWIP_TCPIP_CORE_LOCKING enabled");
+#endif
+
 #if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
     !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
 #define HAVE_LWIP_MULTICAST_LOOP 0


### PR DESCRIPTION
Related to #28590 and followup for #28655

#### Change Overview
- [ESP32] Enable `LWIP_TCPIP_CORE_LOCKING` by default and acquire lwip locks when initializing route_hook
- inet: static assert if LWIP_TCPIP_CORE_LOCKING is disabled
- Static assert is disabled for ASR and bouffalolab platforms

#### Tests
Locally built the ESP32 lighting-app and tested commissioning and wildcard subscription.