### PR TITLE
[Tizen] Exclude *.map file from test runner ISO

### DIFF
--- a/src/test_driver/tizen/chip_tests/BUILD.gn
+++ b/src/test_driver/tizen/chip_tests/BUILD.gn
@@ -30,6 +30,7 @@ tizen_qemu_mkisofs("chip-tests-runner") {
   #              rebuild of the ISO image, so the test will be run with old
   #              binaries.
   assets_non_tracked = [ rebase_path("${root_build_dir}/tests") ]
+  assets_non_tracked_exclude_globs = [ "*.map" ]
 }
 
 tizen_qemu_run("chip-tests") {

--- a/third_party/tizen/tizen_sdk.gni
+++ b/third_party/tizen/tizen_sdk.gni
@@ -190,10 +190,26 @@ template("tizen_qemu_mkisofs") {
       "-input-charset=default",
       "-VCHIP",  # Volume ID = CHIP
       "-JRU",  # Joliet + Rock Ridge with untranslated filenames
+    ]
+
+    # Exclude files from the ISO image which might otherwise be included
+    # by non-tracked assets in case of adding entire directory. This will
+    # not exclude files added explicitly.
+    if (defined(invoker.assets_non_tracked_exclude_globs)) {
+      foreach(glob, invoker.assets_non_tracked_exclude_globs) {
+        args += [
+          "-m",
+          glob,
+        ]
+      }
+    }
+
+    args += [
       "-o",
       rebase_path(image_file),
       rebase_path(invoker.runner),
     ]
+
     if (defined(invoker.assets)) {
       args += invoker.assets
       inputs += invoker.assets


### PR DESCRIPTION
### Problem

From time to time Tizen QEMU tests fails because of "No space left on device" error. It is because we are building all unit tests and bundling them as an ISO image. Currently all files from the out/tizen-.../tests are being added to that ISO image, which doubles the required size (which currently is 3.8 GB). This directory contains *.map files which are not required to run tests. Excluding these files can reduce required extra disk space to 1.4 GB.

E.g. failing job:
https://github.com/project-chip/connectedhomeip/actions/runs/6054791758/job/16432761251

### Testing

CI will test that.