### PR TITLE
Change waitForReport to manual in TC-SMOKECO

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -101,14 +101,20 @@ tests:
     - label:
           "Step 6: TH waits for a report of SmokeState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -181,14 +187,20 @@ tests:
     - label:
           "Step 15: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 16: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -226,14 +238,20 @@ tests:
     - label:
           "Step 19: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -100,14 +100,20 @@ tests:
     - label:
           "Step 6: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -180,14 +186,20 @@ tests:
     - label:
           "Step 15: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 16: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -225,14 +237,20 @@ tests:
     - label:
           "Step 19: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -113,14 +113,20 @@ tests:
     - label:
           "Step 6: TH waits for a report of BatteryAlert attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0003
-      command: "waitForReport"
-      attribute: "BatteryAlert"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0003
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read battery-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0003 DataVersion: 1795725838
+          [TOO]   BatteryAlert: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 7: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -158,14 +164,20 @@ tests:
     - label:
           "Step 10: TH waits for a report of BatteryAlert attribute from DUT
           with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0003
-      command: "waitForReport"
-      attribute: "BatteryAlert"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0003
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read battery-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0003 DataVersion: 1795725838
+          [TOO]   BatteryAlert: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 11: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -203,14 +215,20 @@ tests:
     - label:
           "Step 14: TH waits for a report of BatteryAlert attribute from DUT
           with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0003
-      command: "waitForReport"
-      attribute: "BatteryAlert"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0003
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read battery-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0003 DataVersion: 1795725838
+          [TOO]   BatteryAlert: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 15: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -259,14 +277,20 @@ tests:
     - label:
           "Step 19: TH waits for a report of HardwareFaultAlert attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0006
-      command: "waitForReport"
-      attribute: "HardwareFaultAlert"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: boolean
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0006
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read hardware-fault-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0006 DataVersion: 1795725838
+          [TOO]   HardwareFaultAlert: TRUE
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 20: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -305,14 +329,20 @@ tests:
     - label:
           "Step 23: TH waits for a report of HardwareFaultAlert attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0006
-      command: "waitForReport"
-      attribute: "HardwareFaultAlert"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: boolean
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0006
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read hardware-fault-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0006 DataVersion: 1795725838
+          [TOO]   HardwareFaultAlert: FALSE
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 24: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -361,14 +391,20 @@ tests:
     - label:
           "Step 28: TH waits for a report of EndOfServiceAlert attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0007
-      command: "waitForReport"
-      attribute: "EndOfServiceAlert"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0007
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read end-of-service-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0007 DataVersion: 1795725838
+          [TOO]   EndOfServiceAlert: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 29: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -407,14 +443,20 @@ tests:
     - label:
           "Step 32: TH waits for a report of EndOfServiceAlert attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0007
-      command: "waitForReport"
-      attribute: "EndOfServiceAlert"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0007
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read end-of-service-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0007 DataVersion: 1795725838
+          [TOO]   EndOfServiceAlert: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 33: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -531,14 +573,22 @@ tests:
     - label:
           "Step 45: TH waits for a report of TestInProgress attribute from DUT
           with a timeout of 180 seconds"
-      PICS: SMOKECO.S.A0005
-      command: "waitForReport"
-      attribute: "TestInProgress"
-      timeout: 180
-      response:
-          value: 1
-          constraints:
-              type: boolean
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0005
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read test-in-progress 1 1
+
+          This step needs to be completed quickly
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0005 DataVersion: 1795725838
+          [TOO]   TestInProgress: TRUE
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 46: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -549,8 +599,15 @@ tests:
           constraints:
               type: enum8
 
+    - label: "Step 47a: TH subscribes to TestInProgress attribute from DUT"
+      PICS: SMOKECO.S.A0005
+      command: "subscribeAttribute"
+      attribute: "TestInProgress"
+      minInterval: 1
+      maxInterval: 900
+
     - label:
-          "Step 47: TH waits for a report of TestInProgress attribute from DUT
+          "Step 47b: TH waits for a report of TestInProgress attribute from DUT
           with a timeout of 180 seconds"
       PICS: SMOKECO.S.A0005
       command: "waitForReport"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -148,16 +148,20 @@ tests:
     - label:
           "Step 6: TH waits for a report of InterconnectSmokeAlarm attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0008
