### PR TITLE
[Silabs] updated GNI for B0 2.0 board

### DIFF
--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -46,13 +46,13 @@ template("siwx917_sdk") {
     _include_dirs = [
       "${chip_root}",
       "${chip_root}/examples/platform/silabs/SiWx917/SiWx917",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/hal",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/hal",
       "${efr32_sdk_root}/platform/emdrv/nvm3/inc",
       "${efr32_sdk_root}/platform/emdrv/common/inc",
       "${efr32_sdk_root}/platform/service/device_init/inc",
       "${sdk_support_root}/matter/mbedtls/tinycrypt/inc",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/autogen",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/config",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/autogen",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/config",
       "${chip_root}/third_party/mbedtls/repo/include",
       "${chip_root}/third_party/mbedtls/repo/library",
 
@@ -67,6 +67,7 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/si91x/sl_net/inc",
 
       # siwx917_soc component
+      "${wifi_sdk_root}/components/siwx917_soc/core/config",
       "${wifi_sdk_root}/components/siwx917_soc/inc",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/cmsis_driver",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/cmsis_driver/config",
@@ -106,7 +107,7 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/include",
       "${wifi_sdk_root}/components/protocol/wifi/si91x",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/inc",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/inc",
     ]
 
     # Note that we're setting the mbedTLS and PSA configuration files through a
@@ -322,6 +323,7 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/siwx917_soc/boards/brd4325x/src/rsi_board.c",
       "${wifi_sdk_root}/components/siwx917_soc/core/chip/src/rsi_deepsleep_soc.c",
       "${wifi_sdk_root}/components/siwx917_soc/core/chip/src/system_si91x.c",
+      "${wifi_sdk_root}/components/siwx917_soc/core/config/src/rsi_nvic_priorities_config.c",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/cmsis_driver/UDMA.c",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/cmsis_driver/USART.c",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/ipmu/ipmu_apis.c",
@@ -361,9 +363,9 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/stream_buffer.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/tasks.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/autogen/sl_event_handler.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/hal/rsi_hal_mcu_m4.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/hal/rsi_hal_mcu_platform_init.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/autogen/sl_event_handler.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/hal/rsi_hal_mcu_m4.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/hal/rsi_hal_mcu_platform_init.c",
       "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_nvm3_hal_flash.c",
 
       # mbedtls
@@ -406,14 +408,14 @@ template("siwx917_sdk") {
     # nvm3 ans startup
     if (silabs_board == "BRD4325B") {
       sources += [
-        "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/src/startup_RS1xxxx.c",
+        "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/src/startup_RS1xxxx.c",
         "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_dual_flash_intf.c",
       ]
     }
 
     if (wifi_soc_common_flash) {
       sources += [
-        "${sdk_support_root}/matter/si91x/siwx917/BRD4325x/support/src/startup_common_RS1xxxx.c",
+        "${sdk_support_root}/matter/si91x/siwx917/${sdk_support_board}/support/src/startup_common_RS1xxxx.c",
         "${wifi_sdk_root}/components/siwx917_soc/drivers/middleware/nvm3/src/sl_si91x_common_flash_intf.c",
       ]
     }

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -25,6 +25,12 @@ import("silabs_board.gni")
 declare_args() {
   wifi_sdk_root = "${chip_root}/third_party/silabs/wifi_sdk"
   examples_plat_dir = "${chip_root}/examples/platform/silabs/SiWx917"
+
+  if (silabs_board == "BRD4338A") {
+    sdk_support_board = "BRD4338A"
+  } else {
+    sdk_support_board = "BRD4325x"
+  }
 }
 
 # Defines an siwx917 SDK build target.

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -38,6 +38,7 @@ declare_args() {
 
   wifi_soc = false
   wifi_soc_common_flash = false
+  sdk_support_board = ""
 
   #Disable MQTT by default
   enable_dic = false
@@ -106,6 +107,7 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
+  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4325C") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -113,6 +115,7 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
+  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4325G") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -120,6 +123,7 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
+  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -127,6 +131,7 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
+  sdk_support_board = "BRD4338A"
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -38,7 +38,6 @@ declare_args() {
 
   wifi_soc = false
   wifi_soc_common_flash = false
-  sdk_support_board = ""
 
   #Disable MQTT by default
   enable_dic = false
@@ -107,7 +106,6 @@ if (silabs_board == "BRD4304A") {
   disable_lcd = true
   show_qr_code = false
   wifi_soc = true
-  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4325C") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -115,7 +113,6 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
-  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4325G") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -123,7 +120,6 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
-  sdk_support_board = "BRD4325x"
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -131,7 +127,6 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   wifi_soc_common_flash = true
-  sdk_support_board = "BRD4338A"
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,


### PR DESCRIPTION
* Added new folder **BRD4338A** (B0 2.0 board) in matter_support, and updated the GNI accordingly
* Added required button configurations in matter_support
> matter_support PR: https://github.com/SiliconLabs/sdk_support/pull/141/files
* Updated matter_support pointer