### PR TITLE
Updated YAML Parser to consider wait instruction as command

### DIFF
--- a/examples/placeholder/py_matter_placeholder_adapter/matter_placeholder_adapter/adapter.py
+++ b/examples/placeholder/py_matter_placeholder_adapter/matter_placeholder_adapter/adapter.py
@@ -72,6 +72,8 @@ class PlaceholderDecoder:
                 clusterId = json_response[_CLUSTER_ID]
                 decoded_response[_COMMAND] = self.__definitions.get_response_name(
                     clusterId, value)
+                if not decoded_response[_COMMAND]:
+                    decoded_response[_COMMAND] = self.__definitions.get_command_name(clusterId, value)
             elif key == _ATTRIBUTE_ID:
                 clusterId = json_response[_CLUSTER_ID]
                 decoded_response[_ATTRIBUTE] = self.__definitions.get_attribute_name(

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -189,6 +189,8 @@ class _TestStepWithPlaceholders:
         self.group_id = _value_or_config(test, 'groupId', config)
         self.cluster = _value_or_config(test, 'cluster', config)
         self.command = _value_or_config(test, 'command', config)
+        if not self.command:
+            self.command = _value_or_config(test, 'wait', config)
         self.attribute = _value_or_none(test, 'attribute')
         self.event = _value_or_none(test, 'event')
         self.endpoint = _value_or_config(test, 'endpoint', config)
@@ -777,8 +779,12 @@ class TestStep:
             expected_wait_type
         ]
 
+        wait_for_str = received_response.get('wait_for')
+        if not wait_for_str:
+            wait_for_str = received_response.get('command')
+
         received_values = [
-            received_response.get('wait_for'),
+            wait_for_str,
             received_response.get('endpoint'),
             received_response.get('cluster'),
             received_wait_type

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -265,7 +265,9 @@ class YamlLoader:
 
     def __rule_argument_value_is_only_when_writing_attributes(self, content):
         if 'arguments' in content:
-            command = content.get('command')
+            operation = content.get('command')
+            if not operation:
+                operation = content.get('wait')
             arguments = content.get('arguments')
-            if 'value' in arguments and command != 'writeAttribute':
+            if 'value' in arguments and operation != 'writeAttribute':
                 raise TestStepArgumentsValueError(content)


### PR DESCRIPTION
There are some YAML Scripts for simulated tests that uses `wait` instruction that behaves like `command` instruction, but the YAML parser is not considering some scenarios for that.
The Goal of this PR is to add support to `wait` instruction to the scenarios where it behaves like `command` instruction.

Example of a scenario that is not currently covered.
```
    - label: "PreCondition: Set TH OnOff to On"
      cluster: "On/Off"
      wait: "On"
```