### PR TITLE
Darwin: Bug fixes in BleConnectionDelegateImpl

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -31,6 +31,9 @@ public:
     virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator);
     virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj);
     virtual CHIP_ERROR CancelConnection();
+
+private:
+    CHIP_ERROR DoCancel();
 };
 
 } // namespace Internal


### PR DESCRIPTION
* Avoid clearing the `ble` global if it points to a different instance.
* Capture the CBPeripheral strong ref instead of the void * in dispatches.
* Also read characteristic value before dispatching and improve logging.
