### PR TITLE
[nrfconnect][ota] Change image checking condition for OTA.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -180,11 +180,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -139,11 +139,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -181,11 +181,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize Timers

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -203,6 +203,11 @@ CHIP_ERROR AppTask::Init()
     GetDFUOverSMP().ConfirmNewImage();
 #endif
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+    /* OTA image confirmation must be done before the factory data init. */
+    OtaConfirmNewImage();
+#endif
+
     // Initialize lighting device (PWM)
     uint8_t minLightLevel = kDefaultMinLevel;
     Clusters::LevelControl::Attributes::MinLevel::Get(kLightEndpointId, &minLightLevel);
@@ -216,15 +221,6 @@ CHIP_ERROR AppTask::Init()
         return chip::System::MapErrorZephyr(ret);
     }
     mPWMDevice.SetCallbacks(ActionInitiated, ActionCompleted);
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-    /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
-#endif
 
     // Initialize CHIP server
 #if CONFIG_CHIP_FACTORY_DATA

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -189,11 +189,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -54,7 +54,7 @@ void InitBasicOTARequestor();
  * boot after the OTA update.
  * Other CHIP_ERROR codes if the image could not be confirmed.
  */
-CHIP_ERROR OtaConfirmNewImage();
+void OtaConfirmNewImage();
 
 #endif // CONFIG_CHIP_OTA_REQUESTOR
 

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -162,11 +162,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -160,11 +160,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -167,11 +167,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
     /* OTA image confirmation must be done before the factory data init. */
-    err = OtaConfirmNewImage();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    OtaConfirmNewImage();
 #endif
 
     // Initialize CHIP server


### PR DESCRIPTION
If we want to confirm the new firmware update in the AppTask Init method we cannot rely on the imageProcessor. Instead, for the nRF53 target we should check if the image has been confirmed already, and if not, confirm it, for targets other than nRF53 we should use the  mcuboot_swap_type function to verify whether the swapping type is equal to REVERT before verifying the image.


