### PR TITLE
Allow advertising multiple operational identities on the same fabric on Darwin.

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -268,14 +268,14 @@ CHIP_ERROR MdnsContexts::Has(GenericContext * context)
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-CHIP_ERROR MdnsContexts::GetRegisterContextOfType(const char * type, RegisterContext ** context)
+CHIP_ERROR MdnsContexts::GetRegisterContextOfTypeAndName(const char * type, const char * name, RegisterContext ** context)
 {
     bool found = false;
     std::vector<GenericContext *>::iterator iter;
 
     for (iter = mContexts.begin(); iter != mContexts.end(); iter++)
     {
-        if ((*iter)->type == ContextType::Register && (static_cast<RegisterContext *>(*iter))->matches(type))
+        if ((*iter)->type == ContextType::Register && (static_cast<RegisterContext *>(*iter))->matches(type, name))
         {
             *context = static_cast<RegisterContext *>(*iter);
             found    = true;

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
     RegisterContext * sdCtx = nullptr;
-    if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfType(type, &sdCtx))
+    if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {
         auto err = DNSServiceUpdateRecord(sdCtx->serviceRef, nullptr, kRegisterFlags, record.size(), record.data(), 0 /* ttl */);
         VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -82,12 +82,13 @@ public:
      *                      Example:
      *                        _matterc._udp,_V65521,_S15,_L3840,_CM
      *                        _matter._tcp,_I4CEEAD044CC35B63
+     * @param[in]  name     The instance name for the service.
      * @param[out] context  A reference to the context previously registered
      *
      * @return     On success, the context parameter will point to the previously
      *             registered context.
      */
-    CHIP_ERROR GetRegisterContextOfType(const char * type, RegisterContext ** context);
+    CHIP_ERROR GetRegisterContextOfTypeAndName(const char * type, const char * name, RegisterContext ** context);
 
     /**
      * Return a pointer to an existing ResolveContext for the given
@@ -146,7 +147,7 @@ struct RegisterContext : public GenericContext
     void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;
     void DispatchSuccess() override;
 
-    bool matches(const char * sType) { return mType.compare(sType) == 0; }
+    bool matches(const char * type, const char * name) { return mType == type && mInstanceName == name; }
 };
 
 struct BrowseHandler : public GenericContext


### PR DESCRIPTION
We need to check the instance name before coalescing registrations, not just the type, because all operational advertisements for a given fabric have the same type.

