### PR TITLE
Update smokeco tests as per test plan document update

### DIFF
--- a/examples/darwin-framework-tool/templates/tests/ciTests.json
+++ b/examples/darwin-framework-tool/templates/tests/ciTests.json
@@ -39,6 +39,8 @@
         "Test_TC_SMOKECO_2_3",
         "Test_TC_SMOKECO_2_4",
         "Test_TC_SMOKECO_2_5",
+        "Disabled due to undefined properties",
+        "Test_TC_SMOKECO_2_6",
         "Disabled because the power source configuration cluster is now deprecated and not present in all-clusters",
         "Test_TC_PSCFG_1_1",
         "Test_TC_PSCFG_2_1",

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_1_1.yaml
@@ -84,12 +84,12 @@ tests:
       response:
           constraints:
               type: list
-              contains: [0, 3, 5, 6, 7]
+              contains: [0, 3, 5, 6, 7, 65528, 65529, 65531, 65532, 65533]
 
     - label:
           "Step 4b: TH reads from the DUT the AttributeList
           attribute(SmokeState)"
-      PICS: SMOKECO.S.A0001
+      PICS: SMOKECO.S.A0001 && SMOKECO.S.F00
       command: "readAttribute"
       attribute: "AttributeList"
       response:
@@ -99,7 +99,7 @@ tests:
 
     - label:
           "Step 4c: TH reads from the DUT the AttributeList attribute(COState)"
-      PICS: SMOKECO.S.A0002
+      PICS: SMOKECO.S.A0002 && SMOKECO.S.F01
       command: "readAttribute"
       attribute: "AttributeList"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_1_1.yaml
@@ -23,7 +23,7 @@ config:
     endpoint: 1
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -31,7 +31,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH reads the ClusterRevision attribute from the DUT"
+    - label: "Step 2: TH reads the ClusterRevision attribute from the DUT"
       command: "readAttribute"
       attribute: "ClusterRevision"
       response:
@@ -39,7 +39,7 @@ tests:
           constraints:
               type: int16u
 
-    - label: "TH reads from the DUT the FeatureMap attribute"
+    - label: "Step 3a: TH reads from the DUT the FeatureMap attribute"
       PICS: "!SMOKECO.S.F00 && !SMOKECO.S.F01"
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -48,7 +48,8 @@ tests:
           constraints:
               type: bitmap32
 
-    - label: "TH reads from the DUT the FeatureMap attribute(Smoke Alarm)"
+    - label:
+          "Step 3b: TH reads from the DUT the FeatureMap attribute(Smoke Alarm)"
       PICS: SMOKECO.S.F00 && !SMOKECO.S.F01
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -57,7 +58,7 @@ tests:
           constraints:
               type: bitmap32
 
-    - label: "TH reads from the DUT the FeatureMap attribute(CO Alarm)"
+    - label: "Step 3c: TH reads from the DUT the FeatureMap attribute(CO Alarm)"
       PICS: SMOKECO.S.F01 && !SMOKECO.S.F00
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -67,8 +68,8 @@ tests:
               type: bitmap32
 
     - label:
-          "TH reads from the DUT the FeatureMap attribute(Smoke Alarm & CO
-          Alarm)"
+          "Step 3d: TH reads from the DUT the FeatureMap attribute(Smoke Alarm &
+          CO Alarm)"
       PICS: SMOKECO.S.F00 && SMOKECO.S.F01
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -77,7 +78,7 @@ tests:
           constraints:
               type: bitmap32
 
-    - label: "TH reads from the DUT the AttributeList attribute"
+    - label: "Step 4a: TH reads from the DUT the AttributeList attribute"
       command: "readAttribute"
       attribute: "AttributeList"
       response:
@@ -85,7 +86,9 @@ tests:
               type: list
               contains: [0, 3, 5, 6, 7]
 
-    - label: "TH reads from the DUT the AttributeList attribute(SmokeState)"
+    - label:
+          "Step 4b: TH reads from the DUT the AttributeList
+          attribute(SmokeState)"
       PICS: SMOKECO.S.A0001
       command: "readAttribute"
       attribute: "AttributeList"
@@ -94,7 +97,8 @@ tests:
               type: list
               contains: [1]
 
-    - label: "TH reads from the DUT the AttributeList attribute(COState)"
+    - label:
+          "Step 4c: TH reads from the DUT the AttributeList attribute(COState)"
       PICS: SMOKECO.S.A0002
       command: "readAttribute"
       attribute: "AttributeList"
@@ -103,7 +107,9 @@ tests:
               type: list
               contains: [2]
 
-    - label: "TH reads from the DUT the AttributeList attribute(DeviceMuted)"
+    - label:
+          "Step 4d: TH reads from the DUT the AttributeList
+          attribute(DeviceMuted)"
       PICS: SMOKECO.S.A0004
       command: "readAttribute"
       attribute: "AttributeList"
@@ -113,7 +119,7 @@ tests:
               contains: [4]
 
     - label:
-          "TH reads from the DUT the AttributeList
+          "Step 4e: TH reads from the DUT the AttributeList
           attribute(InterconnectSmokeAlarm)"
       PICS: SMOKECO.S.A0008
       command: "readAttribute"
@@ -124,7 +130,7 @@ tests:
               contains: [8]
 
     - label:
-          "TH reads from the DUT the AttributeList
+          "Step 4f: TH reads from the DUT the AttributeList
           attribute(InterconnectCOAlarm)"
       PICS: SMOKECO.S.A0009
       command: "readAttribute"
@@ -135,7 +141,8 @@ tests:
               contains: [9]
 
     - label:
-          "TH reads from the DUT the AttributeList attribute(ContaminationState)"
+          "Step 4g: TH reads from the DUT the AttributeList
+          attribute(ContaminationState)"
       PICS: SMOKECO.S.A000a
       command: "readAttribute"
       attribute: "AttributeList"
@@ -145,7 +152,7 @@ tests:
               contains: [10]
 
     - label:
-          "TH reads from the DUT the AttributeList
+          "Step 4h: TH reads from the DUT the AttributeList
           attribute(SmokeSensitivityLevel)"
       PICS: SMOKECO.S.A000b
       command: "readAttribute"
@@ -155,7 +162,9 @@ tests:
               type: list
               contains: [11]
 
-    - label: "TH reads from the DUT the AttributeList attribute(ExpiryDate)"
+    - label:
+          "Step 4i: TH reads from the DUT the AttributeList
+          attribute(ExpiryDate)"
       PICS: SMOKECO.S.A000c
       command: "readAttribute"
       attribute: "AttributeList"
@@ -164,7 +173,7 @@ tests:
               type: list
               contains: [12]
 
-    - label: "TH reads from the DUT the EventList attribute"
+    - label: "Step 5a: TH reads from the DUT the EventList attribute"
       PICS: PICS_EVENT_LIST_ENABLED
       command: "readAttribute"
       attribute: "EventList"
@@ -173,7 +182,8 @@ tests:
               type: list
               contains: [2, 3, 4, 5, 10]
 
-    - label: "TH reads from the DUT the EventList attribute(SmokeAlarm)"
+    - label:
+          "Step 5b: TH reads from the DUT the EventList attribute(SmokeAlarm)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E00
       command: "readAttribute"
       attribute: "EventList"
@@ -182,7 +192,7 @@ tests:
               type: list
               contains: [0]
 