-      command: "waitForReport"
-      attribute: "InterconnectSmokeAlarm"
-      timeout: 300
-      response:
-          saveAs: interconnectSmokeAlarmSeverityLevel
-          constraints:
-              type: enum8
-              minValue: 1
-              maxValue: 2
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0008
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-smoke-alarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0008 DataVersion: 1795725838
+          [TOO]   InterconnectSmokeAlarm: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 7: TH reads InterconnectSmokeAlarm event from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.E08
@@ -165,7 +169,7 @@ tests:
       event: "InterconnectSmokeAlarm"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value: { AlarmSeverityLevel: interconnectSmokeAlarmSeverityLevel }
+          value: { AlarmSeverityLevel: 1 }
 
     - label: "Step 8: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.A0000
@@ -196,14 +200,20 @@ tests:
     - label:
           "Step 10: TH waits for a report of InterconnectSmokeAlarm attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0008
-      command: "waitForReport"
-      attribute: "InterconnectSmokeAlarm"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0008
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-smoke-alarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0008 DataVersion: 1795725838
+          [TOO]   InterconnectSmokeAlarm: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 11: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0008 && SMOKECO.S.A0000
@@ -261,16 +271,20 @@ tests:
     - label:
           "Step 16: TH waits for a report of InterconnectCOAlarm attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0009
-      command: "waitForReport"
-      attribute: "InterconnectCOAlarm"
-      timeout: 300
-      response:
-          saveAs: interconnectCOAlarmSeverityLevel
-          constraints:
-              type: enum8
-              minValue: 1
-              maxValue: 2
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0009
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-coalarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0009 DataVersion: 1795725838
+          [TOO]   InterconnectCOAlarm: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 17: TH reads InterconnectCOAlarm event from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.E09
@@ -278,7 +292,7 @@ tests:
       event: "InterconnectCOAlarm"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value: { AlarmSeverityLevel: interconnectCOAlarmSeverityLevel }
+          value: { AlarmSeverityLevel: 1 }
 
     - label: "Step 18: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.A0000
@@ -309,14 +323,20 @@ tests:
     - label:
           "Step 20: TH waits for a report of InterconnectCOAlarm attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0009
-      command: "waitForReport"
-      attribute: "InterconnectCOAlarm"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0009
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-coalarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0009 DataVersion: 1795725838
+          [TOO]   InterconnectCOAlarm: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 21: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0009 && SMOKECO.S.A0000
@@ -366,15 +386,22 @@ tests:
     - label:
           "Step 25: TH waits for a report of ContaminationState attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000a
-      command: "waitForReport"
-      attribute: "ContaminationState"
-      timeout: 300
-      response:
-          constraints:
-              type: enum8
-              minValue: 2
-              maxValue: 3
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000a
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read contamination-state 1 1
+
+          Verify that the value of ContaminationState is 2 or 3
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000A DataVersion: 1795725838
+          [TOO]   ContaminationState: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 26: TH sends TestEventTrigger command to General Diagnostics
@@ -396,14 +423,20 @@ tests:
     - label:
           "Step 27: TH waits for a report of ContaminationState attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000a
-      command: "waitForReport"
-      attribute: "ContaminationState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000a
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read contamination-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000A DataVersion: 1795725838
+          [TOO]   ContaminationState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 28: TH sends TestEventTrigger command to General Diagnostics
@@ -425,14 +458,20 @@ tests:
     - label:
           "Step 29: TH waits for a report of ContaminationState attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000a
-      command: "waitForReport"
-      attribute: "ContaminationState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000a
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read contamination-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000A DataVersion: 1795725838
+          [TOO]   ContaminationState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 30: TH sends TestEventTrigger command to General Diagnostics
@@ -454,14 +493,20 @@ tests:
     - label:
           "Step 31: TH waits for a report of ContaminationState attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000a
-      command: "waitForReport"
-      attribute: "ContaminationState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000a
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read contamination-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000A DataVersion: 1795725838
+          [TOO]   ContaminationState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 32: TH subscribes to SmokeSensitivityLevel attribute from DUT"
@@ -495,14 +540,20 @@ tests:
     - label:
           "Step 34: TH waits for a report of SmokeSensitivityLevel attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000b
-      command: "waitForReport"
-      attribute: "SmokeSensitivityLevel"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000b
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-sensitivity-level 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000B DataVersion: 1795725838
+          [TOO]   SmokeSensitivityLevel: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 35: TH sends TestEventTrigger command to General Diagnostics
@@ -524,14 +575,20 @@ tests:
     - label:
           "Step 36: TH waits for a report of SmokeSensitivityLevel attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000b
