### PR TITLE
Re-enable YAML tests in CI.

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -209,23 +209,20 @@ def target_for_name(name: str):
     return TestTarget.ALL_CLUSTERS
 
 
-def tests_with_command(chip_tool: str, is_manual: bool, is_chip_tool_python_only: bool = False):
+def tests_with_command(chip_tool: str, is_manual: bool):
     """Executes `chip_tool` binary to see what tests are available, using cmd
     to get the list.
     """
     cmd = "list"
     if is_manual:
         cmd += "-manual"
-    elif is_chip_tool_python_only:
-        cmd += "-python-runner-only"
 
     result = subprocess.run([chip_tool, "tests", cmd], capture_output=True)
+    result.check_returncode()
 
     test_tags = set()
     if is_manual:
         test_tags.add(TestTag.MANUAL)
-    if is_chip_tool_python_only:
-        test_tags.add(TestTag.CHIP_TOOL_PYTHON_ONLY)
 
     in_development_tests = [s.replace(".yaml", "") for s in _GetInDevelopmentTests()]
 
@@ -243,9 +240,7 @@ def tests_with_command(chip_tool: str, is_manual: bool, is_chip_tool_python_only
         )
 
 
-# TODO We will move away from hardcoded list of yamltests to run all file when yamltests
-# parser/runner reaches parity with the code gen version.
-def _hardcoded_python_yaml_tests():
+def _AllFoundYamlTests(treat_repl_unsupported_as_in_development: bool):
     manual_tests = _GetManualTests()
     flaky_tests = _GetFlakyTests()
     slow_tests = _GetSlowTests()
@@ -269,7 +264,7 @@ def _hardcoded_python_yaml_tests():
         if path.name in in_development_tests:
             tags.add(TestTag.IN_DEVELOPMENT)
 
-        if path.name in chip_repl_unsupported_tests:
+        if treat_repl_unsupported_as_in_development and path.name in chip_repl_unsupported_tests:
             tags.add(TestTag.IN_DEVELOPMENT)
 
         yield TestDefinition(
@@ -280,8 +275,13 @@ def _hardcoded_python_yaml_tests():
         )
 
 
-def AllYamlTests():
-    for test in _hardcoded_python_yaml_tests():
+def AllReplYamlTests():
+    for test in _AllFoundYamlTests(treat_repl_unsupported_as_in_development=True):
+        yield test
+
+
+def AllChipToolYamlTests():
+    for test in _AllFoundYamlTests(treat_repl_unsupported_as_in_development=False):
         yield test
 
 
@@ -290,9 +290,6 @@ def AllChipToolTests(chip_tool: str):
         yield test
 
     for test in tests_with_command(chip_tool, is_manual=True):
-        yield test
-
-    for test in tests_with_command(chip_tool, is_manual=False, is_chip_tool_python_only=True):
         yield test
 
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -159,7 +159,9 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
 
     # Figures out selected test that match the given name(s)
     if runtime == TestRunTime.CHIP_REPL_PYTHON:
-        all_tests = [test for test in chiptest.AllYamlTests()]
+        all_tests = [test for test in chiptest.AllReplYamlTests()]
+    elif runtime == TestRunTime.CHIP_TOOL_PYTHON:
+        all_tests = [test for test in chiptest.AllChipToolYamlTests()]
     else:
         all_tests = [test for test in chiptest.AllChipToolTests(chip_tool)]
 

--- a/src/app/tests/suites/pythonRunnerOnlyTests.json
+++ b/src/app/tests/suites/pythonRunnerOnlyTests.json
@@ -1,5 +1,0 @@
-{
-    "Groups": ["TestGroupKeyManagementCluster"],
-    "Others": ["TestEqualities"],
-    "collection": ["Groups", "Others"]
-}


### PR DESCRIPTION
Two fixes, basically:

1. Make tests_with_command fail if the command fails.  This would have caught the fact that we were not ending up with a useful test list.
2. Fix the test list determination for the CHIP_TOOL_PYTHON runner.

Note: The removal of the no-longer-generated .h file is fixing a bad merge from d9edecb54e1fec0dc5c3b7693ae7daa426bc0843.
