### PR TITLE
[MatterYamlTests] null values that are saved are not substituted when…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/errors.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/errors.py
@@ -210,3 +210,15 @@ class TestStepArgumentsValueError(TestStepError):
         self.tag_key_with_error(content, 'command')
         arguments = content.get('arguments')
         self.tag_key_with_error(arguments, 'value')
+
+
+class TestStepSaveAsNameError(TestStepError):
+    """Raise when a test step response save an attribute response with the same name than the attribute itself"""
+
+    def __init__(self, content):
+        message = 'The "saveAs" key can not be the same than the "attribute" key'
+        super().__init__(message)
+
+        self.tag_key_with_error(content, 'attribute')
+        response = content.get('response')
+        self.tag_key_with_error(response, 'saveAs')

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -1080,9 +1080,8 @@ class TestStep:
                     variable_info = self._runtime_config_variable_storage[token]
                     if type(variable_info) is dict and 'defaultValue' in variable_info:
                         variable_info = variable_info['defaultValue']
-                    if variable_info is not None:
-                        tokens[idx] = variable_info
-                        substitution_occured = True
+                    tokens[idx] = variable_info
+                    substitution_occured = True
 
             if len(tokens) == 1:
                 return tokens[0]

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -17,7 +17,8 @@ from typing import Tuple, Union
 
 from .errors import (TestStepArgumentsValueError, TestStepError, TestStepGroupEndPointError, TestStepGroupResponseError,
                      TestStepInvalidTypeError, TestStepKeyError, TestStepNodeIdAndGroupIdError, TestStepResponseVariableError,
-                     TestStepValueAndValuesError, TestStepVerificationStandaloneError, TestStepWaitResponseError)
+                     TestStepSaveAsNameError, TestStepValueAndValuesError, TestStepVerificationStandaloneError,
+                     TestStepWaitResponseError)
 from .fixes import add_yaml_support_for_scientific_notation_without_dot
 
 try:
@@ -123,6 +124,7 @@ class YamlLoader:
         self.__rule_wait_should_not_expect_a_response(content)
         self.__rule_response_variable_should_exist_in_config(config, content)
         self.__rule_argument_value_is_only_when_writing_attributes(content)
+        self.__rule_saveas_name_and_attribute_name_should_be_different(content)
 
         if 'arguments' in content:
             arguments = content.get('arguments')
@@ -272,3 +274,11 @@ class YamlLoader:
             arguments = content.get('arguments')
             if 'value' in arguments and operation != 'writeAttribute':
                 raise TestStepArgumentsValueError(content)
+
+    def __rule_saveas_name_and_attribute_name_should_be_different(self, content):
+        if content.get('command') == 'readAttribute' and 'response' in content:
+            attribute_name = content.get('attribute')
+            response = content.get('response')
+            if 'saveAs' in response:
+                if response.get('saveAs') == attribute_name:
+                    raise TestStepSaveAsNameError(content)

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -58,7 +58,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfTotalUsersSupported"
       response:
-          saveAs: NumberOfTotalUsersSupported
+          saveAs: NumberOfTotalUsersSupportedValue
           value: 10
 
     - label:
@@ -67,7 +67,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfWeekDaySchedulesSupportedPerUser"
       response:
-          saveAs: NumberOfWeekDaySchedulesSupportedPerUser
+          saveAs: NumberOfWeekDaySchedulesSupportedPerUserValue
           value: 10
 
     - label:
@@ -76,14 +76,14 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfYearDaySchedulesSupportedPerUser"
       response:
-          saveAs: NumberOfYearDaySchedulesSupportedPerUser
+          saveAs: NumberOfYearDaySchedulesSupportedPerUserValue
           value: 10
 
     - label: "Get Max number of Holiday schedules and verify default value"
       command: "readAttribute"
       attribute: "NumberOfHolidaySchedulesSupported"
       response:
-          saveAs: NumberOfHolidaySchedulesSupported
+          saveAs: NumberOfHolidaySchedulesSupportedValue
           value: 10
 
     #
@@ -115,7 +115,7 @@ tests:
       arguments:
           values:
               - name: "WeekDayIndex"
-                value: NumberOfWeekDaySchedulesSupportedPerUser + 1
+                value: NumberOfWeekDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
               - name: "DaysMask"
@@ -159,7 +159,7 @@ tests:
               - name: "WeekDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "DaysMask"
                 value: 0x01
               - name: "StartHour"
@@ -427,13 +427,13 @@ tests:
       arguments:
           values:
               - name: "WeekDayIndex"
-                value: NumberOfWeekDaySchedulesSupportedPerUser + 1
+                value: NumberOfWeekDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
       response:
           values:
               - name: "WeekDayIndex"
