### PR TITLE
Modify the label for the manual step of the TC-SMOKECO-2.4

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -453,7 +453,9 @@ tests:
           constraints:
               type: enum8
 
-    - label: "Step 37: Start manually DUT self-test"
+    - label:
+          "Step 37: At the start of the next step, please manually initiate the
+          DUT self-test"
       cluster: "LogCommands"
       PICS: PICS_USER_PROMPT && SMOKECO.M.ManuallyControlledTest
       command: "UserPrompt"


### PR DESCRIPTION
Modify the label in step 37 to indicate when the self-test is triggered.

- **Situation**
The Smoke CO self-test may require a longer time for a tester to engage the testing facility (e.g., Pressing and holding the test button) so the device can be put to the self-test. Such activity will be conducted during the DUT test from TC - SMOKECO.

- **The problem** 
Because the PR intending to response #19861 has yet to be merged, if a tester triggers the self-test at step 37 and then goes to step 38 after a longer period of time, it will cause step 38 to miss the report and lead to a test failure/wired waiting for the tester.

- **This PR change is targeted to** 
The label modification is changed to encourage the user to wait until the waitForReport at the consequent step 38 starts, then do the manual DUT self-test. 
