### PR TITLE
Remove server-side command wrongly added to General Diagnostics 

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -4209,16 +4209,6 @@
           "define": "GENERAL_DIAGNOSTICS_CLUSTER",
           "side": "server",
           "enabled": 1,
-          "commands": [
-            {
-              "name": "TestEventTrigger",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "incoming": 1,
-              "outgoing": 0
-            }
-          ],
           "attributes": [
             {
               "name": "NetworkInterfaces",


### PR DESCRIPTION
#28890 only fixed tests, but did not actually fix our test app, which makes #28892 still fail.

Correcting that error.
