### PR TITLE
[Silabs] Bump heap for thread apps by 2kb.

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -227,9 +227,9 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #endif // DIC
 #else  // SL_WIFI
 #if SL_CONFIG_OPENTHREAD_LIB == 1
-#define configTOTAL_HEAP_SIZE ((size_t)(29 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(31 * 1024))
 #else
-#define configTOTAL_HEAP_SIZE ((size_t)(27 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(29 * 1024))
 #endif // SL_CONFIG_OPENTHREAD_LIB
 #endif // configTOTAL_HEAP_SIZE
 #endif // configTOTAL_HEAP_SIZE


### PR DESCRIPTION
The latest addition to our code base increased heap usage at bootup/init. 

While testing extra options enabled, I hit some heap issues during that init phase. 
This 2k increase fixes those issues and gives us a buffer