-    - label: "TH reads from the DUT the EventList attribute(COAlarm)"
+    - label: "Step 5c: TH reads from the DUT the EventList attribute(COAlarm)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E01
       command: "readAttribute"
       attribute: "EventList"
@@ -191,7 +201,8 @@ tests:
               type: list
               contains: [1]
 
-    - label: "TH reads from the DUT the EventList attribute(AlarmMuted)"
+    - label:
+          "Step 5d: TH reads from the DUT the EventList attribute(AlarmMuted)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E06
       command: "readAttribute"
       attribute: "EventList"
@@ -200,7 +211,7 @@ tests:
               type: list
               contains: [6]
 
-    - label: "TH reads from the DUT the EventList attribute(MuteEnded)"
+    - label: "Step 5e: TH reads from the DUT the EventList attribute(MuteEnded)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E07
       command: "readAttribute"
       attribute: "EventList"
@@ -210,7 +221,8 @@ tests:
               contains: [7]
 
     - label:
-          "TH reads from the DUT the EventList attribute(InterconnectSmokeAlarm)"
+          "Step 5f: TH reads from the DUT the EventList
+          attribute(InterconnectSmokeAlarm)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E08
       command: "readAttribute"
       attribute: "EventList"
@@ -220,7 +232,8 @@ tests:
               contains: [8]
 
     - label:
-          "TH reads from the DUT the EventList attribute(InterconnectCOAlarm)"
+          "Step 5g: TH reads from the DUT the EventList
+          attribute(InterconnectCOAlarm)"
       PICS: PICS_EVENT_LIST_ENABLED && SMOKECO.S.E09
       command: "readAttribute"
       attribute: "EventList"
@@ -229,7 +242,7 @@ tests:
               type: list
               contains: [9]
 
-    - label: "TH reads from the DUT the AcceptedCommandList attribute"
+    - label: "Step 6a: TH reads from the DUT the AcceptedCommandList attribute"
       PICS: "!SMOKECO.S.C00.Rsp"
       command: "readAttribute"
       attribute: "AcceptedCommandList"
@@ -238,7 +251,7 @@ tests:
           constraints:
               type: list
 
-    - label: "TH reads from the DUT the AcceptedCommandList attribute"
+    - label: "Step 6b: TH reads from the DUT the AcceptedCommandList attribute"
       PICS: SMOKECO.S.C00.Rsp
       command: "readAttribute"
       attribute: "AcceptedCommandList"
@@ -247,7 +260,7 @@ tests:
               type: list
               contains: [0]
 
-    - label: "TH reads from the DUT the GeneratedCommandList attribute"
+    - label: "Step 7: TH reads from the DUT the GeneratedCommandList attribute"
       command: "readAttribute"
       attribute: "GeneratedCommandList"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_1.yaml
@@ -23,7 +23,7 @@ config:
     endpoint: 1
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -31,7 +31,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH reads from the DUT the ExpressedState attribute"
+    - label: "Step 2: TH reads from the DUT the ExpressedState attribute"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -41,7 +41,7 @@ tests:
               minValue: 0
               maxValue: 8
 
-    - label: "TH reads from the DUT the SmokeState attribute"
+    - label: "Step 3: TH reads from the DUT the SmokeState attribute"
       PICS: SMOKECO.S.A0001
       command: "readAttribute"
       attribute: "SmokeState"
@@ -51,7 +51,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the COState attribute"
+    - label: "Step 4: TH reads from the DUT the COState attribute"
       PICS: SMOKECO.S.A0002
       command: "readAttribute"
       attribute: "COState"
@@ -61,7 +61,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the BatteryAlert attribute"
+    - label: "Step 5: TH reads from the DUT the BatteryAlert attribute"
       PICS: SMOKECO.S.A0003
       command: "readAttribute"
       attribute: "BatteryAlert"
@@ -71,7 +71,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the DeviceMuted attribute"
+    - label: "Step 6: TH reads from the DUT the DeviceMuted attribute"
       PICS: SMOKECO.S.A0004
       command: "readAttribute"
       attribute: "DeviceMuted"
@@ -81,7 +81,7 @@ tests:
               minValue: 0
               maxValue: 1
 
-    - label: "TH reads from the DUT the TestInProgress attribute"
+    - label: "Step 7: TH reads from the DUT the TestInProgress attribute"
       PICS: SMOKECO.S.A0005
       command: "readAttribute"
       attribute: "TestInProgress"
@@ -89,7 +89,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads from the DUT the HardwareFaultAlert attribute"
+    - label: "Step 8: TH reads from the DUT the HardwareFaultAlert attribute"
       PICS: SMOKECO.S.A0006
       command: "readAttribute"
       attribute: "HardwareFaultAlert"
@@ -97,7 +97,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads from the DUT the EndOfServiceAlert attribute"
+    - label: "Step 9: TH reads from the DUT the EndOfServiceAlert attribute"
       PICS: SMOKECO.S.A0007
       command: "readAttribute"
       attribute: "EndOfServiceAlert"
@@ -107,7 +107,8 @@ tests:
               minValue: 0
               maxValue: 1
 
-    - label: "TH reads from the DUT the InterconnectSmokeAlarm attribute"
+    - label:
+          "Step 10: TH reads from the DUT the InterconnectSmokeAlarm attribute"
       PICS: SMOKECO.S.A0008
       command: "readAttribute"
       attribute: "InterconnectSmokeAlarm"
@@ -117,7 +118,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the InterconnectCOAlarm attribute"
+    - label: "Step 11: TH reads from the DUT the InterconnectCOAlarm attribute"
       PICS: SMOKECO.S.A0009
       command: "readAttribute"
       attribute: "InterconnectCOAlarm"
@@ -127,7 +128,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the ContaminationState attribute"
+    - label: "Step 12: TH reads from the DUT the ContaminationState attribute"
       PICS: SMOKECO.S.A000a
       command: "readAttribute"
       attribute: "ContaminationState"
@@ -137,7 +138,8 @@ tests:
               minValue: 0
               maxValue: 3
 
-    - label: "TH reads from the DUT the SmokeSensitivityLevel attribute"
+    - label:
+          "Step 13: TH reads from the DUT the SmokeSensitivityLevel attribute"
       PICS: SMOKECO.S.A000b
       command: "readAttribute"
       attribute: "SmokeSensitivityLevel"
@@ -147,7 +149,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "TH reads from the DUT the ExpiryDate attribute"
+    - label: "Step 14: TH reads from the DUT the ExpiryDate attribute"
       PICS: SMOKECO.S.A000c
       command: "readAttribute"
       attribute: "ExpiryDate"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -53,8 +53,8 @@ tests:
       PICS: SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -41,7 +41,7 @@ config:
         defaultValue: 0
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -49,7 +49,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH subscribes to SmokeState attribute from DUT"
+    - label: "Step 2: TH subscribes to SmokeState attribute from DUT"
       PICS: SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
@@ -60,7 +60,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 3: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -70,8 +70,8 @@ tests:
               type: enum8
 
     - label:
-          "TH reads TestEventTriggersEnabled attribute from General Diagnostics
-          Cluster"
+          "Step 4: TH reads TestEventTriggersEnabled attribute from General
+          Diagnostics Cluster"
       PICS: DGGEN.S.A0008
       cluster: "General Diagnostics"
       endpoint: 0
@@ -81,8 +81,8 @@ tests:
           value: 1
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 5: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Smoke Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -97,8 +97,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 6: TH waits for a report of SmokeState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -108,7 +108,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -117,7 +117,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads SmokeAlarm event from DUT"
+    - label: "Step 8: TH reads SmokeAlarm event from DUT"
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
@@ -125,7 +125,7 @@ tests:
       response:
           value: { AlarmSeverityLevel: 1 }
 
