### PR TITLE
[Silabs] examples readme contained old paths. update them

### DIFF
--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -115,7 +115,7 @@ Silicon Labs platform.
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -124,16 +124,16 @@ Silicon Labs platform.
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ rm -rf out/
 
 *   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app BRD4187C chip_build_libshell=true
+          ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app BRD4187C chip_build_libshell=true
 
 *   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32/ ./out/light-switch-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
@@ -141,11 +141,11 @@ Silicon Labs platform.
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/efr32/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -161,7 +161,7 @@ arguments
 
 -   On the command line:
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ python3 out/debug/matter-silabs-light-switch-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
@@ -172,7 +172,6 @@ Releases page on
 [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases).
 
 -   On the command line:
-
 
           $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
 
@@ -216,11 +215,9 @@ combination with JLinkRTTClient as follows:
 
           $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
 
-
     For MG21 use:
 
           $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
-
 
     For MG24 use:
 
@@ -402,7 +399,7 @@ To track memory usage you can set `enable_heap_monitoring = true` either in the
 BUILD.gn file or pass it as a build argument to gn. This will print on the RTT
 console the RAM usage of each individual task and the number of Memory
 allocation and Free. While this is not extensive monitoring you're welcome to
-modify `examples/platform/silabs/efr32/MemMonitoring.cpp` to add your own memory
+modify `examples/platform/silabs/MemMonitoring.cpp` to add your own memory
 tracking code inside the `trackAlloc` and `trackFree` function
 
 ## OTA Software Update
@@ -421,19 +418,19 @@ features can easily be toggled on or off. Here is a short list of options :
 
 chip_progress_logging, chip_detail_logging, chip_automation_logging
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32 ./out/light-switch-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs ./out/light-switch-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
 
 ### Debug build / release build
 
 is_debug
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32 ./out/light-switch-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs ./out/light-switch-app BRD4164A "is_debug=false"
 
 ### Disabling LCD
 
 show_qr_code
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32 ./out/light-switch-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs ./out/light-switch-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 
@@ -442,4 +439,4 @@ kvs_max_entries
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/efr32 ./out/light-switch-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs ./out/light-switch-app BRD4164A kvs_max_entries=50

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -102,7 +102,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -111,7 +111,7 @@ Silicon Labs platform.
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -120,12 +120,12 @@ Silicon Labs platform.
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ rm -rf out/
 
 *   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32/ ./out/lighting-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
@@ -133,11 +133,11 @@ Silicon Labs platform.
 
 *   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs/efr32/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -155,7 +155,7 @@ arguments
 
 -   On the command line:
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ python3 out/debug/matter-silabs-lighting-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
@@ -341,7 +341,7 @@ To track memory usage you can set `enable_heap_monitoring = true` either in the
 BUILD.gn file or pass it as a build argument to gn. This will print on the RTT
 console the RAM usage of each individual task and the number of Memory
 allocation and Free. While this is not extensive monitoring you're welcome to
-modify `examples/platform/silabs/efr32/MemMonitoring.cpp` to add your own memory
+modify `examples/platform/silabs/MemMonitoring.cpp` to add your own memory
 tracking code inside the `trackAlloc` and `trackFree` function
 
 ## OTA Software Update
@@ -369,19 +369,19 @@ passed to the build scripts.
 
 `chip_progress_logging, chip_detail_logging, chip_automation_logging`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32 ./out/lighting-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs ./out/lighting-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
 
 ### Debug build / release build
 
 `is_debug`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32 ./out/lighting-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs ./out/lighting-app BRD4164A "is_debug=false"
 
 ### Disabling LCD
 
 `show_qr_code`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32 ./out/lighting-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs ./out/lighting-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 
@@ -390,4 +390,4 @@ passed to the build scripts.
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/efr32 ./out/lighting-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs ./out/lighting-app BRD4164A kvs_max_entries=50

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -102,7 +102,7 @@ Mac OS X
 
           ```
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock_app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock_app BRD4187C
           ```
 
 -   To delete generated executable, libraries and object files use:
