### PR TITLE
[kotlin] Initial Core Matter Controller APIs

### DIFF
--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -340,6 +340,43 @@ kotlin_library("chipcluster_test") {
   kotlinc_flags = [ "-Xlint:deprecation" ]
 }
 
+kotlin_library("matter_controller") {
+  output_name = "MatterController.jar"
+
+  deps = [
+    ":java",
+    "${chip_root}/third_party/java_deps:annotation",
+  ]
+
+  sources = [
+    "src/matter/controller/ControllerParams.kt",
+    "src/matter/controller/Paths.kt",
+    "src/matter/controller/States.kt", 
+    "src/matter/controller/Requests.kt",            
+    "src/matter/controller/InvokeCallback.kt",
+    "src/matter/controller/MatterController.kt",
+    "src/matter/controller/MatterControllerException.kt",
+    "src/matter/controller/OperationalKeyConfig.kt",
+    "src/matter/controller/ReportCallback.kt",
+    "src/matter/controller/ResubscriptionAttemptCallback.kt",
+    "src/matter/controller/SubscriptionEstablishedCallback.kt",
+    "src/matter/controller/WriteAttributesCallback.kt",
+  ]
+
+  if (matter_enable_java_compilation) {
+    deps += [
+      "${chip_root}/third_party/java_deps:json",
+      "${chip_root}/third_party/java_deps/stub_src",
+    ]
+  } else {
+    deps += [ ":android" ]
+
+    data_deps += [ "${chip_root}/build/chip/java:shared_cpplib" ]
+  }
+
+  kotlinc_flags = [ "-Xlint:deprecation" ]  
+}
+
 group("unit_tests") {
   deps = [
     ":chipcluster_test",

--- a/src/controller/java/src/matter/controller/ControllerParams.kt
+++ b/src/controller/java/src/matter/controller/ControllerParams.kt
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/**
+ * Parameters representing initialization arguments for [MatterController].
+ *
+ * @param operationalKeyConfig an optional signing configuration for operational control of devices
+ * @param udpListenPort a port for UDP communications, or [UDP_PORT_AUTO] to select automatically
+ * @param vendorId the identifier for the vendor using this controller
+ * @param countryCode the Regulatory Location country code
+ */
+class ControllerParams
+@JvmOverloads
+constructor(
+  val operationalKeyConfig: OperationalKeyConfig? = null,
+  val udpListenPort: Int = UDP_PORT_AUTO,
+  val vendorId: Int = VENDOR_ID_TEST,
+  val countryCode: String? = null,
+) {
+  companion object {
+    /** Matter assigned vendor ID for Google. */
+    const val VENDOR_ID_TEST = 0xFFF1
+    /** Indicates that the UDP listen port should be chosen automatically. */
+    const val UDP_PORT_AUTO = 0
+  }
+}

--- a/src/controller/java/src/matter/controller/InvokeCallback.kt
+++ b/src/controller/java/src/matter/controller/InvokeCallback.kt
@@ -1,0 +1,47 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/** An interface for receiving invoke response. */
+interface InvokeCallback {
+
+  /**
+   * OnError will be called when an error occurs after failing to call
+   *
+   * @param e The IllegalStateException which encapsulated the error message, the possible chip
+   *   error could be - CHIP_ERROR_TIMEOUT: A response was not received within the expected response
+   *   timeout. - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the
+   *   server. - CHIP_ERROR encapsulating the converted error from the StatusIB: If we got a
+   *   non-path-specific status response from the server. - CHIP_ERROR*: All other cases.
+   */
+  fun onError(e: Exception)
+
+  /**
+   * OnResponse will be called when a invoke response has been received and processed for the given
+   * path.
+   *
+   * @param invokeElement The invoke element in invoke response that could have null or nonNull tlv
+   *   data
+   * @param successCode If data in InvokeElement is null, successCode can be any success status,
+   *   including possibly a cluster-specific one. If data in InvokeElement is not null, successCode
+   *   will always be a generic SUCCESS(0) with no-cluster specific information
+   */
+  fun onResponse(invokeElement: InvokeElement, successCode: Long)
+
+  fun onDone() {}
+}

--- a/src/controller/java/src/matter/controller/MatterController.kt
+++ b/src/controller/java/src/matter/controller/MatterController.kt
@@ -1,0 +1,425 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+import chip.devicecontroller.ChipDeviceController
+import chip.devicecontroller.ChipDeviceControllerException
+import chip.devicecontroller.model.AttributeWriteRequest
+import chip.devicecontroller.model.ChipAttributePath
+import chip.devicecontroller.model.ChipEventPath
+import chip.devicecontroller.model.ChipPathId
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/** Controller to interact with the CHIP device. */
+class MatterController(params: ControllerParams) {
+  private val deviceController: ChipDeviceController
+  private var completionListener: CompletionListener? = null
+
+  /** Interface to listen for callbacks from MatterController. */
+  interface CompletionListener {
+    /** Notifies the completion of "ConnectDevice" command. */
+    fun onConnectDeviceComplete()
+
+    /** Notifies the pairing status. */
+    fun onStatusUpdate(status: Int)
+
+    /** Notifies the completion of pairing. */
+    fun onPairingComplete(errorCode: Int)
+
+    /** Notifies the deletion of pairing session. */
+    fun onPairingDeleted(errorCode: Int)
+
+    /** Notifies the completion of commissioning. */
+    fun onCommissioningComplete(nodeId: Long, errorCode: Int)
+
+    /** Notifies the completion of each stage of commissioning. */
+    fun onReadCommissioningInfo(
+      vendorId: Int,
+      productId: Int,
+      wifiEndpointId: Int,
+      threadEndpointId: Int
+    )
+
+    /** Notifies the completion of each stage of commissioning. */
+    fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int)
+
+    /** Notifies the listener of the error. */
+    fun onError(error: Throwable)
+
+    /** Notifies the Commissioner when the OpCSR for the Comissionee is generated. */
+    fun onOpCSRGenerationComplete(csr: ByteArray)
+  }
+
+  fun setCompletionListener(listener: CompletionListener) {
+    completionListener = listener
+  }
+
+  fun pairDeviceWithAddress(
+    deviceId: Long,
+    address: String,
+    port: Int,
+    discriminator: Int,
+    pinCode: Long,
+    csrNonce: ByteArray?
+  ) {
+    deviceController.pairDeviceWithAddress(
+      deviceId,
+      address,
+      port,
+      discriminator,
+      pinCode,
+      csrNonce
+    )
+  }
+
+  /**
+   * Establish a secure PASE connection to the given device via IP address.
+   *
+   * @param deviceId the ID of the node to connect to
+   * @param address the IP address at which the node is located
+   * @param port the port at which the node is located
+   * @param setupPincode the pincode for this node
+   */
+  fun establishPaseConnection(deviceId: Long, address: String, port: Int, setupPincode: Long) {
+    deviceController.establishPaseConnection(deviceId, address, port, setupPincode)
+  }
+
+  fun unpairDevice(deviceId: Long) {
+    deviceController.unpairDevice(deviceId)
+  }
+
+  fun onConnectDeviceComplete() {
+    completionListener?.onConnectDeviceComplete()
+  }
+
+  fun onStatusUpdate(status: Int) {
+    completionListener?.onStatusUpdate(status)
+  }
+
+  fun onPairingComplete(errorCode: Int) {
+    completionListener?.onPairingComplete(errorCode)
+  }
+
+  fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    completionListener?.onCommissioningComplete(nodeId, errorCode)
+  }
+
+  fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int) {
+    completionListener?.onCommissioningStatusUpdate(nodeId, stage, errorCode)
+  }
+
+  fun onReadCommissioningInfo(
+    vendorId: Int,
+    productId: Int,
+    wifiEndpointId: Int,
+    threadEndpointId: Int
+  ) {
+    completionListener?.onReadCommissioningInfo(
+      vendorId,
+      productId,
+      wifiEndpointId,
+      threadEndpointId
+    )
+  }
+
+  fun onOpCSRGenerationComplete(csr: ByteArray) {
+    completionListener?.onOpCSRGenerationComplete(csr)
+  }
+
+  fun onPairingDeleted(errorCode: Int) {
+    completionListener?.onPairingDeleted(errorCode)
+  }
+
+  fun onError(error: Throwable) {
+    completionListener?.onError(error)
+  }
+
+  /**
+   * Subscribe to periodic updates of all attributes and events from a device.
+   *
+   * @param SubscriptionEstablishedCallback Callback when a subscribe response has been received and
+   *   processed
+   * @param ResubscriptionAttemptCallback Callback when a resubscirption haoppens, the termination
+   *   cause is provided to help inform subsequent re-subscription logic.
+   * @param ReportCallback Callback when a report data has been received and processed for the given
+   *   paths.
+   * @param devicePtr connected device pointer
+   * @param subscribeElement subscribe command's path and arguments
+   */
+  fun subscribeDevice(
+    subscriptionEstablishedCallback: SubscriptionEstablishedCallback,
+    resubscriptionAttemptCallback: ResubscriptionAttemptCallback,
+    reportCallback: ReportCallback,
+    devicePtr: Long,
+    subscribeElement: SubscribeElement
+  ) {
+    val subscriptionEstablishedHandler =
+      chip.devicecontroller.SubscriptionEstablishedCallback { subscriptionId ->
+        logger.log(Level.INFO, "Subscription to device established")
+        subscriptionEstablishedCallback.onSubscriptionEstablished(subscriptionId)
+      }
+
+    val resubscriptionAttemptHandler =
+      chip.devicecontroller.ResubscriptionAttemptCallback {
+        terminationCause,
+        nextResubscribeIntervalMsec ->
+        logger.log(
+          Level.WARNING,
+          String.format(
+            "ResubscriptionAttempt terminationCause:%d, nextResubscribeIntervalMsec:%d",
+            terminationCause,
+            nextResubscribeIntervalMsec
+          )
+        )
+        resubscriptionAttemptCallback.onResubscriptionAttempt(
+          terminationCause,
+          nextResubscribeIntervalMsec
+        )
+      }
+
+    val reportHandler =
+      object : chip.devicecontroller.ReportCallback {
+        override fun onError(
+          attributePath: chip.devicecontroller.model.ChipAttributePath?,
+          eventPath: chip.devicecontroller.model.ChipEventPath?,
+          ex: Exception
+        ) {
+          val tmpAttributePath: AttributePath? = attributePath?.wrap()
+          val tmpEventPath: EventPath? = eventPath?.wrap()
+
+          reportCallback.onError(tmpAttributePath, tmpEventPath, ex)
+        }
+
+        override fun onReport(nodeState: chip.devicecontroller.model.NodeState) {
+          val tmpNodeState: NodeState = nodeState.wrap()
+          reportCallback.onReport(tmpNodeState)
+        }
+
+        override fun onDone() {
+          reportCallback.onDone()
+        }
+      }
+
+    deviceController.subscribeToPath(
+      subscriptionEstablishedHandler,
+      resubscriptionAttemptHandler,
+      reportHandler,
+      devicePtr,
+      listOf(
+        chip.devicecontroller.model.ChipAttributePath.newInstance(
+          /* endpointId= */ WILDCARD_ENDPOINT_ID,
+          /* clusterId=*/ WILDCARD_CLUSTER_ID,
+          /* attributeId= */ WILDCARD_ATTRIBUTE_ID
+        )
+      ),
+      listOf(
+        chip.devicecontroller.model.ChipEventPath.newInstance(
+          /* endpointId= */ WILDCARD_ENDPOINT_ID,
+          /* clusterId=*/ WILDCARD_CLUSTER_ID,
+          /* eventId= */ WILDCARD_EVENT_ID
+        )
+      ),
+      subscribeElement.minInterval,
+      subscribeElement.maxInterval,
+      subscribeElement.keepSubscriptions,
+      subscribeElement.isFabricFiltered,
+      CHIP_IM_TIMEOUT_MS
+    )
+  }
+
+  /**
+   * Issue attribute write requests to target device
+   *
+   * @param WriteAttributesCallback Callback when a write response has been received and processed
+   *   for the given path.
+   * @param devicePtr connected device pointer
+   * @param attributeWriteRequests a list of attribute WriteRequest
+   * @param timedRequestTimeoutMs this is timed request if this value is set
+   */
+  fun writeAttributes(
+    callback: WriteAttributesCallback,
+    devicePtr: Long,
+    writeRequests: List<WriteRequest>,
+    timedRequestTimeoutMs: Int?
+  ) {
+    val attributeWriteRequests =
+      writeRequests.map { request ->
+        AttributeWriteRequest.newInstance(
+          ChipPathId.forId(request.endpoint.toLong()),
+          ChipPathId.forId(request.cluster.toLong()),
+          ChipPathId.forId(request.attribute.toLong()),
+          request.tlv
+        )
+      }
+
+    val writeCallback =
+      object : chip.devicecontroller.WriteAttributesCallback {
+        override fun onResponse(attributePath: ChipAttributePath) {
+          logger.log(Level.INFO, "write success for attributePath:%s", attributePath.toString())
+
+          val tmpAttributePath: AttributePath = attributePath.wrap()
+          callback.onSuccess(tmpAttributePath)
+        }
+
+        override fun onError(attributePath: ChipAttributePath?, ex: Exception) {
+          logger.log(Level.SEVERE, "Failed to write attribute at path: %s", attributePath)
+
+          val tmpAttributePath: AttributePath? = attributePath?.wrap()
+          callback.onError(tmpAttributePath, ex)
+        }
+
+        override fun onDone() {
+          logger.log(Level.INFO, "writeAttributes onDone is received")
+
+          callback.onDone()
+        }
+      }
+
+    deviceController.write(
+      writeCallback,
+      devicePtr,
+      attributeWriteRequests.toList(),
+      timedRequestTimeoutMs ?: 0,
+      CHIP_IM_TIMEOUT_MS,
+    )
+  }
+
+  /**
+   * Invoke command to target device
+   *
+   * @param InvokeCallback Callback when an invoke response has been received and processed for the
+   *   given invoke command.
+   * @param devicePtr connected device pointer
+   * @param invokeElement invoke command's path and arguments
+   * @param timedRequestTimeoutMs this is timed request if this value is set
+   */
+  fun invokeCommand(
+    callback: InvokeCallback,
+    devicePtr: Long,
+    invokeElement: InvokeElement,
+    timedRequestTimeoutMs: Int?
+  ) {
+    val invokeRequest =
+      chip.devicecontroller.model.InvokeElement.newInstance(
+        ChipPathId.forId(invokeElement.endpointId.toLong()),
+        ChipPathId.forId(invokeElement.clusterId),
+        ChipPathId.forId(invokeElement.commandId),
+        invokeElement.tlvValue,
+        /* jsonString= */ null
+      )
+
+    var invokeCallback =
+      object : chip.devicecontroller.InvokeCallback {
+        override fun onResponse(
+          invokeElement: chip.devicecontroller.model.InvokeElement,
+          successCode: Long
+        ) {
+          logger.log(Level.INFO, "Invoke onResponse is received")
+
+          val tmpInvokeElement: InvokeElement = invokeElement.wrap()
+          callback.onResponse(tmpInvokeElement, successCode)
+        }
+
+        override fun onError(ex: Exception) {
+          logger.log(Level.SEVERE, "Invoke onError is received: %s", ex.message)
+          callback.onError(ex)
+        }
+      }
+
+    deviceController.invoke(
+      invokeCallback,
+      devicePtr,
+      invokeRequest,
+      timedRequestTimeoutMs ?: 0,
+      CHIP_IM_TIMEOUT_MS
+    )
+  }
+
+  private fun ChipAttributePath.wrap(): AttributePath {
+    return AttributePath(endpointId.getId().toInt(), clusterId.getId(), attributeId.getId())
+  }
+
+  private fun ChipEventPath.wrap(): EventPath {
+    return EventPath(endpointId.getId().toInt(), clusterId.getId(), eventId.getId())
+  }
+
+  private fun chip.devicecontroller.model.NodeState.wrap(): NodeState {
+    return NodeState(
+      endpoints = endpointStates.mapValues { (id, value) -> value.wrap(id) },
+      events = arrayListOf()
+    )
+  }
+
+  private fun chip.devicecontroller.model.EndpointState.wrap(id: Int): EndpointState {
+    return EndpointState(id, clusterStates.mapValues { (id, value) -> value.wrap(id) })
+  }
+
+  private fun chip.devicecontroller.model.ClusterState.wrap(id: Long): ClusterState {
+    return ClusterState(id, attributeStates.mapValues { (id, value) -> value.wrap(id) })
+  }
+
+  private fun chip.devicecontroller.model.AttributeState.wrap(id: Long): AttributeState {
+    return AttributeState(id, tlv, json.toString())
+  }
+
+  private fun chip.devicecontroller.model.InvokeElement.wrap(): InvokeElement {
+    return matter.controller.InvokeElement(
+      endpointId.getId().toInt(),
+      clusterId.getId(),
+      commandId.getId(),
+      getTlvByteArray()!!
+    )
+  }
+
+  init {
+    val config: OperationalKeyConfig? = params.operationalKeyConfig
+    val paramsBuilder =
+      chip.devicecontroller.ControllerParams.newBuilder()
+        .setUdpListenPort(params.udpListenPort)
+        .setControllerVendorId(params.vendorId)
+        .setCountryCode(params.countryCode)
+
+    if (config != null) {
+      val intermediateCertificate = config.intermediateCertificate
+      paramsBuilder
+        .setRootCertificate(config.trustedRootCertificate)
+        .setIntermediateCertificate(intermediateCertificate ?: byteArrayOf())
+        .setOperationalCertificate(config.operationalCertificate)
+        .setKeypairDelegate(config.keypairDelegate)
+        .setIpk(config.ipk)
+    }
+
+    try {
+      deviceController = ChipDeviceController(paramsBuilder.build())
+    } catch (ex: ChipDeviceControllerException) {
+      throw MatterControllerException(ex.errorCode, "Failed to initialize ChipDeviceController.")
+    }
+  }
+
+  companion object {
+    private val logger = Logger.getLogger(MatterController::class.java.simpleName)
+    private const val WILDCARD_ENDPOINT_ID = 0xffff
+    private const val WILDCARD_CLUSTER_ID = 0xffffffff
+    private const val WILDCARD_ATTRIBUTE_ID = 0xffffffff
+    private const val WILDCARD_EVENT_ID = 0xffffffff
+    // im interaction time out value, it would override the default value in c++ im
+    // layer if this value is non-zero.
+    private const val CHIP_IM_TIMEOUT_MS = 0
+  }
+}