-                value: NumberOfWeekDaySchedulesSupportedPerUser + 1
+                value: NumberOfWeekDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
               - name: "Status"
@@ -463,13 +463,13 @@ tests:
               - name: "WeekDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           values:
               - name: "WeekDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "Status"
                 value: 0x85
 
@@ -513,7 +513,7 @@ tests:
       arguments:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser + 1
+                value: NumberOfYearDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
               - name: "LocalStartTime"
@@ -545,7 +545,7 @@ tests:
               - name: "YearDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "LocalStartTime"
                 value: 12345
               - name: "LocalEndTime"
@@ -625,13 +625,13 @@ tests:
       arguments:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser + 1
+                value: NumberOfYearDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
       response:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser + 1
+                value: NumberOfYearDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
               - name: "Status"
@@ -661,13 +661,13 @@ tests:
               - name: "YearDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           values:
               - name: "YearDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "Status"
                 value: 0x85
 
@@ -711,7 +711,7 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported + 1
+                value: NumberOfHolidaySchedulesSupportedValue + 1
               - name: "LocalStartTime"
                 value: 12345
               - name: "LocalEndTime"
@@ -785,11 +785,11 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported + 1
+                value: NumberOfHolidaySchedulesSupportedValue + 1
       response:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported + 1
+                value: NumberOfHolidaySchedulesSupportedValue + 1
               - name: "Status"
                 value: 0x85
 
@@ -925,7 +925,7 @@ tests:
       arguments:
           values:
               - name: "WeekDayIndex"
-                value: NumberOfWeekDaySchedulesSupportedPerUser + 1
+                value: NumberOfWeekDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
       response:
@@ -949,7 +949,7 @@ tests:
               - name: "WeekDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           error: INVALID_COMMAND
 
@@ -1050,7 +1050,7 @@ tests:
       arguments:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser + 1
+                value: NumberOfYearDaySchedulesSupportedPerUserValue + 1
               - name: "UserIndex"
                 value: 1
       response:
@@ -1074,7 +1074,7 @@ tests:
               - name: "YearDayIndex"
                 value: 1
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           error: INVALID_COMMAND
 
@@ -1171,7 +1171,7 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser + 1
+                value: NumberOfYearDaySchedulesSupportedPerUserValue + 1
       response:
           error: INVALID_COMMAND
 
@@ -1896,7 +1896,7 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
               - name: "LocalStartTime"
                 value: 1
               - name: "LocalEndTime"
@@ -1909,11 +1909,11 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
       response:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
               - name: "Status"
                 value: 0x0
               - name: "LocalStartTime"
@@ -2027,11 +2027,11 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
       response:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
               - name: "Status"
                 value: 0x0
               - name: "LocalStartTime"
@@ -2129,11 +2129,11 @@ tests:
       arguments:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
       response:
           values:
               - name: "HolidayIndex"
-                value: NumberOfHolidaySchedulesSupported
+                value: NumberOfHolidaySchedulesSupportedValue
               - name: "Status"
                 value: 0x8B
 

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -61,7 +61,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfTotalUsersSupported"
       response:
-          saveAs: NumberOfTotalUsersSupported
+          saveAs: NumberOfTotalUsersSupportedValue
           value: 10
 
     - label: "Read fails for user with index 0"
@@ -79,7 +79,7 @@ tests:
       arguments:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           error: INVALID_COMMAND
 
@@ -656,7 +656,7 @@ tests:
               - name: "OperationType"
                 value: 0
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported
+                value: NumberOfTotalUsersSupportedValue
               - name: "UserName"
                 value: "last_user"
               - name: "UserUniqueID"
@@ -673,11 +673,11 @@ tests:
       arguments:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported
+                value: NumberOfTotalUsersSupportedValue
       response:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported
+                value: NumberOfTotalUsersSupportedValue
               - name: "UserName"
                 value: "last_user"
               - name: "UserUniqueID"
@@ -727,7 +727,7 @@ tests:
               - name: "OperationType"
                 value: 0
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "UserName"
                 value: null
               - name: "UserUniqueID"
@@ -844,7 +844,7 @@ tests:
       arguments:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
       response:
           error: INVALID_COMMAND
 
@@ -890,11 +890,11 @@ tests:
       arguments:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported
+                value: NumberOfTotalUsersSupportedValue
       response:
           values:
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported
+                value: NumberOfTotalUsersSupportedValue
               - name: "UserName"
                 value: null
               - name: "UserUniqueID"
@@ -922,7 +922,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfPINUsersSupported"
       response:
-          saveAs: NumberOfPINUsersSupported
+          saveAs: NumberOfPINUsersSupportedValue
           value: 10
 
     - label: "Check that PIN credential does not exist"