@@ -115,7 +115,7 @@ Mac OS X
     OR use GN/Ninja directly
 
           ```
-          $ cd ~/connectedhomeip/examples/silabs/lock-app/efr32
+          $ cd ~/connectedhomeip/examples/lock-app/silabs/
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -126,14 +126,14 @@ Mac OS X
 -   To delete generated executable, libraries and object files use:
 
           ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lock-app/silabs
           $ rm -rf out/
           ```
 
 *   Build the example as Intermittently Connected Device (ICD)
 
           ```
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32/ ./out/lock-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock-app_ICD BRD4187C --icd
           ```
 
     or use gn as previously mentioned but adding the following arguments:
@@ -145,13 +145,13 @@ Mac OS X
 *   Build the example with pigweed RCP
 
           ```
-          $ ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs/efr32/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
           ```
 
     or use GN/Ninja Directly
 
           ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lock-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -171,7 +171,7 @@ arguments
 -   On the command line:
 
           ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/lock-app/silabs
           $ python3 out/debug/matter-silabs-lock-example.flash.py
           ```
 
@@ -373,7 +373,7 @@ To track memory usage you can set `enable_heap_monitoring = true` either in the
 BUILD.gn file or pass it as a build argument to gn. This will print on the RTT
 console the RAM usage of each individual task and the number of Memory
 allocation and Free. While this is not extensive monitoring you're welcome to
-modify `examples/platform/silabs/efr32/MemMonitoring.cpp` to add your own memory
+modify `examples/platform/silabs/MemMonitoring.cpp` to add your own memory
 tracking code inside the `trackAlloc` and `trackFree` function
 
 ## OTA Software Update
@@ -393,7 +393,7 @@ features can easily be toggled on or off. Here is a short list of options :
 `chip_progress_logging, chip_detail_logging, chip_automation_logging`
 
     ```
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32 ./out/lock-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs ./out/lock-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
     ```
 
 ### Debug build / release build
@@ -401,7 +401,7 @@ features can easily be toggled on or off. Here is a short list of options :
 `is_debug`
 
     ```
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32 ./out/lock-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs ./out/lock-app BRD4164A "is_debug=false"
     ```
 
 ### Disabling LCD
@@ -409,7 +409,7 @@ features can easily be toggled on or off. Here is a short list of options :
 `show_qr_code`
 
     ```
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32 ./out/lock-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs ./out/lock-app BRD4164A "show_qr_code=false"
     ```
 
 ### KVS maximum entry count
@@ -420,5 +420,5 @@ features can easily be toggled on or off. Here is a short list of options :
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/efr32 ./out/lock-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs ./out/lock-app BRD4164A kvs_max_entries=50
     ```

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -101,7 +101,7 @@ Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32/ ./out/pump-app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -110,7 +110,7 @@ Labs platform.
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -119,12 +119,12 @@ Labs platform.
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ rm -rf out/
 
 *   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32/ ./out/pump-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
@@ -132,11 +132,11 @@ Labs platform.
 
 *   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/pump-app/silabs/efr32/ out/pump_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/pump-app/silabs/ out/pump_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -152,7 +152,7 @@ arguments
 
 -   On the command line:
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ python3 out/debug/matter-silabs-pump-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
@@ -317,7 +317,7 @@ To track memory usage you can set `enable_heap_monitoring = true` either in the
 BUILD.gn file or pass it as a build argument to gn. This will print on the RTT
 console the RAM usage of each individual task and the number of Memory
 allocation and Free. While this is not extensive monitoring you're welcome to
-modify `examples/platform/silabs/efr32/MemMonitoring.cpp` to add your own memory
+modify `examples/platform/silabs/MemMonitoring.cpp` to add your own memory
 tracking code inside the `trackAlloc` and `trackFree` function
 
 ## OTA Software Update