--- a/src/controller/java/src/matter/controller/MatterControllerException.kt
+++ b/src/controller/java/src/matter/controller/MatterControllerException.kt
@@ -1,0 +1,24 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+class MatterControllerException(errorCode: Long, message: String? = null) :
+  RuntimeException(message ?: "Error Code $errorCode") {
+
+  val errorCode: Long = errorCode
+}

--- a/src/controller/java/src/matter/controller/OperationalKeyConfig.kt
+++ b/src/controller/java/src/matter/controller/OperationalKeyConfig.kt
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+import chip.devicecontroller.KeypairDelegate
+
+/**
+ * Represents a configuration to use with CASE session establishment.
+ *
+ * @property keypairDelegate a delegate for signing operations
+ * @property trustedRootCertificate the trusted root X.509 certificate in DER-encoded form
+ * @property intermediateCertificate the optional intermediate X.509 certificate in DER-encoded form
+ * @property operationalCertificate the node operational X.509 certificate in DER-encoded form
+ * @property ipk the Identity Protection Key
+ * @property fabricId the fabric ID to which these operational credentials are associated
+ * @property nodeId the Admin Node ID to which these operational credentials are associated
+ */
+class OperationalKeyConfig(
+  val keypairDelegate: KeypairDelegate,
+  val trustedRootCertificate: ByteArray,
+  val intermediateCertificate: ByteArray?,
+  val operationalCertificate: ByteArray,
+  val ipk: ByteArray,
+  val fabricId: Long,
+  val nodeId: Long,
+)

