### PR TITLE
[Silabs] Enabled BRD4338A board and configured BTN1

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -272,7 +272,7 @@ else
     fi
 
     # 917 exception. TODO find a more generic way
-    if [ "$SILABS_BOARD" == "BRD4325B" ] || [ "$SILABS_BOARD" == "BRD4325C" ]; then
+    if [ "$SILABS_BOARD" == "BRD4325B" ] || [ "$SILABS_BOARD" == "BRD4325C" ] || [ "$SILABS_BOARD" == "BRD4338A" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
         optArgs+="chip_device_platform =\"SiWx917\" "

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -32,6 +32,9 @@ void RSI_Board_LED_Set(int, bool);
 void RSI_Board_LED_Toggle(int);
 void RSI_Wakeupsw_config(void);
 void RSI_Wakeupsw_config_gpio0(void);
+#ifdef SI917_RADIO_BOARD_V2
+void RSI_Wakeupsw_config_gpio11(void);
+#endif
 void sl_system_init(void);
 void soc_pll_config(void);
 }
@@ -58,7 +61,11 @@ CHIP_ERROR SilabsPlatform::Init(void)
 
     // BTN0 and BTN1 init
     RSI_Wakeupsw_config();
+#ifdef SI917_RADIO_BOARD_V2
+    RSI_Wakeupsw_config_gpio11();
+#else
     RSI_Wakeupsw_config_gpio0();
+#endif
 
 #if SILABS_LOG_ENABLED
     silabsInitLog();

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -164,9 +164,7 @@ template("siwx917_sdk") {
     ]
 
     if (silabs_board == "BRD4325B") {
-      defines += [
-        "DUAL_FLASH_EN",
-      ]
+      defines += [ "DUAL_FLASH_EN" ]
     }
     if (wifi_soc_common_flash) {
       defines += [
@@ -174,7 +172,7 @@ template("siwx917_sdk") {
         "COMMON_FLASH_EN=1",
         "EXECUTION_FROM_RAM",
       ]
-      if(silabs_board == "BRD4338A") {
+      if (silabs_board == "BRD4338A") {
         defines += [ "SI917_RADIO_BOARD_V2=1" ]
       }
     }

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -133,6 +133,7 @@ template("siwx917_sdk") {
       "KVS_MAX_ENTRIES=${kvs_max_entries}",
       "${silabs_mcu}=1",
       "${silabs_board}=1",
+      "SL_BOARD_NAME=${silabs_board}",
       "__HEAP_SIZE=0",
       "PLATFORM_HEADER=\"platform-header.h\"",
       "USE_NVM3=1",
@@ -164,31 +165,18 @@ template("siwx917_sdk") {
 
     if (silabs_board == "BRD4325B") {
       defines += [
-        "BRD4325A",
-        "BRD4325B",
         "DUAL_FLASH_EN",
       ]
     }
-    if (silabs_board == "BRD4325C") {
+    if (wifi_soc_common_flash) {
       defines += [
-        "BRD4325C",
         "CHIP_917B0 = 1",
-        "SL_BOARD_NAME=\"BRD4325C\"",
         "COMMON_FLASH_EN=1",
         "EXECUTION_FROM_RAM",
-        "SL_BOARD_REV=\"A01\"",
       ]
-    }
-    if (silabs_board == "BRD4338A") {
-      defines += [
-        "BRD4338A",
-        "CHIP_917B0 = 1",
-        "SL_BOARD_NAME=\"BRD4338A\"",
-        "COMMON_FLASH_EN=1",
-        "EXECUTION_FROM_RAM",
-        "SL_BOARD_REV=\"A01\"",
-        "SI917_RADIO_BOARD_V2=1",
-      ]
+      if(silabs_board == "BRD4338A") {
+        defines += [ "SI917_RADIO_BOARD_V2=1" ]
+      }
     }
 
     if (chip_build_libshell) {
@@ -418,7 +406,7 @@ template("siwx917_sdk") {
       ]
     }
 
-    if (silabs_board == "BRD4325C" || silabs_board == "BRD4338A") {
+    if (wifi_soc_common_flash) {
       sources += [
         "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c",
         "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_common_flash_intf.c",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -179,6 +179,17 @@ template("siwx917_sdk") {
         "SL_BOARD_REV=\"A01\"",
       ]
     }
+    if (silabs_board == "BRD4338A") {
+      defines += [
+        "BRD4338A",
+        "CHIP_917B0 = 1",
+        "SL_BOARD_NAME=\"BRD4338A\"",
+        "COMMON_FLASH_EN=1",
+        "EXECUTION_FROM_RAM",
+        "SL_BOARD_REV=\"A01\"",
+        "SI917_RADIO_BOARD_V2=1",
+      ]
+    }
 
     if (chip_build_libshell) {
       defines += [ "ENABLE_CHIP_SHELL" ]
@@ -407,7 +418,7 @@ template("siwx917_sdk") {
       ]
     }
 
-    if (silabs_board == "BRD4325C") {
+    if ((silabs_board == "BRD4325C") || (silabs_board == "BRD4338A")) {
       sources += [
         "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c",
         "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_common_flash_intf.c",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -418,7 +418,7 @@ template("siwx917_sdk") {
       ]
     }
 
-    if ((silabs_board == "BRD4325C") || (silabs_board == "BRD4338A")) {
+    if (silabs_board == "BRD4325C" || silabs_board == "BRD4338A") {
       sources += [
         "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c",
         "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_common_flash_intf.c",

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -117,6 +117,12 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
+} else if (silabs_board == "BRD4338A") {
+  silabs_family = "SiWx917-common"
+  silabs_mcu = "SiWG917M111MGTBA"
+  disable_lcd = true
+  show_qr_code = false
+  wifi_soc = true
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -37,6 +37,7 @@ declare_args() {
   chip_enable_ble_rs911x = false
 
   wifi_soc = false
+  wifi_soc_common_flash = false
 
   #Disable MQTT by default
   enable_dic = false
@@ -111,18 +112,21 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
+  wifi_soc_common_flash = true
 } else if (silabs_board == "BRD4325G") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
+  wifi_soc_common_flash = true
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
+  wifi_soc_common_flash = true
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,


### PR DESCRIPTION
* Added BRD4338A to GN files
> Now we can use BRD4338A in build argument
* Initializing button 1 with GPIO_11 API for B0 2.0 (BRD4338A) board
> GPIO_11 will be used for BTN1 in 2.0 board