### PR TITLE
Silence warnings about descriptions not being handled when running YAML tests.

### DIFF
--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -110,7 +110,7 @@ class EventHandler(BaseHandler):
             self._event.readacl = AttrsToAccessPrivilege(attrs)
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name.lower() == 'description':
-            return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
+            return DescriptionHandler(self.context, self._event)
         else:
             return BaseHandler(self.context)
 
@@ -347,7 +347,7 @@ class DescriptionHandler(BaseHandler):
     """
 
     def __init__(self, context: Context, target: Any):
-        super().__init__(context)
+        super().__init__(context, handled=HandledDepth.ENTIRE_TREE)
         self.target = target
 
     def HandleContent(self, content):


### PR DESCRIPTION
We kept getting these warnings:

    TEST ERR  : WARNING:root:TAG configurator::cluster::description was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml:33:7
    TEST ERR  : WARNING:root:TAG configurator::cluster::command::description was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml:47:6
    TEST ERR  : WARNING:root:TAG configurator::clusterExtension::command::description was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/clusters-extensions.xml:21:104

The fix is to change DescriptionHandler to note that it's handling the tag. This also lets us switch events to also use DescriptionHandler.
