### PR TITLE
Revert "[Telink] Move SetRouterPromotion(false) at the end of OpenCom…

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -249,17 +249,6 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds16 commiss
 
     mCommissioningTimeoutTimerArmed = true;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-    // Block device role changing into Router if commissioning window opened and device not yet Router.
-    // AdvertiseAndListenForPASE fails doesn't matter, because if it does the callers of OpenCommissioningWindow
-    // will end up calling ResetState, which will reset the boolean.
-    if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
-    {
-        ThreadStackMgr().SetRouterPromotion(false);
-        mRecoverRouterDeviceRole = true;
-    }
-#endif
-
     return AdvertiseAndListenForPASE();
 }
 
@@ -495,6 +484,15 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
 
     // reset all advertising, switching to our new commissioning mode.
     app::DnssdServer::Instance().StartServer();
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
+    // Block device role changing into Router if commissioning window opened and device not yet Router.
+    if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
+    {
+        ThreadStackMgr().SetRouterPromotion(false);
+        mRecoverRouterDeviceRole = true;
+    }
+#endif
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -25,10 +25,6 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceControlServer.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-using namespace chip::DeviceLayer;
-#endif
-
 using namespace chip::app::Clusters;
 using namespace chip::System::Clock;
 
@@ -111,15 +107,6 @@ void CommissioningWindowManager::ResetState()
 #endif
 
     UpdateWindowStatus(CommissioningWindowStatusEnum::kWindowNotOpen);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-    // Recover Router device role.
-    if (mRecoverRouterDeviceRole)
-    {
-        ThreadStackMgr().SetRouterPromotion(true);
-        mRecoverRouterDeviceRole = false;
-    }
-#endif
 
     UpdateOpenerFabricIndex(NullNullable);
     UpdateOpenerVendorId(NullNullable);
@@ -484,15 +471,6 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
 
     // reset all advertising, switching to our new commissioning mode.
     app::DnssdServer::Instance().StartServer();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-    // Block device role changing into Router if commissioning window opened and device not yet Router.
-    if (ConnectivityManagerImpl().GetThreadDeviceType() == ConnectivityManager::kThreadDeviceType_Router)
-    {
-        ThreadStackMgr().SetRouterPromotion(false);
-        mRecoverRouterDeviceRole = true;
-    }
-#endif
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -215,10 +215,6 @@ private:
     bool mSEDActiveModeEnabled = false;
 #endif
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_THREAD_FTD
-    bool mRecoverRouterDeviceRole = false;
-#endif
-
     // For tests only, so that we can test the commissioning window timeout
     // without having to wait 3 minutes.
     Optional<System::Clock::Seconds16> mMinCommissioningTimeoutOverride;

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -105,7 +105,6 @@ public:
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR GetExternalIPv6Address(chip::Inet::IPAddress & addr);
     CHIP_ERROR GetPollPeriod(uint32_t & buf);
-    void SetRouterPromotion(bool val);
 
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(ByteSpan aDataset);
@@ -451,11 +450,6 @@ inline CHIP_ERROR ThreadStackManager::GetExternalIPv6Address(chip::Inet::IPAddre
 inline CHIP_ERROR ThreadStackManager::GetPollPeriod(uint32_t & buf)
 {
     return static_cast<ImplClass *>(this)->_GetPollPeriod(buf);
-}
-
-inline void ThreadStackManager::SetRouterPromotion(bool val)
-{
-    static_cast<ImplClass *>(this)->_SetRouterPromotion(val);
 }
 
 inline CHIP_ERROR ThreadStackManager::JoinerStart()

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -614,11 +614,6 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-void ThreadStackManagerImpl::_SetRouterPromotion(bool val)
-{
-    // Set Router Promotion is not supported on linux
-}
-
 CHIP_ERROR ThreadStackManagerImpl::GLibMatterContextCallScan(ThreadStackManagerImpl * self)
 {
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -118,8 +118,6 @@ public:
 
     CHIP_ERROR _JoinerStart();
 
-    void _SetRouterPromotion(bool val);
-
     void _ResetThreadNetworkDiagnosticsCounts();
 
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -120,7 +120,6 @@ protected:
     void _ResetThreadNetworkDiagnosticsCounts(void);
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
-    void _SetRouterPromotion(bool val);
     void _OnWoBLEAdvertisingStart(void);
     void _OnWoBLEAdvertisingStop(void);
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1678,19 +1678,6 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPollPeriod(u
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetRouterPromotion(bool val)
-{
-#if CHIP_DEVICE_CONFIG_THREAD_FTD
-    Impl()->LockThreadStack();
-    if (otThreadGetDeviceRole(DeviceLayer::ThreadStackMgrImpl().OTInstance()) != OT_DEVICE_ROLE_ROUTER)
-    {
-        otThreadSetRouterEligible(DeviceLayer::ThreadStackMgrImpl().OTInstance(), val);
-    }
-    Impl()->UnlockThreadStack();
-#endif
-}
-
-template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstance * otInst)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -491,11 +491,6 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-void ThreadStackManagerImpl::_SetRouterPromotion(bool val)
-{
-    // Set Router Promotion is not supported on Tizen
-}
-
 CHIP_ERROR ThreadStackManagerImpl::_StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback)
 {
     ChipLogError(DeviceLayer, "Not implemented");

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -100,8 +100,6 @@ public:
 
     CHIP_ERROR _JoinerStart();
 
-    void _SetRouterPromotion(bool val);
-
     void _ResetThreadNetworkDiagnosticsCounts();
 
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);


### PR DESCRIPTION
This set of changes was placed in as a workaround for an OpenThread issue in #25517. This has since been fixed. 

Removing this, as at this point it's actually causing pairing failures for some device configurations.