### PR TITLE
Split JSON log tracing line by line for better alignment

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -133,7 +133,7 @@ class MatterLog:
         base64_message = log["message"].encode('utf-8')
         decoded_message_bytes = base64.b64decode(base64_message)
         # TODO We do assume utf-8 encoding is used, it may not be true though.
-        self.message = decoded_message_bytes.decode('utf-8')
+        self.message = decoded_message_bytes.decode('utf-8', 'replace')
 
     def decode_logs(logs):
         return list(map(MatterLog, logs))

--- a/src/lib/format/protocol_messages.matter
+++ b/src/lib/format/protocol_messages.matter
@@ -175,11 +175,11 @@ client cluster IMProtocol = 0xFFFF0001 {
     int16u min_minterval_floor = 1;
     int16u max_minterval_ceiling = 2;
     optional AttributePathIB attribute_requests[] = 3;
-    optional EventPathIB event_requests = 4;
-    optional EventFilterIB event_filters = 5;
+    optional EventPathIB event_requests[] = 4;
+    optional EventFilterIB event_filters[] = 5;
     // NOTE: 6 is missing here ...
     boolean fabric_filtered = 7;
-    optional DataVersionFilterIB data_version_filters = 8;
+    optional DataVersionFilterIB data_version_filters[] = 8;
 
     // 10.2.2.2. Context Tag Encoded Action Information
     int8u interaction_model_revison = 0xFF;

--- a/src/lib/format/protocol_messages.matter
+++ b/src/lib/format/protocol_messages.matter
@@ -174,7 +174,7 @@ client cluster IMProtocol = 0xFFFF0001 {
     boolean keep_subscriptions = 0;
     int16u min_minterval_floor = 1;
     int16u max_minterval_ceiling = 2;
-    optional AttributePathIB attribute_requests = 3;
+    optional AttributePathIB attribute_requests[] = 3;
     optional EventPathIB event_requests = 4;
     optional EventFilterIB event_filters = 5;
     // NOTE: 6 is missing here ...

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -450,7 +450,8 @@ void JsonBackend::OutputValue(::Json::Value & value)
         chip::StringSplitter splitter(data_string.c_str(), '\n');
 
         chip::CharSpan line;
-        while (splitter.Next(line)) {
+        while (splitter.Next(line))
+        {
             ChipLogProgress(Automation, "%.*s", static_cast<int>(line.size()), line.data());
         }
     }

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -22,6 +22,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ErrorStr.h>
 #include <lib/support/StringBuilder.h>
+#include <lib/support/StringSplitter.h>
 #include <transport/TracingStructs.h>
 
 #include <log_json/log_json_build_config.h>
@@ -444,7 +445,14 @@ void JsonBackend::OutputValue(::Json::Value & value)
     {
         std::stringstream output;
         writer->write(value, &output);
-        ChipLogProgress(Automation, "%s", output.str().c_str());
+        // For pretty-printing, output each log line individually.
+        std::string data_string = output.str();
+        chip::StringSplitter splitter(data_string.c_str(), '\n');
+
+        chip::CharSpan line;
+        while (splitter.Next(line)) {
+            ChipLogProgress(Automation, "%.*s", static_cast<int>(line.size()), line.data());
+        }
     }
 }
 


### PR DESCRIPTION
Existing `trace-decode` seems to output json line by line, so switched trace-to to also do this (this makes things align a bit better in log viewers line when running tests).

Changes:
  - fix a bug where attribute_requests for subscriptions were not marked as a list and decoding was off
  - split json logging to log to be a line-by-line operation
  - made the yaml test decoder more resilient to invalid UTF-8 (I had some bugs during my original output, so figured I would fix this too)