### PR TITLE
Add set Mode in each mode base clusters

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/dishwasher-mode.h
@@ -69,6 +69,8 @@ public:
     ~DishwasherModeDelegate() override = default;
 };
 
+ModeBase::Instance * Instance();
+
 void Shutdown();
 
 } // namespace DishwasherMode

--- a/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
+++ b/examples/all-clusters-app/all-clusters-common/include/laundry-washer-mode.h
@@ -74,6 +74,8 @@ public:
     ~LaundryWasherModeDelegate() override = default;
 };
 
+ModeBase::Instance * Instance();
+
 void Shutdown();
 
 } // namespace LaundryWasherMode

--- a/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
+++ b/examples/all-clusters-app/all-clusters-common/include/rvc-modes.h
@@ -66,6 +66,8 @@ public:
     ~RvcRunModeDelegate() override = default;
 };
 
+ModeBase::Instance * Instance();
+
 void Shutdown();
 
 } // namespace RvcRunMode
@@ -108,6 +110,8 @@ private:
 public:
     ~RvcCleanModeDelegate() override = default;
 };
+
+ModeBase::Instance * Instance();
 
 void Shutdown();
 

--- a/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
@@ -76,6 +76,11 @@ CHIP_ERROR DishwasherModeDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<Mo
     return CHIP_NO_ERROR;
 }
 