--- a/src/controller/java/src/matter/controller/Paths.kt
+++ b/src/controller/java/src/matter/controller/Paths.kt
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/**
+ * A full path representation to read an attribute from a node.
+ *
+ * @param endpointId a Int for the endpoint to read from
+ * @param clusterId a Long for which cluster on the [endpoint] to read from
+ * @param attributeId a Long for which attribute(s) on the cluster to read
+ */
+data class AttributePath(val endpointId: Int, val clusterId: Long, val attributeId: Long) {
+  override fun toString(): String = "$endpointId/$clusterId/$attributeId"
+}
+
+/**
+ * A full path representation to an event emitted from a node.
+ *
+ * @param endpointId a Int for the endpoint to read from
+ * @param clusterId a Long for which cluster on the [endpoint] to read from
+ * @param eventId a Long for which event(s) from the cluster
+ */
+data class EventPath(
+  val endpointId: Int,
+  val clusterId: Long,
+  val eventId: Long,
+) {
+  override fun toString(): String = "$endpointId/$clusterId/$eventId"
+}

--- a/src/controller/java/src/matter/controller/ReportCallback.kt
+++ b/src/controller/java/src/matter/controller/ReportCallback.kt
@@ -1,0 +1,27 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/** An interface for receiving read/subscribe CHIP reports. */
+interface ReportCallback {
+  fun onError(attributePath: AttributePath?, eventPath: EventPath?, e: Exception)
+
+  fun onReport(nodeState: NodeState)
+
+  fun onDone() {}
+}