-    - label: "Start manually DUT self-test"
+    - label: "Step 9:Start manually DUT self-test"
       cluster: "LogCommands"
       PICS: PICS_USER_PROMPT && SMOKECO.M.ManuallyControlledTest
       command: "UserPrompt"
@@ -136,7 +136,7 @@ tests:
               - name: "expectedValue"
                 value: "y"
 
-    - label: "TH reads TestInProgress attribute from DUT"
+    - label: "Step 10: TH reads TestInProgress attribute from DUT"
       PICS: SMOKECO.S.A0005
       command: "readAttribute"
       attribute: "TestInProgress"
@@ -145,13 +145,13 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH sends SelfTestRequest command to DUT"
+    - label: "Step 11 & 12: TH sends SelfTestRequest command to DUT"
       PICS: SMOKECO.S.C00.Rsp
       command: "SelfTestRequest"
       response:
           error: BUSY
 
-    - label: "TH reads TestInProgress attribute from DUT"
+    - label: "Step 13: TH reads TestInProgress attribute from DUT"
       PICS: SMOKECO.S.A0005
       command: "readAttribute"
       attribute: "TestInProgress"
@@ -161,8 +161,8 @@ tests:
               type: boolean
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 14: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical Smoke Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -177,8 +177,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CRITICAL_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 15: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -188,7 +188,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 16: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -197,7 +197,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads SmokeAlarm event from DUT"
+    - label: "Step 17: TH reads SmokeAlarm event from DUT"
       PICS: SMOKECO.S.E00
       command: "readEvent"
       event: "SmokeAlarm"
@@ -206,8 +206,8 @@ tests:
           value: { AlarmSeverityLevel: 2 }
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 18: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Alarm Test Event Clear"
       PICS: DGGEN.S.C00.Rsp
@@ -222,8 +222,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_SMOKE_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 19: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -233,7 +233,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -242,7 +242,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 21: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -40,7 +40,7 @@ config:
         defaultValue: 0
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -48,7 +48,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH subscribes to COState attribute from DUT"
+    - label: "Step 2: TH subscribes to COState attribute from DUT"
       PICS: SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
@@ -59,7 +59,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 3: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -69,8 +69,8 @@ tests:
               type: enum8
 
     - label:
-          "TH reads TestEventTriggersEnabled attribute from General Diagnostics
-          Cluster"
+          "Step 4: TH reads TestEventTriggersEnabled attribute from General
+          Diagnostics Cluster"
       PICS: DGGEN.S.A0008
       cluster: "General Diagnostics"
       endpoint: 0
@@ -80,8 +80,8 @@ tests:
           value: 1
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 5: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning CO Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -96,8 +96,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_CO_ALARM
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 6: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -107,7 +107,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -116,7 +116,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads COAlarm event from DUT"
+    - label: "Step 8: TH reads COAlarm event from DUT"
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
@@ -124,7 +124,7 @@ tests:
       response:
           value: { AlarmSeverityLevel: 1 }
 
-    - label: "Start manually DUT self-test"
+    - label: "Step 9: Start manually DUT self-test"
       cluster: "LogCommands"
       PICS: PICS_USER_PROMPT && SMOKECO.M.ManuallyControlledTest
       command: "UserPrompt"
@@ -135,7 +135,7 @@ tests:
               - name: "expectedValue"
                 value: "y"
 
-    - label: "TH reads TestInProgress attribute from DUT"
+    - label: "Step 10: TH reads TestInProgress attribute from DUT"
       PICS: SMOKECO.S.A0005
       command: "readAttribute"
       attribute: "TestInProgress"
@@ -144,13 +144,13 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH sends SelfTestRequest command to DUT"
+    - label: "Step 11 & 12: TH sends SelfTestRequest command to DUT"
       PICS: SMOKECO.S.C00.Rsp
       command: "SelfTestRequest"
       response:
           error: BUSY
 
-    - label: "TH reads TestInProgress attribute from DUT"
+    - label: "Step 13: TH reads TestInProgress attribute from DUT"
       PICS: SMOKECO.S.A0005
       command: "readAttribute"
       attribute: "TestInProgress"
@@ -160,8 +160,8 @@ tests:
               type: boolean
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 14: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical CO Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -176,8 +176,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CRITICAL_CO_ALARM
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 15: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -187,7 +187,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 16: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -196,7 +196,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads COAlarm event from DUT"
+    - label: "Step 17: TH reads COAlarm event from DUT"
       PICS: SMOKECO.S.E01
       command: "readEvent"
       event: "COAlarm"
@@ -205,8 +205,8 @@ tests:
           value: { AlarmSeverityLevel: 2 }
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 18: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for CO Alarm Test Event Clear"
       PICS: DGGEN.S.C00.Rsp
@@ -221,8 +221,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CO_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 19: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -232,7 +232,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -241,7 +241,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 21: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -52,8 +52,8 @@ tests:
       PICS: SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -53,7 +53,7 @@ config:
         defaultValue: 0
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -61,7 +61,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH subscribes to BatteryAlert attribute from DUT"
+    - label: "Step 2: TH subscribes to BatteryAlert attribute from DUT"
       PICS: SMOKECO.S.A0003
       command: "subscribeAttribute"
       attribute: "BatteryAlert"
@@ -72,7 +72,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 3: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -82,8 +82,8 @@ tests:
               type: enum8
 
     - label:
-          "TH reads TestEventTriggersEnabled attribute from General Diagnostics
-          Cluster"
+          "Step 4: TH reads TestEventTriggersEnabled attribute from General
+          Diagnostics Cluster"
       PICS: DGGEN.S.A0008
       cluster: "General Diagnostics"
       endpoint: 0
@@ -93,8 +93,8 @@ tests:
           value: 1
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 5: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Battery Alert Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -109,8 +109,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_BATTERY_ALERT
 
     - label:
-          "TH waits for a report of BatteryAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 6: TH waits for a report of BatteryAlert attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0003
       command: "waitForReport"
       attribute: "BatteryAlert"
@@ -120,7 +120,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -129,7 +129,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads LowBattery event from DUT"
+    - label: "Step 8: TH reads LowBattery event from DUT"
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
@@ -138,8 +138,8 @@ tests:
           value: { AlarmSeverityLevel: 1 }
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 9: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical Battery Alert Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -154,8 +154,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CRITICAL_BATTERY_ALERT
 
     - label:
-          "TH waits for a report of BatteryAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 10: TH waits for a report of BatteryAlert attribute from DUT
+          with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0003
       command: "waitForReport"
       attribute: "BatteryAlert"
@@ -165,7 +165,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 11: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -174,7 +174,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads LowBattery event from DUT"
+    - label: "Step 12: TH reads LowBattery event from DUT"
       PICS: SMOKECO.S.E02
       command: "readEvent"
       event: "LowBattery"
@@ -183,8 +183,8 @@ tests:
           value: { AlarmSeverityLevel: 2 }
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 13: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Battery Alert Test Event Clear"
       PICS: DGGEN.S.C00.Rsp
@@ -199,8 +199,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_BATTERY_ALERT_CLEAR
 
     - label:
-          "TH waits for a report of BatteryAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 14: TH waits for a report of BatteryAlert attribute from DUT
+          with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0003
       command: "waitForReport"
       attribute: "BatteryAlert"
