### PR TITLE
Allow specifying per-controller OTA delegates in Darwin.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -123,6 +123,8 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                           queue:(dispatch_queue_t)queue
                 storageDelegate:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
            storageDelegateQueue:(dispatch_queue_t _Nullable)storageDelegateQueue
+            otaProviderDelegate:(id<MTROTAProviderDelegate> _Nullable)otaProviderDelegate
+       otaProviderDelegateQueue:(dispatch_queue_t _Nullable)otaProviderDelegateQueue
                uniqueIdentifier:(NSUUID *)uniqueIdentifier
 {
     if (self = [super init]) {
@@ -142,6 +144,58 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 return nil;
             }
         }
+
+        // Ensure the otaProviderDelegate, if any, is valid.
+        if (otaProviderDelegate == nil && otaProviderDelegateQueue != nil) {
+            MTR_LOG_ERROR("Must have otaProviderDelegate when we have otaProviderDelegateQueue");
+            return nil;
+        }
+
+        if (otaProviderDelegate != nil && otaProviderDelegateQueue == nil) {
+            MTR_LOG_ERROR("Must have otaProviderDelegateQueue when we have otaProviderDelegate");
+            return nil;
+        }
+
+        if (otaProviderDelegate != nil) {
+            if (![otaProviderDelegate respondsToSelector:@selector(handleQueryImageForNodeID:controller:params:completion:)]
+                && ![otaProviderDelegate respondsToSelector:@selector(handleQueryImageForNodeID:
+                                                                                     controller:params:completionHandler:)]) {
+                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleQueryImageForNodeID");
+                return nil;
+            }
+            if (![otaProviderDelegate respondsToSelector:@selector(handleApplyUpdateRequestForNodeID:controller:params:completion:)]
+                && ![otaProviderDelegate
+                    respondsToSelector:@selector(handleApplyUpdateRequestForNodeID:controller:params:completionHandler:)]) {
+                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleApplyUpdateRequestForNodeID");
+                return nil;
+            }
+            if (![otaProviderDelegate respondsToSelector:@selector(handleNotifyUpdateAppliedForNodeID:
+                                                                                           controller:params:completion:)]
+                && ![otaProviderDelegate
+                    respondsToSelector:@selector(handleNotifyUpdateAppliedForNodeID:controller:params:completionHandler:)]) {
+                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleNotifyUpdateAppliedForNodeID");
+                return nil;
+            }
+            if (![otaProviderDelegate respondsToSelector:@selector
+                                      (handleBDXTransferSessionBeginForNodeID:controller:fileDesignator:offset:completion:)]
+                && ![otaProviderDelegate respondsToSelector:@selector
+                                         (handleBDXTransferSessionBeginForNodeID:
+                                                                      controller:fileDesignator:offset:completionHandler:)]) {
+                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleBDXTransferSessionBeginForNodeID");
+                return nil;
+            }
+            if (![otaProviderDelegate
+                    respondsToSelector:@selector(handleBDXQueryForNodeID:controller:blockSize:blockIndex:bytesToSkip:completion:)]
+                && ![otaProviderDelegate
+                    respondsToSelector:@selector(handleBDXQueryForNodeID:
+                                                              controller:blockSize:blockIndex:bytesToSkip:completionHandler:)]) {
+                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleBDXQueryForNodeID");
+                return nil;
+            }
+        }
+
+        _otaProviderDelegate = otaProviderDelegate;
+        _otaProviderDelegateQueue = otaProviderDelegateQueue;
 
         _chipWorkQueue = queue;
         _factory = factory;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -61,7 +61,6 @@ static NSString * const kErrorCertificateValidityPolicyInit = @"Init certificate
 static NSString * const kErrorControllerFactoryInit = @"Init failure while initializing controller factory";
 static NSString * const kErrorKeystoreInit = @"Init failure while initializing persistent storage keystore";
 static NSString * const kErrorCertStoreInit = @"Init failure while initializing persistent storage operational certificate store";
-static NSString * const kErrorOtaProviderInit = @"Init failure while creating an OTA provider delegate";
 static NSString * const kErrorSessionKeystoreInit = @"Init failure while initializing session keystore";
 
 static bool sExitHandlerRegistered = false;
