### PR TITLE
Increase value buffer size for payload decoding, make sure overflows are shown.

### DIFF
--- a/src/lib/format/protocol_decoder.cpp
+++ b/src/lib/format/protocol_decoder.cpp
@@ -182,6 +182,8 @@ void PrettyPrintCurrentValue(const TLVReader & reader, chip::StringBuilderBase &
             out.AddFormat(" | 0x%08" PRIX64, value);
         }
     }
+
+    out.AddMarkerIfOverflow();
 }
 
 } // namespace

--- a/src/lib/format/tests/TestDecoding.cpp
+++ b/src/lib/format/tests/TestDecoding.cpp
@@ -157,13 +157,13 @@ void TestFullDataDecoding(nlTestSuite * inSuite, void * inContext)
     TestSampleData(inSuite, params, secure_channel_pase_pake1,
                    // clang-format off
                    "pase_pake1\n"
-                   "  pA: hex:0422ABC7A84352850456BD4A510905FE6BB782A0863A9382550E1228020801B22EEC4102C60F80082842B9739705FCD37F134651442A41E3723DFFE0278\n"
+                   "  pA: hex:0422ABC7A84352850456BD4A510905FE6BB782A0863A9382550E1228020801B22EEC4102C60F80082842B9739705FCD37F134651442A41E3723DFFE0...\n"
                    // clang-format on
     );
     TestSampleData(inSuite, params, secure_channel_pase_pake2,
                    // clang-format off
                    "pase_pake2\n"
-                   "  pB: hex:04B6A44A3347C6B77900A3674CA19F40F25F056F8CB344EC1B4FA7888B9E6B570B7010431C5D0BE4021FE74A96C40721765FDA6802BE8DFDF5624332275\n"
+                   "  pB: hex:04B6A44A3347C6B77900A3674CA19F40F25F056F8CB344EC1B4FA7888B9E6B570B7010431C5D0BE4021FE74A96C40721765FDA6802BE8DFDF5624332...\n"
                    "  cB: hex:40E7452275E38AEBAF0E0F6FAB33A1B0CB5AEB5E824230DD40D0071DC7E55C87\n"
                    // clang-format on
     );

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -227,7 +227,7 @@ void DecodePayloadData(::Json::Value & value, chip::ByteSpan payload, Protocols:
 
 #if MATTER_LOG_JSON_DECODE_FULL
 
-    // As PayloadDecoder contains string buffers, allocate it over heap
+    // As PayloadDecoder is quite large (large strings buffers), we place it in heap
     auto decoder = chip::Platform::MakeUnique<PayloadDecoderType>(PayloadDecoderInitParams()
                                                                       .SetProtocolDecodeTree(chip::TLVMeta::protocols_meta)
                                                                       .SetClusterDecodeTree(chip::TLVMeta::clusters_meta)


### PR DESCRIPTION
Overflows for `attestationElements` were previously overflowing (500+ bytes of data) without any overflow marker.

Changes:
  - ensure an overflow marker will be set if applicable
  - we do want all data, so make the buffer space for output for json very large (2K - platforms supporting json are generally linux/mac/android and they should have resources for this)
  - Allocate this on the heap instead of the stack