### PR TITLE
[XML Spec align]Fix requirements in the matter-device.xml for Ligthing device types

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -195,7 +195,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -218,10 +217,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="false" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -236,6 +231,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
@@ -254,6 +251,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -281,7 +280,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -307,10 +305,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -325,6 +319,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
@@ -343,6 +339,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -370,7 +368,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -393,10 +390,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -411,6 +404,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ON_OFF</requireAttribute>
@@ -429,6 +424,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -444,47 +441,14 @@ limitations under the License.
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
+                <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS</requireAttribute>
                 <requireAttribute>START_UP_COLOR_TEMPERATURE_MIREDS</requireAttribute>
-                <requireCommand>MoveToHue</requireCommand>
-                <requireCommand>MoveHue</requireCommand>
-                <requireCommand>StepHue</requireCommand>
-                <requireCommand>MoveToSaturation</requireCommand>
-                <requireCommand>MoveSaturation</requireCommand>
-                <requireCommand>StepSaturation</requireCommand>
-                <requireCommand>MoveToHueAndSaturation</requireCommand>
-                <requireCommand>MoveToColor</requireCommand>
-                <requireCommand>MoveColor</requireCommand>
-                <requireCommand>StepColor</requireCommand>
                 <requireCommand>MoveToColorTemperature</requireCommand>
-                <requireCommand>EnhancedMoveToHue</requireCommand>
-                <requireCommand>EnhancedMoveHue</requireCommand>
-                <requireCommand>EnhancedStepHue</requireCommand>
-                <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
-                <requireCommand>ColorLoopSet</requireCommand>
                 <requireCommand>StopMoveStep</requireCommand>
                 <requireCommand>MoveColorTemperature</requireCommand>
                 <requireCommand>StepColorTemperature</requireCommand>
@@ -505,7 +469,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -528,10 +491,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -564,6 +523,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -575,8 +536,6 @@ limitations under the License.
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
             <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
@@ -584,52 +543,16 @@ limitations under the License.
                 <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
-                <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS</requireAttribute>
                 <requireAttribute>START_UP_COLOR_TEMPERATURE_MIREDS</requireAttribute>
-                <requireCommand>MoveToHue</requireCommand>
-                <requireCommand>MoveHue</requireCommand>
-                <requireCommand>StepHue</requireCommand>
-                <requireCommand>MoveToSaturation</requireCommand>
-                <requireCommand>MoveSaturation</requireCommand>
-                <requireCommand>StepSaturation</requireCommand>
-                <requireCommand>MoveToHueAndSaturation</requireCommand>
                 <requireCommand>MoveToColor</requireCommand>
                 <requireCommand>MoveColor</requireCommand>
                 <requireCommand>StepColor</requireCommand>
                 <requireCommand>MoveToColorTemperature</requireCommand>
-                <requireCommand>EnhancedMoveToHue</requireCommand>
-                <requireCommand>EnhancedMoveHue</requireCommand>
-                <requireCommand>EnhancedStepHue</requireCommand>
-                <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
-                <requireCommand>ColorLoopSet</requireCommand>
                 <requireCommand>StopMoveStep</requireCommand>
                 <requireCommand>MoveColorTemperature</requireCommand>
                 <requireCommand>StepColorTemperature</requireCommand>
@@ -649,7 +572,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -672,10 +594,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -708,6 +626,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -733,7 +653,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -756,10 +675,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>
@@ -792,6 +707,8 @@ limitations under the License.
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+                <requireAttribute>MINIMUM_LEVEL</requireAttribute>
+                <requireAttribute>ON_LEVEL</requireAttribute>
                 <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>
                 <requireCommand>Move</requireCommand>
@@ -897,7 +814,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -959,7 +875,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -1022,7 +937,6 @@ limitations under the License.
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
                 <requireAttribute>IDENTIFY_TYPE</requireAttribute>
                 <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
                 <requireCommand>TriggerEffect</requireCommand>
             </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -1048,10 +962,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Scenes" client="false" server="false" clientLocked="false" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
                 <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddScene</requireCommand>
                 <requireCommand>AddSceneResponse</requireCommand>


### PR DESCRIPTION
fixes #28799 
The `matter-devices.xml` was listing too many requirements (mostly for the color control cluster) or missing a few.
I went over all the lighting device types and light switches and aligned them with the device type spec.
