### PR TITLE
Relocate json-related method to TextFormat file

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -162,5 +162,6 @@ ALLOW: Dict[str, Set[str]] = {
     # Not intended for embedded clients
     'src/lib/support/jsontlv/JsonToTlv.cpp': {'sstream'},
     'src/lib/support/jsontlv/JsonToTlv.h': {'string'},
-    'src/lib/support/jsontlv/TlvToJson.h': {'string'}
+    'src/lib/support/jsontlv/TlvToJson.h': {'string'},
+    'src/lib/support/jsontlv/TextFormat.h': {'string'}
 }

--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -28,6 +28,7 @@ static_library("jsontlv") {
 
   public = [
     "JsonToTlv.h",
+    "JsonUtilities.h",
     "TlvJson.h",
     "TlvToJson.h",
   ]

--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -24,6 +24,7 @@ static_library("jsontlv") {
     "JsonToTlv.cpp",
     "TlvJson.cpp",
     "TlvToJson.cpp",
+    "TextFormat.cpp",
   ]
 
   public = [

--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -28,7 +28,7 @@ static_library("jsontlv") {
 
   public = [
     "JsonToTlv.h",
-    "JsonUtilities.h",
+    "TextFormat.h",
     "TlvJson.h",
     "TlvToJson.h",
   ]

--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -22,9 +22,9 @@ static_library("jsontlv") {
   sources = [
     "ElementTypes.h",
     "JsonToTlv.cpp",
+    "TextFormat.cpp",
     "TlvJson.cpp",
     "TlvToJson.cpp",
-    "TextFormat.cpp",
   ]
 
   public = [

--- a/src/lib/support/jsontlv/JsonUtilities.h
+++ b/src/lib/support/jsontlv/JsonUtilities.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <algorithm>
+#include <json/json.h>
+#include <lib/core/TLV.h>
+
+namespace chip {
+/*
+ * Pretty-prints the input Json string using standard library pretty-printer.
+ * This pretty-printer generates a Json string in a human friendly format with 3 space indentation
+ * and nice representation of arrays and objects.
+ * The input can be any string, as long as it's valid Json.
+ */
+std::string PrettyPrintJsonString(const std::string & jsonString)
+{
+    Json::Reader reader;
+    Json::Value jsonObject;
+    reader.parse(jsonString, jsonObject);
+    Json::StyledWriter writer;
+    return writer.write(jsonObject);
+}
+
+/*
+ * Reformats the input Json string as a single-line string with no spaces or newlines.
+ * The input can be any string, as long as it's valid Json.
+ */
+std::string MakeJsonSingleLine(const std::string & jsonString)
+{
+    std::string str = PrettyPrintJsonString(jsonString);
+    str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
+    return str;
+}
+
+} // namespace chip

--- a/src/lib/support/jsontlv/TextFormat.cpp
+++ b/src/lib/support/jsontlv/TextFormat.cpp
@@ -29,11 +29,4 @@ std::string PrettyPrintJsonString(const std::string & jsonString)
     return writer.write(jsonObject);
 }
 
-std::string MakeJsonSingleLine(const std::string & jsonString)
-{
-    std::string str = PrettyPrintJsonString(jsonString);
-    str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
-    return str;
-}
-
 } // namespace chip

--- a/src/lib/support/jsontlv/TextFormat.cpp
+++ b/src/lib/support/jsontlv/TextFormat.cpp
@@ -16,21 +16,24 @@
  *    limitations under the License.
  */
 
-#include <string>
+#include <algorithm>
+#include <json/json.h>
 
 namespace chip {
-/*
- * Pretty-prints the input Json string using standard library pretty-printer.
- * This pretty-printer generates a Json string in a human friendly format with 3 space indentation
- * and nice representation of arrays and objects.
- * The input can be any string, as long as it's valid Json.
- */
-std::string PrettyPrintJsonString(const std::string & jsonString);
+std::string PrettyPrintJsonString(const std::string & jsonString)
+{
+    Json::Reader reader;
+    Json::Value jsonObject;
+    reader.parse(jsonString, jsonObject);
+    Json::StyledWriter writer;
+    return writer.write(jsonObject);
+}
 
-/*
- * Reformats the input Json string as a single-line string with no spaces or newlines.
- * The input can be any string, as long as it's valid Json.
- */
-std::string MakeJsonSingleLine(const std::string & jsonString);
+std::string MakeJsonSingleLine(const std::string & jsonString)
+{
+    std::string str = PrettyPrintJsonString(jsonString);
+    str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
+    return str;
+}
 
 } // namespace chip

--- a/src/lib/support/jsontlv/TextFormat.h
+++ b/src/lib/support/jsontlv/TextFormat.h
@@ -27,10 +27,4 @@ namespace chip {
  */
 std::string PrettyPrintJsonString(const std::string & jsonString);
 
-/*
- * Reformats the input Json string as a single-line string with no spaces or newlines.
- * The input can be any string, as long as it's valid Json.
- */
-std::string MakeJsonSingleLine(const std::string & jsonString);
-
 } // namespace chip

--- a/src/lib/support/jsontlv/TextFormat.h
+++ b/src/lib/support/jsontlv/TextFormat.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <json/json.h>
 #include <lib/core/TLV.h>
+#include <string>
 
 namespace chip {
 /*

--- a/src/lib/support/jsontlv/TlvToJson.cpp
+++ b/src/lib/support/jsontlv/TlvToJson.cpp
@@ -362,21 +362,4 @@ CHIP_ERROR TlvToJson(TLV::TLVReader & reader, std::string & jsonString)
     jsonString = writer.write(jsonObject);
     return CHIP_NO_ERROR;
 }
-
-std::string PrettyPrintJsonString(const std::string & jsonString)
-{
-    Json::Reader reader;
-    Json::Value jsonObject;
-    reader.parse(jsonString, jsonObject);
-    Json::StyledWriter writer;
-    return writer.write(jsonObject);
-}
-
-std::string MakeJsonSingleLine(const std::string & jsonString)
-{
-    std::string str = PrettyPrintJsonString(jsonString);
-    str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
-    return str;
-}
-
 } // namespace chip

--- a/src/lib/support/jsontlv/TlvToJson.h
+++ b/src/lib/support/jsontlv/TlvToJson.h
@@ -33,19 +33,4 @@ CHIP_ERROR TlvToJson(TLV::TLVReader & reader, std::string & jsonString);
  * Given a TLV encoded byte array, this function converts it into JSON object.
  */
 CHIP_ERROR TlvToJson(const ByteSpan & tlv, std::string & jsonString);
-
-/*
- * Pretty-prints the input Json string using standard library pretty-printer.
- * This pretty-printer generates a Json string in a human friendly format with 3 space indentation
- * and nice representation of arrays and objects.
- * The input can be any string, as long as it's valid Json.
- */
-std::string PrettyPrintJsonString(const std::string & jsonString);
-
-/*
- * Reformats the input Json string as a single-line string with no spaces or newlines.
- * The input can be any string, as long as it's valid Json.
- */
-std::string MakeJsonSingleLine(const std::string & jsonString);
-
 } // namespace chip

--- a/src/lib/support/tests/TestJsonToTlv.cpp
+++ b/src/lib/support/tests/TestJsonToTlv.cpp
@@ -22,7 +22,7 @@
 #include <lib/core/TLVReader.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
-#include <lib/support/jsontlv/JsonUtilities.h>
+#include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 

--- a/src/lib/support/tests/TestJsonToTlv.cpp
+++ b/src/lib/support/tests/TestJsonToTlv.cpp
@@ -22,6 +22,7 @@
 #include <lib/core/TLVReader.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
+#include <lib/support/jsontlv/JsonUtilities.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 

--- a/src/lib/support/tests/TestJsonToTlvToJson.cpp
+++ b/src/lib/support/tests/TestJsonToTlvToJson.cpp
@@ -20,6 +20,7 @@
 #include <app/data-model/Encode.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
+#include <lib/support/jsontlv/JsonUtilities.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 

--- a/src/lib/support/tests/TestJsonToTlvToJson.cpp
+++ b/src/lib/support/tests/TestJsonToTlvToJson.cpp
@@ -20,7 +20,7 @@
 #include <app/data-model/Encode.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
-#include <lib/support/jsontlv/JsonUtilities.h>
+#include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -19,7 +19,7 @@
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
 #include <lib/support/UnitTestRegistration.h>
-#include <lib/support/jsontlv/JsonUtilities.h>
+#include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 #include <system/SystemPacketBuffer.h>

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -19,6 +19,7 @@
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
 #include <lib/support/UnitTestRegistration.h>
+#include <lib/support/jsontlv/JsonUtilities.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <nlunit-test.h>
 #include <system/SystemPacketBuffer.h>


### PR DESCRIPTION
fixes, https://github.com/project-chip/connectedhomeip/issues/28386
In src/lib/support/jsontlv/TlvToJson.h, there two methods to pretty-print Json strings: PrettyPrintJsonString(), which are not related to TLV, it is better to relocate them to dedicate TextFormat file.
Remove broken MakeJsonSingleLine.
