### PR TITLE
[Silabs]Fix init task stack size on EFR32

### DIFF
--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -41,7 +41,11 @@
 /**********************************************************
  * Defines
  *********************************************************/
-#define MAIN_TASK_STACK_SIZE (1024 * 1)
+#ifdef SIWX_917
+#define MAIN_TASK_STACK_SIZE (1024 * 8)
+#else
+#define MAIN_TASK_STACK_SIZE (1024)
+#endif
 #define MAIN_TASK_PRIORITY (configMAX_PRIORITIES - 1)
 
 using namespace ::chip;

--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -41,7 +41,7 @@
 /**********************************************************
  * Defines
  *********************************************************/
-#define MAIN_TASK_STACK_SIZE (1024 * 8)
+#define MAIN_TASK_STACK_SIZE (1024 * 1)
 #define MAIN_TASK_PRIORITY (configMAX_PRIORITIES - 1)
 
 using namespace ::chip;


### PR DESCRIPTION
8k of stack for the init task is overkill on the efr32 platform. It was busting our configure heap limit.

Reduce the task size to 1k and leave heap unchanged.

For now, keep si917 to the previously set value.
