### PR TITLE
Fix UnsatisfiedLinkError on QrCode read

### DIFF
--- a/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
+++ b/src/controller/java/src/chip/onboardingpayload/OnboardingPayloadParser.kt
@@ -17,9 +17,6 @@
 
 package chip.onboardingpayload
 
-import java.util.logging.Level
-import java.util.logging.Logger
-
 /** Parser for scanned QR code or Manual Pairing Code. */
 class OnboardingPayloadParser {
   /**
@@ -114,18 +111,5 @@ class OnboardingPayloadParser {
     }
 
     return payload
-  }
-
-  companion object {
-    private val LOGGER: Logger =
-      Logger.getLogger(OnboardingPayloadParser::class.java.getSimpleName())
-
-    init {
-      try {
-        System.loadLibrary("OnboardingPayload")
-      } catch (e: UnsatisfiedLinkError) {
-        LOGGER.log(Level.SEVERE, "Cannot load library.", e)
-      }
-    }
   }
 }


### PR DESCRIPTION
OnboardingPayload has converted to kotlin 100%, the native lib has been deleted, so we should not try to load the native lib

```
java.lang.UnsatisfiedLinkError: dlopen failed: library "libOnboardingPayload.so" not found
at java.lang.Runtime.loadLibrary0(Runtime.java:1077)
at java.lang.Runtime.loadLibrary0(Runtime.java:998)
at java.lang.System.loadLibrary(System.java:1661)
at chip.onboardingpayload.OnboardingPayloadParser.<clinit>(OnboardingPayloadParser.kt:125)
at com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment.handleScannedQrCode$lambda$9(BarcodeFragment.kt:206)
at com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment.lambda$NRVVa2Glsayk9lgWADmqvsfpNRo(Unknown Source:0)
at com.google.chip.chiptool.setuppayloadscanner.-$$Lambda$BarcodeFragment$NRVVa2Glsayk9lgWADmqvsfpNRo.run(Unknown Source:4)
```

Fix: https://github.com/project-chip/connectedhomeip/issues/28716
