### PR TITLE
[Silabs] Using Wiseconnect for 917NCP

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -62,13 +62,10 @@ if (chip_enable_wifi) {
   assert(use_rs9116 || use_wf200 || use_SiWx917)
   import("${chip_root}/src/platform/silabs/wifi_args.gni")
 
-  if (use_rs9116) {
+  if (use_rs9116 || use_SiWx917) {
     wiseconnect_sdk_root =
         "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
     import("rs911x/rs911x.gni")
-  } else if (use_SiWx917) {
-    wisemcu_sdk_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
-    import("rs911x/rs9117.gni")
   }
   if (use_wf200) {
     import("wf200/wf200.gni")

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -629,14 +629,6 @@ void wfx_rsi_task(void * arg)
                 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
                 /*
-                 * Checks if the IPv6 event has been notified, if not invoke the nd6_tmr,
-                 * which starts the duplicate address detectation.
-                 */
-                if (!hasNotifiedIPV6)
-                {
-                    nd6_tmr();
-                }
-                /*
                  * Checks if the assigned IPv6 address is preferred by evaluating
                  * the first block of IPv6 address ( block 0)
                  */

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -21,10 +21,8 @@ import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("silabs_board.gni")
 
-if (use_rs9116) {
+if (use_rs9116 || use_SiWx917) {
   wifi_sapi_root = "${chip_root}/third_party/silabs/wiseconnect-wifi-bt-sdk"
-} else {
-  wifi_sapi_root = "${chip_root}/third_party/silabs/wisemcu-wifi-bt-sdk"
 }
 
 declare_args() {


### PR DESCRIPTION
#### Updated gn files to use Wiseconnect  for 917NCP
* Since 917NCP with wifi-sdk 3.0 bring-up is not completed, we will be using Wiseconnect package for 917NCP as well. Will update 917NCP to use wifi-sdk 3.0 once the bring-up is done (in the next release).
* Removed redundant code to fix 917NCP and rs9116 power cycle issue.
* Updated matter_support (submodule pointer)