@@ -210,7 +210,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 15: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -219,7 +219,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 16: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -227,7 +227,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH subscribes to HardwareFaultAlert attribute from DUT"
+    - label: "Step 17: TH subscribes to HardwareFaultAlert attribute from DUT"
       PICS: SMOKECO.S.A0006
       command: "subscribeAttribute"
       attribute: "HardwareFaultAlert"
@@ -239,8 +239,8 @@ tests:
               type: boolean
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 18: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Hardware Fault Alert Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -255,8 +255,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_HARDWARE_FAULT_ALERT
 
     - label:
-          "TH waits for a report of HardwareFaultAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 19: TH waits for a report of HardwareFaultAlert attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0006
       command: "waitForReport"
       attribute: "HardwareFaultAlert"
@@ -266,7 +266,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -275,7 +275,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads HardwareFault event from DUT"
+    - label: "Step 21: TH reads HardwareFault event from DUT"
       PICS: SMOKECO.S.E03
       command: "readEvent"
       event: "HardwareFault"
@@ -284,8 +284,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 22: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Hardware Fault Alert Test Event
           Clear"
@@ -301,8 +301,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_HARDWARE_FAULT_ALERT_CLEAR
 
     - label:
-          "TH waits for a report of HardwareFaultAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 23: TH waits for a report of HardwareFaultAlert attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0006
       command: "waitForReport"
       attribute: "HardwareFaultAlert"
@@ -312,7 +312,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 24: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -321,7 +321,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 25: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -329,7 +329,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH subscribes to EndOfServiceAlert attribute from DUT"
+    - label: "Step 26: TH subscribes to EndOfServiceAlert attribute from DUT"
       PICS: SMOKECO.S.A0007
       command: "subscribeAttribute"
       attribute: "EndOfServiceAlert"
@@ -341,8 +341,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 27: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for End of Service Alert Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -357,8 +357,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_END_OF_SERVICE_ALERT
 
     - label:
-          "TH waits for a report of EndOfServiceAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 28: TH waits for a report of EndOfServiceAlert attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0007
       command: "waitForReport"
       attribute: "EndOfServiceAlert"
@@ -368,7 +368,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 29: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -377,7 +377,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads EndOfService event from DUT"
+    - label: "Step 30: TH reads EndOfService event from DUT"
       PICS: SMOKECO.S.E04
       command: "readEvent"
       event: "EndOfService"
@@ -386,8 +386,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 31: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for End of Service Alert Test Event
           Clear"
@@ -403,8 +403,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_END_OF_SERVICE_ALERT_CLEAR
 
     - label:
-          "TH waits for a report of EndOfServiceAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 32: TH waits for a report of EndOfServiceAlert attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0007
       command: "waitForReport"
       attribute: "EndOfServiceAlert"
@@ -414,7 +414,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 33: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -423,7 +423,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 34: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -431,7 +431,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH subscribes to TestInProgress attribute from DUT"
+    - label: "Step 35: TH subscribes to TestInProgress attribute from DUT"
       PICS: SMOKECO.S.A0005
       command: "subscribeAttribute"
       attribute: "TestInProgress"
@@ -442,7 +442,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 36: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -451,7 +451,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "Start manually DUT self-test"
+    - label: "Step 37: Start manually DUT self-test"
       cluster: "LogCommands"
       PICS: PICS_USER_PROMPT && SMOKECO.M.ManuallyControlledTest
       command: "UserPrompt"
@@ -463,8 +463,8 @@ tests:
                 value: "y"
 
     - label:
-          "TH waits for a report of TestInProgress attribute from DUT with a
-          timeout of 180 seconds"
+          "Step 38: TH waits for a report of TestInProgress attribute from DUT
+          with a timeout of 180 seconds"
       PICS: SMOKECO.S.A0005
       command: "waitForReport"
       attribute: "TestInProgress"
@@ -474,7 +474,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 39: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -484,8 +484,8 @@ tests:
               type: enum8
 
     - label:
-          "TH waits for a report of TestInProgress attribute from DUT with a
-          timeout of 180 seconds"
+          "Step 40: TH waits for a report of TestInProgress attribute from DUT
+          with a timeout of 180 seconds"
       PICS: SMOKECO.S.A0005
       command: "waitForReport"
       attribute: "TestInProgress"
@@ -495,7 +495,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads SelfTestComplete event from DUT"
+    - label: "Step 41: TH reads SelfTestComplete event from DUT"
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
@@ -503,7 +503,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 42: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -512,7 +512,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 43: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -520,13 +520,13 @@ tests:
       response:
           value: {}
 
-    - label: "TH sends SelfTestRequest command to DUT"
+    - label: "Step 44: TH sends SelfTestRequest command to DUT"
       PICS: SMOKECO.S.C00.Rsp
       command: "SelfTestRequest"
 
     - label:
-          "TH waits for a report of TestInProgress attribute from DUT with a
-          timeout of 180 seconds"
+          "Step 45: TH waits for a report of TestInProgress attribute from DUT
+          with a timeout of 180 seconds"
       PICS: SMOKECO.S.A0005
       command: "waitForReport"
       attribute: "TestInProgress"
@@ -536,7 +536,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 46: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -546,8 +546,8 @@ tests:
               type: enum8
 
     - label:
-          "TH waits for a report of TestInProgress attribute from DUT with a
-          timeout of 180 seconds"
+          "Step 47: TH waits for a report of TestInProgress attribute from DUT
+          with a timeout of 180 seconds"
       PICS: SMOKECO.S.A0005
       command: "waitForReport"
       attribute: "TestInProgress"
@@ -557,7 +557,7 @@ tests:
           constraints:
               type: boolean
 
-    - label: "TH reads SelfTestComplete event from DUT"
+    - label: "Step 48: TH reads SelfTestComplete event from DUT"
       PICS: SMOKECO.S.E05
       command: "readEvent"
       event: "SelfTestComplete"
@@ -565,7 +565,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 49: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -574,7 +574,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 50: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -65,8 +65,8 @@ tests:
       PICS: SMOKECO.S.A0003
       command: "subscribeAttribute"
       attribute: "BatteryAlert"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -231,8 +231,8 @@ tests:
       PICS: SMOKECO.S.A0006
       command: "subscribeAttribute"
       attribute: "HardwareFaultAlert"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -333,8 +333,8 @@ tests:
       PICS: SMOKECO.S.A0007
       command: "subscribeAttribute"
       attribute: "EndOfServiceAlert"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -435,8 +435,8 @@ tests:
       PICS: SMOKECO.S.A0005
       command: "subscribeAttribute"
       attribute: "TestInProgress"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -766,14 +766,14 @@ tests:
               - name: "EventTrigger"
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
-    - label: "Step 55a: TH waits 60 Seconds"
+    - label: "Step 55a: TH waits 5 Seconds"
       PICS: "!PICS_SDK_CI_ONLY"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 60000
+                value: 5000
 
     - label: "Step 55b: TH reads DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
@@ -978,14 +978,14 @@ tests:
               - name: "EventTrigger"
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
-    - label: "Step 71a: TH waits 60 Seconds"
+    - label: "Step 71a: TH waits 5 Seconds"
       PICS: "!PICS_SDK_CI_ONLY"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 60000
+                value: 5000
 
     - label: "Step 71b: TH reads DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -797,8 +797,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 56a: TH subscribes to SmokeState attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      command: "subscribeAttribute"
