### PR TITLE
[Scenes] Level control handler bugfix

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -171,9 +171,16 @@ public:
         uint8_t maxLevel;
         VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == Attributes::MaxLevel::Get(endpoint, &maxLevel), CHIP_ERROR_READ_FAILED);
 
-        pairs[0].attributeID    = Attributes::CurrentLevel::Id;
-        pairs[0].attributeValue = (!level.IsNull()) ? level.Value() : maxLevel + 1;
-        size_t attributeCount   = 1;
+        pairs[0].attributeID = Attributes::CurrentLevel::Id;
+        if (!level.IsNull())
+        {
+            pairs[0].attributeValue = level.Value();
+        }
+        else
+        {
+            chip::app::NumericAttributeTraits<uint32_t>::SetNull(pairs[0].attributeValue);
+        }
+        size_t attributeCount = 1;
         if (LevelControlHasFeature(endpoint, LevelControl::Feature::kFrequency))
         {
             uint16_t frequency;
@@ -238,9 +245,9 @@ public:
         CommandId command = LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff) ? Commands::MoveToLevelWithOnOff::Id
                                                                                             : Commands::MoveToLevel::Id;
 
-        status = moveToLevelHandler(
-            endpoint, command, level, app::DataModel::MakeNullable<uint16_t>(static_cast<uint16_t>(timeMs / 100)),
-            chip::Optional<BitMask<LevelControlOptions>>(), chip::Optional<BitMask<LevelControlOptions>>(), INVALID_STORED_LEVEL);
+        status = moveToLevelHandler(endpoint, command, level, app::DataModel::MakeNullable(static_cast<uint16_t>(timeMs / 100)),
+                                    chip::Optional<BitMask<LevelControlOptions>>(), chip::Optional<BitMask<LevelControlOptions>>(),
+                                    INVALID_STORED_LEVEL);
 
         if (status != Status::Success)
         {

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -290,7 +290,7 @@ public:
         }
 
         // This handler assumes it is being used with the default handler for the level control. Therefore if the level control
-        // cluster with on off feature is present on the endpoint, if the level control handler is registered, it assumes this
+        // cluster with on off feature is present on the endpoint and the level control handler is registered, it assumes this
         // handler will take action on the on-off state. This assumes the level control attributes were also saved in the scene.
         // This is to prevent a behavior where the on off state is set by this handler, and then the level control handler or vice
         // versa.

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -289,6 +289,11 @@ public:
             return err;
         }
 
+        // This handler assumes it is being used with the default handler for the level control. Therefore if the level control
+        // cluster with on off feature is present on the endpoint, if the level control handler is registered, it assumes this
+        // handler will take action on the on-off state. This assumes the level control attributes were also saved in the scene.
+        // This is to prevent a behavior where the on off state is set by this handler, and then the level control handler or vice
+        // versa.
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         if (!(LevelControlWithOnOffFeaturePresent(endpoint) &&
               Scenes::ScenesServer::Instance().IsHandlerRegistered(endpoint, LevelControlServer::GetSceneHandler())))


### PR DESCRIPTION
Addresses : https://github.com/project-chip/connectedhomeip/issues/29033

Solves broken null value storage by adding proper null handling for storing the current level.

Also removes un-necessary explicit typing and documents the behavior of the on-off handler when the level-control handler is registered.

