### PR TITLE
[Android] Modify AndroidControllerExceptions errorCode type

### DIFF
--- a/src/controller/java/AndroidControllerExceptions.cpp
+++ b/src/controller/java/AndroidControllerExceptions.cpp
@@ -33,8 +33,8 @@ CHIP_ERROR AndroidControllerExceptions::CreateAndroidControllerException(JNIEnv 
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     JniClass controllerExceptionJniCls(controllerExceptionCls);
 
-    jmethodID exceptionConstructor = env->GetMethodID(controllerExceptionCls, "<init>", "(JLjava/lang/String;)V");
-    outEx = (jthrowable) env->NewObject(controllerExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode),
+    jmethodID exceptionConstructor = env->GetMethodID(controllerExceptionCls, "<init>", "(ILjava/lang/String;)V");
+    outEx = (jthrowable) env->NewObject(controllerExceptionCls, exceptionConstructor, static_cast<jint>(errorCode),
                                         env->NewStringUTF(message));
     VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     return CHIP_NO_ERROR;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
@@ -21,11 +21,11 @@ package chip.devicecontroller;
 public class ChipDeviceControllerException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
-  public long errorCode;
+  public int errorCode;
 
   public ChipDeviceControllerException() {}
 
-  public ChipDeviceControllerException(long errorCode, String message) {
+  public ChipDeviceControllerException(int errorCode, String message) {
     super(message != null ? message : String.format("Error Code %d", errorCode));
     this.errorCode = errorCode;
   }

--- a/src/controller/java/tests/chip/devicecontroller/GetConnectedDeviceCallbackJniTest.java
+++ b/src/controller/java/tests/chip/devicecontroller/GetConnectedDeviceCallbackJniTest.java
@@ -48,10 +48,10 @@ public final class GetConnectedDeviceCallbackJniTest {
   public void connectionFailure() {
     var callback = new FakeGetConnectedDeviceCallback();
     var jniCallback = new GetConnectedDeviceCallbackJni(callback);
-    callbackTestUtil.onDeviceConnectionFailure(jniCallback, 100L);
+    callbackTestUtil.onDeviceConnectionFailure(jniCallback, 100);
 
     assertThat(callback.error).isInstanceOf(ChipDeviceControllerException.class);
-    assertThat(((ChipDeviceControllerException) callback.error).errorCode).isEqualTo(100L);
+    assertThat(((ChipDeviceControllerException) callback.error).errorCode).isEqualTo(100);
   }
 
   class FakeGetConnectedDeviceCallback implements GetConnectedDeviceCallback {


### PR DESCRIPTION
Fix #29039 

Fixed the errorCode variable types of ChipDeviceControllerException class and ThrowError jni type being different.

The return type of the AsInteger() function of CHIP_ERROR is uint32_t. 
For this reason, I think it is okay to change the errorCode variable type of ChipDeviceControllerException to int.

uint32_t range : 0 ~ 4294967295
java int range : -2,147,483,648 ~ 2,147,483,647