### PR TITLE
virtual-device-app: Add cluster stub and initialize code

### DIFF
--- a/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/MatterApp.kt
+++ b/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/MatterApp.kt
@@ -10,7 +10,9 @@ import com.matter.virtual.device.app.DeviceAppCallback
 import com.matter.virtual.device.app.DeviceEventType
 import com.matter.virtual.device.app.core.common.MatterConstants
 import com.matter.virtual.device.app.core.common.MatterSettings
+import com.matter.virtual.device.app.core.matter.manager.DoorLockManagerStub
 import com.matter.virtual.device.app.core.matter.manager.OnOffManagerStub
+import com.matter.virtual.device.app.core.matter.manager.PowerSourceManagerStub
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,7 +24,9 @@ class MatterApp
 constructor(
   @ApplicationContext private val context: Context,
   private val deviceApp: DeviceApp,
-  private val onOffManagerStub: OnOffManagerStub
+  private val onOffManagerStub: OnOffManagerStub,
+  private val doorLockManagerStub: DoorLockManagerStub,
+  private val powerSourceManagerStub: PowerSourceManagerStub
 ) {
 
   private var androidChipPlatform: AndroidChipPlatform? = null
@@ -40,6 +44,14 @@ constructor(
             Clusters.ClusterId_OnOff -> {
               app.setOnOffManager(endpoint, onOffManagerStub)
               onOffManagerStub.initAttributeValue()
+            }
+            Clusters.ClusterId_DoorLock -> {
+              app.setDoorLockManager(endpoint, doorLockManagerStub)
+              doorLockManagerStub.initAttributeValue()
+            }
+            Clusters.ClusterId_PowerSource -> {
+              app.setPowerSourceManager(endpoint, powerSourceManagerStub)
+              powerSourceManagerStub.initAttributeValue()
             }
           }
         }

--- a/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/manager/DoorLockManagerStub.kt
+++ b/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/manager/DoorLockManagerStub.kt
@@ -1,0 +1,61 @@
+package com.matter.virtual.device.app.core.matter.manager
+
+import com.matter.virtual.device.app.DeviceApp
+import com.matter.virtual.device.app.DoorLockManager
+import com.matter.virtual.device.app.core.common.MatterConstants
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import timber.log.Timber
+
+@Singleton
+class DoorLockManagerStub @Inject constructor(private val deviceApp: DeviceApp) : DoorLockManager {
+
+  private val _lockState = MutableStateFlow(false)
+  val lockState: StateFlow<Boolean>
+    get() = _lockState
+
+  override fun initAttributeValue() {
+    Timber.d("initAttributeValue()")
+    deviceApp.setLockType(MatterConstants.DEFAULT_ENDPOINT, DoorLockManager.DlLockType_kMagnetic)
+    deviceApp.setLockState(MatterConstants.DEFAULT_ENDPOINT, lockState.value.asLockState())
+    deviceApp.setActuatorEnabled(MatterConstants.DEFAULT_ENDPOINT, true)
+    deviceApp.setOperatingMode(
+      MatterConstants.DEFAULT_ENDPOINT,
+      DoorLockManager.OperatingModeEnum_kNormal
+    )
+    deviceApp.setSupportedOperatingModes(
+      MatterConstants.DEFAULT_ENDPOINT,
+      DoorLockManager.DlSupportedOperatingModes_kNormal
+    )
+  }
+
+  override fun handleLockStateChanged(value: Int) {
+    Timber.d("handleLockStateChanged():$value")
+    _lockState.value = value.asBooleanLockState()
+  }
+
+  fun setLockState(value: Boolean) {
+    Timber.d("setLockState():$value")
+    deviceApp.setLockState(MatterConstants.DEFAULT_ENDPOINT, value.asLockState())
+  }
+
+  fun sendLockAlarmEvent() {
+    Timber.d("sendLockAlarmEvent()")
+    deviceApp.sendLockAlarmEvent(MatterConstants.DEFAULT_ENDPOINT)
+  }
+
+  private fun Boolean.asLockState() =
+    when (this) {
+      true -> DoorLockManager.DlLockState_kUnlocked
+      false -> DoorLockManager.DlLockState_kLocked
+    }
+
+  private fun Int.asBooleanLockState() =
+    when (this) {
+      DoorLockManager.DlLockState_kUnlocked -> true
+      DoorLockManager.DlLockState_kLocked -> false
+      else -> false
+    }
+}

--- a/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/manager/PowerSourceManagerStub.kt
+++ b/examples/virtual-device-app/android/App/core/matter/src/main/java/com/matter/virtual/device/app/core/matter/manager/PowerSourceManagerStub.kt
@@ -1,0 +1,34 @@
+package com.matter.virtual.device.app.core.matter.manager
+
+import com.matter.virtual.device.app.DeviceApp
+import com.matter.virtual.device.app.PowerSourceManager
+import com.matter.virtual.device.app.core.common.MatterConstants
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import timber.log.Timber
+
+@Singleton
+class PowerSourceManagerStub @Inject constructor(private val deviceApp: DeviceApp) :
+  PowerSourceManager {
+
+  private val _batPercent = MutableStateFlow(DEFAULT_BATTERY_STATUS)
+  val batPercent: StateFlow<Int>
+    get() = _batPercent
+
+  override fun initAttributeValue() {
+    Timber.d("initAttributeValue()")
+    deviceApp.setBatPercentRemaining(MatterConstants.DEFAULT_ENDPOINT, DEFAULT_BATTERY_STATUS)
+  }
+
+  fun setBatPercentRemaining(batteryPercentRemaining: Int) {
+    Timber.d("setBatPercentRemaining():$batteryPercentRemaining")
+    _batPercent.value = batteryPercentRemaining
+    deviceApp.setBatPercentRemaining(MatterConstants.DEFAULT_ENDPOINT, batteryPercentRemaining)
+  }
+
+  companion object {
+    private const val DEFAULT_BATTERY_STATUS = 70
+  }
+}


### PR DESCRIPTION
#### Problem
* Need to initialize cluster stub for receiving cluster event.


#### Change overview
* Add cluster stub and initialize code


#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation





