### PR TITLE
[Android] virtual-device-app: Add Doorlock/PowerSource repository

### DIFF
--- a/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/di/DataModule.kt
+++ b/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/di/DataModule.kt
@@ -1,8 +1,12 @@
 package com.matter.virtual.device.app.core.data.di
 
 import com.matter.virtual.device.app.core.data.repository.*
+import com.matter.virtual.device.app.core.data.repository.cluster.DoorLockManagerRepository
+import com.matter.virtual.device.app.core.data.repository.cluster.DoorLockManagerRepositoryImpl
 import com.matter.virtual.device.app.core.data.repository.cluster.OnOffManagerRepository
 import com.matter.virtual.device.app.core.data.repository.cluster.OnOffManagerRepositoryImpl
+import com.matter.virtual.device.app.core.data.repository.cluster.PowerSourceManagerRepository
+import com.matter.virtual.device.app.core.data.repository.cluster.PowerSourceManagerRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -11,11 +15,20 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 @Module
 internal abstract class DataModule {
+  @Binds
+  abstract fun bindDoorLockManagerRepository(
+    repository: DoorLockManagerRepositoryImpl
+  ): DoorLockManagerRepository
 
   @Binds
   abstract fun bindOnOffManagerRepository(
     repository: OnOffManagerRepositoryImpl
   ): OnOffManagerRepository
+
+  @Binds
+  abstract fun bindPowerSourceManagerRepository(
+    repository: PowerSourceManagerRepositoryImpl
+  ): PowerSourceManagerRepository
 
   @Binds abstract fun bindMatterRepository(repository: MatterRepositoryImpl): MatterRepository
 

--- a/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/DoorLockManagerRepository.kt
+++ b/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/DoorLockManagerRepository.kt
@@ -1,0 +1,11 @@
+package com.matter.virtual.device.app.core.data.repository.cluster
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface DoorLockManagerRepository {
+  fun getLockStateFlow(): StateFlow<Boolean>
+
+  suspend fun setLockState(value: Boolean)
+
+  suspend fun sendLockAlarmEvent()
+}

--- a/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/DoorLockManagerRepositoryImpl.kt
+++ b/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/DoorLockManagerRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.matter.virtual.device.app.core.data.repository.cluster
+
+import com.matter.virtual.device.app.core.matter.manager.DoorLockManagerStub
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+import timber.log.Timber
+
+internal class DoorLockManagerRepositoryImpl
+@Inject
+constructor(private val doorLockManagerStub: DoorLockManagerStub) : DoorLockManagerRepository {
+
+  override fun getLockStateFlow(): StateFlow<Boolean> {
+    return doorLockManagerStub.lockState
+  }
+
+  override suspend fun setLockState(value: Boolean) {
+    Timber.d("setLockState():$value")
+    doorLockManagerStub.setLockState(value)
+  }
+
+  override suspend fun sendLockAlarmEvent() {
+    doorLockManagerStub.sendLockAlarmEvent()
+  }
+}

--- a/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/PowerSourceManagerRepository.kt
+++ b/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/PowerSourceManagerRepository.kt
@@ -1,0 +1,9 @@
+package com.matter.virtual.device.app.core.data.repository.cluster
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface PowerSourceManagerRepository {
+  fun getBatPercent(): StateFlow<Int>
+
+  suspend fun setBatPercentRemaining(batteryPercentRemaining: Int)
+}

--- a/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/PowerSourceManagerRepositoryImpl.kt
+++ b/examples/virtual-device-app/android/App/core/data/src/main/java/com/matter/virtual/device/app/core/data/repository/cluster/PowerSourceManagerRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.matter.virtual.device.app.core.data.repository.cluster
+
+import com.matter.virtual.device.app.core.matter.manager.PowerSourceManagerStub
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+
+internal class PowerSourceManagerRepositoryImpl
+@Inject
+constructor(private val powerSourceManagerStub: PowerSourceManagerStub) :
+  PowerSourceManagerRepository {
+
+  override fun getBatPercent(): StateFlow<Int> {
+    return powerSourceManagerStub.batPercent
+  }
+
+  override suspend fun setBatPercentRemaining(batteryPercentRemaining: Int) {
+    powerSourceManagerStub.setBatPercentRemaining(batteryPercentRemaining)
+  }
+}


### PR DESCRIPTION
#### Problem
* Need a doorlock/powersource cluster repository for data layer


#### Change overview
* Add cluster repository files


#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation





