### PR TITLE
Match the order of ScoreIpAddress with IpScore

### DIFF
--- a/src/lib/dnssd/IPAddressSorter.cpp
+++ b/src/lib/dnssd/IPAddressSorter.cpp
@@ -45,12 +45,10 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 {
     if (ip.IsIPv6())
     {
-#ifdef __APPLE__
         if (ip.IsIPv6LinkLocal())
         {
             return IpScore::kLinkLocal;
         }
-#endif // __APPLE__
 
         if (interfaceId.MatchLocalIPv6Subnet(ip))
         {
@@ -72,13 +70,6 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
         {
             return IpScore::kUniqueLocal;
         }
-
-#ifndef __APPLE__
-        if (ip.IsIPv6LinkLocal())
-        {
-            return IpScore::kLinkLocal;
-        }
-#endif // __APPLE__
 
         return IpScore::kOtherIpv6;
     }


### PR DESCRIPTION
The #27981 PR was merged, but it didn't follow `IpScore`'s comments.

```
// IP addess "suitability"
//   - Larger value means "more suitable"
//   - Enum ordered ascending for easier read. Note however that order of
//     checks MUST match in ScoreIpAddress below.
enum class IpScore : unsigned
```

This change matches the order of `ScoreIpAddress` with the order of `IpScore` enum.
