### PR TITLE
Actually enable RVC tests in CI.

### DIFF
--- a/src/app/tests/suites/ciTests.json
+++ b/src/app/tests/suites/ciTests.json
@@ -305,7 +305,6 @@
         "Test_TC_G_2_1"
     ],
     "Scenes": ["Test_TC_S_1_1"],
-    "RVCOperationalState": ["Test_TC_RVCOPSTATE_1_1"],
     "ResourceMonitoring": [
         "TestActivatedCarbonFilterMonitoring",
         "TestHepaFilterMonitoring",
@@ -378,10 +377,10 @@
         "PowerSourceConfiguration",
         "RefrigeratorAlarm",
         "RelativeHumidityMeasurement",
+        "RoboticVacuumCleaner",
         "SecureChannel",
         "SmokeCOAlarm",
         "Switch",
-        "RVCOperationalState",
         "TemperatureControlledCabinetMode",
         "TemperatureControl",
         "TemperatureMeasurement",


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/28665 didn't enable the YAML bits.
