### PR TITLE
Fix partial revert: Allow SupportedOperatingModes attribute to be any of the valid combinations

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
@@ -944,10 +944,20 @@ tests:
       command: "readAttribute"
       attribute: "SupportedOperatingModes"
       response:
-          value: 0xFFF6
           saveAs: Current_Supported
           constraints:
               type: enum16
+              anyOf:
+                  [
+                      0xFFF6,
+                      0xFFF4,
+                      0xFFF2,
+                      0xFFF0,
+                      0xFFE6,
+                      0xFFE4,
+                      0xFFE2,
+                      0xFFE0,
+                  ]
 
     - label:
           "Step 23b: TH writes Supported OperatingModes attribute as bit 0 is


### PR DESCRIPTION
Fix partial revert of https://github.com/project-chip/connectedhomeip/commit/94c3882388c77e214f502aad94a518a340bb7f24

caused by subsequent PR https://github.com/project-chip/connectedhomeip/commit/76848fe25811fbf55a9c6b92da5d0b77a46221b4 :

- Allow SupportedOperatingModes attribute to be any of the valid combinations
