### PR TITLE
Fix slow test skipping in CI.

### DIFF
--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -169,7 +169,7 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
 
     # If just defaults specified, do not run manual and in development
     # Specific target basically includes everything
-    if 'all' in target and not include_tags:
+    if 'all' in target and not include_tags and not exclude_tags:
         exclude_tags = {
             TestTag.MANUAL,
             TestTag.IN_DEVELOPMENT,


### PR DESCRIPTION
CI does "--exclude-tags SLOW", but it was not specifying any "--include-tags", so the harness overwrote the "--exclude-tags" value and we were in fact running the slow tests when we did not want to be.
