### PR TITLE
Remove SED related code from SDK

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -191,7 +191,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     return SL_STATUS_OK;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
+#if SL_ICD_ENABLED
 /******************************************************************
  * @fn   wfx_rsi_power_save()
  * @brief
@@ -221,7 +221,7 @@ int32_t wfx_rsi_power_save()
     SILABS_LOG("Powersave Config Success");
     return status;
 }
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_SED */
+#endif /* SL_ICD_ENABLED */
 
 /*************************************************************************************
  * @fn  static int32_t wfx_wifi_rsi_init(void)

--- a/examples/pump-app/silabs/src/AppTask.cpp
+++ b/examples/pump-app/silabs/src/AppTask.cpp
@@ -135,7 +135,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         appError(err);
     }
 
-#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
+#if !(defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER)
     sAppTask.StartStatusLEDTimer();
 #endif
 

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -120,7 +120,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         appError(err);
     }
 
-#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
+#if !(defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER)
     sAppTask.StartStatusLEDTimer();
 #endif
 

--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -52,14 +52,6 @@ void FailSafeContext::HandleDisarmFailSafe(intptr_t arg)
 
 void FailSafeContext::SetFailSafeArmed(bool armed)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    if (IsFailSafeArmed() != armed)
-    {
-        // Per spec, we should be staying in active mode while a fail-safe is
-        // armed.
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(armed);
-    }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     if (IsFailSafeArmed() != armed)
     {

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -98,14 +98,6 @@ void CommissioningWindowManager::ResetState()
     mECMIterations    = 0;
     mECMSaltLength    = 0;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    if (mSEDActiveModeEnabled)
-    {
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(false);
-        mSEDActiveModeEnabled = false;
-    }
-#endif
-
     UpdateWindowStatus(CommissioningWindowStatusEnum::kWindowNotOpen);
 
     UpdateOpenerFabricIndex(NullNullable);
@@ -244,14 +236,6 @@ CHIP_ERROR CommissioningWindowManager::AdvertiseAndListenForPASE()
     VerifyOrReturnError(mCommissioningTimeoutTimerArmed, CHIP_ERROR_INCORRECT_STATE);
 
     mPairingSession.Clear();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    if (!mSEDActiveModeEnabled)
-    {
-        mSEDActiveModeEnabled = true;
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(true);
-    }
-#endif
 
     ReturnErrorOnFailure(mServer->GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
         Protocols::SecureChannel::MsgType::PBKDFParamRequest, this));

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -211,10 +211,6 @@ private:
     uint32_t mECMSaltLength              = 0;
     uint8_t mECMSalt[kSpake2p_Max_PBKDF_Salt_Length];
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    bool mSEDActiveModeEnabled = false;
-#endif
-
     // For tests only, so that we can test the commissioning window timeout
     // without having to wait 3 minutes.
     Optional<System::Clock::Seconds16> mMinCommissioningTimeoutOverride;

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -204,28 +204,6 @@ public:
     void ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);
 
-// Sleepy end device methods
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR GetSEDIntervalsConfig(SEDIntervalsConfig & intervalsConfig);
-
-    /**
-     * Sets Sleepy End Device intervals configuration and posts kSEDIntervalChange event to inform other software
-     * modules about the change.
-     *
-     * @param[in]  intervalsConfig intervals configuration to be set
-     */
-    CHIP_ERROR SetSEDIntervalsConfig(const SEDIntervalsConfig & intervalsConfig);
-
-    /**
-     * Requests setting Sleepy End Device active interval on or off.
-     * Every method call with onOff parameter set to true or false results in incrementing or decrementing the active mode
-     * consumers counter. Active mode is set if the consumers counter is bigger than 0.
-     *
-     * @param[in]  onOff  true if active mode should be enabled and false otherwise.
-     */
-    CHIP_ERROR RequestSEDActiveMode(bool onOff, bool delayIdle = false);
-#endif
-
     CHIP_ERROR SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 
     // CHIPoBLE service methods
