### PR TITLE
Update ZAP to v2023.09.05-nightly.

### DIFF
--- a/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
+++ b/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
@@ -10833,6 +10833,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
@@ -11081,6 +11081,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_pump_5f904818cc.zap
+++ b/examples/chef/devices/rootnode_pump_5f904818cc.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 97,
+  "featureLevel": 98,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -36,7 +36,6 @@
       "id": 1,
       "name": "MA-rootdevice",
       "deviceTypeRef": {
-        "id": 2,
         "code": 22,
         "profileId": 259,
         "label": "MA-rootdevice",
@@ -44,15 +43,11 @@
       },
       "deviceTypes": [
         {
-          "id": 2,
           "code": 22,
           "profileId": 259,
           "label": "MA-rootdevice",
           "name": "MA-rootdevice"
         }
-      ],
-      "deviceTypeRefs": [
-        2
       ],
       "deviceVersions": [
         1
@@ -6244,7 +6239,6 @@
       "id": 2,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "id": 14,
         "code": 771,
         "profileId": 2457,
         "label": "MA-pump",
@@ -6252,15 +6246,11 @@
       },
       "deviceTypes": [
         {
-          "id": 14,
           "code": 771,
           "profileId": 2457,
           "label": "MA-pump",
           "name": "MA-pump"
         }
-      ],
-      "deviceTypeRefs": [
-        14
       ],
       "deviceVersions": [
         1
@@ -7689,7 +7679,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -7705,7 +7695,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -7721,7 +7711,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -7737,7 +7727,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -7981,7 +7971,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -7997,7 +7987,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8013,7 +8003,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8029,7 +8019,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8193,7 +8183,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8209,7 +8199,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8225,7 +8215,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8241,7 +8231,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -8302,6 +8292,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
+++ b/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
@@ -12727,6 +12727,5 @@
       "endpointId": 3,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
+++ b/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 97,
+  "featureLevel": 98,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -33,10 +33,9 @@
   ],
   "endpointTypes": [
     {
-      "id": 8,
+      "id": 1,
       "name": "MA-rootdevice",
       "deviceTypeRef": {
-        "id": 2,
         "code": 22,
         "profileId": 259,
         "label": "MA-rootdevice",
@@ -44,15 +43,11 @@
       },
       "deviceTypes": [
         {
-          "id": 2,
           "code": 22,
           "profileId": 259,
           "label": "MA-rootdevice",
           "name": "MA-rootdevice"
         }
-      ],
-      "deviceTypeRefs": [
-        2
       ],
       "deviceVersions": [
         1
@@ -6252,10 +6247,9 @@
       ]
     },
     {
-      "id": 7,
+      "id": 2,
       "name": "MA-refrigerator",
       "deviceTypeRef": {
-        "id": 48,
         "code": 112,
         "profileId": 259,
         "label": "MA-refrigerator",
@@ -6263,15 +6257,11 @@
       },
       "deviceTypes": [
         {
-          "id": 48,
           "code": 112,
           "profileId": 259,
           "label": "MA-refrigerator",
           "name": "MA-refrigerator"
         }
-      ],
-      "deviceTypeRefs": [
-        48
       ],
       "deviceVersions": [
         1
@@ -11686,10 +11676,9 @@
       ]
     },
     {
-      "id": 5,
+      "id": 3,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "id": 51,
         "code": 113,
         "profileId": 259,
         "label": "MA-temperature-controlled-cabinet",
@@ -11697,15 +11686,11 @@
       },
       "deviceTypes": [
         {
-          "id": 51,
           "code": 113,
           "profileId": 259,
           "label": "MA-temperature-controlled-cabinet",
           "name": "MA-temperature-controlled-cabinet"
         }
-      ],
-      "deviceTypeRefs": [
-        51
       ],
       "deviceVersions": [
         1
@@ -12202,10 +12187,9 @@
       ]
     },
     {
-      "id": 6,
+      "id": 4,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "id": 51,
         "code": 113,
         "profileId": 259,
         "label": "MA-temperature-controlled-cabinet",
@@ -12213,15 +12197,11 @@
       },
       "deviceTypes": [
         {
-          "id": 51,
           "code": 113,
           "profileId": 259,
           "label": "MA-temperature-controlled-cabinet",
           "name": "MA-temperature-controlled-cabinet"
         }
-      ],
-      "deviceTypeRefs": [
-        51
       ],
       "deviceVersions": [
         1
@@ -12747,6 +12727,5 @@
       "endpointId": 3,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.zap
+++ b/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.zap
@@ -18,17 +18,17 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "version": "chip-v1"
-    },
-    {
-      "pathRelativity": "relativeToZap",
       "path": "../../../src/app/zap-templates/zcl/zcl.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data"
+    },
+    {
+      "pathRelativity": "relativeToZap",
+      "path": "../../../src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -6993,6 +6993,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.09.01-nightly.1"]
+            "tags": ["version:2@v2023.09.05-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2023.09.01-nightly.1"]
+            "tags": ["version:2@v2023.09.05-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.09.01-nightly
+v2023.09.05-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.9.1'
+MIN_ZAP_VERSION = '2023.9.5'
 
 
 class ZapTool:


### PR DESCRIPTION
This should fix UI issues around enabling/disabling events.

The .zap changes are from ZAP files that were last edited/generated with a too-old version of ZAP (from before v2023.08.30-nightly).
