### PR TITLE
[ESP32] Add rule for esp-insights component

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -484,8 +484,13 @@ foreach(phy_blob ${phy_blobs})
 endforeach()
 
 set(components_to_link esp_event hal esp_system soc efuse vfs driver esp_coex freertos)
+idf_build_get_property(build_components BUILD_COMPONENTS)
 foreach(component ${components_to_link})
-    idf_component_get_property(lib_name ${component} COMPONENT_LIB)
+	# Some of the components are not present in IDF v4.x
+        # So, Check if the component is in the list of build components
+   	if("${component}" IN_LIST build_components)
+        idf_component_get_property(lib_name ${component} COMPONENT_LIB)
+    endif()
     list(APPEND chip_libraries $<TARGET_FILE:${lib_name}>)
 endforeach()
 

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -20,3 +20,7 @@ dependencies:
     espressif/esp_insights:
         version: "1.0.1"
         require: public
+        # There is an issue with IDF-Component-Manager when ESP Insights is included.
+        # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
+        rules:
+            - if: "idf_version >=5.0"


### PR DESCRIPTION
- There is an issue with IDF-Component-Manager when ESP Insights is included.
- Issue: https://github.com/project-chip/connectedhomeip/issues/29125
- Added rule for esp-insights component which adds it for IDF version >=v5.0