+      attribute: "SmokeState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 56: TH sends TestEventTrigger command to General Diagnostics
+          "Step 56b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Alarm Test Event Clear"
@@ -1022,8 +1029,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 72a: TH subscribes to COState attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      command: "subscribeAttribute"
+      attribute: "COState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 72: TH sends TestEventTrigger command to General Diagnostics
+          "Step 72b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for CO Alarm Test Event Clear"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -326,7 +326,7 @@ tests:
               type: enum8
 
     - label: "Step 22: TH reads AllClear event from DUT"
-      PICS: SMOKECO.S.E0a
+      PICS: SMOKECO.S.A0009 && SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
       EVENT_NUMBER: EVENT_NUMBER + 4
@@ -776,7 +776,7 @@ tests:
                 value: 60000
 
     - label: "Step 55b: TH reads DeviceMuted attribute from DUT"
-      PICS: SMOKECO.S.A0004
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
       command: "readAttribute"
       attribute: "DeviceMuted"
       response:
@@ -803,7 +803,7 @@ tests:
     - label:
           "Step 57: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.A0001 && SMOKECO.S.F00
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
       timeout: 300
@@ -988,7 +988,7 @@ tests:
                 value: 60000
 
     - label: "Step 71b: TH reads DeviceMuted attribute from DUT"
-      PICS: SMOKECO.S.A0004
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
       command: "readAttribute"
       attribute: "DeviceMuted"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -615,7 +615,6 @@ tests:
       attribute: "SmokeState"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -649,8 +648,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 46a: TH subscribes to DeviceMuted attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
+      command: "subscribeAttribute"
+      attribute: "DeviceMuted"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 46: TH sends TestEventTrigger command to General Diagnostics
+          "Step 46n: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
@@ -722,8 +728,15 @@ tests:
       response:
           value: {}
 
+    - label: "Step 52a: TH subscribes to SmokeState attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      command: "subscribeAttribute"
+      attribute: "SmokeState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 52: TH sends TestEventTrigger command to General Diagnostics
+          "Step 52b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical Smoke Alarm Test Event"
@@ -827,7 +840,6 @@ tests:
       attribute: "COState"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -861,8 +873,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 62a: TH subscribes to DeviceMuted attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
+      command: "subscribeAttribute"
+      attribute: "DeviceMuted"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 62: TH sends TestEventTrigger command to General Diagnostics
+          "Step 62b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
@@ -934,8 +953,15 @@ tests:
       response:
           value: {}
 
+    - label: "Step 68a: TH subscribes to COState attribute from DUT"
+      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      command: "subscribeAttribute"
+      attribute: "COState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 68: TH sends TestEventTrigger command to General Diagnostics
+          "Step 68b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical CO Alarm Test Event"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -86,7 +86,7 @@ config:
         defaultValue: 0
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -94,7 +94,8 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH subscribes to InterconnectSmokeAlarm attribute from DUT"
+    - label:
+          "Step 2: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
       PICS: SMOKECO.S.A0008
       command: "subscribeAttribute"
       attribute: "InterconnectSmokeAlarm"
@@ -105,7 +106,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 3: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -115,8 +116,8 @@ tests:
               type: enum8
 
     - label:
-          "TH reads TestEventTriggersEnabled attribute from General Diagnostics
-          Cluster"
+          "Step 4: TH reads TestEventTriggersEnabled attribute from General
+          Diagnostics Cluster"
       PICS: SMOKECO.S.A0008 && DGGEN.S.A0008
       cluster: "General Diagnostics"
       endpoint: 0
@@ -126,8 +127,8 @@ tests:
           value: 1
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 5: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
           Event"
@@ -143,8 +144,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of InterconnectSmokeAlarm attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 6: TH waits for a report of InterconnectSmokeAlarm attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0008
       command: "waitForReport"
       attribute: "InterconnectSmokeAlarm"
@@ -156,7 +157,7 @@ tests:
               minValue: 1
               maxValue: 2
 
-    - label: "TH reads InterconnectSmokeAlarm event from DUT"
+    - label: "Step 7: TH reads InterconnectSmokeAlarm event from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E08
       command: "readEvent"
       event: "InterconnectSmokeAlarm"
@@ -164,7 +165,7 @@ tests:
       response:
           value: { AlarmSeverityLevel: interconnectSmokeAlarmSeverityLevel }
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 8: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -174,8 +175,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 9: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
           Event Clear"
@@ -191,8 +192,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_SMOKE_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of InterconnectSmokeAlarm attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 10: TH waits for a report of InterconnectSmokeAlarm attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0008
       command: "waitForReport"
       attribute: "InterconnectSmokeAlarm"
@@ -202,7 +203,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 11: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -211,7 +212,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 12: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -219,7 +220,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH subscribes to InterconnectCOAlarm attribute from DUT"
+    - label: "Step 13: TH subscribes to InterconnectCOAlarm attribute from DUT"
       PICS: SMOKECO.S.A0009
       command: "subscribeAttribute"
       attribute: "InterconnectCOAlarm"
@@ -230,7 +231,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 14: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -240,8 +241,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 15: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event"
       PICS: SMOKECO.S.A0009 && DGGEN.S.C00.Rsp
@@ -256,8 +257,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_CO_ALARM
 
     - label:
-          "TH waits for a report of InterconnectCOAlarm attribute from DUT with
-          a timeout of 300 seconds"
+          "Step 16: TH waits for a report of InterconnectCOAlarm attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0009
       command: "waitForReport"
       attribute: "InterconnectCOAlarm"
@@ -269,7 +270,7 @@ tests:
               minValue: 1
               maxValue: 2
 
-    - label: "TH reads InterconnectCOAlarm event from DUT"
+    - label: "Step 17: TH reads InterconnectCOAlarm event from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.E09
       command: "readEvent"
       event: "InterconnectCOAlarm"
@@ -277,7 +278,7 @@ tests:
       response:
           value: { AlarmSeverityLevel: interconnectCOAlarmSeverityLevel }
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 18: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -287,8 +288,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 19: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event
           Clear"
@@ -304,8 +305,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_CO_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of InterconnectCOAlarm attribute from DUT with
-          a timeout of 300 seconds"
+          "Step 20: TH waits for a report of InterconnectCOAlarm attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0009
       command: "waitForReport"
       attribute: "InterconnectCOAlarm"
@@ -315,7 +316,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 21: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -324,7 +325,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AllClear event from DUT"
+    - label: "Step 22: TH reads AllClear event from DUT"
       PICS: SMOKECO.S.E0a
       command: "readEvent"
       event: "AllClear"
@@ -332,7 +333,7 @@ tests:
       response:
           value: {}
 
-    - label: "TH subscribes to ContaminationState attribute from DUT"
+    - label: "Step 23: TH subscribes to ContaminationState attribute from DUT"
       PICS: SMOKECO.S.A000a
       command: "subscribeAttribute"
       attribute: "ContaminationState"
@@ -344,8 +345,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 24: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Contamination State (High) Test
           Event"
@@ -361,8 +362,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CONTAMINATION_STATE_HIGH
 
     - label:
-          "TH waits for a report of ContaminationState attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 25: TH waits for a report of ContaminationState attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000a
       command: "waitForReport"
       attribute: "ContaminationState"
@@ -374,8 +375,8 @@ tests:
               maxValue: 3
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 26: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Contamination State Test Event
           Clear"
@@ -391,8 +392,8 @@ tests:
                 value: TTEST_EVENT_TRIGGER_CONTAMINATION_STATE_CLEAR
 
     - label:
