### PR TITLE
Fix Step 3a of TC_xxxCONC_1_1

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CDOCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CDOCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !CDOCONC.S.F00 && !CDOCONC.S.F01 && !CDOCONC.S.F02 && !CDOCONC.S.F03
-          && !CDOCONC.S.F04 && !CDOCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given CDOCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_CMOCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CMOCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !CMOCONC.S.F00 && !CMOCONC.S.F01 && !CMOCONC.S.F02 && !CMOCONC.S.F03
-          && !CMOCONC.S.F04 && !CMOCONC.S.F05 "
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given CMOCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_FLDCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLDCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !FLDCONC.S.F00 && !FLDCONC.S.F01 && !FLDCONC.S.F02 && !FLDCONC.S.F03
-          && !FLDCONC.S.F04 && !FLDCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given FLDCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_NDOCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_NDOCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !NDOCONC.S.F00 && !NDOCONC.S.F01 && !NDOCONC.S.F02 && !NDOCONC.S.F03
-          && !NDOCONC.S.F04 && !NDOCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given NDOCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_OZCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OZCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !OZCONC.S.F00 && !OZCONC.S.F01 && !OZCONC.S.F02 && !OZCONC.S.F03 &&
-          !OZCONC.S.F04 && !OZCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given OZCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_PMHCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMHCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !PMHCONC.S.F00 && !PMHCONC.S.F01 && !PMHCONC.S.F02 && !PMHCONC.S.F03
-          && !PMHCONC.S.F04 && !PMHCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given PMHCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_PMICONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMICONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !PMICONC.S.F00 && !PMICONC.S.F01 && !PMICONC.S.F02 && !PMICONC.S.F03
-          && !PMICONC.S.F04 && !PMICONC.S.F05 "
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given PMICONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_PMKCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMKCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !PMKCONC.S.F00 && !PMKCONC.S.F01 && !PMKCONC.S.F02 && !PMKCONC.S.F03
-          && !PMKCONC.S.F04 && !PMKCONC.S.F05 "
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given PMKCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_RNCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RNCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !RNCONC.S.F00 && !RNCONC.S.F01 && !RNCONC.S.F02 && !RNCONC.S.F03 &&
-          !RNCONC.S.F04 && !RNCONC.S.F05"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given RNCONC.S.F00(MEA) ensure featuremap has the correct

--- a/src/app/tests/suites/certification/Test_TC_TVOCCONC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TVOCCONC_1_1.yaml
@@ -42,15 +42,12 @@ tests:
     - label:
           "Step 3a: Read the global attribute: FeatureMap and check for either
           bit 0 or 1 set"
-      PICS:
-          " !TVOCCONC.S.F00 && !TVOCCONC.S.F01 && !TVOCCONC.S.F02 &&
-          !TVOCCONC.S.F03 && !TVOCCONC.S.F04 && !TVOCCONC.S.F05 "
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
-          value: 0
           constraints:
               type: bitmap32
+              hasMasksSet: [0x03]
 
     - label:
           "Step 3b: Given TVOCCONC.S.F00(MEA) ensure featuremap has the correct


### PR DESCRIPTION
### Description

Fixes test step 3a in all Concentration Measurement 1.1 tests. 

Before it was checking for a non-compliant state. 

Now, it checks for the statement in the Test Plan: 

> At least one of bit 0 and bit 1 SHALL be 1.

### Links

Fixes #28838