### PR TITLE
[ReadHandler] Handler Reportable if timer fired

### DIFF
--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -89,7 +89,8 @@ public:
         bool IsReportableNow(const Timestamp & now) const
         {
             return (mReadHandler->CanStartReporting() &&
-                    (now >= mMinTimestamp && (mReadHandler->IsDirty() || now >= mMaxTimestamp || CanBeSynced())));
+                    ((now >= mMinTimestamp && (mReadHandler->IsDirty() || now >= mMaxTimestamp || CanBeSynced())) ||
+                     IsEngineRunScheduled()));
         }
 
         bool IsEngineRunScheduled() const { return mFlags.Has(ReadHandlerNodeFlags::EngineRunScheduled); }
@@ -114,8 +115,8 @@ public:
 
         void TimerFired() override
         {
-            mScheduler->ReportTimerCallback();
             SetEngineRunScheduled(true);
+            mScheduler->ReportTimerCallback();
         }
 
         System::Clock::Timestamp GetMinTimestamp() const { return mMinTimestamp; }

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -84,7 +84,10 @@ public:
 
         /// @brief Check if the Node is reportable now, meaning its readhandler was made reportable by attribute dirtying and
         /// handler state, and minimal time interval since last report has elapsed, or the maximal time interval since last
-        /// report has elapsed
+        /// report has elapsed.
+        /// @note If a handler has been flaged as scheduled for engine run, it will be reported regardless of the timestamps. This
+        /// is done to guarantee that the reporting engine will see the handler as reportable if a timer fires, even if it fires
+        /// early.
         /// @param now current time to use for the check, user must ensure to provide a valid time for this to be reliable
         bool IsReportableNow(const Timestamp & now) const
         {

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -100,9 +100,10 @@ void ReportSchedulerImpl::OnSubscriptionReportSent(ReadHandler * aReadHandler)
     node->SetCanBeSynced(false);
     node->SetIntervalTimeStamps(aReadHandler, now);
     Milliseconds32 newTimeout;
+    // Reset the EngineRunScheduled flag so that the next report is scheduled correctly
+    node->SetEngineRunScheduled(false);
     CalculateNextReportTimeout(newTimeout, node, now);
     ScheduleReport(newTimeout, node, now);
-    node->SetEngineRunScheduled(false);
 }
 
 /// @brief When a ReadHandler is removed, unregister it, which will cancel any scheduled report


### PR DESCRIPTION
This addresses: https://github.com/project-chip/connectedhomeip/issues/28929

We are now using the EngineRunScheduled flag to assess if a ReadHandler is reportable. This means if a timer has fired for a read handler, it will be considered as reportable regardless of the min and max interval as the timer should have fired  for the min interval only if the handler is dirty or have fired on the max interval.