### PR TITLE
Optimize the algorithm to replace all occurrences of java/util/Optional

### DIFF
--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -124,7 +124,6 @@ exit:
 CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
                                      jmethodID * methodId)
 {
-    CHIP_ERROR err   = CHIP_NO_ERROR;
     jclass javaClass = nullptr;
     VerifyOrReturnError(env != nullptr && object != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
 
@@ -132,11 +131,17 @@ CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * 
     VerifyOrReturnError(javaClass != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
     *methodId = env->GetMethodID(javaClass, methodName, methodSignature);
+    env->ExceptionClear();
+
+    if (*methodId != nullptr)
+    {
+        return CHIP_NO_ERROR;
+    }
 
     // Try `j$` when enabling Java8.
     std::string methodSignature_java8_str(methodSignature);
     size_t pos = methodSignature_java8_str.find("java/util/Optional");
-    if (*methodId == nullptr && pos != std::string::npos)
+    if (pos != std::string::npos)
     {
         // Replace all "java/util/Optional" with "j$/util/Optional".
         while (pos != std::string::npos)
@@ -145,11 +150,12 @@ CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * 
             pos = methodSignature_java8_str.find("java/util/Optional");
         }
         *methodId = env->GetMethodID(javaClass, methodName, methodSignature_java8_str.c_str());
+        env->ExceptionClear();
     }
 
     VerifyOrReturnError(*methodId != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void JniReferences::CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument)
@@ -219,11 +225,13 @@ CHIP_ERROR JniReferences::CreateOptional(jobject objectToWrap, jobject & outOpti
     chip::JniClass jniClass(optionalCls);
 
     jmethodID ofMethod = env->GetStaticMethodID(optionalCls, "ofNullable", "(Ljava/lang/Object;)Ljava/util/Optional;");
+    env->ExceptionClear();
 
     // Try `Lj$/util/Optional;` when enabling Java8.
     if (ofMethod == nullptr)
     {
         ofMethod = env->GetStaticMethodID(optionalCls, "ofNullable", "(Ljava/lang/Object;)Lj$/util/Optional;");
+        env->ExceptionClear();
     }
 
     VerifyOrReturnError(ofMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -135,15 +135,16 @@ CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * 
 
     // Try `j$` when enabling Java8.
     std::string methodSignature_java8_str(methodSignature);
-    if (*methodId == nullptr && methodSignature_java8_str.find("java/util/Optional") != std::string::npos)
-    {
+    size_t pos = methodSignature_java8_str.find("java/util/Optional");
+    if (*methodId == nullptr && pos != std::string::npos) {
         // Replace all "java/util/Optional" with "j$/util/Optional".
-        while (methodSignature_java8_str.find("java/util/Optional") != std::string::npos)
-        {
-            size_t pos = methodSignature_java8_str.find("java/util/Optional");
-            methodSignature_java8_str.replace(pos, strlen("java/util/Optional"), "j$/util/Optional");
+        while (pos != std::string::npos) {
+            methodSignature_java8_str.replace(pos, strlen("java/util/Optional"),
+                                              "j$/util/Optional");
+            pos = methodSignature_java8_str.find("java/util/Optional");
         }
-        *methodId = env->GetMethodID(javaClass, methodName, methodSignature_java8_str.c_str());
+        *methodId = env->GetMethodID(javaClass, methodName,
+                                     methodSignature_java8_str.c_str());
     }
 
     VerifyOrReturnError(*methodId != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -136,15 +136,15 @@ CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * 
     // Try `j$` when enabling Java8.
     std::string methodSignature_java8_str(methodSignature);
     size_t pos = methodSignature_java8_str.find("java/util/Optional");
-    if (*methodId == nullptr && pos != std::string::npos) {
+    if (*methodId == nullptr && pos != std::string::npos)
+    {
         // Replace all "java/util/Optional" with "j$/util/Optional".
-        while (pos != std::string::npos) {
-            methodSignature_java8_str.replace(pos, strlen("java/util/Optional"),
-                                              "j$/util/Optional");
+        while (pos != std::string::npos)
+        {
+            methodSignature_java8_str.replace(pos, strlen("java/util/Optional"), "j$/util/Optional");
             pos = methodSignature_java8_str.find("java/util/Optional");
         }
-        *methodId = env->GetMethodID(javaClass, methodName,
-                                     methodSignature_java8_str.c_str());
+        *methodId = env->GetMethodID(javaClass, methodName, methodSignature_java8_str.c_str());
     }
 
     VerifyOrReturnError(*methodId != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);


### PR DESCRIPTION
Reduced Redundancy: In the current version, we call methodSignature_java8_str.find("java/util/Optional") twice in each iteration of the while loop. We should call it once before entering the loop and then update it within the loop. This reduces redundant function calls and improves performance.

Improved Readability: The improved version assigns the result of methodSignature_java8_str.find("java/util/Optional") to the pos variable, making the code more readable and avoiding redundancy. This makes it clear that you are using the same variable for both the initial check and the loop condition.