@@ -122,6 +121,9 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 //    must lock.
 // D. Locking around reads not from the Matter queue is OK but not required.
 @property (nonatomic, readonly) os_unfair_lock controllersLock;
+
+@property (nonatomic, readonly, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
+@property (nonatomic, readonly, nullable) dispatch_queue_t otaProviderDelegateQueue;
 
 - (BOOL)findMatchingFabric:(FabricTable &)fabricTable
                     params:(MTRDeviceControllerStartupParams *)params
@@ -289,9 +291,15 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 
 - (void)cleanupStartupObjects
 {
-    if (_otaProviderDelegateBridge) {
-        delete _otaProviderDelegateBridge;
-        _otaProviderDelegateBridge = nullptr;
+    // Make sure the deinit order here is the reverse of the init order in
+    // startControllerFactory:
+    _certificationDeclarationCertificates = nil;
+    _productAttestationAuthorityCertificates = nil;
+
+    if (_opCertStore) {
+        _opCertStore->Finish();
+        delete _opCertStore;
+        _opCertStore = nullptr;
     }
 
     if (_keystore) {
@@ -300,11 +308,12 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         _keystore = nullptr;
     }
 
-    if (_opCertStore) {
-        _opCertStore->Finish();
-        delete _opCertStore;
-        _opCertStore = nullptr;
+    if (_otaProviderDelegateBridge) {
+        delete _otaProviderDelegateBridge;
+        _otaProviderDelegateBridge = nullptr;
     }
+    _otaProviderDelegateQueue = nil;
+    _otaProviderDelegate = nil;
 
     if (_sessionResumptionStorage) {
         delete _sessionResumptionStorage;
@@ -412,57 +421,12 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
             return;
         }
 
-        if (startupParams.otaProviderDelegate) {
-            if (![startupParams.otaProviderDelegate respondsToSelector:@selector(handleQueryImageForNodeID:
-                                                                                                controller:params:completion:)]
-                && ![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleQueryImageForNodeID:controller:params:completionHandler:)]) {
-                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleQueryImageForNodeID");
-                errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-                return;
-            }
-            if (![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleApplyUpdateRequestForNodeID:controller:params:completion:)]
-                && ![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleApplyUpdateRequestForNodeID:controller:params:completionHandler:)]) {
-                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleApplyUpdateRequestForNodeID");
-                errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-                return;
-            }
-            if (![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleNotifyUpdateAppliedForNodeID:controller:params:completion:)]
-                && ![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleNotifyUpdateAppliedForNodeID:controller:params:completionHandler:)]) {
-                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleNotifyUpdateAppliedForNodeID");
-                errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-                return;
-            }
-            if (![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleBDXTransferSessionBeginForNodeID:
-                                                                             controller:fileDesignator:offset:completion:)]
-                && ![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector
-                    (handleBDXTransferSessionBeginForNodeID:controller:fileDesignator:offset:completionHandler:)]) {
-                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleBDXTransferSessionBeginForNodeID");
-                errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-                return;
-            }
-            if (![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleBDXQueryForNodeID:controller:blockSize:blockIndex:bytesToSkip:completion:)]
-                && ![startupParams.otaProviderDelegate
-                    respondsToSelector:@selector(handleBDXQueryForNodeID:
-                                                              controller:blockSize:blockIndex:bytesToSkip:completionHandler:)]) {
-                MTR_LOG_ERROR("Error: MTROTAProviderDelegate does not support handleBDXQueryForNodeID");
-                errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-                return;
-            }
-            _otaProviderDelegateBridge = new MTROTAProviderDelegateBridge(startupParams.otaProviderDelegate);
-            if (_otaProviderDelegateBridge == nil) {
-                MTR_LOG_ERROR("Error: %@", kErrorOtaProviderInit);
-                errorCode = CHIP_ERROR_NO_MEMORY;
-                return;
-            }
+        _otaProviderDelegate = startupParams.otaProviderDelegate;
+        if (_otaProviderDelegate != nil) {
+            _otaProviderDelegateQueue = dispatch_queue_create(
+                "org.csa-iot.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         }
+        _otaProviderDelegateBridge = new MTROTAProviderDelegateBridge();
 
         // TODO: Allow passing a different keystore implementation via startupParams.
         _keystore = new PersistentStorageOperationalKeystore();
@@ -594,19 +558,25 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         return nil;
     }
 
-    id<MTRDeviceControllerStorageDelegate> storageDelegate;
-    dispatch_queue_t storageDelegateQueue;
+    id<MTRDeviceControllerStorageDelegate> _Nullable storageDelegate;
+    dispatch_queue_t _Nullable storageDelegateQueue;
     NSUUID * uniqueIdentifier;
+    id<MTROTAProviderDelegate> _Nullable otaProviderDelegate;
+    dispatch_queue_t _Nullable otaProviderDelegateQueue;
     if ([startupParams isKindOfClass:[MTRDeviceControllerStartupParameters class]]) {
         MTRDeviceControllerStartupParameters * params = startupParams;
         storageDelegate = params.storageDelegate;
         storageDelegateQueue = params.storageDelegateQueue;
         uniqueIdentifier = params.uniqueIdentifier;
+        otaProviderDelegate = params.otaProviderDelegate;
+        otaProviderDelegateQueue = params.otaProviderDelegateQueue;
     } else if ([startupParams isKindOfClass:[MTRDeviceControllerStartupParams class]]) {
         MTRDeviceControllerStartupParams * params = startupParams;
         storageDelegate = nil;
         storageDelegateQueue = nil;
         uniqueIdentifier = params.uniqueIdentifier;
+        otaProviderDelegate = nil;
+        otaProviderDelegateQueue = nil;
     } else {
         MTR_LOG_ERROR("Unknown kind of startup params: %@", startupParams);
         return nil;
@@ -628,10 +598,19 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         return nil;
     }
 
+    // Fall back to the factory-wide OTA provider delegate if one is not
+    // provided in the startup params.
+    if (otaProviderDelegate == nil) {
+        otaProviderDelegate = self.otaProviderDelegate;
+        otaProviderDelegateQueue = self.otaProviderDelegateQueue;
+    }
+
     // Create the controller, so we start the event loop, since we plan to do
     // our fabric table operations there.
     auto * controller = [self _createController:storageDelegate
                            storageDelegateQueue:storageDelegateQueue
+                            otaProviderDelegate:otaProviderDelegate
+                       otaProviderDelegateQueue:otaProviderDelegateQueue
                                uniqueIdentifier:uniqueIdentifier];
     if (controller == nil) {
         if (error != nil) {
@@ -873,6 +852,8 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 
 - (MTRDeviceController * _Nullable)_createController:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
                                 storageDelegateQueue:(dispatch_queue_t _Nullable)storageDelegateQueue
+                                 otaProviderDelegate:(id<MTROTAProviderDelegate> _Nullable)otaProviderDelegate
+                            otaProviderDelegateQueue:(dispatch_queue_t _Nullable)otaProviderDelegateQueue
                                     uniqueIdentifier:(NSUUID *)uniqueIdentifier
 {
     [self _assertCurrentQueueIsNotMatterQueue];
@@ -881,6 +862,8 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
                                                                               queue:_chipWorkQueue
                                                                     storageDelegate:storageDelegate
                                                                storageDelegateQueue:storageDelegateQueue
+                                                                otaProviderDelegate:otaProviderDelegate
+                                                           otaProviderDelegateQueue:otaProviderDelegateQueue
                                                                    uniqueIdentifier:uniqueIdentifier];
     if (controller == nil) {
         MTR_LOG_ERROR("Failed to init controller");

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParameters.h
@@ -18,6 +18,7 @@
 
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceControllerStorageDelegate.h>
+#import <Matter/MTROTAProviderDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -52,6 +53,12 @@ MTR_NEWLY_AVAILABLE
  */
 - (void)setOperationalCertificateIssuer:(id<MTROperationalCertificateIssuer>)operationalCertificateIssuer
                                   queue:(dispatch_queue_t)queue;
+
+/**
+ * Set an MTROTAProviderDelegate to call (on the provided queue).  Only needs to
+ * be called if this controller should be able to handle OTA for devices.
+ */
+- (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)otaProviderDelegate queue:(dispatch_queue_t)queue;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -287,6 +287,13 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     _operationalCertificateIssuer = operationalCertificateIssuer;
     _operationalCertificateIssuerQueue = queue;
 }
+
+- (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)otaProviderDelegate queue:(dispatch_queue_t)queue
+{
+    _otaProviderDelegate = otaProviderDelegate;
+    _otaProviderDelegateQueue = queue;
+}
+
 @end
 
 @implementation MTRDeviceControllerExternalCertificateStartupParameters

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -77,6 +77,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) dispatch_queue_t storageDelegateQueue;
 @property (nonatomic, strong, readonly) NSUUID * uniqueIdentifier;
 
+@property (nonatomic, strong, readonly, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
+@property (nonatomic, strong, readonly, nullable) dispatch_queue_t otaProviderDelegateQueue;
+
 @end
 
 MTR_HIDDEN

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -30,9 +30,10 @@
 #import "MTRBaseDevice.h"
 #import "MTRDeviceController.h"
 #import "MTRDeviceControllerDataStore.h"
-#import "MTRDeviceControllerStorageDelegate.h"
 
 #import <Matter/MTRDeviceControllerStartupParams.h>
+#import <Matter/MTRDeviceControllerStorageDelegate.h>
+#import <Matter/MTROTAProviderDelegate.h>
 
 @class MTRDeviceControllerStartupParamsInternal;
 @class MTRDeviceControllerFactory;
@@ -75,12 +76,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This property MUST be gotten from the Matter work queue.
  */
-@property (readonly, nullable) NSNumber * compressedFabricID;
+@property (nonatomic, readonly, nullable) NSNumber * compressedFabricID;
 
 /**
  * The per-controller data store this controller was initialized with, if any.
  */
-@property (nonatomic, nullable) MTRDeviceControllerDataStore * controllerDataStore;
+@property (nonatomic, readonly, nullable) MTRDeviceControllerDataStore * controllerDataStore;
+
+/**
+ * OTA delegate and its queue, if this controller supports OTA.  Either both
+ * will be non-nil or both will be nil.
+ */
+@property (nonatomic, readonly, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
+@property (nonatomic, readonly, nullable) dispatch_queue_t otaProviderDelegateQueue;
 
 /**
  * Init a newly created controller.
@@ -91,6 +99,8 @@ NS_ASSUME_NONNULL_BEGIN
                           queue:(dispatch_queue_t)queue
                 storageDelegate:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
            storageDelegateQueue:(dispatch_queue_t _Nullable)storageDelegateQueue
+            otaProviderDelegate:(id<MTROTAProviderDelegate> _Nullable)otaProviderDelegate
+       otaProviderDelegateQueue:(dispatch_queue_t _Nullable)otaProviderDelegateQueue
                uniqueIdentifier:(NSUUID *)uniqueIdentifier;
 
 /**

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 class MTROTAProviderDelegateBridge : public chip::app::Clusters::OTAProviderDelegate
 {
 public:
-    MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate);
+    MTROTAProviderDelegateBridge();
     ~MTROTAProviderDelegateBridge();
 
     CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager);
@@ -65,9 +65,6 @@ private:
     static void ConvertToNotifyUpdateAppliedParams(
         const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::DecodableType & commandData,
         MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams);
-
-    _Nullable id<MTROTAProviderDelegate> mDelegate;
-    dispatch_queue_t mDelegateNotificationQueue;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -69,7 +69,6 @@ public:
     {
         assertChipStackLockedByCurrentThread();
 
-        VerifyOrReturnError(mDelegate != nil, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -121,18 +120,6 @@ public:
         }
     }
 
-    void SetDelegate(id<MTROTAProviderDelegate> delegate, dispatch_queue_t delegateNotificationQueue)
-    {
-        if (delegate) {
-            mDelegate = delegate;
-            mDelegateNotificationQueue = delegateNotificationQueue;
-        } else {
-            ResetState();
-            mDelegate = nil;
-            mDelegateNotificationQueue = nil;
-        }
-    }
-
     void ResetState()
     {
         assertChipStackLockedByCurrentThread();
@@ -160,6 +147,9 @@ public:
             mExchangeCtx->Close();
             mExchangeCtx = nullptr;
         }
+
+        mDelegate = nil;
+        mDelegateNotificationQueue = nil;
 
         mInitialized = false;
     }
@@ -463,6 +453,16 @@ private:
             ResetState();
         }
 
+        auto * controller = [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:fabricIndex];
+        VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
+
+        mDelegate = controller.otaProviderDelegate;
+        mDelegateNotificationQueue = controller.otaProviderDelegateQueue;
+
+        // We should have already checked that this controller supports OTA.
+        VerifyOrReturnError(mDelegate != nil, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mDelegateNotificationQueue != nil, CHIP_ERROR_INCORRECT_STATE);
+
         // Start a timer to track whether we receive a BDX init after a successful query image in a reasonable amount of time
         CHIP_ERROR err = mSystemLayer->StartTimer(kBdxInitReceivedTimeout, HandleBdxInitReceivedTimeoutExpired, this);
         LogErrorOnFailure(err);
@@ -497,18 +497,11 @@ BdxOTASender gOtaSender;
 NSInteger const kOtaProviderEndpoint = 0;
 } // anonymous namespace
 
-MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate)
-    : mDelegate(delegate)
-    , mDelegateNotificationQueue(
-          dispatch_queue_create("org.csa-iot.matter.framework.otaprovider.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
-{
-    gOtaSender.SetDelegate(delegate, mDelegateNotificationQueue);
-    Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this);
-}
+MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge() { Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this); }
 
 MTROTAProviderDelegateBridge::~MTROTAProviderDelegateBridge()
 {
-    gOtaSender.SetDelegate(nil, nil);
+    gOtaSender.ResetState();
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, nullptr);
 }
 
@@ -544,6 +537,12 @@ bool GetPeerNodeInfo(CommandHandler * commandHandler, const ConcreteCommandPath 
         [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:commandHandler->GetAccessingFabricIndex()];
     if (controller == nil) {
         commandHandler->AddStatus(commandPath, Status::Failure);
+        return false;
+    }
+
+    if (!controller.otaProviderDelegate) {
+        // This controller does not support OTA.
+        commandHandler->AddStatus(commandPath, Status::UnsupportedCommand);
         return false;
     }
 
@@ -722,8 +721,8 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                           }];
     };
 
-    auto strongDelegate = mDelegate;
-    dispatch_async(mDelegateNotificationQueue, ^{
+    auto strongDelegate = controller.otaProviderDelegate;
+    dispatch_async(controller.otaProviderDelegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(handleQueryImageForNodeID:controller:params:completion:)]) {
             [strongDelegate handleQueryImageForNodeID:@(nodeId)
                                            controller:controller
@@ -782,8 +781,8 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
     auto * commandParams = [[MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
     ConvertToApplyUpdateRequestParams(commandData, commandParams);
 
-    auto strongDelegate = mDelegate;
-    dispatch_async(mDelegateNotificationQueue, ^{
+    auto strongDelegate = controller.otaProviderDelegate;
+    dispatch_async(controller.otaProviderDelegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(handleApplyUpdateRequestForNodeID:controller:params:completion:)]) {
             [strongDelegate handleApplyUpdateRequestForNodeID:@(nodeId)
                                                    controller:controller
@@ -838,8 +837,8 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
     auto * commandParams = [[MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
     ConvertToNotifyUpdateAppliedParams(commandData, commandParams);
 
-    auto strongDelegate = mDelegate;
-    dispatch_async(mDelegateNotificationQueue, ^{
+    auto strongDelegate = controller.otaProviderDelegate;
+    dispatch_async(controller.otaProviderDelegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(handleNotifyUpdateAppliedForNodeID:controller:params:completion:)]) {
             [strongDelegate handleNotifyUpdateAppliedForNodeID:@(nodeId)
                                                     controller:controller


### PR DESCRIPTION
Review note: the delegate-validation code in initWithFactory just moved there from startControllerFactory, with no real changes to it other than changing what it returns on error.