@@ -469,23 +447,6 @@ inline CHIP_ERROR ConnectivityManager::SetThreadDeviceType(ThreadDeviceType devi
 {
     return static_cast<ImplClass *>(this)->_SetThreadDeviceType(deviceType);
 }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-inline CHIP_ERROR ConnectivityManager::GetSEDIntervalsConfig(SEDIntervalsConfig & intervalsConfig)
-{
-    return static_cast<ImplClass *>(this)->_GetSEDIntervalsConfig(intervalsConfig);
-}
-
-inline CHIP_ERROR ConnectivityManager::SetSEDIntervalsConfig(const SEDIntervalsConfig & intervalsConfig)
-{
-    return static_cast<ImplClass *>(this)->_SetSEDIntervalsConfig(intervalsConfig);
-}
-
-inline CHIP_ERROR ConnectivityManager::RequestSEDActiveMode(bool onOff, bool delayIdle)
-{
-    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff, delayIdle);
-}
-#endif
 
 inline CHIP_ERROR ConnectivityManager::SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
 {

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -163,26 +163,6 @@ private:
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType();
     CHIP_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-
-    /**
-     * Sets Sleepy End Device intervals configuration and posts kICDPollingIntervalChange event to inform other software
-     * modules about the change.
-     *
-     * @param[in]  intervalsConfig  intervals configuration to be set
-     */
-    CHIP_ERROR SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-
-    /**
-     * Requests setting Sleepy End Device active interval on or off.
-     * Every method call with onOff parameter set to true or false results in incrementing or decrementing the active mode
-     * consumers counter. Active mode is set if the consumers counter is bigger than 0.
-     *
-     * @param[in]  onOff  true if active mode should be enabled and false otherwise.
-     */
-    CHIP_ERROR RequestSEDActiveMode(bool onOff, bool delayIdle = false);
-#endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif
@@ -392,23 +372,6 @@ inline CHIP_ERROR ThreadStackManager::SetThreadDeviceType(ConnectivityManager::T
 {
     return static_cast<ImplClass *>(this)->_SetThreadDeviceType(deviceType);
 }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-inline CHIP_ERROR ThreadStackManager::GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    return static_cast<ImplClass *>(this)->_GetSEDIntervalsConfig(intervalsConfig);
-}
-
-inline CHIP_ERROR ThreadStackManager::SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    return static_cast<ImplClass *>(this)->_SetSEDIntervalsConfig(intervalsConfig);
-}
-
-inline CHIP_ERROR ThreadStackManager::RequestSEDActiveMode(bool onOff, bool delayIdle)
-{
-    return static_cast<ImplClass *>(this)->_RequestSEDActiveMode(onOff, delayIdle);
-}
-#endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 inline CHIP_ERROR ThreadStackManager::SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -63,11 +63,6 @@ protected:
     bool _IsThreadApplicationControlled();
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
-#endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
@@ -143,28 +138,6 @@ GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadDeviceType(Connectiv
 {
     return ThreadStackMgrImpl().SetThreadDeviceType(deviceType);
 }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-template <class ImplClass>
-inline CHIP_ERROR
-GenericConnectivityManagerImpl_Thread<ImplClass>::_GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    return ThreadStackMgrImpl().GetSEDIntervalsConfig(intervalsConfig);
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetSEDIntervalsConfig(
-    const ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    return ThreadStackMgrImpl().SetSEDIntervalsConfig(intervalsConfig);
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_RequestSEDActiveMode(bool onOff, bool delayIdle)
-{
-    return ThreadStackMgrImpl().RequestSEDActiveMode(onOff, delayIdle);
-}
-#endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 template <class ImplClass>

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -91,45 +91,6 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
     mResponseTimeout = timeout;
 }
 
-#if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
-void ExchangeContext::UpdateSEDIntervalMode()
-{
-    if (!HasSessionHandle())
-    {
-        // After the session has been deleted, no further communication can occur on the exchange,
-        // so withdraw a SED active mode request.
-        UpdateSEDIntervalMode(false);
-        return;
-    }
-
-    Transport::PeerAddress address;
-
-    switch (GetSessionHandle()->GetSessionType())
-    {
-    case Transport::Session::SessionType::kSecure:
-        address = GetSessionHandle()->AsSecureSession()->GetPeerAddress();
-        break;
-    case Transport::Session::SessionType::kUnauthenticated:
-        address = GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
-        break;
-    default:
-        return;
-    }
-
-    VerifyOrReturn(address.GetTransportType() != Transport::Type::kBle);
-    UpdateSEDIntervalMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked());
-}
-
-void ExchangeContext::UpdateSEDIntervalMode(bool activeMode)
-{
-    if (activeMode != IsRequestingActiveMode())
-    {
-        SetRequestingActiveMode(activeMode);
-        DeviceLayer::ConnectivityMgr().RequestSEDActiveMode(activeMode, true);
-    }
-}
-#endif
-
 CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle && msgBuf,
                                         const SendFlags & sendFlags)
 {
@@ -399,11 +360,6 @@ ExchangeContext::~ExchangeContext()
     // Ensure that DoClose has been called by the time we get here. If not, we have a leak somewhere.
     //
     VerifyOrDie(mFlags.Has(Flags::kFlagClosed));
-
-#if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
-    // Make sure that the exchange withdraws the request for Sleepy End Device active mode.
-    UpdateSEDIntervalMode(false);
-#endif
 
     // Ideally, in this scenario, the retransmit table should
     // be clear of any outstanding messages for this context and
@@ -681,10 +637,6 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
 
 void ExchangeContext::MessageHandled()
 {
-#if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
-    UpdateSEDIntervalMode();
-#endif
-
     if (mFlags.Has(Flags::kFlagClosed) || IsResponseExpected() || IsSendExpected())
     {
         return;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -258,13 +258,6 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
     //   "An ICD sender SHOULD increase t to also account for its own sleepy interval
     //   required to receive the acknowledgment"
     mrpBackoffTime += app::ICDManager::GetFastPollingInterval();
-#elif CHIP_DEVICE_CONFIG_ENABLE_SED
-    DeviceLayer::ConnectivityManager::SEDIntervalsConfig sedIntervals;
-
-    if (DeviceLayer::ConnectivityMgr().GetSEDIntervalsConfig(sedIntervals) == CHIP_NO_ERROR)
-    {
-        mrpBackoffTime += System::Clock::Timestamp(sedIntervals.ActiveIntervalMS);
-    }
 #endif
 
     mrpBackoffTime += CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;

--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -76,16 +76,6 @@ Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
     config.mIdleRetransTimeout += app::ICDManager::GetSlowPollingInterval();
     config.mActiveRetransTimeout += app::ICDManager::GetFastPollingInterval();
     config.mActiveThresholdTime = System::Clock::Milliseconds16(IcdManagementServer::GetInstance().GetActiveModeThreshold());
-#elif CHIP_DEVICE_CONFIG_ENABLE_SED
-    DeviceLayer::ConnectivityManager::SEDIntervalsConfig sedIntervalsConfig;
-
-    if (DeviceLayer::ConnectivityMgr().GetSEDIntervalsConfig(sedIntervalsConfig) == CHIP_NO_ERROR)
-    {
-        // Increase local MRP retry intervals by SED intervals. That is, intervals for
-        // which the device can be at sleep and not be able to receive any messages).
-        config.mIdleRetransTimeout += sedIntervalsConfig.IdleIntervalMS;
-        config.mActiveRetransTimeout += sedIntervalsConfig.ActiveIntervalMS;
-    }
 #endif
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -518,32 +518,6 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::Thr
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-CHIP_ERROR ThreadStackManagerImpl::_GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    (void) intervalsConfig;
-
-    ChipLogError(DeviceLayer, "SED intervals config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ThreadStackManagerImpl::_SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    (void) intervalsConfig;
-
-    ChipLogError(DeviceLayer, "SED intervals config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ThreadStackManagerImpl::_RequestSEDActiveMode(bool onOff, bool delayIdle)
-{
-    (void) onOff;
-    (void) delayIdle;
-
-    ChipLogError(DeviceLayer, "SED intervals config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-#endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 CHIP_ERROR ThreadStackManagerImpl::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
 {

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -93,11 +93,6 @@ public:
 
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
-#endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -100,13 +100,6 @@ protected:
     void _OnNetworkScanFinished(otActiveScanResult * aResult);
     void _UpdateNetworkStatus();
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle);
-    CHIP_ERROR SEDUpdateMode();
-    static void RequestSEDModeUpdate(chip::System::Layer * apSystemLayer, void * apAppState);
-#endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -165,13 +158,6 @@ private:
     NetworkCommissioning::ThreadDriver::ScanCallback * mpScanCallback;
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    ConnectivityManager::SEDIntervalsConfig mIntervalsConfig;
-    ConnectivityManager::SEDIntervalMode mIntervalsMode = ConnectivityManager::SEDIntervalMode::Idle;
-    uint32_t mActiveModeConsumers                       = 0;
-    bool mDelayIdleTimerRunning                         = false;
-#endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -278,10 +264,6 @@ private:
 
     static void OnJoinerComplete(otError aError, void * aContext);
     void OnJoinerComplete(otError aError);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR SetSEDIntervalMode(ConnectivityManager::SEDIntervalMode intervalType);
-#endif
 
     inline ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -123,26 +123,6 @@ CHIP_ERROR ConnectivityManagerImplWiFi::_GetAndLogWiFiStatsCounters(void)
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-CHIP_ERROR ConnectivityManagerImplWiFi::_GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & SEDIntervalsConfig)
-{
-    // For now Wi-Fi uses legacy power save mode that has fixed inactivity interval
-    SEDIntervalsConfig.ActiveIntervalMS =
-        chip::System::Clock::Milliseconds32(WiFiManager::kDefaultDTIMInterval * WiFiManager::kBeaconIntervalMs);
-    SEDIntervalsConfig.IdleIntervalMS =
-        chip::System::Clock::Milliseconds32(WiFiManager::kDefaultDTIMInterval * WiFiManager::kBeaconIntervalMs);
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR ConnectivityManagerImplWiFi::_SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-CHIP_ERROR ConnectivityManagerImplWiFi::_RequestSEDActiveMode(bool onOff, bool delayIdle)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-#endif
-
 ConnectivityManager::WiFiAPMode ConnectivityManagerImplWiFi::_GetWiFiAPMode(void)
 {
     /* AP mode is unsupported */

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
@@ -55,12 +55,6 @@ private:
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
-    CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle = false);
-#endif
-
     // Wi-Fi access point - not supported
     ConnectivityManager::WiFiAPMode _GetWiFiAPMode(void);
     CHIP_ERROR _SetWiFiAPMode(ConnectivityManager::WiFiAPMode val);

--- a/src/platform/qpg/ThreadStackManagerImpl.cpp
+++ b/src/platform/qpg/ThreadStackManagerImpl.cpp
@@ -113,13 +113,3 @@ extern "C" void otPlatFree(void * aPtr)
 {
     CHIPPlatformMemoryFree(aPtr);
 }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-CHIP_ERROR ThreadStackManagerImpl::_RequestSEDFastPollingMode(bool onOff)
-{
-    (void) onOff;
-
-    ChipLogError(DeviceLayer, "Polling config is not supported on this platform");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-#endif

--- a/src/platform/qpg/ThreadStackManagerImpl.h
+++ b/src/platform/qpg/ThreadStackManagerImpl.h
@@ -74,10 +74,6 @@ public:
     using ThreadStackManager::InitThreadStack;
     CHIP_ERROR InitThreadStack(otInstance * otInst);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _RequestSEDFastPollingMode(bool onOff);
-#endif
-
 private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -481,32 +481,6 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::Thr
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-CHIP_ERROR ThreadStackManagerImpl::_GetSEDPollingConfig(ConnectivityManager::SEDPollingConfig & pollingConfig)
-{
-    (void) pollingConfig;
-
-    ChipLogError(DeviceLayer, "Polling config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ThreadStackManagerImpl::_SetSEDPollingConfig(const ConnectivityManager::SEDPollingConfig & pollingConfig)
-{
-    (void) pollingConfig;
-
-    ChipLogError(DeviceLayer, "Polling config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ThreadStackManagerImpl::_RequestSEDFastPollingMode(bool onOff)
-{
-    (void) onOff;
-
-    ChipLogError(DeviceLayer, "Polling config is not supported on linux");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-#endif
-
 bool ThreadStackManagerImpl::_HaveMeshConnectivity()
 {
     // TODO: Remove Weave legacy APIs

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -86,12 +86,6 @@ public:
 
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    CHIP_ERROR _GetSEDPollingConfig(ConnectivityManager::SEDPollingConfig & pollingConfig);
-    CHIP_ERROR _SetSEDPollingConfig(const ConnectivityManager::SEDPollingConfig & pollingConfig);
-    CHIP_ERROR _RequestSEDFastPollingMode(bool onOff);
-#endif
-
     bool _HaveMeshConnectivity();
 
     CHIP_ERROR _GetAndLogThreadStatsCounters();


### PR DESCRIPTION
fixes #28237
SED is deprecated by the ICD behaviour. 

Some definitions of `CHIP_DEVICE_CONFIG_ENABLE_SED` and use if its ifdef still exist on some platform code. 

I'll make an announcement on the `tsg-tt-platform-software-dev` channel before changing their configurations. 