### PR TITLE
[Silabs] Update linker config

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -230,6 +230,7 @@ source_set("efr32-common") {
   public_configs = [
     ":efr32-common-config",
     "${efr32_sdk_build_root}:silabs_config",
+    ":chip_examples_project_config",
   ]
 
   # DIC


### PR DESCRIPTION
Linker configuration wasn't propagated properly for builds without the OT libs.

