### PR TITLE
Add decoded data into python tracing builds

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -156,7 +156,10 @@ source "$CHIP_ROOT/scripts/activate.sh"
 [[ -n "$chip_case_retry_delta" ]] && chip_case_retry_arg="chip_case_retry_delta=$chip_case_retry_delta" || chip_case_retry_arg=""
 [[ -n "$pregen_dir" ]] && pregen_dir_arg="chip_code_pre_generated_directory=\"$pregen_dir\"" || pregen_dir_arg=""
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="matter_enable_tracing_support=true chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg"
+# Make all possible human redable tracing available.
+tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
+
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg"
 
 function ninja_target() {
     # Print the ninja target required to build a gn label.

--- a/third_party/perfetto/BUILD.gn
+++ b/third_party/perfetto/BUILD.gn
@@ -15,6 +15,8 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+import("${build_root}/config/compiler/compiler.gni")
+
 config("sdk_config") {
   include_dirs = [ "repo/sdk" ]
 
@@ -23,6 +25,12 @@ config("sdk_config") {
 
 config("sdk_private_config") {
   cflags = [ "-Wno-shadow" ]
+
+  if (!is_clang) {
+    # Based on comments from perfetto/repo/gn/standalone/BUILD.gn:
+    # Use return std::move(...) for compatibility with old GCC compilers.
+    cflags += [ "-Wno-redundant-move" ]
+  }
 }
 
 source_set("sdk") {


### PR DESCRIPTION
Make sure decoded trace data available for python (not just headers).
Also fixed some perfetto compile flags since on my machine gcc needed this (and it seems to be inline with perfetto standalone gn args).

Tested via:

```
./scripts/tests/run_python_test.py --factoryreset    \
    --script "src/python_testing/TC_TIMESYNC_2_2.py" \
    --script-args "--trace-to json:log --storage-path admin_storage.json --commissioning-method on-network --discriminator 3840 --passcode 20202021"
```

and saw content like:

```
...
[2023-08-23 12:58:36.041031][TEST][STDOUT][2454937:2454942] CHIP:ATM: {                                                                         [2023-08-23 12:58:36.041052][TEST][STDOUT]      "event" : "MessageSend",
[2023-08-23 12:58:36.041058][TEST][STDOUT]      "messageType" : "Secure",
[2023-08-23 12:58:36.041065][TEST][STDOUT]      "packetHeader" :
[2023-08-23 12:58:36.041071][TEST][STDOUT]      {
[2023-08-23 12:58:36.041077][TEST][STDOUT]              "flags" : 0,
[2023-08-23 12:58:36.041083][TEST][STDOUT]              "msgCounter" : 58142049,
[2023-08-23 12:58:36.041090][TEST][STDOUT]              "securityFlags" : 0,
[2023-08-23 12:58:36.041096][TEST][STDOUT]              "sessionId" : 17422
[2023-08-23 12:58:36.041103][TEST][STDOUT]      },
[2023-08-23 12:58:36.041109][TEST][STDOUT]      "payload" :
[2023-08-23 12:58:36.041115][TEST][STDOUT]      {
[2023-08-23 12:58:36.041121][TEST][STDOUT]              "decoded" :
[2023-08-23 12:58:36.041130][TEST][STDOUT]              {
[2023-08-23 12:58:36.041136][TEST][STDOUT]                      "read_request" :
[2023-08-23 12:58:36.041143][TEST][STDOUT]                      {
[2023-08-23 12:58:36.041152][TEST][STDOUT]                              "attribute_requests" :
[2023-08-23 12:58:36.041159][TEST][STDOUT]                              {
[2023-08-23 12:58:36.041166][TEST][STDOUT]                                      "Anonymous<0>" :
[2023-08-23 12:58:36.041173][TEST][STDOUT]                                      {
[2023-08-23 12:58:36.041182][TEST][STDOUT]                                              "attribute_id" : "0 == 'UTCTime'",
[2023-08-23 12:58:36.041189][TEST][STDOUT]                                              "cluster_id" : "56 == 'TimeSynchronization'",
[2023-08-23 12:58:36.041197][TEST][STDOUT]                                              "endpoint_id" : "0"
[2023-08-23 12:58:36.041205][TEST][STDOUT]                                      }
[2023-08-23 12:58:36.041212][TEST][STDOUT]                              },
[2023-08-23 12:58:36.041220][TEST][STDOUT]                              "fabric_filtered" : "true",
[2023-08-23 12:58:36.041227][TEST][STDOUT]                              "interaction_model_revison" : "10"
[2023-08-23 12:58:36.041234][TEST][STDOUT]                      }
[2023-08-23 12:58:36.041244][TEST][STDOUT]              },
...
```

I believe this fixes #28702 (i.e. need to pass trace-to and either send json:log or json:file_path.