--- a/src/controller/java/src/matter/controller/Requests.kt
+++ b/src/controller/java/src/matter/controller/Requests.kt
@@ -1,0 +1,68 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/**
+ * Information about a invoke request element.
+ *
+ * @param endpointId invoked command's endpoint Id
+ * @param clusterId invoked command's cluster Id
+ * @param commandId invoked command's command Id
+ * @param tlvByteArray byteArray representation in terms of TLV for invoke command's argument
+ */
+data class InvokeElement(
+  val endpointId: Int,
+  val clusterId: Long,
+  val commandId: Long,
+  val tlvValue: ByteArray
+)
+
+/**
+ * Information about a subscribe request element.
+ *
+ * @param minInterval the requested minimum interval boundary floor in seconds
+ * @param maxInterval the requested maximum interval boundary ceiling in seconds
+ * @param keepSubscriptions If KeepSubscriptions is FALSE, all existing or pending subscriptions on
+ *   the publisher for this subscriber SHALL be terminated.
+ * @param isFabricFiltered limits the data read within fabric-scoped lists to the accessing fabric
+ */
+data class SubscribeElement(
+  val minInterval: Int,
+  val maxInterval: Int,
+  val keepSubscriptions: Boolean,
+  val isFabricFiltered: Boolean
+)
+
+/**
+ * A write request representation
+ *
+ * @param endpoint a UShort endpoint to write into
+ * @param cluster a UInt for which cluster on the [endpoint] to write into
+ * @param attribute a UInt for which attribute on the cluster to write into
+ * @param tlv a tlv byteArray
+ * @param dataVersion a optional data version
+ */
+data class WriteRequest(
+  val endpoint: UShort,
+  val cluster: UInt,
+  val attribute: UInt,
+  val tlv: ByteArray,
+  val dataVersion: Long? = null
+) {
+  override fun toString(): String = "$endpoint/$cluster/$attribute/$tlv/$dataVersion"
+}