-      command: "waitForReport"
-      attribute: "SmokeSensitivityLevel"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000b
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-sensitivity-level 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000B DataVersion: 1795725838
+          [TOO]   SmokeSensitivityLevel: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 37: TH sends TestEventTrigger command to General Diagnostics
@@ -553,14 +610,20 @@ tests:
     - label:
           "Step 38: TH waits for a report of SmokeSensitivityLevel attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000b
-      command: "waitForReport"
-      attribute: "SmokeSensitivityLevel"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000b
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-sensitivity-level 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000B DataVersion: 1795725838
+          [TOO]   SmokeSensitivityLevel: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 39: TH sends TestEventTrigger command to General Diagnostics
@@ -582,14 +645,20 @@ tests:
     - label:
           "Step 40: TH waits for a report of SmokeSensitivityLevel attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A000b
-      command: "waitForReport"
-      attribute: "SmokeSensitivityLevel"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A000b
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-sensitivity-level 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_000B DataVersion: 1795725838
+          [TOO]   SmokeSensitivityLevel: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 41: TH subscribes to DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004
@@ -641,14 +710,20 @@ tests:
     - label:
           "Step 45: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 46a: TH subscribes to DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
@@ -676,14 +751,20 @@ tests:
     - label:
           "Step 47: TH waits for a report of DeviceMuted attribute from DUT with
           a timeout of 120 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
-      command: "waitForReport"
-      attribute: "DeviceMuted"
-      timeout: 120
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read device-muted 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0004 DataVersion: 1795725838
+          [TOO]   DeviceMuted: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 48: TH reads AlarmMuted event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E06
@@ -713,14 +794,20 @@ tests:
     - label:
           "Step 50: TH waits for a report of DeviceMuted attribute from DUT with
           a timeout of 120 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00
-      command: "waitForReport"
-      attribute: "DeviceMuted"
-      timeout: 120
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read device-muted 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0004 DataVersion: 1795725838
+          [TOO]   DeviceMuted: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 51: TH reads MuteEnded event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.E07
@@ -756,14 +843,20 @@ tests:
     - label:
           "Step 53: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 54: TH sends TestEventTrigger command to General Diagnostics
@@ -825,14 +918,20 @@ tests:
     - label:
           "Step 57: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 58: TH reads FeatureMap attribute(CO Alarm) from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
@@ -873,14 +972,20 @@ tests:
     - label:
           "Step 61: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 62a: TH subscribes to DeviceMuted attribute from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
@@ -908,14 +1013,20 @@ tests:
     - label:
           "Step 63: TH waits for a report of DeviceMuted attribute from DUT with
           a timeout of 120 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
-      command: "waitForReport"
-      attribute: "DeviceMuted"
-      timeout: 120
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read device-muted 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0004 DataVersion: 1795725838
+          [TOO]   DeviceMuted: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 64: TH reads AlarmMuted event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E06
@@ -945,14 +1056,20 @@ tests:
     - label:
           "Step 66: TH waits for a report of DeviceMuted attribute from DUT with
           a timeout of 120 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01
-      command: "waitForReport"
-      attribute: "DeviceMuted"
-      timeout: 120
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read device-muted 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0004 DataVersion: 1795725838
+          [TOO]   DeviceMuted: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 67: TH reads MuteEnded event from DUT"
       PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.E07
@@ -988,14 +1105,20 @@ tests:
     - label:
           "Step 69: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 2
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 2
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 70: TH sends TestEventTrigger command to General Diagnostics
@@ -1057,11 +1180,17 @@ tests:
     - label:
           "Step 73: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_5.yaml
@@ -710,7 +710,9 @@ tests:
     - label:
           "Step 45: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 &&
+          SMOKECO.S.A0001
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |
@@ -843,7 +845,9 @@ tests:
     - label:
           "Step 53: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 &&
+          SMOKECO.S.A0001
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |
@@ -918,7 +922,9 @@ tests:
     - label:
           "Step 57: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 && SMOKECO.S.A0001
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F00 &&
+          SMOKECO.S.A0001
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |
@@ -972,7 +978,9 @@ tests:
     - label:
           "Step 61: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 &&
+          SMOKECO.S.A0002
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |
@@ -1105,7 +1113,9 @@ tests:
     - label:
           "Step 69: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 &&
+          SMOKECO.S.A0002
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |
@@ -1180,7 +1190,9 @@ tests:
     - label:
           "Step 73: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 && SMOKECO.S.A0002
+      PICS:
+          PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0004 && SMOKECO.S.F01 &&
+          SMOKECO.S.A0002
       cluster: "LogCommands"
       command: "UserPrompt"
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_6.yaml
@@ -184,14 +184,20 @@ tests:
     - label:
           "Step 10: TH waits for a report of BatteryAlert attribute from DUT
           with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0003