@@ -345,19 +345,19 @@ passed to the build scripts.
 
 `chip_progress_logging, chip_detail_logging, chip_automation_logging`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32 ./out/pump-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs ./out/pump-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
 
 ### Debug build / release build
 
 `is_debug`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32 ./out/pump-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs ./out/pump-app BRD4164A "is_debug=false"
 
 ### Disabling LCD
 
 `show_qr_code`
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32 ./out/pump-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs ./out/pump-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 
@@ -366,4 +366,4 @@ passed to the build scripts.
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/efr32 ./out/pump-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs ./out/pump-app BRD4164A kvs_max_entries=50

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -330,7 +330,7 @@ To track memory usage you can set `enable_heap_monitoring = true` either in the
 BUILD.gn file or pass it as a build argument to gn. This will print on the RTT
 console the RAM usage of each individual task and the number of Memory
 allocation and Free. While this is not extensive monitoring you're welcome to
-modify `examples/platform/silabs/efr32/MemMonitoring.cpp` to add your own memory
+modify `examples/platform/silabs/MemMonitoring.cpp` to add your own memory
 tracking code inside the `trackAlloc` and `trackFree` function
 
 ## OTA Software Update

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -106,7 +106,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -115,7 +115,7 @@ Silicon Labs platform.
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
+          $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -124,16 +124,16 @@ Silicon Labs platform.
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
+          $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ rm -rf out/
 
 *   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app BRD4187C chip_build_libshell=true
+          ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app BRD4187C chip_build_libshell=true
 
 *   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32/ ./out/thermostat-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
@@ -141,11 +141,11 @@ Silicon Labs platform.
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/efr32/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
+          $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -161,7 +161,7 @@ arguments
 
 -   On the command line:
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs/efr32
+          $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ python3 out/debug/matter-silabs-thermostat-switch-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
@@ -353,19 +353,19 @@ features can easily be toggled on or off. Here is a short list of options :
 
 chip_progress_logging, chip_detail_logging, chip_automation_logging
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32 ./out/thermostat-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs ./out/thermostat-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
 
 ### Debug build / release build
 
 is_debug
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32 ./out/thermostat-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs ./out/thermostat-app BRD4164A "is_debug=false"
 
 ### Disabling LCD
 
 show_qr_code
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32 ./out/thermostat-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs ./out/thermostat-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 
@@ -374,4 +374,4 @@ kvs_max_entries
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/efr32 ./out/thermostat-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs ./out/thermostat-app BRD4164A kvs_max_entries=50

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -99,7 +99,7 @@ Silicon Labs platform.
 *   Build the example application:
 
           cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app BRD4187C
+          ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app BRD4187C
 
 -   To delete generated executable, libraries and object files use:
 
@@ -108,7 +108,7 @@ Silicon Labs platform.
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/window-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -117,12 +117,12 @@ Silicon Labs platform.
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/window-app/silabs
           $ rm -rf out/
 
 *   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32/ ./out/window-app_ICD BRD4187C --icd
+          $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
@@ -130,11 +130,11 @@ Silicon Labs platform.
 
 *   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/window-app/silabs/efr32/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+          $ ./scripts/examples/gn_silabs_example.sh examples/window-app/silabs/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/window-app/silabs
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export SILABS_BOARD=BRD4187C
@@ -150,7 +150,7 @@ arguments
 
 -   On the command line:
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs/efr32
+          $ cd ~/connectedhomeip/examples/window-app/silabs
           $ python3 out/debug/matter-silabs-window-example.flash.py
 
 -   Or with the Ozone debugger, just load the .out file.
@@ -353,19 +353,19 @@ features can easily be toggled on or off. Here is a short list of options :
 
 chip_progress_logging, chip_detail_logging, chip_automation_logging
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32 ./out/window-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs ./out/window-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
 
 ### Debug build / release build
 
 is_debug
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32 ./out/window-app BRD4164A "is_debug=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs ./out/window-app BRD4164A "is_debug=false"
 
 ### Disabling LCD
 
 show_qr_code
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32 ./out/window-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs ./out/window-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 
@@ -374,4 +374,4 @@ kvs_max_entries
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/efr32 ./out/window-app BRD4164A kvs_max_entries=50
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs ./out/window-app BRD4164A kvs_max_entries=50


### PR DESCRIPTION
`<app>/silabs/efr32 ` doesn't exist anymore. 
All Silabs platforms use the same app-specific files  in `<app>/silabs/`