--- a/src/controller/java/src/matter/controller/ResubscriptionAttemptCallback.kt
+++ b/src/controller/java/src/matter/controller/ResubscriptionAttemptCallback.kt
@@ -1,0 +1,22 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+interface ResubscriptionAttemptCallback {
+  fun onResubscriptionAttempt(terminationCause: Long, nextResubscribeIntervalMsec: Long)
+}

--- a/src/controller/java/src/matter/controller/States.kt
+++ b/src/controller/java/src/matter/controller/States.kt
@@ -1,0 +1,74 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/**
+ * Information about a node, including data on all available endpoints.
+ *
+ * @param endpoints a mapping of endpoint IDs with the associated cluster data
+ * @param events a list of events occurred on the node
+ */
+data class NodeState(val endpoints: Map<Int, EndpointState>, val events: ArrayList<EventState>)
+
+/**
+ * Information about an endpoint and its cluster data.
+ *
+ * @param id the endpoint ID
+ * @param clusters a mapping of cluster IDs to the cluster data
+ */
+data class EndpointState(val id: Int, val clusters: Map<Long, ClusterState>)
+
+/**
+ * Information about a cluster.
+ *
+ * @param id the cluster ID
+ * @param attributes a mapping of attribute IDs in this cluster with their respective values
+ */
+data class ClusterState(val id: Long, val attributes: Map<Long, AttributeState>)
+
+/**
+ * Information about an attribute.
+ *
+ * @param id the attribute ID
+ * @param tlvValue the raw TLV-encoded attribute value
+ * @param jsonValue a JSON string representing the raw attribute value
+ */
+data class AttributeState(val id: Long, val tlvValue: ByteArray, val jsonValue: String)
+
+/**
+ * Information about an event.
+ *
+ * @param eventId the event ID
+ * @param endpointId the endpoint ID
+ * @param clusterId the clusterId ID
+ * @param eventNumber the event number value that is scoped to the node
+ * @param priorityLevel the priority describes the usage semantics of the event
+ * @param timestampType indicates POSIX Time or SYSTEM Time, in milliseconds
+ * @param timestampValue represents an offset, in milliseconds since the UNIX epoch or boot
+ * @param tlvValue the raw TLV-encoded event value
+ */
+data class EventState(
+  val eventId: Long,
+  val endpointId: Int,
+  val clusterId: Long,
+  val eventNumber: Long,
+  val priorityLevel: Int,
+  val timestampType: Int,
+  val timestampValue: Long,
+  val tlvValue: ByteArray,
+)

