### PR TITLE
Modify the steps in TC-SMOKECO-2.6 that include HIEST_PRI_ALARM to Manual Verification

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -339,13 +339,13 @@ tests:
 
     # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 19: TH reads ExpressedState attribute from DUT"
-    #   PICS: SMOKECO.S.A0000
-    #   command: "readAttribute"
-    #   attribute: "ExpressedState"
-    #   response:
-    #       value: HIEST_PRI_ALARM
-    #       constraints:
-    #           type: enum8
+      #   PICS: SMOKECO.S.A0000
+      #   command: "readAttribute"
+      #   attribute: "ExpressedState"
+      #   response:
+      #       value: HIEST_PRI_ALARM
+      #       constraints:
+      #           type: enum8
       verification: |
           ./chip-tool smokecoalarm read expressed-state 1 1
 
@@ -393,13 +393,13 @@ tests:
 
     # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 22: TH reads ExpressedState attribute from DUT"
-    #   PICS: SMOKECO.S.A0000
-    #   command: "readAttribute"
-    #   attribute: "ExpressedState"
-    #   response:
-    #       value: HIEST_PRI_ALARM_2
-    #       constraints:
-    #           type: enum8
+      #   PICS: SMOKECO.S.A0000
+      #   command: "readAttribute"
+      #   attribute: "ExpressedState"
+      #   response:
+      #       value: HIEST_PRI_ALARM_2
+      #       constraints:
+      #           type: enum8
       verification: |
           ./chip-tool smokecoalarm read expressed-state 1 1
 
@@ -454,13 +454,13 @@ tests:
 
     # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 25: TH reads ExpressedState attribute from DUT"
-    #   PICS: SMOKECO.S.A0000
-    #   command: "readAttribute"
-    #   attribute: "ExpressedState"
-    #   response:
-    #       value: HIEST_PRI_ALARM_3
-    #       constraints:
-    #           type: enum8
+      #   PICS: SMOKECO.S.A0000
+      #   command: "readAttribute"
+      #   attribute: "ExpressedState"
+      #   response:
+      #       value: HIEST_PRI_ALARM_3
+      #       constraints:
+      #           type: enum8
       verification: |
           ./chip-tool smokecoalarm read expressed-state 1 1
 
@@ -516,13 +516,13 @@ tests:
 
     # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 28: TH reads ExpressedState attribute from DUT"
-    #   PICS: SMOKECO.S.A0000
-    #   command: "readAttribute"
-    #   attribute: "ExpressedState"
-    #   response:
-    #       value: HIEST_PRI_ALARM_4
-    #       constraints:
-    #           type: enum8
+      #   PICS: SMOKECO.S.A0000
+      #   command: "readAttribute"
+      #   attribute: "ExpressedState"
+      #   response:
+      #       value: HIEST_PRI_ALARM_4
+      #       constraints:
+      #           type: enum8
       verification: |
           ./chip-tool smokecoalarm read expressed-state 1 1
 
@@ -579,13 +579,13 @@ tests:
 
     # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 31: TH reads ExpressedState attribute from DUT"
-    #   PICS: SMOKECO.S.A0000
-    #   command: "readAttribute"
-    #   attribute: "ExpressedState"
-    #   response:
-    #       value: HIEST_PRI_ALARM_5
-    #       constraints:
-    #           type: enum8
+      #   PICS: SMOKECO.S.A0000
+      #   command: "readAttribute"
+      #   attribute: "ExpressedState"
+      #   response:
+      #       value: HIEST_PRI_ALARM_5
+      #       constraints:
+      #           type: enum8
       verification: |
           ./chip-tool smokecoalarm read expressed-state 1 1
 

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -337,14 +337,31 @@ tests:
           constraints:
               type: enum8
 
+    # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 19: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
-      command: "readAttribute"
-      attribute: "ExpressedState"
-      response:
-          value: HIEST_PRI_ALARM
-          constraints:
-              type: enum8
+    #   PICS: SMOKECO.S.A0000
+    #   command: "readAttribute"
+    #   attribute: "ExpressedState"
+    #   response:
+    #       value: HIEST_PRI_ALARM
+    #       constraints:
+    #           type: enum8
+      verification: |
+          ./chip-tool smokecoalarm read expressed-state 1 1
+
+          On TH(chip-tool)  Logs, Verify that "expressed-state" attribute value is the expected HIEST_PRI_ALARM.
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0000 DataVersion: 152533340
+          [TOO]   ExpressedState: 0
+      cluster: "LogCommands"
+      PICS: PICS_USER_PROMPT && SMOKECO.S.A0000
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 20: TH sends TestEventTrigger command to General Diagnostics
@@ -374,14 +391,31 @@ tests:
           constraints:
               type: enum8
 