-          "TH waits for a report of ContaminationState attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 27: TH waits for a report of ContaminationState attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000a
       command: "waitForReport"
       attribute: "ContaminationState"
@@ -403,8 +404,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 28: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Contamination State (Low) Test
           Event"
@@ -420,8 +421,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CONTAMINATION_STATE_LOW
 
     - label:
-          "TH waits for a report of ContaminationState attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 29: TH waits for a report of ContaminationState attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000a
       command: "waitForReport"
       attribute: "ContaminationState"
@@ -432,8 +433,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 30: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Contamination State Test Event
           Clear"
@@ -449,8 +450,8 @@ tests:
                 value: TTEST_EVENT_TRIGGER_CONTAMINATION_STATE_CLEAR
 
     - label:
-          "TH waits for a report of ContaminationState attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 31: TH waits for a report of ContaminationState attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000a
       command: "waitForReport"
       attribute: "ContaminationState"
@@ -460,7 +461,8 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to SmokeSensitivityLevel attribute from DUT"
+    - label:
+          "Step 32: TH subscribes to SmokeSensitivityLevel attribute from DUT"
       PICS: SMOKECO.S.A000b
       command: "subscribeAttribute"
       attribute: "SmokeSensitivityLevel"
@@ -472,8 +474,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 33: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Sensitivity Level (High)
           Test Event"
@@ -489,8 +491,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_SENSITIVITY_LEVEL_HIGH
 
     - label:
-          "TH waits for a report of SmokeSensitivityLevel attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 34: TH waits for a report of SmokeSensitivityLevel attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000b
       command: "waitForReport"
       attribute: "SmokeSensitivityLevel"
@@ -501,8 +503,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 35: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Sensitivity Level Test
           Event Clear"
@@ -518,8 +520,8 @@ tests:
                 value: TTEST_EVENT_TRIGGER_SENSITIVITY_LEVEL_CLEAR
 
     - label:
-          "TH waits for a report of SmokeSensitivityLevel attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 36: TH waits for a report of SmokeSensitivityLevel attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000b
       command: "waitForReport"
       attribute: "SmokeSensitivityLevel"
@@ -530,8 +532,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 37: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Sensitivity Level (Low)
           Test Event"
@@ -547,8 +549,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_SENSITIVITY_LEVEL_LOW
 
     - label:
-          "TH waits for a report of SmokeSensitivityLevel attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 38: TH waits for a report of SmokeSensitivityLevel attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000b
       command: "waitForReport"
       attribute: "SmokeSensitivityLevel"
@@ -559,8 +561,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 39: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Sensitivity Level Test
           Event Clear"
@@ -576,8 +578,8 @@ tests:
                 value: TTEST_EVENT_TRIGGER_SENSITIVITY_LEVEL_CLEAR
 
     - label:
-          "TH waits for a report of SmokeSensitivityLevel attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 40: TH waits for a report of SmokeSensitivityLevel attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A000b
       command: "waitForReport"
       attribute: "SmokeSensitivityLevel"
@@ -587,7 +589,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to DeviceMuted attribute from DUT"
+    - label: "Step 41: TH subscribes to DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004
       command: "subscribeAttribute"
       attribute: "DeviceMuted"
@@ -598,7 +600,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads FeatureMap attribute(Smoke Alarm) from DUT"
+    - label: "Step 42: TH reads FeatureMap attribute(Smoke Alarm) from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -607,7 +609,7 @@ tests:
               type: bitmap32
               hasMasksSet: [0x1]
 
-    - label: "TH subscribes to SmokeState attribute from DUT"
+    - label: "Step 43: TH subscribes to SmokeState attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
@@ -620,8 +622,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 44: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Smoke Alarm Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && DGGEN.S.C00.Rsp
@@ -636,8 +638,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 45: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -648,8 +650,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 46: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && DGGEN.S.C00.Rsp
@@ -664,8 +666,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
     - label:
-          "TH waits for a report of DeviceMuted attribute from DUT with a
-          timeout of 120 seconds"
+          "Step 47: TH waits for a report of DeviceMuted attribute from DUT with
+          a timeout of 120 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
       command: "waitForReport"
       attribute: "DeviceMuted"
@@ -675,7 +677,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AlarmMuted event from DUT"
+    - label: "Step 48: TH reads AlarmMuted event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
@@ -684,8 +686,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 49: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event
           Clear"
@@ -701,8 +703,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED_CLEAR
 
     - label:
-          "TH waits for a report of DeviceMuted attribute from DUT with a
-          timeout of 120 seconds"
+          "Step 50: TH waits for a report of DeviceMuted attribute from DUT with
+          a timeout of 120 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
       command: "waitForReport"
       attribute: "DeviceMuted"
@@ -712,7 +714,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads MuteEnded event from DUT"
+    - label: "Step 51: TH reads MuteEnded event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
@@ -721,8 +723,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 52: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical Smoke Alarm Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && DGGEN.S.C00.Rsp
@@ -737,8 +739,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CRITICAL_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 53: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -749,8 +751,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 54: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && DGGEN.S.C00.Rsp
@@ -764,7 +766,7 @@ tests:
               - name: "EventTrigger"
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
-    - label: "TH waits 60 Seconds"
+    - label: "Step 55a: TH waits 60 Seconds"
       PICS: "!PICS_SDK_CI_ONLY"
       cluster: "DelayCommands"
       command: "WaitForMs"
@@ -773,7 +775,7 @@ tests:
               - name: "ms"
                 value: 60000
 
-    - label: "TH reads DeviceMuted attribute from DUT"
+    - label: "Step 55b: TH reads DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004
       command: "readAttribute"
       attribute: "DeviceMuted"
@@ -783,8 +785,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 56: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Alarm Test Event Clear"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && DGGEN.S.C00.Rsp
@@ -799,8 +801,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_SMOKE_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 57: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.A0001 && SMOKECO.S.F00
       command: "waitForReport"
       attribute: "SmokeState"
@@ -810,7 +812,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads FeatureMap attribute(CO Alarm) from DUT"
+    - label: "Step 58: TH reads FeatureMap attribute(CO Alarm) from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
       command: "readAttribute"
       attribute: "FeatureMap"
@@ -819,7 +821,7 @@ tests:
               type: bitmap32
               hasMasksSet: [0x2]
 
-    - label: "TH subscribes to COState attribute from DUT"
+    - label: "Step 59: TH subscribes to COState attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
@@ -832,8 +834,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 60: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning CO Alarm Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && DGGEN.S.C00.Rsp
@@ -848,8 +850,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_CO_ALARM
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 61: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -860,8 +862,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 62: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && DGGEN.S.C00.Rsp
@@ -876,8 +878,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
     - label:
-          "TH waits for a report of DeviceMuted attribute from DUT with a
-          timeout of 120 seconds"
+          "Step 63: TH waits for a report of DeviceMuted attribute from DUT with
+          a timeout of 120 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
       command: "waitForReport"
       attribute: "DeviceMuted"
@@ -887,7 +889,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads AlarmMuted event from DUT"
+    - label: "Step 64: TH reads AlarmMuted event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E06
       command: "readEvent"
       event: "AlarmMuted"
@@ -896,8 +898,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 65: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event
           Clear"
@@ -913,8 +915,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED_CLEAR
 
     - label:
