### PR TITLE
[Telink] Fix restart BLE adv after basic commissioning fail

### DIFF
--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -157,7 +157,7 @@ class AppFabricTableDelegate : public FabricTable::Delegate
     {
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
         {
-            bool isBasicCommissioningMode = 
+            bool isBasicCommissioningMode =
                     chip::Server::GetInstance().GetCommissioningWindowManager().GetCommissioningMode() ==
                     Dnssd::CommissioningMode::kEnabledBasic;
             ChipLogProgress(DeviceLayer, "Performing erasing of settings partition");

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -157,7 +157,9 @@ class AppFabricTableDelegate : public FabricTable::Delegate
     {
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
         {
-            bool isCommissioningFailed = chip::Server::GetInstance().GetCommissioningWindowManager().IsCommissioningWindowOpen();
+            bool isBasicCommissioningMode = 
+                    chip::Server::GetInstance().GetCommissioningWindowManager().GetCommissioningMode() ==
+                    Dnssd::CommissioningMode::kEnabledBasic;
             ChipLogProgress(DeviceLayer, "Performing erasing of settings partition");
 
 #ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_NVS
@@ -169,7 +171,7 @@ class AppFabricTableDelegate : public FabricTable::Delegate
                 status = nvs_clear(static_cast<nvs_fs *>(storage));
             }
 
-            if (!isCommissioningFailed)
+            if (!isBasicCommissioningMode)
             {
                 if (!status)
                 {
@@ -191,7 +193,7 @@ class AppFabricTableDelegate : public FabricTable::Delegate
 
             ConnectivityMgr().ErasePersistentInfo();
 #endif
-            if (isCommissioningFailed)
+            if (isBasicCommissioningMode)
             {
                 PlatformMgr().Shutdown();
             }

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -157,9 +157,8 @@ class AppFabricTableDelegate : public FabricTable::Delegate
     {
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
         {
-            bool isBasicCommissioningMode =
-                    chip::Server::GetInstance().GetCommissioningWindowManager().GetCommissioningMode() ==
-                    Dnssd::CommissioningMode::kEnabledBasic;
+            bool isBasicCommissioningMode = chip::Server::GetInstance().GetCommissioningWindowManager().GetCommissioningMode() ==
+                Dnssd::CommissioningMode::kEnabledBasic;
             ChipLogProgress(DeviceLayer, "Performing erasing of settings partition");
 
 #ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_NVS


### PR DESCRIPTION
To restart the BLE advertising after the basic commissioning failed to need to restore the default values to the setting partition after erasing. 
For this need to reboot the system only after a problem during the basic commissioning mode.
The setting partition will be set during the system initialization.