### PR TITLE
[Android] Fix Commissioning Crash

### DIFF
--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -84,12 +84,13 @@ CHIP_ERROR JniReferences::GetClassRef(JNIEnv * env, const char * clsType, jclass
     if (strcmp(clsType, "java/util/Optional") == 0)
     {
         cls = env->FindClass("j$/util/Optional");
+        env->ExceptionClear();
     }
 
     if (cls == nullptr)
     {
-        env->ExceptionClear();
         cls = env->FindClass(clsType);
+        env->ExceptionClear();
     }
 
     if (cls == nullptr)


### PR DESCRIPTION
After merging some PRs, Android CHIPTool has crash when commission device. (#28991)

I upload the correction code to resolve this issue.

09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : Build fingerprint: google/flame/flame:11/RQ3A.211001.001/7641976:user/release-keys 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : Revision: MP1.0 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : ABI: arm64 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : Timestamp: 2023-09-04 16:08:00+0900 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : pid: 14767, tid: 14891, name: CHIP Device Con  >>> com.google.chip.chiptool <<< 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : uid: 10292 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr -------- 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   : Abort message: JNI DETECTED ERROR IN APPLICATION: JNI NewStringUTF called with pending exception java.lang.ClassNotFoundException: Didnt find class "chip.devicecontroller.DeviceAttestationDelegate" on path: DexPathList[[directory "."],nativeLibraryDirectories=[/system/lib64, /system_ext/lib64, /system/lib64, /system_ext/lib64]] 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   :   at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:207) 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379) 
09-04 16:08:00.309 F 14908    14908    DEBUG                                                   :   at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312) 
