### PR TITLE
[Silabs] Fix SiWx917 compilation error due to attestation provider

### DIFF
--- a/examples/platform/silabs/SilabsDeviceAttestationCreds.cpp
+++ b/examples/platform/silabs/SilabsDeviceAttestationCreds.cpp
@@ -100,6 +100,9 @@ public:
         if (SilabsConfig::ConfigValueExists(SilabsConfig::kConfigKey_Creds_KeyId))
         {
             // Provisioned DAC key
+#ifdef SIWX_917
+            return CHIP_ERROR_NOT_IMPLEMENTED;
+#else
             uint32_t key_id       = SILABS_CREDENTIALS_DAC_KEY_ID;
             uint8_t signature[64] = { 0 };
             size_t signature_size = sizeof(signature);
@@ -114,6 +117,7 @@ public:
             VerifyOrReturnError(!err, CHIP_ERROR_INTERNAL);
 
             return CopySpanToMutableSpan(ByteSpan(signature, signature_size), out_span);
+#endif
         }
         else
         {

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -44,6 +44,7 @@ template("siwx917_sdk") {
 
     # Treat these includes as system includes, so warnings in them are not fatal.
     _include_dirs = [
+      "${chip_root}",
       "${chip_root}/examples/platform/silabs/SiWx917/SiWx917",
       "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/hal",
       "${efr32_sdk_root}/platform/emdrv/nvm3/inc",


### PR DESCRIPTION
Since PSA crypto is not available on SiWx917, the Silabs attestation provider fails to compile on these devices.
For now, when the attestation credentials are present, the SiWx917 provider will return NOT IMPLEMENTED.
Affect only Silicon Labs SiWx917 devices.
