### PR TITLE
Take into account manufacturerCode when generating .matter files

### DIFF
--- a/src/app/zap-templates/partials/idl/attribute_definition.zapt
+++ b/src/app/zap-templates/partials/idl/attribute_definition.zapt
@@ -28,5 +28,10 @@
       {{~/if~}}
     {{~/if~}}
   {{/unless}} {{asLowerCamelCase name~}}
-  {{~#if isArray~}} [] {{~/if}} = {{asMEI manufacturerCode code~}}
+  {{~#if isArray~}} [] {{~/if}} = {{!}}
+     {{~#if manufacturerCode}}
+        {{~asMEI manufacturerCode code~}}
+     {{else}}
+        {{~code~}}
+     {{/if~}}
   ;

--- a/src/app/zap-templates/partials/idl/attribute_definition.zapt
+++ b/src/app/zap-templates/partials/idl/attribute_definition.zapt
@@ -28,5 +28,5 @@
       {{~/if~}}
     {{~/if~}}
   {{/unless}} {{asLowerCamelCase name~}}
-  {{~#if isArray~}} [] {{~/if}} = {{code~}}
+  {{~#if isArray~}} [] {{~/if}} = {{asMEI manufacturerCode code~}}
   ;

--- a/src/app/zap-templates/partials/idl/cluster_definition.zapt
+++ b/src/app/zap-templates/partials/idl/cluster_definition.zapt
@@ -1,6 +1,6 @@
 /** {{description}} */
 {{#if generateClientCluster}}client {{else}}server {{/if~}}
-cluster {{asUpperCamelCase name}} = {{code}} {
+cluster {{asUpperCamelCase name}} = {{asMEI manufacturerCode code}} {
   {{#zcl_enums}}
   enum {{asUpperCamelCase name preserveAcronyms=true}} : ENUM{{multiply size 8}} {
     {{#zcl_enum_items}}
@@ -29,7 +29,7 @@ cluster {{asUpperCamelCase name}} = {{code}} {
         {{operation}}: {{role}}
       {{~#last}}) {{/last~}}
   {{~/chip_access_elements~}}
-  {{asUpperCamelCase name preserveAcronyms=true}} = {{code}} {
+  {{asUpperCamelCase name preserveAcronyms=true}} = {{asMEI manufacturerCode code}} {
     {{#zcl_event_fields}}
     {{>idl_structure_member label=name}}
 

--- a/src/app/zap-templates/partials/idl/cluster_definition.zapt
+++ b/src/app/zap-templates/partials/idl/cluster_definition.zapt
@@ -1,6 +1,11 @@
 /** {{description}} */
 {{#if generateClientCluster}}client {{else}}server {{/if~}}
-cluster {{asUpperCamelCase name}} = {{asMEI manufacturerCode code}} {
+cluster {{asUpperCamelCase name}} = {{!}}
+     {{~#if manufacturerCode}}
+        {{~asMEI manufacturerCode code~}}
+     {{else}}
+        {{~code~}}
+     {{/if}} {
   {{#zcl_enums}}
   enum {{asUpperCamelCase name preserveAcronyms=true}} : ENUM{{multiply size 8}} {
     {{#zcl_enum_items}}
@@ -29,7 +34,12 @@ cluster {{asUpperCamelCase name}} = {{asMEI manufacturerCode code}} {
         {{operation}}: {{role}}
       {{~#last}}) {{/last~}}
   {{~/chip_access_elements~}}
-  {{asUpperCamelCase name preserveAcronyms=true}} = {{asMEI manufacturerCode code}} {
+  {{asUpperCamelCase name preserveAcronyms=true}} = {{!}}
+    {{~#if manufacturerCode}}
+       {{~asMEI manufacturerCode code~}}
+    {{else}}
+       {{~code~}}
+    {{/if}} {
     {{#zcl_event_fields}}
     {{>idl_structure_member label=name}}
 

--- a/src/app/zap-templates/partials/idl/command_response_struct.zapt
+++ b/src/app/zap-templates/partials/idl/command_response_struct.zapt
@@ -1,6 +1,6 @@
 {{#zcl_command_arguments}}
     {{#first}}
-        {{~new_line 1~}}{{~indent 1~}}response struct {{asUpperCamelCase parent.commandName}} = {{parent.code}} {
+        {{~new_line 1~}}{{~indent 1~}}response struct {{asUpperCamelCase parent.commandName}} = {{asMEI parent.manufacturerCode parent.code}} {
     {{/first}}    
     {{~indent 2~}}{{> idl_structure_member}}
     {{#last}}

--- a/src/app/zap-templates/partials/idl/command_response_struct.zapt
+++ b/src/app/zap-templates/partials/idl/command_response_struct.zapt
@@ -1,7 +1,12 @@
 {{#zcl_command_arguments}}
     {{#first}}
-        {{~new_line 1~}}{{~indent 1~}}response struct {{asUpperCamelCase parent.commandName}} = {{asMEI parent.manufacturerCode parent.code}} {
-    {{/first}}    
+        {{~new_line 1~}}{{~indent 1~}}response struct {{asUpperCamelCase parent.commandName}} = {{!}}
+        {{~#if parent.manufacturerCode}}
+           {{~asMEI parent.manufacturerCode parent.code~}}
+        {{else}}
+           {{~parent.code~}}
+        {{/if}} {
+    {{/first}}
     {{~indent 2~}}{{> idl_structure_member}}
     {{#last}}
 


### PR DESCRIPTION
It seems that zap supports a "manufacturerCode" for clusters, however our example test clusters do not use that and instead set the code directly to a large number.

Using MEI seems what the C++ SDK does, so adapt this into .matter file codegen as well.

I did not update FaultInjection or UnitTestingCluster at this point as changing those requires more updates (need to update all zap files and structure references and that is a larger change).