### PR TITLE
Update description tag handling in xml

### DIFF
--- a/scripts/py_matter_idl/matter_idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_types.py
@@ -166,6 +166,7 @@ class Event:
     fields: List[Field]
     readacl: AccessPrivilege = AccessPrivilege.VIEW
     qualities: EventQuality = EventQuality.NONE
+    description: Optional[str] = None
 
     @property
     def is_fabric_sensitive(self):

--- a/scripts/py_matter_idl/matter_idl/test_xml_parser.py
+++ b/scripts/py_matter_idl/matter_idl/test_xml_parser.py
@@ -212,6 +212,7 @@ class TestXmlParser(unittest.TestCase):
                                                events=[Event(priority=EventPriority.INFO,
                                                              name='FabricEvent',
                                                              code=0x1234,
+                                                             description="This is a test event",
                                                              fields=[Field(data_type=DataType(name='node_id'),
                                                                            code=1,
                                                                            name='AdminNodeID',

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -110,7 +110,7 @@ class EventHandler(BaseHandler):
             self._event.readacl = AttrsToAccessPrivilege(attrs)
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name.lower() == 'description':
-            return DescriptionHandler(self.context, self._event)
+            return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         else:
             return BaseHandler(self.context)
 
@@ -347,7 +347,7 @@ class DescriptionHandler(BaseHandler):
     """
 
     def __init__(self, context: Context, target: Any):
-        super().__init__(context, handled=HandledDepth.ENTIRE_TREE)
+        super().__init__(context, handled=HandledDepth.SINGLE_TAG)
         self.target = target
 
     def HandleContent(self, content):

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/handlers.py
@@ -110,7 +110,7 @@ class EventHandler(BaseHandler):
             self._event.readacl = AttrsToAccessPrivilege(attrs)
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name.lower() == 'description':
-            return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
+            return DescriptionHandler(self.context, self._event)
         else:
             return BaseHandler(self.context)
 


### PR DESCRIPTION
Slight update on top of #29111

- add description to event tags
- mark description as "single tree processing" as we do not recognize sub-items in descriptions.