### PR TITLE
Fix incorrect loop condition in HasValidEventPathForEndpointAndCluster.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -452,7 +452,7 @@ static bool HasValidEventPathForEndpointAndCluster(EndpointId aEndpoint, const E
     if (aEventPath.HasWildcardEventId())
     {
 #if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        for (decltype(aCluster->eventCount) idx = 0; idx > aCluster->eventCount; ++idx)
+        for (decltype(aCluster->eventCount) idx = 0; idx < aCluster->eventCount; ++idx)
         {
             ConcreteEventPath path(aEndpoint, aCluster->clusterId, aCluster->eventList[idx]);
             // If we get here, the path exists.  We just have to do an ACL check for it.


### PR DESCRIPTION
The test was backwards, so when CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE was defined for the "wildcard event" case we always ended up treating the list of events for the cluster as empty.

Fixes https://github.com/project-chip/connectedhomeip/issues/28981
