### PR TITLE
Optionally avoid global constructors

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -23,18 +23,19 @@
 
 #include "AccessControl.h"
 
+#include <lib/core/Global.h>
+
 namespace chip {
 namespace Access {
 
 using chip::CATValues;
 using chip::FabricIndex;
 using chip::NodeId;
-using namespace chip::Access;
 
 namespace {
 
-AccessControl defaultAccessControl;
-AccessControl * globalAccessControl = &defaultAccessControl;
+Global<AccessControl> defaultAccessControl;
+AccessControl * globalAccessControl = nullptr; // lazily defaulted to defaultAccessControl in GetAccessControl
 
 static_assert(((unsigned(Privilege::kAdminister) & unsigned(Privilege::kManage)) == 0) &&
                   ((unsigned(Privilege::kAdminister) & unsigned(Privilege::kOperate)) == 0) &&
@@ -174,8 +175,8 @@ char GetPrivilegeStringForLogging(Privilege privilege)
 
 } // namespace
 
-AccessControl::Entry::Delegate AccessControl::Entry::mDefaultDelegate;
-AccessControl::EntryIterator::Delegate AccessControl::EntryIterator::mDefaultDelegate;
+Global<AccessControl::Entry::Delegate> AccessControl::Entry::mDefaultDelegate;
+Global<AccessControl::EntryIterator::Delegate> AccessControl::EntryIterator::mDefaultDelegate;
 
 CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate, DeviceTypeResolver & deviceTypeResolver)
 {
@@ -631,7 +632,7 @@ void AccessControl::NotifyEntryChanged(const SubjectDescriptor * subjectDescript
 
 AccessControl & GetAccessControl()
 {
-    return *globalAccessControl;
+    return (globalAccessControl) ? *globalAccessControl : *defaultAccessControl;
 }
 
 void SetAccessControl(AccessControl & accessControl)
@@ -642,7 +643,7 @@ void SetAccessControl(AccessControl & accessControl)
 
 void ResetAccessControlToDefault()
 {
-    globalAccessControl = &defaultAccessControl;
+    globalAccessControl = nullptr;
 }
 
 } // namespace Access

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -632,7 +632,7 @@ void AccessControl::NotifyEntryChanged(const SubjectDescriptor * subjectDescript
 
 AccessControl & GetAccessControl()
 {
-    return (globalAccessControl) ? *globalAccessControl : *defaultAccessControl;
+    return (globalAccessControl) ? *globalAccessControl : defaultAccessControl.get();
 }
 
 void SetAccessControl(AccessControl & accessControl)

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -22,8 +22,9 @@
 #include "RequestPath.h"
 #include "SubjectDescriptor.h"
 
-#include "lib/support/CodeUtils.h"
 #include <lib/core/CHIPCore.h>
+#include <lib/core/Global.h>
+#include <lib/support/CodeUtils.h>
 
 // Dump function for use during development only (0 for disabled, non-zero for enabled).
 #define CHIP_ACCESS_CONTROL_DUMP_ENABLED 0
@@ -104,7 +105,7 @@ public:
 
         Entry() = default;
 
-        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = &mDefaultDelegate; }
+        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = &*mDefaultDelegate; }
 
         Entry & operator=(Entry && other)
         {
@@ -112,7 +113,7 @@ public:
             {
                 mDelegate->Release();
                 mDelegate       = other.mDelegate;
-                other.mDelegate = &mDefaultDelegate;
+                other.mDelegate = &*mDefaultDelegate;
             }
             return *this;
         }
@@ -208,7 +209,7 @@ public:
          */
         CHIP_ERROR RemoveTarget(size_t index) { return mDelegate->RemoveTarget(index); }
 
-        bool HasDefaultDelegate() const { return mDelegate == &mDefaultDelegate; }
+        bool HasDefaultDelegate() const { return mDelegate == &*mDefaultDelegate; }
 
         const Delegate & GetDelegate() const { return *mDelegate; }
 
@@ -223,12 +224,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &mDefaultDelegate;
+            mDelegate = &*mDefaultDelegate;
         }
 
     private:
-        static Delegate mDefaultDelegate;
-        Delegate * mDelegate = &mDefaultDelegate;
+        static Global<Delegate> mDefaultDelegate;
+        Delegate * mDelegate = &*mDefaultDelegate;
     };
 
     /**
@@ -276,12 +277,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &mDefaultDelegate;
+            mDelegate = &*mDefaultDelegate;
         }
 
     private:
-        static Delegate mDefaultDelegate;
-        Delegate * mDelegate = &mDefaultDelegate;
+        static Global<Delegate> mDefaultDelegate;
+        Delegate * mDelegate = &*mDefaultDelegate;
     };
 
     /**

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -105,7 +105,7 @@ public:
 
         Entry() = default;
 
-        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = &*mDefaultDelegate; }
+        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = &mDefaultDelegate.get(); }
 
         Entry & operator=(Entry && other)
         {
@@ -113,7 +113,7 @@ public:
             {
                 mDelegate->Release();
                 mDelegate       = other.mDelegate;
-                other.mDelegate = &*mDefaultDelegate;
+                other.mDelegate = &mDefaultDelegate.get();
             }
             return *this;
         }
@@ -209,7 +209,7 @@ public:
          */
         CHIP_ERROR RemoveTarget(size_t index) { return mDelegate->RemoveTarget(index); }
 