--- a/src/controller/java/src/matter/controller/SubscriptionEstablishedCallback.kt
+++ b/src/controller/java/src/matter/controller/SubscriptionEstablishedCallback.kt
@@ -1,0 +1,22 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+interface SubscriptionEstablishedCallback {
+  fun onSubscriptionEstablished(subscriptionId: Long)
+}

--- a/src/controller/java/src/matter/controller/WriteAttributesCallback.kt
+++ b/src/controller/java/src/matter/controller/WriteAttributesCallback.kt
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package matter.controller
+
+/** An interface for receiving write response. */
+interface WriteAttributesCallback {
+
+  /**
+   * OnError will be called when an error occurs after failing to write
+   *
+   * @param attributePath The attribute path field
+   * @param e The IllegalStateException which encapsulated the error message, the possible chip
+   *   error could be CHIP_ERROR_TIMEOUT: A response was not received within the expected response
+   *   timeout. - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the
+   *   server. - CHIP_ERROR encapsulating the converted error from the StatusIB: If we got a
+   *   non-path-specific status response from the server. CHIP_ERROR*: All other cases.
+   */
+  fun onError(attributePath: AttributePath?, e: Exception)
+
+  /**
+   * onSuccess will be called when a write response has been received and processed for the given
+   * path.
+   *
+   * @param attributePath The attribute path field in write response.
+   */
+  fun onSuccess(attributePath: AttributePath)
+
+  fun onDone() {}
+}


### PR DESCRIPTION
This is the initial set of kotlin Core Matter Controller APIs

The Matter Pairing API contains the basic pairing API to allow us verify Matter Interaction API, we will have - Matter Commissioning API which will be built on top of the Matter Interaction API for custom commissioning.