+ModeBase::Instance * DishwasherMode::Instance()
+{
+    return gDishwasherModeInstance;
+}
+
 void DishwasherMode::Shutdown()
 {
     if (gDishwasherModeInstance != nullptr)

--- a/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
@@ -75,6 +75,11 @@ CHIP_ERROR LaundryWasherModeDelegate::GetModeTagsByIndex(uint8_t modeIndex, List
     return CHIP_NO_ERROR;
 }
 
+ModeBase::Instance * LaundryWasherMode::Instance()
+{
+    return gLaundryWasherModeInstance;
+}
+
 void LaundryWasherMode::Shutdown()
 {
     if (gLaundryWasherModeInstance != nullptr)

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
@@ -88,6 +88,11 @@ CHIP_ERROR RvcRunModeDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<ModeTa
     return CHIP_NO_ERROR;
 }
 
+ModeBase::Instance * RvcRunMode::Instance()
+{
+    return gRvcRunModeInstance;
+}
+
 void RvcRunMode::Shutdown()
 {
     if (gRvcRunModeInstance != nullptr)
@@ -170,6 +175,11 @@ CHIP_ERROR RvcCleanModeDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<Mode
     tags.reduce_size(kModeOptions[modeIndex].modeTags.size());
 
     return CHIP_NO_ERROR;
+}
+
+ModeBase::Instance * RvcCleanMode::Instance()
+{
+    return gRvcCleanModeInstance;
 }
 
 void RvcCleanMode::Shutdown()

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -150,13 +150,16 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
     else if (name == "ModeChange")
     {
         using chip::app::DataModel::MakeNullable;
-        std::string device = self->mJsonValue["Device"].asString();
-        std::string type = self->mJsonValue["Type"].asString();
-        Json::Value jsonMode            = self->mJsonValue["Mode"];
+        std::string device   = self->mJsonValue["Device"].asString();
+        std::string type     = self->mJsonValue["Type"].asString();
+        Json::Value jsonMode = self->mJsonValue["Mode"];
         DataModel::Nullable<uint8_t> mode;
-        if (!jsonMode.isNull()) {
+        if (!jsonMode.isNull())
+        {
             mode = MakeNullable(static_cast<uint8_t>(jsonMode.asUInt()));
-        } else {
+        }
+        else
+        {
             mode.SetNull();
         }
         self->OnModeChangeHandler(device, type, mode);
@@ -365,30 +368,47 @@ void AllClustersAppCommandHandler::OnSwitchMultiPressCompleteHandler(uint8_t pre
 void AllClustersAppCommandHandler::OnModeChangeHandler(std::string device, std::string type, DataModel::Nullable<uint8_t> mode)
 {
     ModeBase::Instance * modeInstance = nullptr;
-    if (device == "DishWasher") {
+    if (device == "DishWasher")
+    {
         modeInstance = DishwasherMode::Instance();
-    } else if (device == "LaundryWasher") {
+    }
+    else if (device == "LaundryWasher")
+    {
         modeInstance = LaundryWasherMode::Instance();
-    } else if (device == "RvcClean") {
+    }
+    else if (device == "RvcClean")
+    {
         modeInstance = RvcCleanMode::Instance();
-    } else if (device == "RvcRun") {
+    }
+    else if (device == "RvcRun")
+    {
         modeInstance = RvcRunMode::Instance();
-    } else {
+    }
+    else
+    {
         ChipLogDetail(NotSpecified, "Invalid device type : %s", device.c_str());
         return;
     }
 
-    if (type == "Current") {
-        if (mode.IsNull()) {
+    if (type == "Current")
+    {
+        if (mode.IsNull())
+        {
             ChipLogDetail(NotSpecified, "Invalid value : null");
             return;
         }
         modeInstance->UpdateCurrentMode(mode.Value());
-    } else if (type == "StartUp") {
+    }
+    else if (type == "StartUp")
+    {
         modeInstance->UpdateStartUpMode(mode);
-    } else if (type == "On") {
+    }
+    else if (type == "On")
+    {
         modeInstance->UpdateOnMode(mode);
-    } else {
+    }
+    else
+    {
         ChipLogDetail(NotSpecified, "Invalid mode type : %s", type.c_str());
         return;
     }

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -27,6 +27,10 @@
 #include <app/server/Server.h>
 #include <platform/PlatformManager.h>
 
+#include <dishwasher-mode.h>
+#include <laundry-washer-mode.h>
+#include <rvc-modes.h>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -142,6 +146,20 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
     else if (name == "SoftwareReset")
     {
         self->OnRebootSignalHandler(BootReasonType::kSoftwareReset);
+    }
+    else if (name == "ModeChange")
+    {
+        using chip::app::DataModel::MakeNullable;
+        std::string device = self->mJsonValue["Device"].asString();
+        std::string type = self->mJsonValue["Type"].asString();
+        Json::Value jsonMode            = self->mJsonValue["Mode"];
+        DataModel::Nullable<uint8_t> mode;
+        if (!jsonMode.isNull()) {
+            mode = MakeNullable(static_cast<uint8_t>(jsonMode.asUInt()));
+        } else {
+            mode.SetNull();
+        }
+        self->OnModeChangeHandler(device, type, mode);
     }
     else
     {
@@ -342,6 +360,38 @@ void AllClustersAppCommandHandler::OnSwitchMultiPressCompleteHandler(uint8_t pre
     ChipLogDetail(NotSpecified, "%d times the momentary switch has been pressed", count);
 
     Clusters::SwitchServer::Instance().OnMultiPressComplete(endpoint, previousPosition, count);
+}
+
+void AllClustersAppCommandHandler::OnModeChangeHandler(std::string device, std::string type, DataModel::Nullable<uint8_t> mode)
+{
+    ModeBase::Instance * modeInstance = nullptr;
+    if (device == "DishWasher") {
+        modeInstance = DishwasherMode::Instance();
+    } else if (device == "LaundryWasher") {
+        modeInstance = LaundryWasherMode::Instance();
+    } else if (device == "RvcClean") {
+        modeInstance = RvcCleanMode::Instance();
+    } else if (device == "RvcRun") {
+        modeInstance = RvcRunMode::Instance();
+    } else {
+        ChipLogDetail(NotSpecified, "Invalid device type : %s", device.c_str());
+        return;
+    }
+
+    if (type == "Current") {
+        if (mode.IsNull()) {
+            ChipLogDetail(NotSpecified, "Invalid value : null");
+            return;
+        }
+        modeInstance->UpdateCurrentMode(mode.Value());
+    } else if (type == "StartUp") {
+        modeInstance->UpdateStartUpMode(mode);
+    } else if (type == "On") {
+        modeInstance->UpdateOnMode(mode);
+    } else {
+        ChipLogDetail(NotSpecified, "Invalid mode type : %s", type.c_str());
+        return;
+    }
 }
 
 void AllClustersCommandDelegate::OnEventCommandReceived(const char * json)

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
@@ -88,6 +88,11 @@ private:
      * sequence, after it has been detected that the sequence has ended.
      */
     void OnSwitchMultiPressCompleteHandler(uint8_t previousPosition, uint8_t count);
+
+    /**
+     * Should be called when it is necessary to change the mode to manual operation.
+     */
+    void OnModeChangeHandler(std::string device, std::string type, chip::app::DataModel::Nullable<uint8_t> mode);
 };
 
 class AllClustersCommandDelegate : public NamedPipeCommandDelegate


### PR DESCRIPTION
For reference test using all-cluster-app, all-cluster-app can't change mode.
(LaundryWasherMode, DishWasherMode, RvcRunMode, RvcCleanMode)

Example Test Case : TC-LWM-2.1, TC-DISHM-2.1 etc.

In this reason, I add "ChangeMode" trigger event in all-cluster-app.

After merged, we can change mode like below command.
`echo '{"Name":"ModeChange","Device":"Dishwasher","Type":"Current","Mode":1}' > /tmp/chip_all_clusters_fifo_[PID`