-        bool HasDefaultDelegate() const { return mDelegate == &*mDefaultDelegate; }
+        bool HasDefaultDelegate() const { return mDelegate == &mDefaultDelegate.get(); }
 
         const Delegate & GetDelegate() const { return *mDelegate; }
 
@@ -224,12 +224,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &*mDefaultDelegate;
+            mDelegate = &mDefaultDelegate.get();
         }
 
     private:
         static Global<Delegate> mDefaultDelegate;
-        Delegate * mDelegate = &*mDefaultDelegate;
+        Delegate * mDelegate = &mDefaultDelegate.get();
     };
 
     /**
@@ -277,12 +277,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &*mDefaultDelegate;
+            mDelegate = &mDefaultDelegate.get();
         }
 
     private:
         static Global<Delegate> mDefaultDelegate;
-        Delegate * mDelegate = &*mDefaultDelegate;
+        Delegate * mDelegate = &mDefaultDelegate.get();
     };
 
     /**

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -32,6 +32,7 @@
 #include <app/RequiredPrivilege.h>
 #include <app/util/af-types.h>
 #include <app/util/endpoint-config-api.h>
+#include <lib/core/Global.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/FibonacciUtils.h>
@@ -41,13 +42,13 @@ namespace app {
 
 using Protocols::InteractionModel::Status;
 
-InteractionModelEngine sInteractionModelEngine;
+Global<InteractionModelEngine> sInteractionModelEngine;
 
 InteractionModelEngine::InteractionModelEngine() {}
 
 InteractionModelEngine * InteractionModelEngine::GetInstance()
 {
-    return &sInteractionModelEngine;
+    return &*sInteractionModelEngine;
 }
 
 CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -48,7 +48,7 @@ InteractionModelEngine::InteractionModelEngine() {}
 
 InteractionModelEngine * InteractionModelEngine::GetInstance()
 {
-    return &*sInteractionModelEngine;
+    return &sInteractionModelEngine.get();
 }
 
 CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
@@ -370,8 +370,7 @@ Status Delegate::OnResetCondition()
     if (emberAfContainsAttribute(mInstance->GetEndpointId(), mInstance->GetClusterId(), Attributes::LastChangedTime::Id))
     {
         System::Clock::Milliseconds64 currentUnixTimeMS;
-        System::Clock::ClockImpl clock;
-        CHIP_ERROR err = clock.GetClock_RealTimeMS(currentUnixTimeMS);
+        CHIP_ERROR err = System::SystemClock().GetClock_RealTimeMS(currentUnixTimeMS);
         if (err == CHIP_NO_ERROR)
         {
             System::Clock::Seconds32 currentUnixTime = std::chrono::duration_cast<System::Clock::Seconds32>(currentUnixTimeMS);

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -90,7 +90,7 @@ namespace app {
 namespace dynamic_server {
 void InitAccessControl()
 {
-    (void) *gControllerAccessControl;
+    gControllerAccessControl.get(); // force initialization
 }
 } // namespace dynamic_server
 } // namespace app

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/InteractionModelEngine.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/Global.h>
 
 using namespace chip;
 using namespace chip::Access;
@@ -40,7 +41,7 @@ public:
     {
         return app::IsDeviceTypeOnEndpoint(deviceType, endpoint);
     }
-} gDeviceTypeResolver;
+};
 
 // TODO: Make the policy more configurable by consumers.
 class AccessControlDelegate : public Access::AccessControl::Delegate
@@ -73,7 +74,15 @@ class AccessControlDelegate : public Access::AccessControl::Delegate
     }
 };
 
-AccessControlDelegate gDelegate;
+struct ControllerAccessControl
+{
+    DeviceTypeResolver mDeviceTypeResolver;
+    AccessControlDelegate mDelegate;
+    ControllerAccessControl() { GetAccessControl().Init(&mDelegate, mDeviceTypeResolver); }
+};
+
+Global<ControllerAccessControl> gControllerAccessControl;
+
 } // anonymous namespace
 
 namespace chip {
@@ -81,7 +90,7 @@ namespace app {
 namespace dynamic_server {
 void InitAccessControl()
 {
-    GetAccessControl().Init(&gDelegate, gDeviceTypeResolver);
+    (void) *gControllerAccessControl;
 }
 } // namespace dynamic_server
 } // namespace app

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -691,7 +691,7 @@ CHIP_ERROR CsaCdKeysTrustStore::LookupVerifyingKey(const ByteSpan & kid, Crypto:
 
 const AttestationTrustStore * GetTestAttestationTrustStore()
 {
-    return &*gTestAttestationTrustStore;
+    return &gTestAttestationTrustStore.get();
 }
 
 DeviceAttestationVerifier * GetDefaultDACVerifier(const AttestationTrustStore * paaRootStore)

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -22,7 +22,6 @@
 #include <credentials/DeviceAttestationConstructor.h>
 #include <credentials/DeviceAttestationVendorReserved.h>
 #include <crypto/CHIPCryptoPAL.h>
-#include <string.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/Global.h>
@@ -32,12 +31,12 @@
 
 namespace chip {
 namespace TestCerts {
-extern const ByteSpan sTestCert_PAA_FFF1_Cert;
-extern const ByteSpan sTestCert_PAA_NoVID_Cert;
+extern const Span<const ByteSpan> kTestAttestationTrustStoreRoots;
 } // namespace TestCerts
 } // namespace chip
 
 using namespace chip::Crypto;
+using chip::TestCerts::kTestAttestationTrustStoreRoots;
 
 namespace chip {
 namespace Credentials {
@@ -273,14 +272,11 @@ constexpr std::array<MatterCDSigningKey, 6> gCdSigningKeys = { {
     { FixedByteSpan<20>{ gCdSigningKey005Kid }, FixedByteSpan<65>{ gCdSigningKey005PubkeyBytes } },
 } };
 
-constexpr ByteSpan const * kTestPaaRoots[] = {
-    &TestCerts::sTestCert_PAA_FFF1_Cert,
-    &TestCerts::sTestCert_PAA_NoVID_Cert,
-};
-
 struct TestAttestationTrustStore final : public ArrayAttestationTrustStore
 {
-    TestAttestationTrustStore() : ArrayAttestationTrustStore(kTestPaaRoots, ArraySize(kTestPaaRoots)) {}
+    TestAttestationTrustStore() :
+        ArrayAttestationTrustStore(kTestAttestationTrustStoreRoots.data(), kTestAttestationTrustStoreRoots.size())
+    {}
 };
 Global<TestAttestationTrustStore> gTestAttestationTrustStore;
 

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
@@ -226,17 +226,20 @@ public:
 class ArrayAttestationTrustStore : public AttestationTrustStore
 {
 public:
-    ArrayAttestationTrustStore(const ByteSpan * const * derCerts, size_t numCerts) : mDerCerts(derCerts), mNumCerts(numCerts) {}
+    ArrayAttestationTrustStore(const ByteSpan * derCerts, size_t numCerts) : mDerCerts(derCerts), mNumCerts(numCerts) {}
 
     CHIP_ERROR GetProductAttestationAuthorityCert(const ByteSpan & skid, MutableByteSpan & outPaaDerBuffer) const override
     {
         VerifyOrReturnError(!skid.empty() && (skid.data() != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(skid.size() == Crypto::kSubjectKeyIdentifierLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-        for (size_t paaIdx = 0; paaIdx < mNumCerts; ++paaIdx)
+        size_t paaIdx;
+        ByteSpan candidate;
+
+        for (paaIdx = 0; paaIdx < mNumCerts; ++paaIdx)
         {
             uint8_t skidBuf[Crypto::kSubjectKeyIdentifierLength] = { 0 };
-            ByteSpan const & candidate                           = *mDerCerts[paaIdx];
+            candidate                                            = mDerCerts[paaIdx];
             MutableByteSpan candidateSkidSpan{ skidBuf };
             VerifyOrReturnError(CHIP_NO_ERROR == Crypto::ExtractSKIDFromX509Cert(candidate, candidateSkidSpan),
                                 CHIP_ERROR_INTERNAL);
@@ -252,7 +255,7 @@ public:
     }
 
 protected:
-    const ByteSpan * const * mDerCerts;
+    const ByteSpan * mDerCerts;
     const size_t mNumCerts;
 };
 

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
@@ -226,20 +226,17 @@ public:
 class ArrayAttestationTrustStore : public AttestationTrustStore
 {
 public:
-    ArrayAttestationTrustStore(const ByteSpan * derCerts, size_t numCerts) : mDerCerts(derCerts), mNumCerts(numCerts) {}
+    ArrayAttestationTrustStore(const ByteSpan * const * derCerts, size_t numCerts) : mDerCerts(derCerts), mNumCerts(numCerts) {}
 
     CHIP_ERROR GetProductAttestationAuthorityCert(const ByteSpan & skid, MutableByteSpan & outPaaDerBuffer) const override
     {
         VerifyOrReturnError(!skid.empty() && (skid.data() != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(skid.size() == Crypto::kSubjectKeyIdentifierLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-        size_t paaIdx;
-        ByteSpan candidate;
-
-        for (paaIdx = 0; paaIdx < mNumCerts; ++paaIdx)
+        for (size_t paaIdx = 0; paaIdx < mNumCerts; ++paaIdx)
         {
             uint8_t skidBuf[Crypto::kSubjectKeyIdentifierLength] = { 0 };
-            candidate                                            = mDerCerts[paaIdx];
+            ByteSpan const & candidate                           = *mDerCerts[paaIdx];
             MutableByteSpan candidateSkidSpan{ skidBuf };
             VerifyOrReturnError(CHIP_NO_ERROR == Crypto::ExtractSKIDFromX509Cert(candidate, candidateSkidSpan),
                                 CHIP_ERROR_INTERNAL);
@@ -255,7 +252,7 @@ public:
     }
 
 protected:
-    const ByteSpan * mDerCerts;
+    const ByteSpan * const * mDerCerts;
     const size_t mNumCerts;
 };
 

--- a/src/credentials/tests/CHIPAttCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPAttCert_test_vectors.cpp
@@ -4289,5 +4289,10 @@ constexpr uint8_t sTestCert_PAI_FFF2_NoPID_Resigned_SKID_Array[] = {
 
 extern const ByteSpan sTestCert_PAI_FFF2_NoPID_Resigned_SKID = ByteSpan(sTestCert_PAI_FFF2_NoPID_Resigned_SKID_Array);
 
+extern constexpr Span<const ByteSpan> kTestAttestationTrustStoreRoots((const ByteSpan[]){
+    sTestCert_PAA_FFF1_Cert,
+    sTestCert_PAA_NoVID_Cert,
+});
+
 } // namespace TestCerts
 } // namespace chip

--- a/src/credentials/tests/CHIPAttCert_test_vectors.h
+++ b/src/credentials/tests/CHIPAttCert_test_vectors.h
@@ -23,6 +23,9 @@
 namespace chip {
 namespace TestCerts {
 
+// Root CA certs for chip::Credentials::GetTestAttestationTrustStore()
+extern const Span<const ByteSpan> kTestAttestationTrustStoreRoots;
+
 extern const ByteSpan sTestCert_DAC_FFF1_8000_0000_2CDPs_Cert;
 extern const ByteSpan sTestCert_DAC_FFF1_8000_0000_2CDPs_SKID;
 extern const ByteSpan sTestCert_DAC_FFF1_8000_0000_2CDPs_PublicKey;

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -25,6 +25,7 @@
 
 #include <app/clusters/ota-provider/ota-provider.h>
 #include <controller/CHIPDeviceController.h>
+#include <lib/core/Global.h>
 #include <lib/support/TypeTraits.h>
 #include <platform/PlatformManager.h>
 #include <protocols/interaction_model/Constants.h>
@@ -492,29 +493,29 @@ private:
 };
 
 namespace {
-BdxOTASender gOtaSender;
+Global<BdxOTASender> gOtaSender;
 
-NSInteger const kOtaProviderEndpoint = 0;
+NSInteger constexpr kOtaProviderEndpoint = 0;
 } // anonymous namespace
 
 MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge() { Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this); }
 
 MTROTAProviderDelegateBridge::~MTROTAProviderDelegateBridge()
 {
-    gOtaSender.ResetState();
+    gOtaSender->ResetState();
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, nullptr);
 }
 
 CHIP_ERROR MTROTAProviderDelegateBridge::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeManager)
 {
-    return gOtaSender.Init(systemLayer, exchangeManager);
+    return gOtaSender->Init(systemLayer, exchangeManager);
 }
 
-void MTROTAProviderDelegateBridge::Shutdown() { gOtaSender.Shutdown(); }
+void MTROTAProviderDelegateBridge::Shutdown() { gOtaSender->Shutdown(); }
 
 void MTROTAProviderDelegateBridge::ControllerShuttingDown(MTRDeviceController * controller)
 {
-    gOtaSender.ControllerShuttingDown(controller);
+    gOtaSender->ControllerShuttingDown(controller);
 }
 
 namespace {
@@ -675,7 +676,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                 }
 
                 // If there is an update available, try to prepare for a transfer.
-                CHIP_ERROR err = gOtaSender.PrepareForTransfer(fabricIndex, nodeId);
+                CHIP_ERROR err = gOtaSender->PrepareForTransfer(fabricIndex, nodeId);
                 if (CHIP_NO_ERROR != err) {
 
                     // Handle busy error separately as we have a query image response status that maps to busy
@@ -698,7 +699,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                     handle.Release();
                     // We need to reset state here to clean up any initialization we might have done including starting the BDX
                     // timeout timer while preparing for transfer if any failure occurs afterwards.
-                    gOtaSender.ResetState();
+                    gOtaSender->ResetState();
                     return;
                 }
 
@@ -709,7 +710,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
                     LogErrorOnFailure(err);
                     handler->AddStatus(cachedCommandPath, StatusIB(err).mStatus);
                     handle.Release();
-                    gOtaSender.ResetState();
+                    gOtaSender->ResetState();
                     return;
                 }
                 delegateResponse.imageURI.SetValue(uri);

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -164,6 +164,30 @@
 #endif // CHIP_CONFIG_MEMORY_DEBUG_DMALLOC
 
 /**
+ *  @def CHIP_CONFIG_GLOBALS_LAZY_INIT
+ *
+ *  @brief
+ *    Whether to perform chip::Global initialization lazily (1) or eagerly (0).
+ *
+ *    The default is standard (eager) C++ global initialization behavior.
+ */
+#ifndef CHIP_CONFIG_GLOBALS_LAZY_INIT
+#define CHIP_CONFIG_GLOBALS_LAZY_INIT 0
+#endif // CHIP_CONFIG_GLOBALS_LAZY_INIT
+
+/**
+ *  @def CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+ *
+ *  @brief
+ *    Whether to omit calling destructors for chip::Global objects.
+ *
+ *    The default is to call destructors.
+ */
+#ifndef CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+#define CHIP_CONFIG_GLOBALS_NO_DESTRUCT 0
+#endif // CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+
+/**
  *  @def CHIP_CONFIG_SHA256_CONTEXT_SIZE
  *
  *  @brief

--- a/src/lib/core/Global.h
+++ b/src/lib/core/Global.h
@@ -36,7 +36,7 @@ class Global
 {
 public:
     /// Returns the global object, initializing it if necessary.
-    /// NOT threads-safe, external synchronization is required.
+    /// NOT thread-safe, external synchronization is required.
     T & get() { return _get(); }
     T * operator->() { return &_get(); }
 

--- a/src/lib/core/Global.h
+++ b/src/lib/core/Global.h
@@ -1,0 +1,102 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPConfig.h>
+
+#include <new>
+
+namespace chip {
+
+/**
+ * A wrapper for global object that enables initialization and destruction to
+ * be configured by the platform via `CHIP_CONFIG_GLOBALS_*` options.
+ *
+ * The contained object of type T is default constructed, possibly lazily.
+ *
+ * This class is generally NOT thread-safe; external synchronization is required.
+ */
+template <class T>
+class Global
+{
+public:
+    /// Returns the global object, initializing it if necessary.
+    T & operator*() { return get(); }
+    T * operator->() { return &get(); }
+
+#if CHIP_CONFIG_GLOBALS_LAZY_INIT
+public:
+    constexpr Global() = default;
+    ~Global()          = default;
+
+private:
+    // Zero-initialize everything. We should technically leave mStorage uninitialized,
+    // but that can sometimes cause clang to be unable to constant-initialize the object.
+    alignas(T) unsigned char mStorage[sizeof(T)] = {};
+    bool mInitialized                            = false;
+
+    T & value() { return *reinterpret_cast<T *>(mStorage); }
+
+    T & get()
+    {
+        if (!mInitialized)
+        {
+            new (mStorage) T();
+            mInitialized = true;
+#if !CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+            CHIP_CXA_ATEXIT(&destroy, this);
+#endif // CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+        }
+        return value();
+    }
+
+    static void destroy(void * context) { static_cast<Global<T> *>(context)->value().~T(); }
+
+#else // CHIP_CONFIG_GLOBALS_LAZY_INIT
+public:
+    constexpr Global() : mValue() {}
+
+private:
+    T & get() { return mValue; }
+
+#if CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+public:
+    // For not-trivially-destructible T, hiding it inside a union means the destructor
+    // won't get called automatically, however our own default destructor will be implicitly
+    // deleted. So Global<T> is technically not trivially-destructible, however the compiler
+    // tends to be able to optimize away the empty destructor call in practice. Getting around
+    // this cleanly requires using the "storage" approach used in the lazy variant, however
+    // this would require std::construct_at from C++20 to get constexpr initialization.
+    ~Global() {} // not "= default"
+
+private:
+    union
+    {
+        T mValue;
+    };
+#else  // CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+public:
+    ~Global() = default;
+
+private:
+    T mValue;
+#endif // CHIP_CONFIG_GLOBALS_NO_DESTRUCT
+#endif // CHIP_CONFIG_GLOBALS_LAZY_INIT
+};
+
+} // namespace chip

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -679,7 +679,7 @@ CHIP_ERROR DiscoveryImplPlatform::ReconfirmRecord(const char * hostname, Inet::I
 
 DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
 {
-    return *sManager;
+    return sManager.get();
 }
 
 ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -370,9 +370,7 @@ void DnssdService::ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses,
     }
 }
 