@@ -972,7 +972,7 @@ tests:
                 value:
                     {
                         CredentialType: 1,
-                        CredentialIndex: NumberOfPINUsersSupported + 1,
+                        CredentialIndex: NumberOfPINUsersSupportedValue + 1,
                     }
       response:
           values:
@@ -1154,7 +1154,7 @@ tests:
                 value:
                     {
                         CredentialType: 1,
-                        CredentialIndex: NumberOfPINUsersSupported + 1,
+                        CredentialIndex: NumberOfPINUsersSupportedValue + 1,
                     }
               - name: "CredentialData"
                 value: "123456"
@@ -1177,7 +1177,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfRFIDUsersSupported"
       response:
-          saveAs: NumberOfRFIDUsersSupported
+          saveAs: NumberOfRFIDUsersSupportedValue
           value: 10
 
     - label: "Reading RFID credential with index 0 returns no credential"
@@ -1209,7 +1209,7 @@ tests:
                 value:
                     {
                         CredentialType: 2,
-                        CredentialIndex: NumberOfRFIDUsersSupported + 1,
+                        CredentialIndex: NumberOfRFIDUsersSupportedValue + 1,
                     }
       response:
           values:
@@ -1443,7 +1443,7 @@ tests:
                 value:
                     {
                         CredentialType: 2,
-                        CredentialIndex: NumberOfRFIDUsersSupported + 1,
+                        CredentialIndex: NumberOfRFIDUsersSupportedValue + 1,
                     }
               - name: "CredentialData"
                 value: "new_rfid_data_field"
@@ -1500,7 +1500,7 @@ tests:
               - name: "CredentialData"
                 value: "123465"
               - name: "UserIndex"
-                value: NumberOfTotalUsersSupported + 1
+                value: NumberOfTotalUsersSupportedValue + 1
               - name: "UserStatus"
                 value: null
               - name: "UserType"
@@ -2692,7 +2692,7 @@ tests:
                 value:
                     {
                         CredentialType: 1,
-                        CredentialIndex: NumberOfPINUsersSupported + 1,
+                        CredentialIndex: NumberOfPINUsersSupportedValue + 1,
                     }
       response:
           error: INVALID_COMMAND
@@ -2716,7 +2716,7 @@ tests:
                 value:
                     {
                         CredentialType: 2,
-                        CredentialIndex: NumberOfRFIDUsersSupported + 1,
+                        CredentialIndex: NumberOfRFIDUsersSupportedValue + 1,
                     }
       response:
           error: INVALID_COMMAND

--- a/src/app/tests/suites/TestColorControl_9_2.yaml
+++ b/src/app/tests/suites/TestColorControl_9_2.yaml
@@ -233,7 +233,7 @@ tests:
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       response:
-          saveAs: ColorLoopStartEnhancedHue
+          saveAs: ColorLoopStartEnhancedHueValue2
 
     - label: "Read EnhancedCurrentHue attribute from DUT"
       command: "readAttribute"
@@ -241,7 +241,7 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: ColorLoopStartEnhancedHue
+              minValue: ColorLoopStartEnhancedHueValue2
               maxValue: 65535
 
     - label: "Wait for 5S"
@@ -258,7 +258,7 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: ColorLoopStartEnhancedHue
+              minValue: ColorLoopStartEnhancedHueValue2
               maxValue: 65535
 
     - label:
@@ -294,13 +294,13 @@ tests:
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       response:
-          saveAs: ColorLoopStoredEnhancedHueValue
+          saveAs: ColorLoopStoredEnhancedHueValue3
 
     - label: "Read EnhancedCurrentHue attribute from DUT."
       command: "readAttribute"
       attribute: "EnhancedCurrentHue"
       response:
-          value: ColorLoopStoredEnhancedHueValue
+          value: ColorLoopStoredEnhancedHueValue3
 
     - label: "Turn off light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/TestSaveAs.yaml
+++ b/src/app/tests/suites/TestSaveAs.yaml
@@ -802,3 +802,38 @@ tests:
       attribute: "octet_string"
       arguments:
           value: readAttributeOctetStringDefaultValue
+
+    # Tests for null values
+    - label: "Read attribute nullable_boolean Default Value"
+      command: "readAttribute"
+      attribute: "nullable_boolean"
+      response:
+          saveAs: readAttributeNullableBooleanDefaultValue
+          value: false
+
+    - label: "Write attribute nullable_boolean to null"
+      command: "writeAttribute"
+      attribute: "nullable_boolean"
+      arguments:
+          value: null
+
+    - label: "Read attribute nullable_boolean null Value"
+      command: "readAttribute"
+      attribute: "nullable_boolean"
+      response:
+          saveAs: readAttributeNullableBooleanNullValue
+          value: null
+
+    - label:
+          "Read attribute nullable_boolean null Value again and compare it to
+          the previously saved value"
+      command: "readAttribute"
+      attribute: "nullable_boolean"
+      response:
+          value: readAttributeNullableBooleanNullValue
+
+    - label: "Write attribute nullable_boolean Default Value"
+      command: "writeAttribute"
+      attribute: "nullable_boolean"
+      arguments:
+          value: readAttributeNullableBooleanDefaultValue

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
@@ -69,7 +69,7 @@ tests:
       command: "readAttribute"
       attribute: "CurrentFabricIndex"
       response:
-          saveAs: CurrentFabricIndex
+          saveAs: CurrentFabricIndexValue
 
     - label:
           "Step 3: TH1 reads DUT Endpoint 0 AccessControl cluster Extension
