### PR TITLE
Increase HEAP availability for EFR32.

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -227,9 +227,9 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #endif // DIC
 #else  // SL_WIFI
 #if SL_CONFIG_OPENTHREAD_LIB == 1
-#define configTOTAL_HEAP_SIZE ((size_t)(31 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(40 * 1024))
 #else
-#define configTOTAL_HEAP_SIZE ((size_t)(29 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(38 * 1024))
 #endif // SL_CONFIG_OPENTHREAD_LIB
 #endif // configTOTAL_HEAP_SIZE
 #endif // configTOTAL_HEAP_SIZE


### PR DESCRIPTION
I had lock-rpc failing to commission with a
vApplicationMallocFailedHook.

The non-rpc version seems to work, however overall we seem to be tight on RAM. Increasing RAM to 40/38 from 31/29, which leaves a bit of buffer room (confirmed I was able to comission with 38/36 even with rpc).

## Testing

Did `chip-tool pairing ble-thread`

