### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-9 : [Ameba] Fix onnetwork fastconnect failure
+10 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=6bd9f0efd2d31a80fab550c2ea31f101c53c0946
+ARG ZEPHYR_REVISION=ab848725befd1a358c41961aae0d5c273fab9ac6
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=ab848725befd1a358c41961aae0d5c273fab9ac6
+ARG ZEPHYR_REVISION=333abf31311e73def9db739026d217fca547a01f
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \


### PR DESCRIPTION
**Change overview**

- Add Telink B92 (TLSR9528A) soc support
- drivers: flash: telink: Change read/write interface to use 4wire spi
- drivers: flash: telink: Flash write-modify algorithm
- uart: pinctrl: added extra config of UART
- boards: tlsr9518adk80d: Support USB DFU by mcuboot
- samples: net: openthread: cli: Use USB as openthread console
- drivers: flash: telink: Flash write-modify speed up

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully
