### PR TITLE
Android tv-casting-app: refactored Initialization

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -8,9 +8,9 @@ import androidx.fragment.app.FragmentTransaction;
 import com.chip.casting.AppParameters;
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.TvCastingApp;
-import com.chip.casting.util.DACProviderStub;
 import com.chip.casting.util.GlobalCastingConstants;
 import com.chip.casting.util.PreferencesConfigurationManager;
+import com.matter.casting.InitializationExample;
 import java.util.Random;
 
 public class MainActivity extends AppCompatActivity
@@ -27,7 +27,10 @@ public class MainActivity extends AppCompatActivity
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    boolean ret = initJni();
+    boolean ret =
+        GlobalCastingConstants.ChipCastingSimplified
+            ? InitializationExample.initAndStart(this.getApplicationContext()).hasNoError()
+            : initJni();
     if (!ret) {
       Log.e(TAG, "Failed to initialize Matter TV casting library");
       return;
@@ -78,7 +81,7 @@ public class MainActivity extends AppCompatActivity
   private boolean initJni() {
     tvCastingApp = TvCastingApp.getInstance();
 
-    tvCastingApp.setDACProvider(new DACProviderStub());
+    tvCastingApp.setDACProvider(new com.chip.casting.util.DACProviderStub());
 
     AppParameters appParameters = new AppParameters();
     appParameters.setConfigurationManager(

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
@@ -5,4 +5,6 @@ public class GlobalCastingConstants {
   public static final int CommissioningWindowDurationSecs = 3 * 60;
   public static final int SetupPasscode = 20202021;
   public static final int Discriminator = 0xF00;
+  public static final boolean ChipCastingSimplified =
+      false; // set this flag to true to demo simplified casting APIs
 }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -1,0 +1,99 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting;
+
+import android.util.Base64;
+import com.matter.casting.support.DACProvider;
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPrivateKeySpec;
+
+public class DACProviderStub implements DACProvider {
+
+  private String kDevelopmentDAC_Cert_FFF1_8001 =
+      "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=";
+
+  private String kDevelopmentDAC_PrivateKey_FFF1_8001 =
+      "qrYAroroqrfXNifCF7fCBHCcppRq9fL3UwgzpStE+/8=";
+
+  private String kDevelopmentDAC_PublicKey_FFF1_8001 =
+      "BEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoI=";
+
+  private String KPAI_FFF1_8000_Cert_Array =
+      "MIIByzCCAXGgAwIBAgIIVq2CIq2UW2QwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMjAyMDUwMDAwMDBaGA85OTk5MTIzMTIzNTk1OVowPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARBmpMVwhc+DIyHbQPM/JRIUmR/f+xeUIL0BZko7KiUxZQVEwmsYx5MsDOSr2hLC6+35ls7gWLC9Sv5MbjneqqCo2YwZDASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUY1QOR/ZLHDjROISkYtFsGV2P+zwwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGhcX4wCgYIKoZIzj0EAwIDSAAwRQIhALLvJ/Sa6bUPuR7qyUxNC9u415KcbLiPrOUpNo0SBUwMAiBlXckrhr2QmIKmxiF3uCXX0F7b58Ivn+pxIg5+pwP4kQ==";
+
+  /**
+   * format_version = 1 vendor_id = 0xFFF1 product_id_array = [ 0x8000,0x8001...0x8063]
+   * device_type_id = 0x1234 certificate_id = "ZIG20141ZB330001-24" security_level = 0
+   * security_information = 0 version_number = 0x2694 certification_type = 0 dac_origin_vendor_id is
+   * not present dac_origin_product_id is not present
+   */
+  private String kCertificationDeclaration =
+      "MIICGQYJKoZIhvcNAQcCoIICCjCCAgYCAQMxDTALBglghkgBZQMEAgEwggFxBgkqhkiG9w0BBwGgggFiBIIBXhUkAAElAfH/NgIFAIAFAYAFAoAFA4AFBIAFBYAFBoAFB4AFCIAFCYAFCoAFC4AFDIAFDYAFDoAFD4AFEIAFEYAFEoAFE4AFFIAFFYAFFoAFF4AFGIAFGYAFGoAFG4AFHIAFHYAFHoAFH4AFIIAFIYAFIoAFI4AFJIAFJYAFJoAFJ4AFKIAFKYAFKoAFK4AFLIAFLYAFLoAFL4AFMIAFMYAFMoAFM4AFNIAFNYAFNoAFN4AFOIAFOYAFOoAFO4AFPIAFPYAFPoAFP4AFQIAFQYAFQoAFQ4AFRIAFRYAFRoAFR4AFSIAFSYAFSoAFS4AFTIAFTYAFToAFT4AFUIAFUYAFUoAFU4AFVIAFVYAFVoAFV4AFWIAFWYAFWoAFW4AFXIAFXYAFXoAFX4AFYIAFYYAFYoAFY4AYJAMWLAQTWklHMjAxNDJaQjMzMDAwMy0yNCQFACQGACUHlCYkCAAYMX0wewIBA4AUYvqCM1ms+qmWPhz6FArd9QTzcWAwCwYJYIZIAWUDBAIBMAoGCCqGSM49BAMCBEcwRQIgJOXR9Hp9ew0gaibvaZt8l1e3LUaQid4xkuZ4x0Xn9gwCIQD4qi+nEfy3m5fjl87aZnuuRk4r0//fw8zteqjKX0wafA==";
+
+  @Override
+  public byte[] GetCertificationDeclaration() {
+    return Base64.decode(kCertificationDeclaration, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetFirmwareInformation() {
+    return new byte[0];
+  }
+
+  @Override
+  public byte[] GetDeviceAttestationCert() {
+    return Base64.decode(kDevelopmentDAC_Cert_FFF1_8001, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetProductAttestationIntermediateCert() {
+    return Base64.decode(KPAI_FFF1_8000_Cert_Array, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] SignWithDeviceAttestationKey(byte[] message) {
+
+    try {
+      byte[] privateKeyBytes = Base64.decode(kDevelopmentDAC_PrivateKey_FFF1_8001, Base64.DEFAULT);
+
+      AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
+      algorithmParameters.init(new ECGenParameterSpec("secp256r1"));
+      ECParameterSpec parameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
+      ECPrivateKeySpec ecPrivateKeySpec =
+          new ECPrivateKeySpec(new BigInteger(1, privateKeyBytes), parameterSpec);
+
+      KeyFactory keyFactory = KeyFactory.getInstance("EC");
+      PrivateKey privateKey = keyFactory.generatePrivate(ecPrivateKeySpec);
+
+      Signature signature = Signature.getInstance("SHA256withECDSA");
+      signature.initSign(privateKey);
+
+      signature.update(message);
+
+      return signature.sign();
+
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
@@ -1,0 +1,100 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting;
+
+import android.content.Context;
+import android.util.Log;
+import chip.platform.ConfigurationManager;
+import com.chip.casting.util.PreferencesConfigurationManager;
+import com.matter.casting.core.CastingApp;
+import com.matter.casting.support.AppParameters;
+import com.matter.casting.support.CommissionableData;
+import com.matter.casting.support.DACProvider;
+import com.matter.casting.support.DataProvider;
+import com.matter.casting.support.MatterError;
+
+public class InitializationExample {
+  private static final String TAG = InitializationExample.class.getSimpleName();
+
+  /**
+   * DataProvider implementation for the Unique ID that is used by the SDK to generate the Rotating
+   * Device ID
+   */
+  private static final DataProvider<byte[]> rotatingDeviceIdUniqueIdProvider =
+      new DataProvider<byte[]>() {
+        private static final String ROTATING_DEVICE_ID_UNIQUE_ID =
+            "EXAMPLE_ID"; // dummy value for demonstration only
+
+        @Override
+        public byte[] get() {
+          return ROTATING_DEVICE_ID_UNIQUE_ID.getBytes();
+        }
+      };
+
+  /**
+   * DataProvider implementation for the Commissioning Data used by the SDK when the CastingApp goes
+   * through commissioning
+   */
+  private static final DataProvider<CommissionableData> commissionableDataProvider =
+      new DataProvider<CommissionableData>() {
+        @Override
+        public CommissionableData get() {
+          // dummy values for demonstration only
+          return new CommissionableData(20202021, 3874);
+        }
+      };
+
+  /**
+   * DACProvider implementation for the Device Attestation Credentials required at the time of
+   * commissioning
+   */
+  private static final DACProvider dacProvider = new DACProviderStub();
+
+  /**
+   * @param applicationContext Given android.content.Context, initialize and start the CastingApp
+   */
+  public static MatterError initAndStart(Context applicationContext) {
+    // Create an AppParameters object to pass in global casting parameters to the SDK
+    final AppParameters appParameters =
+        new AppParameters(
+            applicationContext,
+            new DataProvider<ConfigurationManager>() {
+              @Override
+              public ConfigurationManager get() {
+                return new PreferencesConfigurationManager(
+                    applicationContext, "chip.platform.ConfigurationManager");
+              }
+            },
+            rotatingDeviceIdUniqueIdProvider,
+            commissionableDataProvider,
+            dacProvider);
+
+    // Initialize the SDK using the appParameters and check if it returns successfully
+    MatterError err = CastingApp.getInstance().initialize(appParameters);
+    if (err.hasError()) {
+      Log.e(TAG, "Failed to initialize Matter CastingApp");
+      return err;
+    }
+
+    err = CastingApp.getInstance().start();
+    if (err.hasError()) {
+      Log.e(TAG, "Failed to start Matter CastingApp");
+      return err;
+    }
+    return err;
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
@@ -61,6 +61,8 @@ public class InitializationExample {
   /**
    * DACProvider implementation for the Device Attestation Credentials required at the time of
    * commissioning
+   *
+   * <p>Using the DACProviderStub which provides dummy values for demonstration only
    */
   private static final DACProvider dacProvider = new DACProviderStub();
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
@@ -1,0 +1,163 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.core;
+
+import android.content.Context;
+import android.util.Log;
+import chip.appserver.ChipAppServer;
+import chip.platform.AndroidBleManager;
+import chip.platform.AndroidChipPlatform;
+import chip.platform.ChipMdnsCallbackImpl;
+import chip.platform.DiagnosticDataProviderImpl;
+import chip.platform.NsdManagerServiceBrowser;
+import chip.platform.NsdManagerServiceResolver;
+import chip.platform.PreferencesKeyValueStoreManager;
+import com.matter.casting.support.AppParameters;
+import com.matter.casting.support.CommissionableData;
+import com.matter.casting.support.MatterError;
+
+/**
+ * CastingApp represents an app that can cast content to a Casting Player. This class is a
+ * singleton.
+ */
+public final class CastingApp {
+  private static final String TAG = CastingApp.class.getSimpleName();
+
+  private static CastingApp sInstance;
+
+  private CastingAppState mState = CastingAppState.UNINITIALIZED;
+  private AppParameters appParameters;
+  private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
+  private ChipAppServer chipAppServer;
+
+  private CastingApp() {}
+
+  public static CastingApp getInstance() {
+    if (sInstance == null) {
+      sInstance = new CastingApp();
+    }
+    return sInstance;
+  }
+
+  /**
+   * Initializes the CastingApp with appParameters
+   *
+   * @param appParameters
+   */
+  public MatterError initialize(AppParameters appParameters) {
+    Log.i(TAG, "CastingApp.initialize called");
+    if (mState != CastingAppState.UNINITIALIZED) {
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    this.appParameters = appParameters;
+    this.nsdManagerResolverAvailState =
+        new NsdManagerServiceResolver.NsdManagerResolverAvailState();
+
+    Context applicationContext = appParameters.getApplicationContext();
+    AndroidChipPlatform chipPlatform =
+        new AndroidChipPlatform(
+            new AndroidBleManager(),
+            new PreferencesKeyValueStoreManager(appParameters.getApplicationContext()),
+            appParameters.getConfigurationManagerProvider().get(),
+            new NsdManagerServiceResolver(applicationContext, nsdManagerResolverAvailState),
+            new NsdManagerServiceBrowser(applicationContext),
+            new ChipMdnsCallbackImpl(),
+            new DiagnosticDataProviderImpl(applicationContext));
+
+    CommissionableData commissionableData = appParameters.getCommissionableDataProvider().get();
+    boolean updated =
+        chipPlatform.updateCommissionableDataProviderData(
+            commissionableData.getSpake2pVerifierBase64(),
+            commissionableData.getSpake2pSaltBase64(),
+            commissionableData.getSpake2pIterationCount(),
+            commissionableData.getSetupPasscode(),
+            commissionableData.getDiscriminator());
+    if (!updated) {
+      Log.e(
+          TAG, "CastingApp.initApp failed to updateCommissionableDataProviderData on chipPlatform");
+      return MatterError.CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    MatterError err = finishInitialization(appParameters);
+
+    if (err.hasNoError()) {
+      chipAppServer = new ChipAppServer(); // get a reference to the Matter server now
+      mState = CastingAppState.NOT_RUNNING; // initialization done, set state to NOT_RUNNING
+    }
+    return err;
+  }
+
+  /**
+   * Starts the Matter server that the CastingApp runs on and registers all the necessary delegates
+   */
+  public MatterError start() {
+    Log.i(TAG, "CastingApp.start called");
+    if (mState != CastingAppState.NOT_RUNNING) {
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    boolean serverStarted = chipAppServer.startApp();
+    if (!serverStarted) {
+      Log.e(TAG, "CastingApp.start failed to start Matter server");
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    MatterError err = finishStartup();
+    if (err.hasNoError()) {
+      mState = CastingAppState.RUNNING; // CastingApp started successfully, set state to RUNNING
+    }
+    return err;
+  }
+
+  /**
+   * Stops the Matter server that the CastingApp runs on
+   *
+   * @return
+   */
+  public MatterError stop() {
+    Log.i(TAG, "CastingApp.stop called");
+    if (mState != CastingAppState.RUNNING) {
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    boolean serverStopped = chipAppServer.stopApp();
+    if (!serverStopped) {
+      Log.e(TAG, "CastingApp.stop failed to stop Matter server");
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+    mState =
+        CastingAppState.NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
+
+    return MatterError.NO_ERROR;
+  }
+
+  /**
+   * Sets DeviceAttestationCrdentials provider and RotatingDeviceIdUniqueId
+   *
+   * @param appParameters
+   */
+  private native MatterError finishInitialization(AppParameters appParameters);
+
+  /** Performs post Matter server startup registrations */
+  private native MatterError finishStartup();
+
+  static {
+    System.loadLibrary("TvCastingApp");
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingAppState.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingAppState.java
@@ -1,0 +1,8 @@
+package com.matter.casting.core;
+
+/** Represents the state of the CastingApp */
+enum CastingAppState {
+  UNINITIALIZED, // Before Initialize() success
+  NOT_RUNNING, // After Initialize() success before Start()ing, OR After stop() success
+  RUNNING, // After Start() success
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/AppParameters.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/AppParameters.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import chip.platform.ConfigurationManager;
+
+public class AppParameters {
+  @NonNull private final Context applicationContext;
+
+  @NonNull private final DataProvider<ConfigurationManager> configurationManagerProvider;
+
+  @NonNull private final DataProvider<byte[]> rotatingDeviceIdUniqueIdProvider;
+
+  @NonNull private final DataProvider<CommissionableData> commissionableDataProvider;
+
+  @NonNull private final DACProvider dacProvider;
+
+  /**
+   * @param applicationContext the Android app's android.content.Context
+   * @param configurationManagerProvider Implementation of chip.platform.ConfigurationManager
+   * @param rotatingDeviceIdUniqueIdProvider Provides values of the uniqueID used to generate the
+   *     RotatingDeviceId of the CastingApp
+   * @param commissionableDataProvider Provides CommissionableData (such as setupPasscode,
+   *     discriminator, etc) used to get the CastingApp commissioned
+   * @param dacProvider Provides DeviceAttestationCredentials of the CastingApp during commissioning
+   */
+  public AppParameters(
+      @NonNull Context applicationContext,
+      @NonNull DataProvider<ConfigurationManager> configurationManagerProvider,
+      @NonNull DataProvider<byte[]> rotatingDeviceIdUniqueIdProvider,
+      @NonNull DataProvider<CommissionableData> commissionableDataProvider,
+      @NonNull DACProvider dacProvider) {
+    this.applicationContext = applicationContext;
+    this.configurationManagerProvider = configurationManagerProvider;
+    this.rotatingDeviceIdUniqueIdProvider = rotatingDeviceIdUniqueIdProvider;
+    this.commissionableDataProvider = commissionableDataProvider;
+    this.dacProvider = dacProvider;
+  }
+
+  @NonNull
+  public Context getApplicationContext() {
+    return applicationContext;
+  }
+
+  @NonNull
+  public DataProvider<ConfigurationManager> getConfigurationManagerProvider() {
+    return configurationManagerProvider;
+  }
+
+  @NonNull
+  public DataProvider<byte[]> getRotatingDeviceIdUniqueIdProvider() {
+    return rotatingDeviceIdUniqueIdProvider;
+  }
+
+  @NonNull
+  public DataProvider<CommissionableData> getCommissionableDataProvider() {
+    return commissionableDataProvider;
+  }
+
+  @NonNull
+  public DACProvider getDacProvider() {
+    return dacProvider;
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionableData.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionableData.java
@@ -1,0 +1,71 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import androidx.annotation.Nullable;
+
+public class CommissionableData {
+  private long setupPasscode;
+
+  private int discriminator;
+
+  @Nullable private String spake2pVerifierBase64;
+
+  @Nullable private String spake2pSaltBase64;
+
+  private int spake2pIterationCount;
+
+  public CommissionableData(long setupPasscode, int discriminator) {
+    this.setupPasscode = setupPasscode;
+    this.discriminator = discriminator;
+  }
+
+  public long getSetupPasscode() {
+    return setupPasscode;
+  }
+
+  public int getDiscriminator() {
+    return discriminator;
+  }
+
+  @Nullable
+  public String getSpake2pVerifierBase64() {
+    return spake2pVerifierBase64;
+  }
+
+  public void setSpake2pVerifierBase64(@Nullable String spake2pVerifierBase64) {
+    this.spake2pVerifierBase64 = spake2pVerifierBase64;
+  }
+
+  @Nullable
+  public String getSpake2pSaltBase64() {
+    return spake2pSaltBase64;
+  }
+
+  public void setSpake2pSaltBase64(@Nullable String spake2pSaltBase64) {
+    this.spake2pSaltBase64 = spake2pSaltBase64;
+  }
+
+  public int getSpake2pIterationCount() {
+    return spake2pIterationCount;
+  }
+
+  public void setSpake2pIterationCount(int spake2pIterationCount) {
+    this.spake2pIterationCount = spake2pIterationCount;
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DACProvider.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DACProvider.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.matter.casting.support;
+
+public interface DACProvider {
+  byte[] GetCertificationDeclaration();
+
+  byte[] GetFirmwareInformation();
+
+  byte[] GetDeviceAttestationCert();
+
+  byte[] GetProductAttestationIntermediateCert();
+
+  /**
+   * Sign a mesage with the device attestation key.
+   *
+   * <p>The signature should be a SHA256withECDSA Signature that's returned in the ECDSA X9.62 Asn1
+   * format. This is the default behavior when using java.security.Signature with an EC P-256 curve.
+   *
+   * @param message The message to sign
+   * @return The signature in ECDSA X9.62 Asn1 format.
+   */
+  byte[] SignWithDeviceAttestationKey(byte[] message);
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DataProvider.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DataProvider.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import android.util.Log;
+
+public abstract class DataProvider<T> {
+  private static final String TAG = DataProvider.class.getSimpleName();
+
+  protected T _get() {
+    T val = null;
+    try {
+      val = get();
+    } catch (Throwable t) {
+      Log.e(TAG, "DataProvider::Caught an unhandled Throwable from the client: " + t);
+    }
+    return val;
+  }
+
+  public abstract T get();
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterError.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/MatterError.java
@@ -1,0 +1,76 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.matter.casting.support;
+
+import java.util.Objects;
+
+public class MatterError {
+  private long errorCode;
+  private String errorMessage;
+
+  public static final MatterError NO_ERROR = new MatterError(0, null);
+
+  public static final MatterError CHIP_ERROR_INVALID_ARGUMENT =
+      new MatterError(0x2f, "CHIP_ERROR_INVALID_ARGUMENT");
+
+  public static final MatterError CHIP_ERROR_INCORRECT_STATE =
+      new MatterError(0x03, "CHIP_ERROR_INCORRECT_STATE");
+
+  public MatterError(long errorCode, String errorMessage) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+  }
+
+  public boolean hasError() {
+    return !this.equals(NO_ERROR);
+  }
+
+  public boolean hasNoError() {
+    return this.equals(NO_ERROR);
+  }
+
+  public long getErrorCode() {
+    return errorCode;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public String toString() {
+    return "MatterError{"
+        + (hasNoError()
+            ? "No error"
+            : "errorCode=" + errorCode + ", errorMessage='" + errorMessage + '\'')
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MatterError matterError = (MatterError) o;
+    return errorCode == matterError.getErrorCode();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorCode);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -1,0 +1,132 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CastingApp-JNI.h"
+
+#include "../JNIDACProvider.h"
+#include "../support/ErrorConverter-JNI.h"
+#include "../support/RotatingDeviceIdUniqueIdProvider-JNI.h"
+#include "core/CastingApp.h" // from tv-casting-common
+
+#include <app/clusters/bindings/BindingManager.h>
+#include <app/server/Server.h>
+#include <jni.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+using namespace chip;
+
+#define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_casting_core_CastingApp_##METHOD_NAME
+
+namespace matter {
+namespace casting {
+namespace core {
+
+CastingAppJNI CastingAppJNI::sInstance;
+
+jobject extractJAppParameter(jobject jAppParameters, const char * methodName, const char * methodSig);
+
+JNI_METHOD(jobject, finishInitialization)(JNIEnv *, jobject, jobject jAppParameters)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD CastingAppJNI.finishInitialization called");
+    VerifyOrReturnValue(jAppParameters != nullptr, support::createJMatterError(CHIP_ERROR_INVALID_ARGUMENT));
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    jobject jUniqueIdProvider =
+        extractJAppParameter(jAppParameters, "getRotatingDeviceIdUniqueIdProvider", "()Lcom/matter/casting/support/DataProvider;");
+    VerifyOrReturnValue(jUniqueIdProvider != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+    support::RotatingDeviceIdUniqueIdProviderJNI * uniqueIdProvider = new support::RotatingDeviceIdUniqueIdProviderJNI();
+    err                                                             = uniqueIdProvider->Initialize(jUniqueIdProvider);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, support::createJMatterError(CHIP_ERROR_INVALID_ARGUMENT));
+
+    // set the RotatingDeviceIdUniqueId
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    chip::MutableByteSpan * uniqueId = uniqueIdProvider->Get();
+    if (uniqueId != nullptr)
+    {
+        chip::DeviceLayer::ConfigurationMgr().SetRotatingDeviceIdUniqueId(*uniqueId);
+    }
+#endif // CHIP_ENABLE_ROTATING_DEVICE_ID
+
+    // get the DACProvider
+    jobject jDACProvider = extractJAppParameter(jAppParameters, "getDacProvider", "()Lcom/matter/casting/support/DACProvider;");
+    VerifyOrReturnValue(jDACProvider != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+
+    // set the DACProvider
+    JNIDACProvider * dacProvider = new JNIDACProvider(jDACProvider);
+    chip::Credentials::SetDeviceAttestationCredentialsProvider(dacProvider);
+
+    return support::createJMatterError(CHIP_NO_ERROR);
+}
+
+JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD CastingAppJNI.finishStartup called");
+    auto & server = chip::Server::GetInstance();
+
+    // TODO: Set AppDelegate
+    // &server.GetCommissioningWindowManager().SetAppDelegate(??);
+
+    // Initialize binding handlers
+    chip::BindingManager::GetInstance().Init(
+        { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
+
+    // TODO: Set FabricDelegate
+    // chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&mPersistenceManager);
+
+    // TODO: Add DeviceEvent Handler
+    // ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(DeviceEventCallback, 0));
+
+    return support::createJMatterError(CHIP_NO_ERROR);
+}
+
+jobject extractJAppParameter(jobject jAppParameters, const char * methodName, const char * methodSig)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD extractJAppParameter called");
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+
+    jclass jAppParametersClass;
+    CHIP_ERROR err =
+        chip::JniReferences::GetInstance().GetClassRef(env, "com/matter/casting/support/AppParameters", jAppParametersClass);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr);
+
+    // get the RotatingDeviceIdUniqueIdProvider
+    jmethodID getMethod = env->GetMethodID(jAppParametersClass, methodName, methodSig);
+    if (env->ExceptionCheck())
+    {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    jobject jParameter = (jobject) env->CallObjectMethod(jAppParameters, getMethod);
+    if (env->ExceptionCheck())
+    {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    return jParameter;
+}
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.h
@@ -18,38 +18,24 @@
 
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
-
-#include <cstdint>
-#include <memory>
+#include <jni.h>
 
 namespace matter {
 namespace casting {
-
-namespace memory {
-
-template <typename T>
-using Weak = std::weak_ptr<T>;
-
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
 namespace core {
 
-class CastingApp;
+class CastingAppJNI
+{
+public:
+private:
+    friend CastingAppJNI & CastingAppJNIMgr();
+    static CastingAppJNI sInstance;
+};
 
+inline class CastingAppJNI & CastingAppJNIMgr()
+{
+    return CastingAppJNI::sInstance;
+}
 }; // namespace core
-
-namespace support {
-
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
-
-} // namespace support
-
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "ErrorConverter-JNI.h"
+#include <lib/support/JniReferences.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+using namespace chip;
+
+jobject createJMatterError(CHIP_ERROR inErr)
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    jclass jMatterErrorClass;
+    CHIP_ERROR err =
+        chip::JniReferences::GetInstance().GetClassRef(env, "com/matter/casting/support/MatterError", jMatterErrorClass);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr);
+
+    jmethodID jMatterErrorConstructor = env->GetMethodID(jMatterErrorClass, "<init>", "(JLjava/lang/String;)V");
+
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, err.AsInteger(), nullptr);
+}
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.h
@@ -1,7 +1,6 @@
 /*
  *
  *    Copyright (c) 2023 Project CHIP Authors
- *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,41 +14,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include <lib/core/CHIPError.h>
 
-#include <cstdint>
-#include <memory>
+#include <jni.h>
 
 namespace matter {
 namespace casting {
-
-namespace memory {
-
-template <typename T>
-using Weak = std::weak_ptr<T>;
-
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
-namespace core {
-
-class CastingApp;
-
-}; // namespace core
-
 namespace support {
 
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
+jobject createJMatterError(CHIP_ERROR inErr);
 
-} // namespace support
-
+}; // namespace support
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
@@ -82,10 +82,11 @@ CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::GetJavaByteByMethod(jmethodID me
 MutableByteSpan * RotatingDeviceIdUniqueIdProviderJNI::Get()
 {
     ChipLogProgress(AppServer, "RotatingDeviceIdUniqueIdProviderJNI.Get() called");
-    CHIP_ERROR err = GetJavaByteByMethod(mGetMethod, rotatingDeviceIdUniqueIdSpan);
+    mRotatingDeviceIdUniqueIdSpan = MutableByteSpan(mRotatingDeviceIdUniqueId);
+    CHIP_ERROR err                = GetJavaByteByMethod(mGetMethod, mRotatingDeviceIdUniqueIdSpan);
     VerifyOrReturnValue(err != CHIP_NO_ERROR, nullptr,
                         ChipLogError(AppServer, "Error calling GetJavaByteByMethod %" CHIP_ERROR_FORMAT, err.Format()));
-    return &rotatingDeviceIdUniqueIdSpan;
+    return &mRotatingDeviceIdUniqueIdSpan;
 }
 
 }; // namespace support

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
@@ -1,0 +1,93 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "RotatingDeviceIdUniqueIdProvider-JNI.h"
+#include "lib/support/logging/CHIPLogging.h"
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
+
+namespace matter {
+namespace casting {
+namespace support {
+
+CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::Initialize(jobject provider)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnValue(env != nullptr, CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(AppServer, "Failed to GetEnvForCurrentThread for RotatingDeviceIdUniqueIdProviderJNI"));
+
+    mJNIProviderObject = env->NewGlobalRef(provider);
+    VerifyOrReturnValue(mJNIProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(AppServer, "Failed to NewGlobalRef JNIProvider"));
+
+    jclass JNIProviderClass = env->GetObjectClass(provider);
+    VerifyOrReturnValue(JNIProviderClass != nullptr, CHIP_ERROR_INCORRECT_STATE,
+                        ChipLogError(AppServer, "Failed to get JNIProvider Java class"));
+
+    mGetMethod = env->GetMethodID(JNIProviderClass, "_get", "()Ljava/lang/Object;");
+    if (mGetMethod == nullptr)
+    {
+        ChipLogError(AppServer, "Failed to access JNIProvider '_get' method");
+        env->ExceptionClear();
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnLogError(mJNIProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
+
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIProviderObject, method);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(AppServer, "Java exception in get Method");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    if (outArray == nullptr || env->GetArrayLength(outArray) <= 0)
+    {
+        out_buffer.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    JniByteArray JniOutArray(env, outArray);
+    return CopySpanToMutableSpan(JniOutArray.byteSpan(), out_buffer);
+}
+
+MutableByteSpan * RotatingDeviceIdUniqueIdProviderJNI::Get()
+{
+    ChipLogProgress(AppServer, "RotatingDeviceIdUniqueIdProviderJNI.Get() called");
+    CHIP_ERROR err = GetJavaByteByMethod(mGetMethod, rotatingDeviceIdUniqueIdSpan);
+    VerifyOrReturnValue(err != CHIP_NO_ERROR, nullptr,
+                        ChipLogError(AppServer, "Error calling GetJavaByteByMethod %" CHIP_ERROR_FORMAT, err.Format()));
+    return &rotatingDeviceIdUniqueIdSpan;
+}
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
@@ -1,7 +1,6 @@
 /*
  *
  *    Copyright (c) 2023 Project CHIP Authors
- *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,41 +14,31 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include "core/Types.h"
 
-#include <cstdint>
-#include <memory>
+#include <jni.h>
 
 namespace matter {
 namespace casting {
-
-namespace memory {
-
-template <typename T>
-using Weak = std::weak_ptr<T>;
-
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
-namespace core {
-
-class CastingApp;
-
-}; // namespace core
-
 namespace support {
 
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
+class RotatingDeviceIdUniqueIdProviderJNI : public MutableByteSpanDataProvider
+{
+public:
+    CHIP_ERROR Initialize(jobject provider);
+    chip::MutableByteSpan * Get() override;
 
-} // namespace support
+private:
+    CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
+    jobject mJNIProviderObject = nullptr;
+    jmethodID mGetMethod       = nullptr;
 
+    chip::MutableByteSpan rotatingDeviceIdUniqueIdSpan;
+    uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+};
+
+}; // namespace support
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
@@ -35,8 +35,8 @@ private:
     jobject mJNIProviderObject = nullptr;
     jmethodID mGetMethod       = nullptr;
 
-    chip::MutableByteSpan rotatingDeviceIdUniqueIdSpan;
-    uint8_t rotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
+    chip::MutableByteSpan mRotatingDeviceIdUniqueIdSpan;
+    uint8_t mRotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];
 };
 
 }; // namespace support

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -34,6 +34,16 @@ shared_library("jni") {
     "App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp",
   ]
 
+  # add simplified casting API files here
+  sources += [
+    "App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp",
+    "App/app/src/main/jni/cpp/core/CastingApp-JNI.h",
+    "App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp",
+    "App/app/src/main/jni/cpp/support/ErrorConverter-JNI.h",
+    "App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp",
+    "App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h",
+  ]
+
   deps = [
     "${chip_root}/examples/tv-casting-app/tv-casting-common",
     "${chip_root}/src/app/server/java:jni",
@@ -81,6 +91,17 @@ android_library("java") {
     "App/app/src/main/jni/com/chip/casting/TargetNavigatorTypes.java",
     "App/app/src/main/jni/com/chip/casting/TvCastingApp.java",
     "App/app/src/main/jni/com/chip/casting/VideoPlayer.java",
+  ]
+
+  # add simplified casting API files here
+  sources += [
+    "App/app/src/main/jni/com/matter/casting/core/CastingApp.java",
+    "App/app/src/main/jni/com/matter/casting/core/CastingAppState.java",
+    "App/app/src/main/jni/com/matter/casting/support/AppParameters.java",
+    "App/app/src/main/jni/com/matter/casting/support/CommissionableData.java",
+    "App/app/src/main/jni/com/matter/casting/support/DACProvider.java",
+    "App/app/src/main/jni/com/matter/casting/support/DataProvider.java",
+    "App/app/src/main/jni/com/matter/casting/support/MatterError.java",
   ]
 
   javac_flags = [ "-Xlint:deprecation" ]

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -118,7 +118,7 @@ CHIP_ERROR CastingApp::Stop()
     // Shutdown the Matter server
     chip::Server::GetInstance().Shutdown();
 
-    mState = NOT_RUNNING; // CastingApp started successfully, set state to RUNNING
+    mState = NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
 
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
@@ -53,19 +53,12 @@ public:
     CHIP_ERROR Initialize(const matter::casting::support::AppParameters & appParameters);
 
     /**
-     * @brief Starts the Matter server that the CastingApp runs on and calls PostStartRegistrations() to finish starting up the
+     * @brief Starts the Matter server that the CastingApp runs on and registers all the necessary delegates
      * CastingApp.
      *
      * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server started successfully, specific error code otherwise.
      */
     CHIP_ERROR Start();
-
-    /**
-     * @brief Perform post Matter server startup registrations
-     *
-     * @return CHIP_ERROR  - CHIP_NO_ERROR if all registrations succeeded, specific error code otherwise
-     */
-    CHIP_ERROR PostStartRegistrations();
 
     /**
      * @brief Stops the Matter server that the CastingApp runs on
@@ -80,6 +73,13 @@ private:
 
     CastingApp(CastingApp & other) = delete;
     void operator=(const CastingApp &) = delete;
+
+    /**
+     * @brief Perform post Matter server startup registrations
+     *
+     * @return CHIP_ERROR  - CHIP_NO_ERROR if all registrations succeeded, specific error code otherwise
+     */
+    CHIP_ERROR PostStartRegistrations();
 
     const matter::casting::support::AppParameters * mAppParameters;
 


### PR DESCRIPTION
The TvCastingApp.java and TvCastingApp-JNI.h/cpp in the Android tv-casting-app have grown in size and should be broken down. This PR is the first step towards doing that. It introduces a simplified version of the Initialization code and corresponding APIs.

\### Change summary  
1\. Added an InitializationExample.java under tv-casting-app/android. It has a initAndStart menthod which is called by the MainActivity, if and only if GlobalCastingConstants.ChipCastingSimplified is set to true (false by default). While these APIs are being refactored, we will keep this flag off (can be turned to true for local testing)   
2\. Added a CastingApp.java class where we've added the Initialize(), Start() and Stop() APIs. There are some supporting classes in the "support" namespace and there is a CastingApp-JNI.h/cpp that carries native implementation of a couple of private methods.

Some items are marked TODO - they will be addressed in following PRs, when the dependent workflows (commissioning, CASE, etc) are refactored.

\### Testing  
Tested by building (with the GlobalCastingConstants.ChipCastingSimplified=true flag set) and running the Android tv-casting-app on Mac to see that it initializes and starts the Matter server.