### PR TITLE
Address some review comments on Darwin controller data store.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -138,8 +138,7 @@ static bool IsValidCATNumber(id _Nullable value)
                 return nil;
             }
         }
-        _nodesWithResumptionInfo = [NSMutableArray arrayWithCapacity:[resumptionNodeList count]];
-        [_nodesWithResumptionInfo addObjectsFromArray:resumptionNodeList];
+        _nodesWithResumptionInfo = [resumptionNodeList mutableCopy];
     } else {
         _nodesWithResumptionInfo = [[NSMutableArray alloc] init];
     }
@@ -184,7 +183,7 @@ static bool IsValidCATNumber(id _Nullable value)
         // Update our resumption info node list.
         [_nodesWithResumptionInfo addObject:resumptionInfo.nodeID];
         [_storageDelegate controller:_controller
-                          storeValue:[NSArray arrayWithArray:_nodesWithResumptionInfo]
+                          storeValue:[_nodesWithResumptionInfo copy]
                               forKey:sResumptionNodeListKey
                        securityLevel:MTRStorageSecurityLevelSecure
                          sharingType:MTRStorageSharingTypeNotShared];
@@ -349,6 +348,9 @@ static NSString * const sCATsKey = @"CATs";
 
 NSSet<Class> * MTRDeviceControllerStorageClasses()
 {
+    // This only needs to return the classes for toplevel things we are storing,
+    // plus NSNumber because some archivers use that internally to store
+    // information about what's being archived.
     static NSSet * const sStorageClasses = [NSSet setWithArray:@[
         [NSNumber class],
         [NSData class],


### PR DESCRIPTION
1) More efficient copying of arrays.
2) Make it clear what classes need to go in our storage class list.
