### PR TITLE
[nrfconnect] [OTA] Confirm the new image in the app init.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -178,6 +178,15 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -137,6 +137,15 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -179,6 +179,15 @@ CHIP_ERROR AppTask::Init()
         return System::MapErrorZephyr(ret);
     }
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize Timers
     k_timer_init(&sFunctionTimer, AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_init(&sDimmerPressKeyTimer, AppTask::FunctionTimerTimeoutCallback, nullptr);

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -217,6 +217,15 @@ CHIP_ERROR AppTask::Init()
     }
     mPWMDevice.SetCallbacks(ActionInitiated, ActionCompleted);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -187,6 +187,15 @@ CHIP_ERROR AppTask::Init()
 
     BoltLockMgr().Init(LockStateChanged);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -46,6 +46,16 @@ chip::DeviceLayer::OTAImageProcessorImpl & GetOTAImageProcessor();
  */
 void InitBasicOTARequestor();
 
+/**
+ * Check if the current image is the first boot the after OTA update and if so
+ * confirm it in MCUBoot.
+ *
+ * @return CHIP_NO_ERROR if the image has been confirmed, or it is not the first
+ * boot after the OTA update.
+ * Other CHIP_ERROR codes if the image could not be confirmed.
+ */
+CHIP_ERROR OtaConfirmNewImage();
+
 #endif // CONFIG_CHIP_OTA_REQUESTOR
 
 /**

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -160,6 +160,15 @@ CHIP_ERROR AppTask::Init()
     GetDFUOverSMP().ConfirmNewImage();
 #endif
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -158,6 +158,15 @@ CHIP_ERROR AppTask::Init()
     GetDFUOverSMP().ConfirmNewImage();
 #endif
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -165,6 +165,15 @@ CHIP_ERROR AppTask::Init()
     GetDFUOverSMP().ConfirmNewImage();
 #endif
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    err = OtaConfirmNewImage();
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+#endif
+
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA
     ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -207,7 +207,7 @@ bool OTAImageProcessorImpl::IsFirstImageRun()
 CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
 {
     PostOTAStateChangeEvent(DeviceLayer::kOtaApplyComplete);
-    return System::MapErrorZephyr(boot_write_img_confirmed());
+    return mImageConfirmed ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 }
 
 CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & aBlock)

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -44,6 +44,7 @@ public:
     CHIP_ERROR ProcessBlock(ByteSpan & aBlock) override;
     bool IsFirstImageRun() override;
     CHIP_ERROR ConfirmCurrentImage() override;
+    void SetImageConfirmed() { mImageConfirmed = true; }
 
 protected:
     CHIP_ERROR PrepareDownloadImpl();
@@ -53,6 +54,9 @@ protected:
     OTAImageHeaderParser mHeaderParser;
     uint8_t mBuffer[kBufferSize];
     ExternalFlashManager * mFlashHandler;
+
+private:
+    bool mImageConfirmed = false;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
The nRF5340 target requires 4kB of FPROTECT block size (SPU limitation) and after making a restriction for the factory data partition the new image cannot be confirmed after the OTA update finishes. Due to that, we need to confirm the current OTA image before factory data initialization.

To do it we should allow confirming the image in the other place rather than during posting the OTAStateChange event and then we should inform the image processor of the confirmation status.