@@ -88,7 +88,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 5: TH1 reads DUT Endpoint 0 AccessControl cluster Extension
@@ -97,7 +97,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 6: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -108,7 +108,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster Extension
@@ -117,7 +117,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 8: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -128,7 +128,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster Extension
@@ -137,7 +137,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -148,7 +148,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_LENGTH, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_LENGTH, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -160,7 +160,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_STRUCT, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_STRUCT, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -173,7 +173,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_LIST, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_LIST, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -186,7 +186,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_ELEM, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_ELEM, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -199,7 +199,8 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_OVERFLOW, FabricIndex: CurrentFabricIndex }]
+          value:
+              [{ Data: D_BAD_OVERFLOW, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -212,7 +213,8 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_UNDERFLOW, FabricIndex: CurrentFabricIndex }]
+          value:
+              [{ Data: D_BAD_UNDERFLOW, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -224,7 +226,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_NONE, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_NONE, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -241,8 +243,8 @@ tests:
       arguments:
           value:
               [
-                  { Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex },
-                  { Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndex },
+                  { Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue },
+                  { Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndexValue },
               ]
       response:
           error: CONSTRAINT_ERROR
@@ -254,7 +256,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 19: TH1 writes DUT Endpoint 0 AccessControl cluster Extension

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -59,7 +59,7 @@ tests:
       cluster: "Operational Credentials"
       attribute: "CurrentFabricIndex"
       response:
-          saveAs: CurrentFabricIndex
+          saveAs: CurrentFabricIndexValue
 
     - label:
           "Step 3:TH1 reads DUT Endpoint 0 AccessControl cluster ACL attribute"
@@ -74,7 +74,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -98,7 +98,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -106,7 +106,7 @@ tests:
                       Subjects: [111, 222, 333, 444],
                       Targets:
                           [{ Cluster: 11, Endpoint: 22, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -114,7 +114,7 @@ tests:
                       Subjects: [555, 666, 777, 888],
                       Targets:
                           [{ Cluster: 55, Endpoint: 66, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -131,7 +131,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -139,7 +139,7 @@ tests:
                       Subjects: [111, 222, 333, 444],
                       Targets:
                           [{ Cluster: 11, Endpoint: 22, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -147,7 +147,7 @@ tests:
                       Subjects: [555, 666, 777, 888],
                       Targets:
                           [{ Cluster: 55, Endpoint: 66, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -171,7 +171,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 4,
@@ -179,7 +179,7 @@ tests:
                       Subjects: [444, 333, 222, 111],
                       Targets:
                           [{ Cluster: 44, Endpoint: 33, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 5,
@@ -187,7 +187,7 @@ tests:
                       Subjects: [888, 777, 666, 555],
                       Targets:
                           [{ Cluster: 88, Endpoint: 77, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -204,7 +204,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 4,
@@ -212,7 +212,7 @@ tests:
                       Subjects: [444, 333, 222, 111],
                       Targets:
                           [{ Cluster: 44, Endpoint: 33, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 5,
@@ -220,7 +220,7 @@ tests:
                       Subjects: [888, 777, 666, 555],
                       Targets:
                           [{ Cluster: 88, Endpoint: 77, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -245,7 +245,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -256,7 +256,7 @@ tests:
                               { Cluster: 11, Endpoint: 22, DeviceType: null },
                               { Cluster: 33, Endpoint: null, DeviceType: 44 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -267,7 +267,7 @@ tests:
                               { Cluster: 55, Endpoint: 66, DeviceType: null },
                               { Cluster: 77, Endpoint: null, DeviceType: 88 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -283,7 +283,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -294,7 +294,7 @@ tests:
                               { Cluster: 11, Endpoint: 22, DeviceType: null },
                               { Cluster: 33, Endpoint: null, DeviceType: 44 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -305,7 +305,7 @@ tests:
                               { Cluster: 55, Endpoint: 66, DeviceType: null },
                               { Cluster: 77, Endpoint: null, DeviceType: 88 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -330,7 +330,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -341,7 +341,7 @@ tests:
                               { Cluster: 11, Endpoint: 22, DeviceType: null },
                               { Cluster: 33, Endpoint: null, DeviceType: 44 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -352,7 +352,7 @@ tests:
                               { Cluster: 55, Endpoint: 66, DeviceType: null },
                               { Cluster: 77, Endpoint: null, DeviceType: 88 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -368,7 +368,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
@@ -379,7 +379,7 @@ tests:
                               { Cluster: 11, Endpoint: 22, DeviceType: null },
                               { Cluster: 33, Endpoint: null, DeviceType: 44 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -390,7 +390,7 @@ tests:
                               { Cluster: 55, Endpoint: 66, DeviceType: null },
                               { Cluster: 77, Endpoint: null, DeviceType: 88 },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -414,21 +414,21 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
                       AuthMode: 2,
                       Subjects: [111, 222, 333, 444],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: [555, 666, 777, 888],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -444,21 +444,21 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 1,
                       AuthMode: 2,
                       Subjects: [111, 222, 333, 444],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: [555, 666, 777, 888],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -480,14 +480,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -503,14 +503,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -532,14 +532,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 2,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -555,14 +555,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 2,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -719,14 +719,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: [CAT1, CAT2, CAT3, CAT4],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -742,14 +742,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: [CAT1, CAT2, CAT3, CAT4],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -760,7 +760,7 @@ tests:
       command: "readAttribute"
       attribute: "TargetsPerAccessControlEntry"
       response:
-          saveAs: TargetsPerAccessControlEntry
+          saveAs: TargetsPerAccessControlEntryValue
 
     #Need if support : https://github.com/project-chip/connectedhomeip/issues/16719
     - label:
@@ -926,21 +926,21 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -956,21 +956,21 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -992,14 +992,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 1,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1017,7 +1017,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -1039,14 +1039,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 5,
                       AuthMode: 3,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1070,14 +1070,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: "6",
                       AuthMode: 3,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1097,14 +1097,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: "6",
                       AuthMode: "4",
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1124,14 +1124,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: [0],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1155,14 +1155,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: ["18446744073709551615"],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1186,14 +1186,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: ["18446744060824649728"],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1217,14 +1217,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: ["18446744073709486080"],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1248,7 +1248,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -1256,7 +1256,7 @@ tests:
                       Subjects: null,
                       Targets:
                           [{ Cluster: null, Endpoint: null, DeviceType: null }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1280,7 +1280,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -1294,7 +1294,7 @@ tests:
                                   DeviceType: null,
                               },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1318,7 +1318,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -1332,7 +1332,7 @@ tests:
                                   DeviceType: null,
                               },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1356,7 +1356,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -1370,7 +1370,7 @@ tests:
                                   DeviceType: 4294967295,
                               },
                           ],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1394,7 +1394,7 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
@@ -1402,7 +1402,7 @@ tests:
                       Subjects: null,
                       Targets:
                           [{ Cluster: null, Endpoint: 22, DeviceType: 33 }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:
@@ -1426,14 +1426,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: [{ Cluster: 11, Endpoint: 22, DeviceType: 33 }],
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -56,7 +56,7 @@ tests:
       cluster: "Operational Credentials"
       attribute: "CurrentFabricIndex"
       response:
-          saveAs: CurrentFabricIndex
+          saveAs: CurrentFabricIndexValue
 
     #Issue: https://github.com/project-chip/connectedhomeip/issues/24081
     - label:
@@ -94,7 +94,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 5: TH reads DUT Endpoint 0 AccessControl cluster
@@ -109,8 +109,11 @@ tests:
                   AdminPasscodeID: null,
                   ChangeType: 1,
                   LatestValue:
-                      { Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex },
-                  FabricIndex: CurrentFabricIndex,
+                      {
+                          Data: D_OK_EMPTY,
+                          FabricIndex: CurrentFabricIndexValue,
+                      },
+                  FabricIndex: CurrentFabricIndexValue,
               }
 
     - label:
@@ -121,7 +124,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndexValue }]
 
     #Issue: https://github.com/project-chip/connectedhomeip/issues/24149
     - label:
@@ -178,7 +181,7 @@ tests:
       command: "writeAttribute"
       attribute: "Extension"
       arguments:
-          value: [{ Data: D_BAD_LENGTH, FabricIndex: CurrentFabricIndex }]
+          value: [{ Data: D_BAD_LENGTH, FabricIndex: CurrentFabricIndexValue }]
       response:
           error: CONSTRAINT_ERROR
 
@@ -224,8 +227,8 @@ tests:
       arguments:
           value:
               [
-                  { Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndex },
-                  { Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndex },
+                  { Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue },
+                  { Data: D_OK_SINGLE, FabricIndex: CurrentFabricIndexValue },
               ]
       response:
           error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -46,7 +46,7 @@ tests:
       cluster: "Operational Credentials"
       attribute: "CurrentFabricIndex"
       response:
-          saveAs: CurrentFabricIndex
+          saveAs: CurrentFabricIndexValue
 
     - label:
           "Step 3: TH reads DUT Endpoint 0 AccessControl cluster
@@ -66,9 +66,9 @@ tests:
                           AuthMode: 2,
                           Subjects: [CommissionerNodeId],
                           Targets: null,
-                          FabricIndex: CurrentFabricIndex,
+                          FabricIndex: CurrentFabricIndexValue,
                       },
-                  FabricIndex: CurrentFabricIndex,
+                  FabricIndex: CurrentFabricIndexValue,
               }
 
     - label:
@@ -89,14 +89,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: null,
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -210,14 +210,14 @@ tests:
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
                   {
                       Privilege: 3,
                       AuthMode: 3,
                       Subjects: [0],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_9.yaml
@@ -52,7 +52,7 @@ tests:
       cluster: "Operational Credentials"
       attribute: "CurrentFabricIndex"
       response:
-          saveAs: CurrentFabricIndex
+          saveAs: CurrentFabricIndexValue
 
     - label:
           "Step 2:TH1 writes DUT Endpoint 0 AccessControl cluster ACL attribute"
@@ -67,7 +67,7 @@ tests:
                       AuthMode: "2",
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
 
@@ -92,7 +92,7 @@ tests:
                       AuthMode: "2",
                       Subjects: [CommissionerNodeId],
                       Targets: null,
-                      FabricIndex: CurrentFabricIndex,
+                      FabricIndex: CurrentFabricIndexValue,
                   },
               ]
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
@@ -218,7 +218,7 @@ tests:
       command: "readAttribute"
       attribute: "ColorTempPhysicalMinMireds"
       response:
-          saveAs: ColorTempPhysicalMinMireds
+          saveAs: ColorTempPhysicalMinMiredsValue
           constraints:
               type: int16u
               minValue: 0
@@ -229,7 +229,7 @@ tests:
       command: "readAttribute"
       attribute: "ColorTempPhysicalMaxMireds"
       response:
-          saveAs: ColorTempPhysicalMaxMireds
+          saveAs: ColorTempPhysicalMaxMiredsValue
           constraints:
               type: int16u
               minValue: 0
@@ -245,8 +245,8 @@ tests:
           values:
               - name: "ColorTemperatureMireds"
                 value:
-                    ( ColorTempPhysicalMinMireds + ColorTempPhysicalMaxMireds )
-                    / 2
+                    ( ColorTempPhysicalMinMiredsValue +
+                    ColorTempPhysicalMaxMiredsValue ) / 2
               - name: "TransitionTime"
                 value: 0
               - name: "OptionsMask"
@@ -274,12 +274,12 @@ tests:
                 value: 1
               - name: "Rate"
                 value:
-                    ( ColorTempPhysicalMaxMireds - ColorTempPhysicalMinMireds )
-                    / 40
+                    ( ColorTempPhysicalMaxMiredsValue -
+                    ColorTempPhysicalMinMiredsValue ) / 40
               - name: "ColorTemperatureMinimumMireds"
-                value: ColorTempPhysicalMinMireds
+                value: ColorTempPhysicalMinMiredsValue
               - name: "ColorTemperatureMaximumMireds"
-                value: ColorTempPhysicalMaxMireds
+                value: ColorTempPhysicalMaxMiredsValue
               - name: "OptionsMask"
                 value: 0
               - name: "OptionsOverride"
@@ -309,8 +309,8 @@ tests:
       attribute: "ColorTemperatureMireds"
       response:
           constraints:
-              minValue: ColorTempPhysicalMinMireds
-              maxValue: ColorTempPhysicalMaxMireds
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Wait 2s"
       cluster: "DelayCommands"
@@ -326,8 +326,8 @@ tests:
       attribute: "ColorTemperatureMireds"
       response:
           constraints:
-              minValue: ColorTempPhysicalMinMireds
-              maxValue: ColorTempPhysicalMaxMireds
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label:
           "Step 5a: TH sends EnhancedMoveToHue command to DUT with

--- a/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
@@ -255,7 +255,7 @@ tests:
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4005 && CC.S.C44.Rsp
       response:
-          saveAs: ColorLoopStartEnhancedHue
+          saveAs: ColorLoopStartEnhancedHueValue2
 
     - label: "Step 3c: Read EnhancedCurrentHue attribute from DUT"
       command: "readAttribute"
@@ -264,7 +264,7 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: ColorLoopStartEnhancedHue
+              minValue: ColorLoopStartEnhancedHueValue2
               maxValue: 65535
 
     - label: "Wait for 30S"
@@ -283,7 +283,7 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: ColorLoopStartEnhancedHue
+              minValue: ColorLoopStartEnhancedHueValue2
               maxValue: 65535
 
     - label:
@@ -323,14 +323,14 @@ tests:
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4006 && CC.S.C44.Rsp
       attribute: "ColorLoopStoredEnhancedHue"
       response:
-          saveAs: ColorLoopStoredEnhancedHueValue
+          saveAs: ColorLoopStoredEnhancedHueValue3
 
     - label: "Step 4c: Read EnhancedCurrentHue attribute from DUT."
       command: "readAttribute"
       attribute: "EnhancedCurrentHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4000 && CC.S.C44.Rsp
       response:
-          value: ColorLoopStoredEnhancedHueValue
+          value: ColorLoopStoredEnhancedHueValue3
 
     - label: "Turn off light for color control tests"
       PICS: OO.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CDOCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CDOCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: CDOCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: CDOCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_CMOCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CMOCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: CMOCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: CMOCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_5.yaml
@@ -89,7 +89,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfWeekDaySchedulesSupportedPerUser"
       response:
-          saveAs: NumberOfWeekDaySchedulesSupportedPerUser
+          saveAs: NumberOfWeekDaySchedulesSupportedPerUserValue
           constraints:
               minValue: 0
               maxValue: 255
@@ -99,7 +99,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfTotalUsersSupported"
       response:
-          saveAs: NumberOfTotalUsersSupported
+          saveAs: NumberOfTotalUsersSupportedValue
           constraints:
               minValue: 0
               maxValue: 65534

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_6.yaml
@@ -41,7 +41,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfHolidaySchedulesSupported"
       response:
-          saveAs: NumberOfHolidaySchedulesSupported
+          saveAs: NumberOfHolidaySchedulesSupportedValue
           constraints:
               minValue: 0
               maxValue: 255

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
@@ -89,7 +89,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfYearDaySchedulesSupportedPerUser"
       response:
-          saveAs: NumberOfYearDaySchedulesSupportedPerUser
+          saveAs: NumberOfYearDaySchedulesSupportedPerUserValue
           constraints:
               minValue: 0
               maxValue: 255
@@ -99,7 +99,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfTotalUsersSupported"
       response:
-          saveAs: NumberOfTotalUsersSupported
+          saveAs: NumberOfTotalUsersSupportedValue
           constraints:
               minValue: 0
               maxValue: 65534
@@ -208,13 +208,13 @@ tests:
       arguments:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser
+                value: NumberOfYearDaySchedulesSupportedPerUserValue
               - name: "UserIndex"
                 value: 5
       response:
           values:
               - name: "YearDayIndex"
-                value: NumberOfYearDaySchedulesSupportedPerUser
+                value: NumberOfYearDaySchedulesSupportedPerUserValue
               - name: "UserIndex"
                 value: 5
               - name: "Status"

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_9.yaml
@@ -90,7 +90,7 @@ tests:
       command: "readAttribute"
       attribute: "NumberOfTotalUsersSupported"
       response:
-          saveAs: NumberOfTotalUsersSupported
+          saveAs: NumberOfTotalUsersSupportedValue
           constraints:
               minValue: 0
               maxValue: 65534

--- a/src/app/tests/suites/certification/Test_TC_FLDCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLDCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: FLDCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: FLDCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_ILL_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ILL_2_2.yaml
@@ -37,7 +37,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: int16u
 
@@ -46,7 +46,7 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: int16u
 

--- a/src/app/tests/suites/certification/Test_TC_NDOCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_NDOCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: NDOCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: NDOCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_OZCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OZCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: OZCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: OZCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_PMHCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMHCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: PMHCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: PMHCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_PMICONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMICONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: PMICONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: PMICONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_PMKCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PMKCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: PMKCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: PMKCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
@@ -37,7 +37,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: int16s
               minValue: -32767
@@ -49,10 +49,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: int16s
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
               maxValue: 32767
 
     - label: "Step 4: Read the mandatory attribute constraints: MeasuredValue"
@@ -62,8 +62,8 @@ tests:
       response:
           constraints:
               type: int16s
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: Read the optional attribute: Tolerance"
       PICS: PRS.S.A0003
@@ -80,7 +80,7 @@ tests:
       command: "readAttribute"
       attribute: "MinScaledValue"
       response:
-          saveAs: MinScaledValue
+          saveAs: MinScaledValueValue
           constraints:
               type: int16s
               minValue: -32767
@@ -91,10 +91,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxScaledValue"
       response:
-          saveAs: MaxScaledValue
+          saveAs: MaxScaledValueValue
           constraints:
               type: int16s
-              minValue: MinScaledValue
+              minValue: MinScaledValueValue
               maxValue: 32767
 
     - label: "Step 8: Read the optional attribute: ScaledValue"
@@ -104,8 +104,8 @@ tests:
       response:
           constraints:
               type: int16s
-              minValue: MinScaledValue
-              maxValue: MaxScaledValue
+              minValue: MinScaledValueValue
+              maxValue: MaxScaledValueValue
 
     - label: "Step 9: Read the optional attribute: ScaledTolerance"
       PICS: PRS.S.A0013

--- a/src/app/tests/suites/certification/Test_TC_RNCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RNCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: RNCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: RNCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_TVOCCONC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TVOCCONC_2_1.yaml
@@ -36,7 +36,7 @@ tests:
       command: "readAttribute"
       attribute: "MinMeasuredValue"
       response:
-          saveAs: MinMeasuredValue
+          saveAs: MinMeasuredValueValue
           constraints:
               type: single
               minValue: 0
@@ -46,10 +46,10 @@ tests:
       command: "readAttribute"
       attribute: "MaxMeasuredValue"
       response:
-          saveAs: MaxMeasuredValue
+          saveAs: MaxMeasuredValueValue
           constraints:
               type: single
-              minValue: MinMeasuredValue
+              minValue: MinMeasuredValueValue
 
     - label: "Step 4: TH reads from the DUT the MeasuredValue attribute."
       PICS: TVOCCONC.S.A0000
@@ -58,8 +58,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label: "Step 5: TH reads from the DUT the PeakMeasuredValue attribute."
       PICS: TVOCCONC.S.A0003
@@ -68,8 +68,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 6: TH reads from the DUT the PeakMeasuredValueWindow attribute."
@@ -89,8 +89,8 @@ tests:
       response:
           constraints:
               type: single
-              minValue: MinMeasuredValue
-              maxValue: MaxMeasuredValue
+              minValue: MinMeasuredValueValue
+              maxValue: MaxMeasuredValueValue
 
     - label:
           "Step 8: TH reads from the DUT the AverageMeasuredValueWindow

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
@@ -159,7 +159,7 @@ tests:
       attribute: "InstalledOpenLimitLift"
       PICS: WNCV.S.A0010
       response:
-          saveAs: InstalledOpenLimitLift
+          saveAs: InstalledOpenLimitLiftValue
           constraints:
               type: int16u
               minValue: 0
@@ -173,7 +173,7 @@ tests:
       attribute: "InstalledClosedLimitLift"
       PICS: WNCV.S.A0011
       response:
-          saveAs: InstalledClosedLimitLift
+          saveAs: InstalledClosedLimitLiftValue
           constraints:
               type: int16u
               minValue: 0
@@ -187,7 +187,7 @@ tests:
       attribute: "InstalledOpenLimitTilt"
       PICS: WNCV.S.A0012
       response:
-          saveAs: InstalledOpenLimitTilt
+          saveAs: InstalledOpenLimitTiltValue
           constraints:
               type: int16u
               minValue: 0
@@ -201,7 +201,7 @@ tests:
       attribute: "InstalledClosedLimitTilt"
       PICS: WNCV.S.A0013
       response:
-          saveAs: InstalledClosedLimitTilt
+          saveAs: InstalledClosedLimitTiltValue
           constraints:
               type: int16u
               minValue: 0
@@ -266,8 +266,8 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: InstalledOpenLimitLift
-              maxValue: InstalledClosedLimitLift
+              minValue: InstalledOpenLimitLiftValue
+              maxValue: InstalledClosedLimitLiftValue
 
     ### Attribute[  4]: CurrentPositionTilt  ====================
     - label:
@@ -290,8 +290,8 @@ tests:
       response:
           constraints:
               type: int16u
-              minValue: InstalledOpenLimitTilt
-              maxValue: InstalledClosedLimitTilt
+              minValue: InstalledOpenLimitTiltValue
+              maxValue: InstalledClosedLimitTiltValue
 
     ### Attribute[  5]: NumberOfActuationsLift  ====================
     - label:


### PR DESCRIPTION
… the key used to saved them is used

fix #29086

It looks like a regression that I have introduced while working on the pics checker. I have added a test in `TestSaveAs.yaml`