### PR TITLE
Remove NOCSR Request size limits and fix ReadDerLength bugs

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -1038,7 +1038,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
 
     // Prepare NOCSRElements structure
     {
-        constexpr size_t csrLength = Crypto::kMAX_CSR_Length;
+        constexpr size_t csrLength = Crypto::kMIN_CSR_Buffer_Size;
         size_t nocsrLengthEstimate = 0;
         ByteSpan kNoVendorReserved;
         Platform::ScopedMemoryBuffer<uint8_t> csr;
@@ -1060,7 +1060,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
 
         err = fabricTable.AllocatePendingOperationalKey(fabricIndexForCsr, csrSpan);
 
-        if (csrSpan.size() > Crypto::kMAX_CSR_Length)
+        if (csrSpan.size() > csrLength)
         {
             err = CHIP_ERROR_INTERNAL;
         }

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1540,7 +1540,7 @@ CHIP_ERROR FabricTable::AllocatePendingOperationalKey(Optional<FabricIndex> fabr
     // We can only allocate a pending key if no pending state (NOC, ICAC) already present,
     // since there can only be one pending state per fail-safe.
     VerifyOrReturnError(!mStateFlags.Has(StateFlags::kIsPendingFabricDataPresent), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(outputCsr.size() >= Crypto::kMAX_CSR_Length, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(outputCsr.size() >= Crypto::kMIN_CSR_Buffer_Size, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     EnsureNextAvailableFabricIndexUpdated();
     FabricIndex fabricIndexToUse = kUndefinedFabricIndex;

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -712,7 +712,7 @@ public:
      * @param fabricIndex - Existing FabricIndex for which a new keypair must be made available. If it
      *                      doesn't have a value, the key will be marked pending for the next available
      *                      fabric index that would apply for `AddNewFabric`.
-     * @param outputCsr - Buffer to contain the CSR. Must be at least `kMAX_CSR_Length` large.
+     * @param outputCsr - Buffer to contain the CSR. Must be at least `kMIN_CSR_Buffer_Size` large.
      *
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_BUFFER_TOO_SMALL if `outputCsr` buffer is too small

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -690,7 +690,7 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 44;
         NodeId nodeId     = 999;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -810,7 +810,7 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
         NodeId nodeId           = 1000;
         FabricIndex fabricIndex = 2;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
@@ -1070,7 +1070,7 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1113,7 +1113,7 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
         FabricId fabricId = 2222;
         NodeId nodeId     = 66;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1177,7 +1177,7 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1220,7 +1220,7 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
         FabricId fabricId = 1111;
         NodeId nodeId     = 66;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1302,7 +1302,7 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
             FabricId fabricId = 1111;
             NodeId nodeId     = 55;
 
-            uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+            uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
             NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1361,7 +1361,7 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
             FabricId fabricId = 2222;
             NodeId nodeId     = 66;
 
-            uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+            uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
             NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1614,7 +1614,7 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 11;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1700,7 +1700,7 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 44;
         NodeId nodeId     = 999;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1846,7 +1846,7 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 44;
         NodeId nodeId     = 999;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -1937,7 +1937,7 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         NodeId nodeId           = 1000;
         FabricIndex fabricIndex = 1;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
@@ -2049,7 +2049,7 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         NodeId nodeId           = 1001;
         FabricIndex fabricIndex = 1;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
@@ -2220,7 +2220,7 @@ void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2291,7 +2291,7 @@ void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 1111;
         NodeId nodeId     = 66; // Update node ID from 55 to 66
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite,
                                fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan));
@@ -2449,7 +2449,7 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2502,7 +2502,7 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2556,7 +2556,7 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 2222;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2629,7 +2629,7 @@ void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
         FabricId fabricId = 1111;
         NodeId nodeId     = 55;
 
-        uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2816,7 +2816,7 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
             FabricId fabricId = 1111;
             NodeId nodeId     = 55;
 
-            uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+            uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
             NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 
@@ -2882,7 +2882,7 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
             FabricId fabricId = 2222;
             NodeId nodeId     = 66;
 
-            uint8_t csrBuf[chip::Crypto::kMAX_CSR_Length];
+            uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
             NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -571,7 +571,7 @@ CHIP_ERROR ReadDerLength(Reader & reader, size_t & length)
     for (uint8_t i = 0; i < length_bytes; i++)
     {
         uint8_t cur_length_byte = 0;
-        err       = reader.Read8(&cur_length_byte).StatusCode();
+        err                     = reader.Read8(&cur_length_byte).StatusCode();
         if (err != CHIP_NO_ERROR)
             break;
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -575,7 +575,7 @@ CHIP_ERROR ReadDerLength(Reader & reader, size_t & length)
         if (err != CHIP_NO_ERROR)
             break;
 
-        // Cannot have zero padding on multi-bytes lengths in DER, so first
+        // Cannot have zero padding on multi-byte lengths in DER, so first
         // byte must always be > 0.
         if ((i == 0) && (cur_length_byte == 0))
         {

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -70,11 +70,12 @@ constexpr size_t kMAX_FE_Length              = kP256_FE_Length;
 constexpr size_t kMAX_Point_Length           = kP256_Point_Length;
 constexpr size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
 
-// Max CSR length should be relatively small since it's a single P256 key and
-// no metadata is expected to be honored by the CA. This size is an implementation
-// compromise and is not spec-mandated. It is sufficiently large for a PKCS#10
-// CSR that contains approximately 150 bytes of ASN.1 extensions.
-constexpr size_t kMAX_CSR_Length = 400;
+// Minimum required CSR length buffer length is relatively small since it's a single
+// P256 key and no metadata/extensions are expected to be honored by the CA.
+constexpr size_t kMIN_CSR_Buffer_Size = 255;
+
+[[deprecated("This constant is no longer used by common code and should be replaced by kMIN_CSR_Buffer_Size. Checks that a CSR is <= kMAX_CSR_Buffer_size must be updated. This remains to keep valid buffers working from previous public API usage.")]]
+constexpr size_t kMAX_CSR_Buffer_Size = 255;
 
 constexpr size_t CHIP_CRYPTO_HASH_LEN_BYTES = kSHA256_Hash_Length;
 
@@ -753,8 +754,9 @@ CHIP_ERROR AES_CTR_crypt(const uint8_t * input, size_t input_length, const Aes12
  * be configured to ignore CSR requested subject.
  *
  * @param keypair The key pair for which a CSR should be generated. Must not be null.
- * @param csr_span Span to hold the resulting CSR. Must be at least kMAX_CSR_Length.  Otherwise returns CHIP_ERROR_BUFFER_TOO_SMALL.
- *                 It will get resized to actual size needed on success.
+ * @param csr_span Span to hold the resulting CSR. Must be at least kMIN_CSR_Buffer_Size.
+ *                 Otherwise returns CHIP_ERROR_BUFFER_TOO_SMALL. It will get resized to
+ *                 actual size needed on success.
 
  * @return Returns a CHIP_ERROR from P256Keypair or ASN.1 backend on error, CHIP_NO_ERROR otherwise
  **/

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -74,8 +74,9 @@ constexpr size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
 // P256 key and no metadata/extensions are expected to be honored by the CA.
 constexpr size_t kMIN_CSR_Buffer_Size = 255;
 
-[[deprecated("This constant is no longer used by common code and should be replaced by kMIN_CSR_Buffer_Size. Checks that a CSR is <= kMAX_CSR_Buffer_size must be updated. This remains to keep valid buffers working from previous public API usage.")]]
-constexpr size_t kMAX_CSR_Buffer_Size = 255;
+[[deprecated("This constant is no longer used by common code and should be replaced by kMIN_CSR_Buffer_Size. Checks that a CSR is "
+             "<= kMAX_CSR_Buffer_size must be updated. This remains to keep valid buffers working from previous public API "
+             "usage.")]] constexpr size_t kMAX_CSR_Buffer_Size = 255;
 
 constexpr size_t CHIP_CRYPTO_HASH_LEN_BYTES = kSHA256_Hash_Length;
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -31,6 +31,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/Optional.h>
+#include <lib/support/BufferReader.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafePointerCast.h>
 #include <lib/support/Span.h>
@@ -70,8 +71,10 @@ constexpr size_t kMAX_Point_Length           = kP256_Point_Length;
 constexpr size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
 
 // Max CSR length should be relatively small since it's a single P256 key and
-// no metadata is expected to be honored by the CA.
-constexpr size_t kMAX_CSR_Length = 255;
+// no metadata is expected to be honored by the CA. This size is an implementation
+// compromise and is not spec-mandated. It is sufficiently large for a PKCS#10
+// CSR that contains approximately 150 bytes of ASN.1 extensions.
+constexpr size_t kMAX_CSR_Length = 400;
 
 constexpr size_t CHIP_CRYPTO_HASH_LEN_BYTES = kSHA256_Hash_Length;
 
@@ -638,6 +641,14 @@ CHIP_ERROR EcdsaRawSignatureToAsn1(size_t fe_length_bytes, const ByteSpan & raw_
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  */
 CHIP_ERROR EcdsaAsn1SignatureToRaw(size_t fe_length_bytes, const ByteSpan & asn1_sig, MutableByteSpan & out_raw_sig);
+
+/**
+ * @brief Utility to read a length field after a tag in a DER-encoded stream.
+ * @param[in] reader Reader instance from which the input will be read
+ * @param[out] length Length of the following element read from the stream
+ * @return CHIP_ERROR_INVALID_ARGUMENT or CHIP_ERROR_BUFFER_TOO_SMALL on error, CHIP_NO_ERROR otherwise
+ */
+CHIP_ERROR ReadDerLength(chip::Encoding::LittleEndian::Reader & reader, size_t & length);
 
 /**
  * @brief Utility to emit a DER-encoded INTEGER given a raw unsigned large integer

--- a/src/crypto/OperationalKeystore.h
+++ b/src/crypto/OperationalKeystore.h
@@ -67,7 +67,7 @@ public:
      *  Only one pending operational keypair is supported at a time.
      *
      * @param fabricIndex - FabricIndex for which a new keypair must be made available
-     * @param outCertificateSigningRequest - Buffer to contain the CSR. Must be at least `kMAX_CSR_Length` large.
+     * @param outCertificateSigningRequest - Buffer to contain the CSR. Must be at least `kMIN_CSR_Buffer_Size` large.
      *
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_BUFFER_TOO_SMALL if `outCertificateSigningRequest` buffer is too small

--- a/src/crypto/PersistentStorageOperationalKeystore.cpp
+++ b/src/crypto/PersistentStorageOperationalKeystore.cpp
@@ -197,7 +197,7 @@ CHIP_ERROR PersistentStorageOperationalKeystore::NewOpKeypairForFabric(FabricInd
     {
         return CHIP_ERROR_INVALID_FABRIC_INDEX;
     }
-    VerifyOrReturnError(outCertificateSigningRequest.size() >= Crypto::kMAX_CSR_Length, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(outCertificateSigningRequest.size() >= Crypto::kMIN_CSR_Buffer_Size, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Replace previous pending keypair, if any was previously allocated
     ResetPendingKey();

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -40,6 +40,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
+#include <lib/support/UnitTestExtendedAssertions.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>
 
@@ -604,6 +605,138 @@ static void TestRawIntegerToDerInvalidCases(nlTestSuite * inSuite, void * inCont
         {
             ChipLogError(Crypto, "Failed TestRawIntegerToDerInvalidCases sub-case %d", case_idx);
             NL_TEST_ASSERT(inSuite, v.expected_status == status);
+        }
+        ++case_idx;
+    }
+}
+
+static void TestReadDerLengthValidCases(nlTestSuite * inSuite, void * inContext)
+{
+    const uint8_t short_zero_length[] = {0x00};
+    ByteSpan short_zero_length_buf(short_zero_length);
+
+    const uint8_t short_length[] = {0x15};
+    ByteSpan short_length_buf(short_length);
+
+    const uint8_t single_byte_length[] = {0x81, 0x80};
+    ByteSpan single_byte_length_buf(single_byte_length);
+
+    const uint8_t single_byte_length_large[] = {0x81, 0xFF};
+    ByteSpan single_byte_length_large_buf(single_byte_length_large);
+
+    const uint8_t two_byte_length[] = {0x82, 0xFF, 0x01};
+    ByteSpan two_byte_length_buf(two_byte_length);
+
+    const uint8_t three_byte_length[] = {0x83, 0xFF, 0x00, 0xAA};
+    ByteSpan three_byte_length_buf(three_byte_length);
+
+    const uint8_t four_byte_length[] = {0x84, 0x01, 0x02, 0x03, 0x04};
+    ByteSpan four_byte_length_buf(four_byte_length);
+
+    const uint8_t four_byte_length_large[] = {0x84, 0xFF, 0xFF, 0xFF, 0xFF};
+    ByteSpan four_byte_length_large_buf(four_byte_length_large);
+
+    uint8_t max_byte_length_large[1 + sizeof(size_t)];
+    ByteSpan max_byte_length_large_buf(max_byte_length_large);
+
+    // We build a DER length value of SIZE_MAX programmatically.
+    max_byte_length_large[0] = 0x80 | sizeof(size_t);
+    memset(&max_byte_length_large[1], 0xFF, sizeof(size_t));
+
+    struct SuccessCase
+    {
+        const ByteSpan & input_buf;
+        const size_t expected_length;
+    };
+
+    const SuccessCase cases[] = {
+        { .input_buf = short_zero_length_buf, .expected_length = static_cast<size_t>(0x00) },
+        { .input_buf = short_length_buf, .expected_length = static_cast<size_t>(0x15) },
+        { .input_buf = single_byte_length_buf, .expected_length = static_cast<size_t>(0x80) },
+        { .input_buf = single_byte_length_large_buf, .expected_length = static_cast<size_t>(0xFF) },
+        { .input_buf = two_byte_length_buf, .expected_length = static_cast<size_t>(0xFF01) },
+        { .input_buf = three_byte_length_buf, .expected_length = static_cast<size_t>(0xFF00AAUL) },
+        { .input_buf = four_byte_length_buf, .expected_length = static_cast<size_t>(0x01020304UL) },
+        { .input_buf = four_byte_length_large_buf, .expected_length = static_cast<size_t>(0xFFFFFFFFUL) },
+        { .input_buf = max_byte_length_large_buf, .expected_length = SIZE_MAX },
+    };
+
+    int case_idx = 0;
+    for (const SuccessCase & v : cases)
+    {
+        size_t output_length = SIZE_MAX - 1;
+        chip::Encoding::LittleEndian::Reader input_reader{v.input_buf};
+        CHIP_ERROR status = ReadDerLength(input_reader, output_length);
+        if ((status != CHIP_NO_ERROR) || (v.expected_length != output_length))
+        {
+            ChipLogError(Crypto, "Failed TestReadDerLengthValidCases sub-case %d", case_idx);
+            NL_TEST_ASSERT_EQUALS(inSuite, output_length, v.expected_length);
+            NL_TEST_ASSERT_SUCCESS(inSuite, status);
+        }
+        ++case_idx;
+    }
+}
+
+static void TestReadDerLengthInvalidCases(nlTestSuite * inSuite, void * inContext)
+{
+    uint8_t placeholder[1];
+
+    ByteSpan bad_buffer_nullptr(nullptr, sizeof(placeholder));
+    ByteSpan bad_buffer_empty(placeholder, 0);
+
+    const uint8_t zero_multi_byte_length[] = {0x80};
+    ByteSpan zero_multi_byte_length_buf(zero_multi_byte_length);
+
+    const uint8_t single_byte_length_zero[] = {0x81, 0x00};
+    ByteSpan single_byte_length_zero_buf(single_byte_length_zero);
+
+    const uint8_t single_byte_length_too_small[] = {0x81, 0x7F};
+    ByteSpan single_byte_length_too_small_buf(single_byte_length_too_small);
+
+    const uint8_t multiple_byte_length_zero_padded[] = {0x82, 0x00, 0xFF};
+    ByteSpan multiple_byte_length_zero_padded_buf(multiple_byte_length_zero_padded);
+
+    const uint8_t multiple_byte_length_insufficient_bytes[] = {0x84, 0xFF, 0xAA, 0x01};
+    ByteSpan multiple_byte_length_insufficient_bytes_buf(multiple_byte_length_insufficient_bytes);
+
+    const uint8_t multiple_byte_length_insufficient_bytes2[] = {0x83};
+    ByteSpan multiple_byte_length_insufficient_bytes2_buf(multiple_byte_length_insufficient_bytes2);
+
+    uint8_t max_byte_length_large_insufficient_bytes[1 + sizeof(size_t) - 1];
+    ByteSpan max_byte_length_large_insufficient_bytes_buf(max_byte_length_large_insufficient_bytes);
+
+    // We build a DER length value of SIZE_MAX programmatically, with one byte too few.
+    max_byte_length_large_insufficient_bytes[0] = 0x80 | sizeof(size_t);
+    memset(&max_byte_length_large_insufficient_bytes[1], 0xFF, sizeof(max_byte_length_large_insufficient_bytes) - 1);
+
+    struct ErrorCase
+    {
+        const ByteSpan & input_buf;
+        CHIP_ERROR expected_status;
+    };
+
+    const ErrorCase error_cases[] = {
+        { .input_buf = bad_buffer_nullptr, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
+        { .input_buf = bad_buffer_empty, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
+        { .input_buf = zero_multi_byte_length_buf,.expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = single_byte_length_zero_buf,.expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = single_byte_length_too_small_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = multiple_byte_length_zero_padded_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = multiple_byte_length_insufficient_bytes_buf, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
+        { .input_buf = multiple_byte_length_insufficient_bytes2_buf, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
+        { .input_buf = max_byte_length_large_insufficient_bytes_buf, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
+    };
+
+    int case_idx = 0;
+    for (const ErrorCase & v : error_cases)
+    {
+        size_t output_length = SIZE_MAX;
+        chip::Encoding::LittleEndian::Reader input_reader{v.input_buf};
+        CHIP_ERROR status = ReadDerLength(input_reader, output_length);
+        if (status != v.expected_status)
+        {
+            ChipLogError(Crypto, "Failed TestReadDerLengthInvalidCases sub-case %d", case_idx);
+            NL_TEST_ASSERT_EQUALS(inSuite, v.expected_status, status);
         }
         ++case_idx;
     }
@@ -2781,6 +2914,8 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid nonce", TestAES_CCM_128DecryptInvalidNonceLen),
     NL_TEST_DEF("Test encrypt/decrypt AES-CTR-128 test vectors", TestAES_CTR_128CryptTestVectors),
     NL_TEST_DEF("Test ASN.1 signature conversion routines", TestAsn1Conversions),
+    NL_TEST_DEF("Test reading a length from ASN.1 DER stream success cases", TestReadDerLengthValidCases),
+    NL_TEST_DEF("Test reading a length from ASN.1 DER stream error cases", TestReadDerLengthInvalidCases),
     NL_TEST_DEF("Test Integer to ASN.1 DER conversion", TestRawIntegerToDerValidCases),
     NL_TEST_DEF("Test Integer to ASN.1 DER conversion error cases", TestRawIntegerToDerInvalidCases),
     NL_TEST_DEF("Test ECDSA signing and validation message using SHA256", TestECDSA_Signing_SHA256_Msg),

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1423,7 +1423,7 @@ void TestCSR_Verify(nlTestSuite * inSuite, void * inContext)
 
 void TestCSR_GenDirect(nlTestSuite * inSuite, void * inContext)
 {
-    uint8_t csrBuf[kMAX_CSR_Length];
+    uint8_t csrBuf[kMIN_CSR_Buffer_Size];
     ClearSecretData(csrBuf);
     MutableByteSpan csrSpan(csrBuf);
 
@@ -1432,7 +1432,7 @@ void TestCSR_GenDirect(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
 
     // Validate case of buffer too small
-    uint8_t csrBufTooSmall[kMAX_CSR_Length - 1];
+    uint8_t csrBufTooSmall[kMIN_CSR_Buffer_Size - 1];
     MutableByteSpan csrSpanTooSmall(csrBufTooSmall);
     NL_TEST_ASSERT(inSuite, GenerateCertificateSigningRequest(&keypair, csrSpanTooSmall) == CHIP_ERROR_BUFFER_TOO_SMALL);
 
@@ -1468,7 +1468,7 @@ void TestCSR_GenDirect(nlTestSuite * inSuite, void * inContext)
 static void TestCSR_GenByKeypair(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
-    uint8_t csr[kMAX_CSR_Length];
+    uint8_t csr[kMIN_CSR_Buffer_Size];
     size_t length = sizeof(csr);
 
     Test_P256Keypair keypair;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -612,28 +612,28 @@ static void TestRawIntegerToDerInvalidCases(nlTestSuite * inSuite, void * inCont
 
 static void TestReadDerLengthValidCases(nlTestSuite * inSuite, void * inContext)
 {
-    const uint8_t short_zero_length[] = {0x00};
+    const uint8_t short_zero_length[] = { 0x00 };
     ByteSpan short_zero_length_buf(short_zero_length);
 
-    const uint8_t short_length[] = {0x15};
+    const uint8_t short_length[] = { 0x15 };
     ByteSpan short_length_buf(short_length);
 
-    const uint8_t single_byte_length[] = {0x81, 0x80};
+    const uint8_t single_byte_length[] = { 0x81, 0x80 };
     ByteSpan single_byte_length_buf(single_byte_length);
 
-    const uint8_t single_byte_length_large[] = {0x81, 0xFF};
+    const uint8_t single_byte_length_large[] = { 0x81, 0xFF };
     ByteSpan single_byte_length_large_buf(single_byte_length_large);
 
-    const uint8_t two_byte_length[] = {0x82, 0xFF, 0x01};
+    const uint8_t two_byte_length[] = { 0x82, 0xFF, 0x01 };
     ByteSpan two_byte_length_buf(two_byte_length);
 
-    const uint8_t three_byte_length[] = {0x83, 0xFF, 0x00, 0xAA};
+    const uint8_t three_byte_length[] = { 0x83, 0xFF, 0x00, 0xAA };
     ByteSpan three_byte_length_buf(three_byte_length);
 
-    const uint8_t four_byte_length[] = {0x84, 0x01, 0x02, 0x03, 0x04};
+    const uint8_t four_byte_length[] = { 0x84, 0x01, 0x02, 0x03, 0x04 };
     ByteSpan four_byte_length_buf(four_byte_length);
 
-    const uint8_t four_byte_length_large[] = {0x84, 0xFF, 0xFF, 0xFF, 0xFF};
+    const uint8_t four_byte_length_large[] = { 0x84, 0xFF, 0xFF, 0xFF, 0xFF };
     ByteSpan four_byte_length_large_buf(four_byte_length_large);
 
     uint8_t max_byte_length_large[1 + sizeof(size_t)];
@@ -665,7 +665,7 @@ static void TestReadDerLengthValidCases(nlTestSuite * inSuite, void * inContext)
     for (const SuccessCase & v : cases)
     {
         size_t output_length = SIZE_MAX - 1;
-        chip::Encoding::LittleEndian::Reader input_reader{v.input_buf};
+        chip::Encoding::LittleEndian::Reader input_reader{ v.input_buf };
         CHIP_ERROR status = ReadDerLength(input_reader, output_length);
         if ((status != CHIP_NO_ERROR) || (v.expected_length != output_length))
         {
@@ -684,22 +684,22 @@ static void TestReadDerLengthInvalidCases(nlTestSuite * inSuite, void * inContex
     ByteSpan bad_buffer_nullptr(nullptr, sizeof(placeholder));
     ByteSpan bad_buffer_empty(placeholder, 0);
 
-    const uint8_t zero_multi_byte_length[] = {0x80};
+    const uint8_t zero_multi_byte_length[] = { 0x80 };
     ByteSpan zero_multi_byte_length_buf(zero_multi_byte_length);
 
-    const uint8_t single_byte_length_zero[] = {0x81, 0x00};
+    const uint8_t single_byte_length_zero[] = { 0x81, 0x00 };
     ByteSpan single_byte_length_zero_buf(single_byte_length_zero);
 
-    const uint8_t single_byte_length_too_small[] = {0x81, 0x7F};
+    const uint8_t single_byte_length_too_small[] = { 0x81, 0x7F };
     ByteSpan single_byte_length_too_small_buf(single_byte_length_too_small);
 
-    const uint8_t multiple_byte_length_zero_padded[] = {0x82, 0x00, 0xFF};
+    const uint8_t multiple_byte_length_zero_padded[] = { 0x82, 0x00, 0xFF };
     ByteSpan multiple_byte_length_zero_padded_buf(multiple_byte_length_zero_padded);
 
-    const uint8_t multiple_byte_length_insufficient_bytes[] = {0x84, 0xFF, 0xAA, 0x01};
+    const uint8_t multiple_byte_length_insufficient_bytes[] = { 0x84, 0xFF, 0xAA, 0x01 };
     ByteSpan multiple_byte_length_insufficient_bytes_buf(multiple_byte_length_insufficient_bytes);
 
-    const uint8_t multiple_byte_length_insufficient_bytes2[] = {0x83};
+    const uint8_t multiple_byte_length_insufficient_bytes2[] = { 0x83 };
     ByteSpan multiple_byte_length_insufficient_bytes2_buf(multiple_byte_length_insufficient_bytes2);
 
     uint8_t max_byte_length_large_insufficient_bytes[1 + sizeof(size_t) - 1];
@@ -718,8 +718,8 @@ static void TestReadDerLengthInvalidCases(nlTestSuite * inSuite, void * inContex
     const ErrorCase error_cases[] = {
         { .input_buf = bad_buffer_nullptr, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
         { .input_buf = bad_buffer_empty, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
-        { .input_buf = zero_multi_byte_length_buf,.expected_status = CHIP_ERROR_INVALID_ARGUMENT },
-        { .input_buf = single_byte_length_zero_buf,.expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = zero_multi_byte_length_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
+        { .input_buf = single_byte_length_zero_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
         { .input_buf = single_byte_length_too_small_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
         { .input_buf = multiple_byte_length_zero_padded_buf, .expected_status = CHIP_ERROR_INVALID_ARGUMENT },
         { .input_buf = multiple_byte_length_insufficient_bytes_buf, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
@@ -731,7 +731,7 @@ static void TestReadDerLengthInvalidCases(nlTestSuite * inSuite, void * inContex
     for (const ErrorCase & v : error_cases)
     {
         size_t output_length = SIZE_MAX;
-        chip::Encoding::LittleEndian::Reader input_reader{v.input_buf};
+        chip::Encoding::LittleEndian::Reader input_reader{ v.input_buf };
         CHIP_ERROR status = ReadDerLength(input_reader, output_length);
         if (status != v.expected_status)
         {

--- a/src/crypto/tests/TestPSAOpKeyStore.cpp
+++ b/src/crypto/tests/TestPSAOpKeyStore.cpp
@@ -39,7 +39,7 @@ void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
     FabricIndex kBadFabricIndex = static_cast<FabricIndex>(kFabricIndex + 10u);
 
     // Can generate a key and get a CSR
-    uint8_t csrBuf[kMAX_CSR_Length];
+    uint8_t csrBuf[kMIN_CSR_Buffer_Size];
     MutableByteSpan csrSpan{ csrBuf };
     CHIP_ERROR err = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -62,7 +62,7 @@ void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !csrPublicKey1.Matches(csrPublicKey2));
 
     // Cannot NewOpKeypair for a different fabric if one already pending
-    uint8_t badCsrBuf[kMAX_CSR_Length];
+    uint8_t badCsrBuf[kMIN_CSR_Buffer_Size];
     MutableByteSpan badCsrSpan{ badCsrBuf };
     err = opKeystore.NewOpKeypairForFabric(kBadFabricIndex, badCsrSpan);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);

--- a/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
+++ b/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
@@ -48,7 +48,7 @@ void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
 
     // Failure before Init of NewOpKeypairForFabric
-    uint8_t unusedCsrBuf[kMAX_CSR_Length];
+    uint8_t unusedCsrBuf[kMIN_CSR_Buffer_Size];
     MutableByteSpan unusedCsrSpan{ unusedCsrBuf };
     err = opKeystore.NewOpKeypairForFabric(kFabricIndex, unusedCsrSpan);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
@@ -66,7 +66,7 @@ void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Can generate a key and get a CSR
-    uint8_t csrBuf[kMAX_CSR_Length];
+    uint8_t csrBuf[kMIN_CSR_Buffer_Size];
     MutableByteSpan csrSpan{ csrBuf };
     err = opKeystore.NewOpKeypairForFabric(kFabricIndex, csrSpan);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -85,7 +85,7 @@ void TestBasicLifeCycle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, opKeystore.HasPendingOpKeypair() == true);
 
     // Cannot NewOpKeypair for a different fabric if one already pending
-    uint8_t badCsrBuf[kMAX_CSR_Length];
+    uint8_t badCsrBuf[kMIN_CSR_Buffer_Size];
     MutableByteSpan badCsrSpan = MutableByteSpan{ badCsrBuf };
     err                        = opKeystore.NewOpKeypairForFabric(kBadFabricIndex, badCsrSpan);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -220,7 +220,7 @@ using namespace chip::Credentials;
             break;
         }
 
-        uint8_t buf[kMAX_CSR_Length];
+        uint8_t buf[kMIN_CSR_Buffer_Size];
         MutableByteSpan csr(buf);
         err = GenerateCertificateSigningRequest(&keypairBridge, csr);
         if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -335,7 +335,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 }
             } else {
                 // Generate a new random keypair.
-                uint8_t csrBuffer[chip::Crypto::kMAX_CSR_Length];
+                uint8_t csrBuffer[chip::Crypto::kMIN_CSR_Buffer_Size];
                 chip::MutableByteSpan csr(csrBuffer);
                 errorCode = startupParams.fabricTable->AllocatePendingOperationalKey(startupParams.fabricIndex, csr);
                 if ([self checkForStartError:errorCode logMsg:kErrorKeyAllocation]) {

--- a/src/lib/support/UnitTestExtendedAssertions.h
+++ b/src/lib/support/UnitTestExtendedAssertions.h
@@ -50,28 +50,27 @@
     } while (0)
 
 /**
- *  @def NL_TEST_ASSERT_SUCCESS(inSuite, expression)
+ *  @def NL_TEST_ASSERT_EQUALS(inSuite, inExpr1,, inExpr2)
  *
  *  @brief
- *    This is used to assert that an expression is equal to CHIP_NO_ERROR
- *    throughout a test in a test suite.
+ *    This is used to assert that two expressions are equal, and to print both sides on failure. This
+ *    does not attempt to print the value of variables. It only prints the expressions.
  *
  *  @param[in]    inSuite       A pointer to the test suite the assertion
  *                              should be accounted against.
- *  @param[in]    inExpression  Expression to be checked for equality to CHIP_NO_ERROR.
- *                              If the expression is different than CHIP_NO_ERROR, the
- *                              assertion fails.
+ *  @param[in]    inExpr1       Left hand-side to check
+ *  @param[in]    inExpr2       Right hand-side to check
  *
  */
-#define NL_TEST_ASSERT_EQUALS(inSuite, inExpr1, inExpr2)                                                                           \
-    do                                                                                                                             \
-    {                                                                                                                              \
-        (inSuite)->performedAssertions += 1;                                                                                       \
-                                                                                                                                   \
-        if ((inExpr1) != (inExpr2))                                                                                                \
-        {                                                                                                                          \
-            printf("%s:%u: assertion failed: %s == %s\n", __FILE__, __LINE__, #inExpr1, #inExpr2);                                 \
-            (inSuite)->failedAssertions += 1;                                                                                      \
-            (inSuite)->flagError = true;                                                                                           \
-        }                                                                                                                          \
+#define NL_TEST_ASSERT_EQUALS(inSuite, inExpr1, inExpr2)                                               \
+    do                                                                                                 \
+    {                                                                                                  \
+        (inSuite)->performedAssertions += 1;                                                           \
+                                                                                                       \
+        if (!((inExpr1) == (inExpr2)))                                                                 \
+        {                                                                                              \
+            printf("%s:%u: assertion failed: %s == %s\n", __FILE__, __LINE__, #inExpr1, #inExpr2);     \
+            (inSuite)->failedAssertions += 1;                                                          \
+            (inSuite)->flagError = true;                                                               \
+        }                                                                                              \
     } while (0)

--- a/src/lib/support/UnitTestExtendedAssertions.h
+++ b/src/lib/support/UnitTestExtendedAssertions.h
@@ -62,15 +62,15 @@
  *  @param[in]    inExpr2       Right hand-side to check
  *
  */
-#define NL_TEST_ASSERT_EQUALS(inSuite, inExpr1, inExpr2)                                               \
-    do                                                                                                 \
-    {                                                                                                  \
-        (inSuite)->performedAssertions += 1;                                                           \
-                                                                                                       \
-        if (!((inExpr1) == (inExpr2)))                                                                 \
-        {                                                                                              \
-            printf("%s:%u: assertion failed: %s == %s\n", __FILE__, __LINE__, #inExpr1, #inExpr2);     \
-            (inSuite)->failedAssertions += 1;                                                          \
-            (inSuite)->flagError = true;                                                               \
-        }                                                                                              \
+#define NL_TEST_ASSERT_EQUALS(inSuite, inExpr1, inExpr2)                                                                           \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        (inSuite)->performedAssertions += 1;                                                                                       \
+                                                                                                                                   \
+        if (!((inExpr1) == (inExpr2)))                                                                                             \
+        {                                                                                                                          \
+            printf("%s:%u: assertion failed: %s == %s\n", __FILE__, __LINE__, #inExpr1, #inExpr2);                                 \
+            (inSuite)->failedAssertions += 1;                                                                                      \
+            (inSuite)->flagError = true;                                                                                           \
+        }                                                                                                                          \
     } while (0)

--- a/src/platform/silabs/efr32/Efr32PsaOperationalKeystore.cpp
+++ b/src/platform/silabs/efr32/Efr32PsaOperationalKeystore.cpp
@@ -194,7 +194,7 @@ CHIP_ERROR Efr32PsaOperationalKeystore::NewOpKeypairForFabric(FabricIndex fabric
         return CHIP_ERROR_INVALID_FABRIC_INDEX;
     }
 
-    VerifyOrReturnError(outCertificateSigningRequest.size() >= Crypto::kMAX_CSR_Length, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(outCertificateSigningRequest.size() >= Crypto::kMIN_CSR_Buffer_Size, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Generate new key
     EFR32OpaqueKeyId id = kEFR32OpaqueKeyIdUnknown;


### PR DESCRIPTION
- Some implementers ran out of space when adding even a single extension to a CSR.
- The forced max size in CSR verification logic didn't help anyone.
- All existing limitations were due to other artificial limitations that are now remove.
- ReadDerLength was private and insufficiently tested. Some issues were found by @bluebin14.

Testing done:
- Existing test coverage passes
- Added exhaustive unit tests for ReadDerLength, covering all failing cases, and expanding it usability beyond 8 bits of range.