-      command: "waitForReport"
-      attribute: "BatteryAlert"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0003
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read battery-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0003 DataVersion: 1795725838
+          [TOO]   BatteryAlert: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label:
           "Step 11a: TH subscribes to InterconnectSmokeAlarm attribute from DUT"
@@ -221,15 +227,20 @@ tests:
     - label:
           "Step 12: TH waits for a report of InterconnectSmokeAlarm attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0008
-      command: "waitForReport"
-      attribute: "InterconnectSmokeAlarm"
-      timeout: 300
-      response:
-          constraints:
-              type: enum8
-              minValue: 1
-              maxValue: 2
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0008
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-smoke-alarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0008 DataVersion: 1795725838
+          [TOO]   InterconnectSmokeAlarm: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 13a: TH subscribes to InterconnectCOAlarm attribute from DUT"
       PICS: SMOKECO.S.A0009
@@ -257,15 +268,20 @@ tests:
     - label:
           "Step 14: TH waits for a report of InterconnectCOAlarm attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0009
-      command: "waitForReport"
-      attribute: "InterconnectCOAlarm"
-      timeout: 300
-      response:
-          constraints:
-              type: enum8
-              minValue: 1
-              maxValue: 2
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0009
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-coalarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0009 DataVersion: 1795725838
+          [TOO]   InterconnectCOAlarm: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 15a: TH subscribes to COState attribute from DUT"
       PICS: SMOKECO.S.A0002
@@ -293,14 +309,20 @@ tests:
     - label:
           "Step 16: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 17a: TH subscribes to SmokeState attribute from DUT"
       PICS: SMOKECO.S.A0001
@@ -328,14 +350,20 @@ tests:
     - label:
           "Step 18: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 1
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 1
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 19: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -365,14 +393,20 @@ tests:
     - label:
           "Step 21: TH waits for a report of SmokeState attribute from DUT with
           a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0001
-      command: "waitForReport"
-      attribute: "SmokeState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0001
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read smoke-state 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0001 DataVersion: 1795725838
+          [TOO]   SmokeState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 22: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -409,14 +443,20 @@ tests:
     - label:
           "Step 24: TH waits for a report of COState attribute from DUT with a
           timeout of 300 seconds"
-      PICS: SMOKECO.S.A0002
-      command: "waitForReport"
-      attribute: "COState"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0002
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read costate 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0002 DataVersion: 1795725838
+          [TOO]   COState: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 25: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -454,14 +494,20 @@ tests:
     - label:
           "Step 27: TH waits for a report of InterconnectCOAlarm attribute from
           DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0009
-      command: "waitForReport"
-      attribute: "InterconnectCOAlarm"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0009
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-coalarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0009 DataVersion: 1795725838
+          [TOO]   InterconnectCOAlarm: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 28: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -500,14 +546,20 @@ tests:
     - label:
           "Step 30: TH waits for a report of InterconnectSmokeAlarm attribute
           from DUT with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0008
-      command: "waitForReport"
-      attribute: "InterconnectSmokeAlarm"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0008
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read interconnect-smoke-alarm 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0008 DataVersion: 1795725838
+          [TOO]   InterconnectSmokeAlarm: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 31: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000
@@ -544,14 +596,20 @@ tests:
     - label:
           "Step 33: TH waits for a report of BatteryAlert attribute from DUT
           with a timeout of 300 seconds"
-      PICS: SMOKECO.S.A0003
-      command: "waitForReport"
-      attribute: "BatteryAlert"
-      timeout: 300
-      response:
-          value: 0
-          constraints:
-              type: enum8
+      PICS: PICS_SKIP_SAMPLE_APP && SMOKECO.S.A0003
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      verification: |
+          ./chip-tool.py smokecoalarm read battery-alert 1 1
+
+          [TOO] Endpoint: 1 Cluster: 0x0000_005C Attribute 0x0000_0003 DataVersion: 1795725838
+          [TOO]   BatteryAlert: 0
+      arguments:
+          values:
+              - name: "message"
+                value: "Enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Step 34: TH reads ExpressedState attribute from DUT"
       PICS: SMOKECO.S.A0000


### PR DESCRIPTION
- **Situation**
In TH tests, TC-SMOKECO may fail at the waitForReport step.

- **The problem** 
Because TH tests are slow, events are received before the waitForReport step.

-  **This PR change is targeted to** 
This is a PR backup that changes most of the waitForReport to a manual operation.