### PR TITLE
[ICD] Fix ICD Manager Init

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -252,13 +252,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     }
 #endif // CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
 
+    // This initializes clusters, so should come after lower level initialization.
+    InitDataModelHandler();
+
+// ICD Init needs to be after data model init
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     mICDManager.Init(mDeviceStorage, &GetFabricTable(), mReportScheduler);
     mICDEventManager.Init(&mICDManager);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-
-    // This initializes clusters, so should come after lower level initialization.
-    InitDataModelHandler();
 
 #if defined(CHIP_APP_USE_ECHO)
     err = InitEchoHandler(&mExchangeMgr);


### PR DESCRIPTION
ICD Manager needs to retrieve Info from the data model (e.g. featureMap for check-in protocol support). As such the data model needs to be initialized first. 