-          "TH waits for a report of DeviceMuted attribute from DUT with a
-          timeout of 120 seconds"
+          "Step 66: TH waits for a report of DeviceMuted attribute from DUT with
+          a timeout of 120 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
       command: "waitForReport"
       attribute: "DeviceMuted"
@@ -924,7 +926,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads MuteEnded event from DUT"
+    - label: "Step 67: TH reads MuteEnded event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E07
       command: "readEvent"
       event: "MuteEnded"
@@ -933,8 +935,8 @@ tests:
           value: {}
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 68: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Critical CO Alarm Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && DGGEN.S.C00.Rsp
@@ -949,8 +951,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CRITICAL_CO_ALARM
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 69: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -961,8 +963,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 70: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Manual Device Mute Test Event"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && DGGEN.S.C00.Rsp
@@ -976,7 +978,7 @@ tests:
               - name: "EventTrigger"
                 value: TEST_EVENT_TRIGGER_DEVICE_MUTED
 
-    - label: "TH waits 60 Seconds"
+    - label: "Step 71a: TH waits 60 Seconds"
       PICS: "!PICS_SDK_CI_ONLY"
       cluster: "DelayCommands"
       command: "WaitForMs"
@@ -985,7 +987,7 @@ tests:
               - name: "ms"
                 value: 60000
 
-    - label: "TH reads DeviceMuted attribute from DUT"
+    - label: "Step 71b: TH reads DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004
       command: "readAttribute"
       attribute: "DeviceMuted"
@@ -995,8 +997,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 72: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for CO Alarm Test Event Clear"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && DGGEN.S.C00.Rsp
@@ -1011,8 +1013,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CO_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 73: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -99,8 +99,8 @@ tests:
       PICS: SMOKECO.S.A0008
       command: "subscribeAttribute"
       attribute: "InterconnectSmokeAlarm"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -224,8 +224,8 @@ tests:
       PICS: SMOKECO.S.A0009
       command: "subscribeAttribute"
       attribute: "InterconnectCOAlarm"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -337,8 +337,8 @@ tests:
       PICS: SMOKECO.S.A000a
       command: "subscribeAttribute"
       attribute: "ContaminationState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -466,8 +466,8 @@ tests:
       PICS: SMOKECO.S.A000b
       command: "subscribeAttribute"
       attribute: "SmokeSensitivityLevel"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 1
           constraints:
@@ -593,8 +593,8 @@ tests:
       PICS: SMOKECO.S.A0004
       command: "subscribeAttribute"
       attribute: "DeviceMuted"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -613,8 +613,8 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0
@@ -825,8 +825,8 @@ tests:
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -95,8 +95,8 @@ tests:
       PICS: SMOKECO.S.A0003
       command: "subscribeAttribute"
       attribute: "BatteryAlert"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       response:
           value: 0
           constraints:
@@ -107,8 +107,8 @@ tests:
       PICS: SMOKECO.S.A0008
       command: "subscribeAttribute"
       attribute: "InterconnectSmokeAlarm"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0
@@ -119,8 +119,8 @@ tests:
       PICS: SMOKECO.S.A0009
       command: "subscribeAttribute"
       attribute: "InterconnectCOAlarm"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0
@@ -131,8 +131,8 @@ tests:
       PICS: SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0
@@ -143,8 +143,8 @@ tests:
       PICS: SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
-      minInterval: 3
-      maxInterval: 30
+      minInterval: 1
+      maxInterval: 900
       keepSubscriptions: true
       response:
           value: 0

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -109,7 +109,6 @@ tests:
       attribute: "InterconnectSmokeAlarm"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -121,7 +120,6 @@ tests:
       attribute: "InterconnectCOAlarm"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -133,7 +131,6 @@ tests:
       attribute: "COState"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -145,7 +142,6 @@ tests:
       attribute: "SmokeState"
       minInterval: 1
       maxInterval: 900
-      keepSubscriptions: true
       response:
           value: 0
           constraints:
@@ -162,8 +158,15 @@ tests:
       response:
           value: 1
 
+    - label: "Step 9a: TH subscribes to BatteryAlert attribute from DUT"
+      PICS: SMOKECO.S.A0003
+      command: "subscribeAttribute"
+      attribute: "BatteryAlert"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 9: TH sends TestEventTrigger command to General Diagnostics
+          "Step 9b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Battery Alert Test Event"
@@ -191,7 +194,15 @@ tests:
               type: enum8
 
     - label:
-          "Step 11: TH sends TestEventTrigger command to General Diagnostics
+          "Step 11a: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
+      PICS: SMOKECO.S.A0008
+      command: "subscribeAttribute"
+      attribute: "InterconnectSmokeAlarm"
+      minInterval: 1
+      maxInterval: 900
+
+    - label:
+          "Step 11b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
@@ -220,8 +231,15 @@ tests:
               minValue: 1
               maxValue: 2
 
+    - label: "Step 13a: TH subscribes to InterconnectCOAlarm attribute from DUT"
+      PICS: SMOKECO.S.A0009
+      command: "subscribeAttribute"
+      attribute: "InterconnectCOAlarm"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 13: TH sends TestEventTrigger command to General Diagnostics
+          "Step 13b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event"
@@ -249,8 +267,15 @@ tests:
               minValue: 1
               maxValue: 2
 
+    - label: "Step 15a: TH subscribes to COState attribute from DUT"
+      PICS: SMOKECO.S.A0002
+      command: "subscribeAttribute"
+      attribute: "COState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 15: TH sends TestEventTrigger command to General Diagnostics
+          "Step 15b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning CO Alarm Test Event"
@@ -277,8 +302,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 17a: TH subscribes to SmokeState attribute from DUT"
+      PICS: SMOKECO.S.A0001
+      command: "subscribeAttribute"
+      attribute: "SmokeState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 17: TH sends TestEventTrigger command to General Diagnostics
+          "Step 17b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Smoke Alarm Test Event"
@@ -351,8 +383,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 23a: TH subscribes to COState attribute from DUT"
+      PICS: SMOKECO.S.A0002
+      command: "subscribeAttribute"
+      attribute: "COState"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 23: TH sends TestEventTrigger command to General Diagnostics
+          "Step 23b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for CO Alarm Test Event clear"
@@ -388,8 +427,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 26a: TH subscribes to InterconnectCOAlarm attribute from DUT"
+      PICS: SMOKECO.S.A0009
+      command: "subscribeAttribute"
+      attribute: "InterconnectCOAlarm"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 26: TH sends TestEventTrigger command to General Diagnostics
+          "Step 26b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event
@@ -427,7 +473,15 @@ tests:
               type: enum8
 
     - label:
-          "Step 29: TH sends TestEventTrigger command to General Diagnostics
+          "Step 29a: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
+      PICS: SMOKECO.S.A0008
+      command: "subscribeAttribute"
+      attribute: "InterconnectSmokeAlarm"
+      minInterval: 1
+      maxInterval: 900
+
+    - label:
+          "Step 29b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
@@ -464,8 +518,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 32a: TH subscribes to BatteryAlert attribute from DUT"
+      PICS: SMOKECO.S.A0003
+      command: "subscribeAttribute"
+      attribute: "BatteryAlert"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 32: TH sends TestEventTrigger command to General Diagnostics
+          "Step 32b: TH sends TestEventTrigger command to General Diagnostics
           Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Battery Alert Test Event Clear"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -62,7 +62,7 @@ config:
         defaultValue: 1
     HIEST_PRI_ALARM_2:
         type: int8u
