### PR TITLE
Added Feature Map to `AirQuality` Read Handler

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -6826,7 +6826,7 @@ endpoint 1 {
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 15;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 1;
   }
 

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -10495,7 +10495,7 @@
       ]
     },
     {
-      "id": 4,
+      "id": 2,
       "name": "MA-onofflight",
       "deviceTypeRef": {
         "code": 256,
@@ -16926,7 +16926,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "15",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -34866,7 +34866,7 @@
       ]
     },
     {
-      "id": 2,
+      "id": 4,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
         "code": 61442,

--- a/src/app/clusters/air-quality-server/air-quality-server.cpp
+++ b/src/app/clusters/air-quality-server/air-quality-server.cpp
@@ -115,6 +115,9 @@ CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValu
     case Attributes::AirQuality::Id:
         ReturnErrorOnFailure(aEncoder.Encode(mAirQuality));
         break;
+    case Attributes::FeatureMap::Id:
+        ReturnErrorOnFailure(aEncoder.Encode(mFeature.Raw()));
+        break;
     }
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
The `mFeature` value that is passed to the class as an arg was not included in the Read Handler for this class.

This was not picked up in CI as the all-clusters-app zapfile was set to the correct value and as such, this was getting returned when the Read Handler failed to encode anything.

So I have fixed it and zero'ed out the zapfile so as to catch this error in future.