-DiscoveryImplPlatform DiscoveryImplPlatform::sManager;
-
-DiscoveryImplPlatform::DiscoveryImplPlatform() = default;
+Global<DiscoveryImplPlatform> DiscoveryImplPlatform::sManager;
 
 CHIP_ERROR DiscoveryImplPlatform::InitImpl()
 {
@@ -681,7 +679,7 @@ CHIP_ERROR DiscoveryImplPlatform::ReconfirmRecord(const char * hostname, Inet::I
 
 DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
 {
-    return sManager;
+    return *sManager;
 }
 
 ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -20,6 +20,7 @@
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/Global.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/dnssd/ResolverProxy.h>
@@ -72,7 +73,7 @@ private:
         kInitialized
     };
 
-    DiscoveryImplPlatform();
+    DiscoveryImplPlatform() = default;
 
     DiscoveryImplPlatform(const DiscoveryImplPlatform &) = delete;
     DiscoveryImplPlatform & operator=(const DiscoveryImplPlatform &) = delete;
@@ -99,7 +100,8 @@ private:
     ResolverProxy mResolverProxy;
     OperationalResolveDelegate * mOperationalDelegate = nullptr;
 
-    static DiscoveryImplPlatform sManager;
+    friend class Global<DiscoveryImplPlatform>;
+    static Global<DiscoveryImplPlatform> sManager;
 };
 
 } // namespace Dnssd

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -24,12 +24,11 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <ble/CHIPBleServiceData.h>
+#include <lib/core/Global.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/Darwin/BleApplicationDelegate.h>
 #include <platform/Darwin/BleConnectionDelegate.h>
 #include <platform/Darwin/BlePlatformDelegate.h>