-        defaultValue: 2
+        defaultValue: 7
     HIEST_PRI_ALARM_3:
         type: int8u
         defaultValue: 7

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -74,7 +74,7 @@ config:
         defaultValue: 3
 
 tests:
-    - label: "Commission DUT to TH"
+    - label: "Step 1: Commission DUT to TH"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
       arguments:
@@ -82,7 +82,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 2: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -91,7 +91,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to BatteryAlert attribute from DUT"
+    - label: "Step 3: TH subscribes to BatteryAlert attribute from DUT"
       PICS: SMOKECO.S.A0003
       command: "subscribeAttribute"
       attribute: "BatteryAlert"
@@ -102,7 +102,8 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to InterconnectSmokeAlarm attribute from DUT"
+    - label:
+          "Step 4: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
       PICS: SMOKECO.S.A0008
       command: "subscribeAttribute"
       attribute: "InterconnectSmokeAlarm"
@@ -114,7 +115,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to InterconnectCOAlarm attribute from DUT"
+    - label: "Step 5: TH subscribes to InterconnectCOAlarm attribute from DUT"
       PICS: SMOKECO.S.A0009
       command: "subscribeAttribute"
       attribute: "InterconnectCOAlarm"
@@ -126,7 +127,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to COState attribute from DUT"
+    - label: "Step 6: TH subscribes to COState attribute from DUT"
       PICS: SMOKECO.S.A0002
       command: "subscribeAttribute"
       attribute: "COState"
@@ -138,7 +139,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH subscribes to SmokeState attribute from DUT"
+    - label: "Step 7: TH subscribes to SmokeState attribute from DUT"
       PICS: SMOKECO.S.A0001
       command: "subscribeAttribute"
       attribute: "SmokeState"
@@ -151,8 +152,8 @@ tests:
               type: enum8
 
     - label:
-          "TH reads TestEventTriggersEnabled attribute from General Diagnostics
-          Cluster"
+          "Step 8: TH reads TestEventTriggersEnabled attribute from General
+          Diagnostics Cluster"
       PICS: DGGEN.S.A0008
       cluster: "General Diagnostics"
       endpoint: 0
@@ -162,8 +163,8 @@ tests:
           value: 1
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 9: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Battery Alert Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -178,8 +179,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_BATTERY_ALERT
 
     - label:
-          "TH waits for a report of BatteryAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 10: TH waits for a report of BatteryAlert attribute from DUT
+          with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0003
       command: "waitForReport"
       attribute: "BatteryAlert"
@@ -190,8 +191,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 11: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
           Event"
@@ -207,8 +208,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of InterconnectSmokeAlarm attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 12: TH waits for a report of InterconnectSmokeAlarm attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0008
       command: "waitForReport"
       attribute: "InterconnectSmokeAlarm"
@@ -220,8 +221,8 @@ tests:
               maxValue: 2
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 13: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event"
       PICS: SMOKECO.S.A0009 && DGGEN.S.C00.Rsp
@@ -236,8 +237,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_CO_ALARM
 
     - label:
-          "TH waits for a report of InterconnectCOAlarm attribute from DUT with
-          a timeout of 300 seconds"
+          "Step 14: TH waits for a report of InterconnectCOAlarm attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0009
       command: "waitForReport"
       attribute: "InterconnectCOAlarm"
@@ -249,8 +250,8 @@ tests:
               maxValue: 2
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 15: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning CO Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -265,8 +266,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_CO_ALARM
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 16: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -277,8 +278,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 17: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Warning Smoke Alarm Test Event"
       PICS: DGGEN.S.C00.Rsp
@@ -293,8 +294,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_WARNING_SMOKE_ALARM
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 18: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -304,7 +305,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 19: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -314,8 +315,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 20: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Smoke Alarm Test Event Clear"
       PICS: DGGEN.S.C00.Rsp
@@ -330,8 +331,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_SMOKE_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of SmokeState attribute from DUT with a timeout
-          of 300 seconds"
+          "Step 21: TH waits for a report of SmokeState attribute from DUT with
+          a timeout of 300 seconds"
       PICS: SMOKECO.S.A0001
       command: "waitForReport"
       attribute: "SmokeState"
@@ -341,7 +342,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 22: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -351,8 +352,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 23: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for CO Alarm Test Event clear"
       PICS: DGGEN.S.C00.Rsp
@@ -367,8 +368,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_CO_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of COState attribute from DUT with a timeout of
-          300 seconds"
+          "Step 24: TH waits for a report of COState attribute from DUT with a
+          timeout of 300 seconds"
       PICS: SMOKECO.S.A0002
       command: "waitForReport"
       attribute: "COState"
@@ -378,7 +379,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 25: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -388,8 +389,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 26: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect CO Alarm Test Event
           Clear"
@@ -405,8 +406,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_CO_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of InterconnectCOAlarm attribute from DUT with
-          a timeout of 300 seconds"
+          "Step 27: TH waits for a report of InterconnectCOAlarm attribute from
+          DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0009
       command: "waitForReport"
       attribute: "InterconnectCOAlarm"
@@ -416,7 +417,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 28: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -426,8 +427,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 29: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Interconnect Smoke Alarm Test
           Event Clear"
@@ -443,8 +444,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_INTERCONNECT_SMOKE_ALARM_CLEAR
 
     - label:
-          "TH waits for a report of InterconnectSmokeAlarm attribute from DUT
-          with a timeout of 300 seconds"
+          "Step 30: TH waits for a report of InterconnectSmokeAlarm attribute
+          from DUT with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0008
       command: "waitForReport"
       attribute: "InterconnectSmokeAlarm"
@@ -454,7 +455,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 31: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"
@@ -464,8 +465,8 @@ tests:
               type: enum8
 
     - label:
-          "TH sends TestEventTrigger command to General Diagnostics Cluster on
-          Endpoint 0 with EnableKey field set to
+          "Step 32: TH sends TestEventTrigger command to General Diagnostics
+          Cluster on Endpoint 0 with EnableKey field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to
           PIXIT.SMOKECO.TEST_EVENT_TRIGGER for Battery Alert Test Event Clear"
       PICS: DGGEN.S.C00.Rsp
@@ -480,8 +481,8 @@ tests:
                 value: TEST_EVENT_TRIGGER_BATTERY_ALERT_CLEAR
 
     - label:
-          "TH waits for a report of BatteryAlert attribute from DUT with a
-          timeout of 300 seconds"
+          "Step 33: TH waits for a report of BatteryAlert attribute from DUT
+          with a timeout of 300 seconds"
       PICS: SMOKECO.S.A0003
       command: "waitForReport"
       attribute: "BatteryAlert"
@@ -491,7 +492,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "TH reads ExpressedState attribute from DUT"
+    - label: "Step 34: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
       command: "readAttribute"
       attribute: "ExpressedState"


### PR DESCRIPTION
Test Plan: [smco.adoc](https://github.com/CHIP-Specifications/chip-test-plans/blob/bc9c039d11c690814eb201ca904a8376e218e0e7/src/cluster/smco.adoc)
1. Add SMOKECO tests serial number.
2. Fix the difference between scripts and test plan.
3. Keep HIEST_PRI_ALARM priorities and examples consistent.
4. Reduce WaitForMs time.
5. Modify minInterval and maxInterval.
6. Remove keepSubscriptions because it hasn't been implemented yet, and there seems to be an error.
7. Add subscribe after WaitForMs because WaitForMs cause the lose of subscription.
8. Disable TC-SMOKECO-2.6 in darwin due to unknown generation errors.