### PR TITLE
[Silabs] [WiFi] Build fix for the wifi devices when using 91x bluetooth

### DIFF
--- a/src/platform/silabs/rs911x/wfx_sl_ble_init.c
+++ b/src/platform/silabs/rs911x/wfx_sl_ble_init.c
@@ -23,6 +23,7 @@
 #include "wfx_sl_ble_init.h"
 #include "ble_config.h"
 #include "silabs_utils.h"
+#include "cmsis_os2.h"
 // Global Variables
 rsi_ble_t att_list;
 sl_wfx_msg_t event_msg;

--- a/src/platform/silabs/rs911x/wfx_sl_ble_init.c
+++ b/src/platform/silabs/rs911x/wfx_sl_ble_init.c
@@ -22,8 +22,8 @@
  */
 #include "wfx_sl_ble_init.h"
 #include "ble_config.h"
-#include "silabs_utils.h"
 #include "cmsis_os2.h"
+#include "silabs_utils.h"
 // Global Variables
 rsi_ble_t att_list;
 sl_wfx_msg_t event_msg;


### PR DESCRIPTION
From this change https://github.com/project-chip/connectedhomeip/commit/48420b43ab0ca76680ebe692fd5bf153e573eab3#diff-c99b691e5dfff6a31d831f019e9969f2eb11cd9a8c8add178b0b7476cd6ee07d 
the 9116 bluetooth was broken

This PR fixes the build issue with the 911x ble