### PR TITLE
Update Interaction Model revision to spec.

### DIFF
--- a/src/app/InteractionModelRevision.h
+++ b/src/app/InteractionModelRevision.h
@@ -29,7 +29,7 @@
  * Specification" chapter of the core Matter specification.
  */
 #ifndef CHIP_DEVICE_INTERACTION_MODEL_REVISION
-#define CHIP_DEVICE_INTERACTION_MODEL_REVISION 10
+#define CHIP_DEVICE_INTERACTION_MODEL_REVISION 11
 #endif
 
 constexpr uint8_t kInteractionModelRevisionTag = 0xFF;


### PR DESCRIPTION
Spec got stealth-bumped (no corresponding SDK issue) to 11 last month sometime.
