### PR TITLE
[Android] Fix Android read attribute error

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -231,8 +231,8 @@ CHIP_ERROR ConvertReportTlvToJson(const uint32_t id, TLV::TLVReader & data, std:
     TLV::TLVWriter writer;
     TLV::TLVReader readerForJavaTLV;
     uint32_t size    = 0;
-    size_t bufferLen = readerForJavaTLV.GetTotalLength() + EXTRA_SPACE_FOR_ATTRIBUTE_TAG;
     readerForJavaTLV.Init(data);
+    size_t bufferLen = readerForJavaTLV.GetTotalLength() + EXTRA_SPACE_FOR_ATTRIBUTE_TAG;
     std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(new uint8_t[bufferLen]);
     writer.Init(buffer.get(), bufferLen);
     TLV::TLVType outer;

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -230,9 +230,9 @@ CHIP_ERROR ConvertReportTlvToJson(const uint32_t id, TLV::TLVReader & data, std:
 {
     TLV::TLVWriter writer;
     TLV::TLVReader readerForJavaTLV;
-    uint32_t size    = 0;
+    uint32_t size = 0;
     readerForJavaTLV.Init(data);
-    size_t bufferLen = readerForJavaTLV.GetTotalLength() + EXTRA_SPACE_FOR_ATTRIBUTE_TAG;
+    size_t bufferLen                  = readerForJavaTLV.GetTotalLength() + EXTRA_SPACE_FOR_ATTRIBUTE_TAG;
     std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(new uint8_t[bufferLen]);
     writer.Init(buffer.get(), bufferLen);
     TLV::TLVType outer;


### PR DESCRIPTION
Fix #28962 

In the ConvertReportTlvToJson function, buffer length calculation must be done after tlvReader init.