-
-#include <new>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
@@ -40,7 +39,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-BLEManagerImpl BLEManagerImpl::sInstance;
+Global<BLEManagerImpl> BLEManagerImpl::sInstance;
 
 CHIP_ERROR BLEManagerImpl::_Init()
 {

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <lib/core/Global.h>
+#include <lib/support/CodeUtils.h>
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 namespace chip {
@@ -68,7 +71,7 @@ private:
     friend BLEManager & BLEMgr(void);
     friend BLEManagerImpl & BLEMgrImpl(void);
 
-    static BLEManagerImpl sInstance;
+    static Global<BLEManagerImpl> sInstance;
 
     BleConnectionDelegate * mConnectionDelegate   = nullptr;
     BlePlatformDelegate * mPlatformDelegate       = nullptr;
@@ -83,7 +86,7 @@ private:
  */
 inline BLEManager & BLEMgr(void)
 {
-    return BLEManagerImpl::sInstance;
+    return *BLEManagerImpl::sInstance;
 }
 
 /**
@@ -94,7 +97,7 @@ inline BLEManager & BLEMgr(void)
  */
 inline BLEManagerImpl & BLEMgrImpl(void)
 {
-    return BLEManagerImpl::sInstance;
+    return *BLEManagerImpl::sInstance;
 }
 
 } // namespace Internal

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -86,7 +86,7 @@ private:
  */
 inline BLEManager & BLEMgr(void)
 {
-    return *BLEManagerImpl::sInstance;
+    return BLEManagerImpl::sInstance.get();
 }
 
 /**
@@ -97,7 +97,7 @@ inline BLEManager & BLEMgr(void)
  */
 inline BLEManagerImpl & BLEMgrImpl(void)
 {
-    return *BLEManagerImpl::sInstance;
+    return BLEManagerImpl::sInstance.get();
 }
 
 } // namespace Internal

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -27,6 +27,11 @@
 
 #define CHIP_CONFIG_ABORT() abort()
 
