### PR TITLE
[ESP32] Skip the WiFi interface initialization if already done

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -526,7 +526,8 @@ void ConnectivityManagerImpl::OnWiFiPlatformEvent(const ChipDeviceEvent * event)
                 break;
             case IP_EVENT_GOT_IP6:
                 ChipLogProgress(DeviceLayer, "IP_EVENT_GOT_IP6");
-                if (strcmp(esp_netif_get_ifkey(event->Platform.ESPSystemEvent.Data.IpGotIp6.esp_netif), "WIFI_STA_DEF") == 0)
+                if (strcmp(esp_netif_get_ifkey(event->Platform.ESPSystemEvent.Data.IpGotIp6.esp_netif),
+                           ESP32Utils::kDefaultWiFiStationNetifKey) == 0)
                 {
                     OnStationIPv6AddressAvailable(event->Platform.ESPSystemEvent.Data.IpGotIp6);
                 }
@@ -670,10 +671,11 @@ void ConnectivityManagerImpl::DriveStationState()
 void ConnectivityManagerImpl::OnStationConnected()
 {
     // Assign an IPv6 link local address to the station interface.
-    esp_err_t err = esp_netif_create_ip6_linklocal(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
+    esp_err_t err = esp_netif_create_ip6_linklocal(esp_netif_get_handle_from_ifkey(ESP32Utils::kDefaultWiFiStationNetifKey));
     if (err != ESP_OK)
     {
-        ChipLogError(DeviceLayer, "esp_netif_create_ip6_linklocal() failed for WIFI_STA_DEF interface: %s", esp_err_to_name(err));
+        ChipLogError(DeviceLayer, "esp_netif_create_ip6_linklocal() failed for %s interface, err:%s",
+                     ESP32Utils::kDefaultWiFiStationNetifKey, esp_err_to_name(err));
     }
     NetworkCommissioning::ESPWiFiDriver::GetInstance().OnConnectWiFiNetwork();
     // TODO Invoke WARM to perform actions that occur when the WiFi station interface comes up.
@@ -907,14 +909,14 @@ void ConnectivityManagerImpl::DriveAPState()
 
     // If AP is active, but the interface doesn't have an IPv6 link-local
     // address, assign one now.
-    if (mWiFiAPState == kWiFiAPState_Active && Internal::ESP32Utils::IsInterfaceUp("WIFI_AP_DEF") &&
-        !Internal::ESP32Utils::HasIPv6LinkLocalAddress("WIFI_AP_DEF"))
+    if (mWiFiAPState == kWiFiAPState_Active && ESP32Utils::IsInterfaceUp(ESP32Utils::kDefaultWiFiAPNetifKey) &&
+        !ESP32Utils::HasIPv6LinkLocalAddress(ESP32Utils::kDefaultWiFiAPNetifKey))
     {
-        esp_err_t error = esp_netif_create_ip6_linklocal(esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"));
+        esp_err_t error = esp_netif_create_ip6_linklocal(esp_netif_get_handle_from_ifkey(ESP32Utils::kDefaultWiFiAPNetifKey));
         if (error != ESP_OK)
         {
-            ChipLogError(DeviceLayer, "esp_netif_create_ip6_linklocal() failed for WIFI_AP_DEF interface: %s",
-                         esp_err_to_name(error));
+            ChipLogError(DeviceLayer, "esp_netif_create_ip6_linklocal() failed for %s interface, err:%s",
+                         ESP32Utils::kDefaultWiFiAPNetifKey, esp_err_to_name(error));
             goto exit;
         }
     }
@@ -1002,7 +1004,8 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                     haveIPv4Conn = true;
 
                     esp_netif_ip_info_t ipInfo;
-                    if (esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ipInfo) == ESP_OK)
+                    if (esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey(ESP32Utils::kDefaultWiFiStationNetifKey), &ipInfo) ==
+                        ESP_OK)
                     {
                         char addrStr[INET_ADDRSTRLEN];
                         // ToDo: change the code to using IPv6 address
@@ -1105,7 +1108,7 @@ void ConnectivityManagerImpl::OnStationIPv6AddressAvailable(const ip_event_got_i
     event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV6_Assigned;
     PlatformMgr().PostEventOrDie(&event);
 #if CONFIG_ENABLE_ROUTE_HOOK
-    esp_route_hook_init(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
+    esp_route_hook_init(esp_netif_get_handle_from_ifkey(ESP32Utils::kDefaultWiFiStationNetifKey));
 #endif
 }
 

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -321,16 +321,25 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
-    if (!esp_netif_create_default_wifi_ap())
+    // Lets not create a default AP interface if already present
+    if (!esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"))
     {
-        ChipLogError(DeviceLayer, "Failed to create the WiFi AP netif");
-        return CHIP_ERROR_INTERNAL;
+        if (!esp_netif_create_default_wifi_ap())
+        {
+            ChipLogError(DeviceLayer, "Failed to create the WiFi AP netif");
+            return CHIP_ERROR_INTERNAL;
+        }
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
-    if (!esp_netif_create_default_wifi_sta())
+
+    // Lets not create a default station interface if already present
+    if (!esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"))
     {
-        ChipLogError(DeviceLayer, "Failed to create the WiFi STA netif");
-        return CHIP_ERROR_INTERNAL;
+        if (!esp_netif_create_default_wifi_sta())
+        {
+            ChipLogError(DeviceLayer, "Failed to create the WiFi STA netif");
+            return CHIP_ERROR_INTERNAL;
+        }
     }
 
     // Initialize the ESP WiFi layer.

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -223,7 +223,7 @@ const char * ESP32Utils::WiFiModeToStr(wifi_mode_t wifiMode)
 
 struct netif * ESP32Utils::GetStationNetif(void)
 {
-    return GetNetif("WIFI_STA_DEF");
+    return GetNetif(kDefaultWiFiStationNetifKey);
 }
 
 CHIP_ERROR ESP32Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials)
@@ -322,7 +322,7 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
     // Lets not create a default AP interface if already present
-    if (!esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"))
+    if (!esp_netif_get_handle_from_ifkey(kDefaultWiFiAPNetifKey))
     {
         if (!esp_netif_create_default_wifi_ap())
         {
@@ -333,7 +333,7 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
 
     // Lets not create a default station interface if already present
-    if (!esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"))
+    if (!esp_netif_get_handle_from_ifkey(kDefaultWiFiStationNetifKey))
     {
         if (!esp_netif_create_default_wifi_sta())
         {

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -51,6 +51,9 @@ public:
     static CHIP_ERROR MapError(esp_err_t error);
     static void RegisterESP32ErrorFormatter();
     static bool FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err);
+
+    static constexpr char kDefaultWiFiStationNetifKey[] = "WIFI_STA_DEF";
+    static constexpr char kDefaultWiFiAPNetifKey[]      = "WIFI_AP_DEF";
 };
 
 #define ReturnMappedErrorOnFailure(expr)                                                                                           \

--- a/src/platform/ESP32/WiFiDnssdImpl.cpp
+++ b/src/platform/ESP32/WiFiDnssdImpl.cpp
@@ -27,6 +27,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/ESP32/ESP32Utils.h>
 
 namespace {
 
@@ -332,9 +333,8 @@ static CHIP_ERROR OnBrowseDone(BrowseContext * ctx)
                 if (ctx->mInterfaceId == chip::Inet::InterfaceId::Null())
                 {
                     // If the InterfaceId in the context is Null, we will use the Station netif by default.
-                    struct netif * lwip_netif =
-                        reinterpret_cast<struct netif *>(esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF")));
-                    ctx->mService[servicesIndex].mInterface = chip::Inet::InterfaceId(lwip_netif);
+                    ctx->mService[servicesIndex].mInterface =
+                        Inet::InterfaceId(DeviceLayer::Internal::ESP32Utils::GetStationNetif());
                 }
                 else
                 {
@@ -419,9 +419,7 @@ static CHIP_ERROR ParseSrvResult(ResolveContext * ctx)
         if (ctx->mInterfaceId == chip::Inet::InterfaceId::Null())
         {
             // If the InterfaceId in the context is Null, we will use the Station netif by default.
-            struct netif * lwip_netif =
-                reinterpret_cast<struct netif *>(esp_netif_get_netif_impl(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF")));
-            ctx->mService->mInterface = chip::Inet::InterfaceId(lwip_netif);
+            ctx->mService->mInterface = Inet::InterfaceId(DeviceLayer::Internal::ESP32Utils::GetStationNetif());
         }
         else
         {


### PR DESCRIPTION
There could be some use cases where WiFi is initialized before even initializing the Matter stack.

If the interfaces are already created and initialized then `esp_netif_create_default_wifi_ap()` and `esp_netif_create_default_wifi_sta()` it sends an assert, so skip initialization is interface is already present.