+    # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 22: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
-      command: "readAttribute"
-      attribute: "ExpressedState"
-      response:
-          value: HIEST_PRI_ALARM_2
-          constraints:
-              type: enum8
+    #   PICS: SMOKECO.S.A0000
+    #   command: "readAttribute"
+    #   attribute: "ExpressedState"
+    #   response:
+    #       value: HIEST_PRI_ALARM_2
+    #       constraints:
+    #           type: enum8
+      verification: |
+          ./chip-tool smokecoalarm read expressed-state 1 1
+
+          On TH(chip-tool)  Logs, Verify that "expressed-state" attribute value is the expected HIEST_PRI_ALARM.
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0000 DataVersion: 152533340
+          [TOO]   ExpressedState: 0
+      cluster: "LogCommands"
+      PICS: PICS_USER_PROMPT && SMOKECO.S.A0000
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 23a: TH subscribes to COState attribute from DUT"
       PICS: SMOKECO.S.A0002
@@ -418,14 +452,31 @@ tests:
           constraints:
               type: enum8
 
+    # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 25: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
-      command: "readAttribute"
-      attribute: "ExpressedState"
-      response:
-          value: HIEST_PRI_ALARM_3
-          constraints:
-              type: enum8
+    #   PICS: SMOKECO.S.A0000
+    #   command: "readAttribute"
+    #   attribute: "ExpressedState"
+    #   response:
+    #       value: HIEST_PRI_ALARM_3
+    #       constraints:
+    #           type: enum8
+      verification: |
+          ./chip-tool smokecoalarm read expressed-state 1 1
+
+          On TH(chip-tool)  Logs, Verify that "expressed-state" attribute value is the expected HIEST_PRI_ALARM.
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0000 DataVersion: 152533340
+          [TOO]   ExpressedState: 0
+      cluster: "LogCommands"
+      PICS: PICS_USER_PROMPT && SMOKECO.S.A0000
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 26a: TH subscribes to InterconnectCOAlarm attribute from DUT"
       PICS: SMOKECO.S.A0009
@@ -463,14 +514,31 @@ tests:
           constraints:
               type: enum8
 
+    # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 28: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
-      command: "readAttribute"
-      attribute: "ExpressedState"
-      response:
-          value: HIEST_PRI_ALARM_4
-          constraints:
-              type: enum8
+    #   PICS: SMOKECO.S.A0000
+    #   command: "readAttribute"
+    #   attribute: "ExpressedState"
+    #   response:
+    #       value: HIEST_PRI_ALARM_4
+    #       constraints:
+    #           type: enum8
+      verification: |
+          ./chip-tool smokecoalarm read expressed-state 1 1
+
+          On TH(chip-tool)  Logs, Verify that "expressed-state" attribute value is the expected HIEST_PRI_ALARM.
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0000 DataVersion: 152533340
+          [TOO]   ExpressedState: 0
+      cluster: "LogCommands"
+      PICS: PICS_USER_PROMPT && SMOKECO.S.A0000
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 29a: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
@@ -509,14 +577,31 @@ tests:
           constraints:
               type: enum8
 
+    # TODO: Since TH was unable to accept the test parameters, it was changed to manual operation.
     - label: "Step 31: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
-      command: "readAttribute"
-      attribute: "ExpressedState"
-      response:
-          value: HIEST_PRI_ALARM_5
-          constraints:
-              type: enum8
+    #   PICS: SMOKECO.S.A0000
+    #   command: "readAttribute"
+    #   attribute: "ExpressedState"
+    #   response:
+    #       value: HIEST_PRI_ALARM_5
+    #       constraints:
+    #           type: enum8
+      verification: |
+          ./chip-tool smokecoalarm read expressed-state 1 1
+
+          On TH(chip-tool)  Logs, Verify that "expressed-state" attribute value is the expected HIEST_PRI_ALARM.
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0000 DataVersion: 152533340
+          [TOO]   ExpressedState: 0
+      cluster: "LogCommands"
+      PICS: PICS_USER_PROMPT && SMOKECO.S.A0000
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 32a: TH subscribes to BatteryAlert attribute from DUT"
       PICS: SMOKECO.S.A0003


### PR DESCRIPTION
Modify the steps in TC-SMOKECO-2.6 that include HIEST_PRI_ALARM to Manual Verification.

- **Situation**
The ExpressedState attribute of smokeco indicates the condition with the highest priority, and the manufacturer determines the priority order of conditions. Recent TH integration made TH only take the "endpoint" parameter change. So changing HIEST_PRI_ALARM from the project config is temporarily not valid.

- **The problem** 
Because the issue https://github.com/CHIP-Specifications/chip-certification-tool/issues/945 has not yet been resolved, testers can't modify the priority order of automated tests. Modifying the YMAL should not be a proper way to input this manufacture-dependent list during the test. 


- **This PR change is targeted to** 
The modification is changed to allow testers to manually determine whether the priority order is met or not via their inspection.


**Note:** If the change allows TH to take other parameters to effect the SVE TH, I can close this PR, since such manual inspection steps will not be necessary. 