+extern "C" int __cxa_atexit(void (*f)(void *), void * p, void * d);
+#define CHIP_CXA_ATEXIT(f, p) __cxa_atexit((f), (p), &__dso_handle)
+
+#define CHIP_CONFIG_GLOBALS_LAZY_INIT 1
+
 #define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
 #define CHIP_CONFIG_ERROR_SOURCE 1
 

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -27,6 +27,7 @@
 
 #define CHIP_CONFIG_ABORT() abort()
 
+#include <os/trace_base.h> // for __dso_handle
 extern "C" int __cxa_atexit(void (*f)(void *), void * p, void * d);
 #define CHIP_CXA_ATEXIT(f, p) __cxa_atexit((f), (p), &__dso_handle)
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -23,13 +23,14 @@
  *          for Darwin platforms.
  */
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/Darwin/ConfigurationManagerImpl.h>
 
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Darwin/DiagnosticDataProviderImpl.h>
 #include <platform/Darwin/PosixConfig.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 #include <lib/support/CHIPMemString.h>

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -131,7 +131,7 @@ std::shared_ptr<uint32_t> GetCounterHolder(const char * name)
 namespace chip {
 namespace Dnssd {
 
-MdnsContexts MdnsContexts::sInstance;
+Global<MdnsContexts> MdnsContexts::sInstance;
 
 namespace {
 

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -66,7 +66,7 @@ public:
     MdnsContexts(const MdnsContexts &) = delete;
     MdnsContexts & operator=(const MdnsContexts &) = delete;
     ~MdnsContexts();
-    static MdnsContexts & GetInstance() { return *sInstance; }
+    static MdnsContexts & GetInstance() { return sInstance.get(); }
 
     CHIP_ERROR Add(GenericContext * context, DNSServiceRef sdRef);
     CHIP_ERROR Remove(GenericContext * context);

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <dns_sd.h>
+#include <lib/core/Global.h>
 #include <lib/dnssd/platform/Dnssd.h>
 
 #include "DnssdHostNameRegistrar.h"
@@ -65,7 +66,7 @@ public:
     MdnsContexts(const MdnsContexts &) = delete;
     MdnsContexts & operator=(const MdnsContexts &) = delete;
     ~MdnsContexts();
-    static MdnsContexts & GetInstance() { return sInstance; }
+    static MdnsContexts & GetInstance() { return *sInstance; }
 
     CHIP_ERROR Add(GenericContext * context, DNSServiceRef sdRef);
     CHIP_ERROR Remove(GenericContext * context);
@@ -128,8 +129,9 @@ public:
     }
 
 private:
-    MdnsContexts(){};
-    static MdnsContexts sInstance;
+    MdnsContexts() = default;
+    friend class Global<MdnsContexts>;
+    static Global<MdnsContexts> sInstance;
 
     std::vector<GenericContext *> mContexts;
 };

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -40,7 +40,7 @@
 namespace chip {
 namespace DeviceLayer {
 
-PlatformManagerImpl PlatformManagerImpl::sInstance;
+Global<PlatformManagerImpl> PlatformManagerImpl::sInstance;
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -23,8 +23,10 @@
 
 #pragma once
 
-#include <dispatch/dispatch.h>
+#include <lib/core/Global.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
+
+#include <dispatch/dispatch.h>
 
 static constexpr const char * const CHIP_CONTROLLER_QUEUE = "org.csa-iot.matter.framework.controller.workqueue";
 
@@ -77,9 +79,8 @@ private:
 
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
-    friend class Internal::BLEManagerImpl;
 
-    static PlatformManagerImpl sInstance;
+    static Global<PlatformManagerImpl> sInstance;
 
     System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
@@ -104,7 +105,7 @@ private:
  */
 inline PlatformManager & PlatformMgr(void)
 {
-    return PlatformManagerImpl::sInstance;
+    return *PlatformManagerImpl::sInstance;
 }
 
 /**
@@ -115,7 +116,7 @@ inline PlatformManager & PlatformMgr(void)
  */
 inline PlatformManagerImpl & PlatformMgrImpl(void)
 {
-    return PlatformManagerImpl::sInstance;
+    return *PlatformManagerImpl::sInstance;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -105,7 +105,7 @@ private:
  */
 inline PlatformManager & PlatformMgr(void)
 {
-    return *PlatformManagerImpl::sInstance;
+    return PlatformManagerImpl::sInstance.get();
 }
 
 /**
@@ -116,7 +116,7 @@ inline PlatformManager & PlatformMgr(void)
  */
 inline PlatformManagerImpl & PlatformMgrImpl(void)
 {
-    return *PlatformManagerImpl::sInstance;
+    return PlatformManagerImpl::sInstance.get();
 }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
Introduce a chip::Global wrapper for managing global objects with non-trivial constructors / destructors.

The behavior of the wrapper can be configured via two `CHIP_CONFIG_GLOBALS_*` options in the platform config header (the default is current standard C++ behavior). By setting `CHIP_CONFIG_GLOBALS_LAZY_INIT = 1` globals can instead be constructed lazily (note this is done in a thread-unsafe way as synchronization is assumed to be external).

Adopt chip::Global in the Darwin platform layer and for key core singletons and enable CHIP_CONFIG_GLOBALS_LAZY_INIT = 1 on Darwin.