### PR TITLE
ESP32: Enable BLE Deinit for ESP32H2 after successful commissioning

### DIFF
--- a/examples/platform/esp32/common/Esp32AppServer.cpp
+++ b/examples/platform/esp32/common/Esp32AppServer.cpp
@@ -27,6 +27,19 @@
 #if CONFIG_ENABLE_ICD_SERVER
 #include <ICDSubscriptionCallback.h>
 #endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#if CONFIG_BT_ENABLED
+#include "esp_bt.h"
+#if CONFIG_BT_NIMBLE_ENABLED
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "esp_nimble_hci.h"
+#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "nimble/nimble_port.h"
+#endif // CONFIG_BT_NIMBLE_ENABLED
+#endif // CONFIG_BT_ENABLED
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
 #include <string.h>
 
 using namespace chip;
@@ -100,6 +113,50 @@ static size_t hex_string_to_binary(const char * hex_string, uint8_t * buf, size_
 }
 #endif // CONFIG_TEST_EVENT_TRIGGER_ENABLED
 
+void Esp32AppServer::DeInitBLEIfCommissioned(void)
+{
+#if CONFIG_BT_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
+    if (chip::Server::GetInstance().GetFabricTable().FabricCount() > 0)
+    {
+        esp_err_t err = ESP_OK;
+
+#if CONFIG_BT_NIMBLE_ENABLED
+        if (!ble_hs_is_enabled())
+        {
+            ESP_LOGI(TAG, "BLE already deinited");
+            return;
+        }
+        if (nimble_port_stop() != 0)
+        {
+            ESP_LOGE(TAG, "nimble_port_stop() failed");
+            return;
+        }
+        vTaskDelay(100);
+        nimble_port_deinit();
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+        err = esp_nimble_hci_and_controller_deinit();
+#endif
+#endif /* CONFIG_BT_NIMBLE_ENABLED */
+
+#if CONFIG_IDF_TARGET_ESP32
+        err |= esp_bt_mem_release(ESP_BT_MODE_BTDM);
+#elif CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32H2
+        err |= esp_bt_mem_release(ESP_BT_MODE_BLE);
+#endif
+
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "BLE deinit failed");
+        }
+        else
+        {
+            ESP_LOGI(TAG, "BLE deinit successful and memory reclaimed");
+        }
+    }
+#endif /* CONFIG_BT_ENABLED && CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING */
+}
+
 void Esp32AppServer::Init(AppDelegate * sAppDelegate)
 {
     // Init ZCL Data Model and CHIP App Server
@@ -136,4 +193,5 @@ void Esp32AppServer::Init(AppDelegate * sAppDelegate)
         chip::app::DnssdServer::Instance().StartServer();
     }
 #endif
+    DeInitBLEIfCommissioned();
 }

--- a/examples/platform/esp32/common/Esp32AppServer.h
+++ b/examples/platform/esp32/common/Esp32AppServer.h
@@ -22,5 +22,6 @@
 #include <stdint.h>
 
 namespace Esp32AppServer {
+void DeInitBLEIfCommissioned(void);
 void Init(AppDelegate * context = nullptr);
 } // namespace Esp32AppServer

--- a/src/platform/ESP32/OpenthreadLauncher.c
+++ b/src/platform/ESP32/OpenthreadLauncher.c
@@ -55,9 +55,18 @@ static void ot_task_worker(void * context)
     vTaskDelete(NULL);
 }
 
-void set_openthread_platform_config(esp_openthread_platform_config_t * config)
+esp_err_t set_openthread_platform_config(esp_openthread_platform_config_t * config)
 {
-    s_platform_config = config;
+    if (!s_platform_config)
+    {
+        s_platform_config = (esp_openthread_platform_config_t *) malloc(sizeof(esp_openthread_platform_config_t));
+        if (!s_platform_config)
+        {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+    memcpy(s_platform_config, config, sizeof(esp_openthread_platform_config_t));
+    return ESP_OK;
 }
 
 esp_err_t openthread_init_stack(void)
@@ -77,6 +86,8 @@ esp_err_t openthread_init_stack(void)
     ESP_ERROR_CHECK(esp_openthread_init(s_platform_config));
     // Initialize the esp_netif bindings
     openthread_netif = init_openthread_netif(s_platform_config);
+    free(s_platform_config);
+    s_platform_config = NULL;
     return ESP_OK;
 }
 

--- a/src/platform/ESP32/OpenthreadLauncher.h
+++ b/src/platform/ESP32/OpenthreadLauncher.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-void set_openthread_platform_config(esp_openthread_platform_config_t * config);
+esp_err_t set_openthread_platform_config(esp_openthread_platform_config_t * config);
 esp_err_t openthread_init_stack(void);
 esp_err_t openthread_launch_task(void);
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -211,21 +211,6 @@ void HandleIncomingBleConnection(BLEEndPoint * bleEP)
 
 CHIP_ERROR BLEManagerImpl::_Init()
 {
-#if CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    if (ConnectivityMgr().IsThreadProvisioned())
-    {
-        ESP_LOGI(TAG, "Thread credentials already provisioned, not initializing BLE");
-#else
-    if (ConnectivityMgr().IsWiFiStationProvisioned())
-    {
-        ESP_LOGI(TAG, "WiFi station already provisioned, not initializing BLE");
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
-        esp_bt_mem_release(ESP_BT_MODE_BTDM);
-        return CHIP_NO_ERROR;
-    }
-#endif /* CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING */
-
     CHIP_ERROR err;
 
     // Initialize the Chip BleLayer.


### PR DESCRIPTION
We shouldn't call APIs from `ConnectivityMgr()` in `BLEMgr().Init()` since the `ConnectivityMgr()` is not initialized at that time, which will cause that we cannot enable `USE_BLE_ONLY_FOR_COMMISSIONING` for ESP32H2.

In this PR we will always initialize the BLE Layer, but we will deinitialize it if the device is commissioned after the app::Server starts.