### PR TITLE
[Android]Fix the local reference leaks for attribute and event

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/model/AttributeState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/AttributeState.java
@@ -39,6 +39,12 @@ public final class AttributeState {
     }
   }
 
+  public AttributeState(Object valueObject, byte[] tlv, JSONObject json) {
+    this.valueObject = valueObject;
+    this.tlv = tlv;
+    this.json = json;
+  }
+
   public Object getValue() {
     return valueObject;
   }
@@ -53,4 +59,21 @@ public final class AttributeState {
   public JSONObject getJson() {
     return json;
   }
+
+  public AttributeState clone() {
+    // Copy the value object.
+    // Object valueObjectCopy;
+    //if (valueObject instanceof Cloneable) {
+    //    valueObjectCopy = ((Cloneable) valueObject).clone();
+    //}
+
+    // Copy the TLV byte array.
+    byte[] tlvCopy = new byte[tlv.length];
+    System.arraycopy(tlv, 0, tlvCopy, 0, tlv.length);
+
+    // Copy the JSON object.
+    JSONObject jsonCopy = new JSONObject(json.toString());
+
+    return new AttributeState(null, tlvCopy, jsonCopy);
+}
 }

--- a/src/controller/java/src/chip/devicecontroller/model/EventState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/EventState.java
@@ -58,6 +58,23 @@ public final class EventState {
     }
   }
 
+  public EventState(
+    long eventNumber,
+    int priorityLevel,
+    int timestampType,
+    long timestampValue,
+    Object valueObject,
+    byte[] tlv,
+    JSONObject json) {
+  this.eventNumber = eventNumber;
+  this.priorityLevel = priorityLevel;
+  this.timestampType = timestampType;
+  this.timestampValue = timestampValue;
+  this.valueObject = valueObject;
+  this.tlv = tlv;
+  this.json = json;
+}
+
   public long getEventNumber() {
     return eventNumber;
   }
@@ -93,4 +110,21 @@ public final class EventState {
   public String toString() {
     return valueObject.toString();
   }
+
+  public EventState clone() {
+    // Copy the value object.
+    // Object valueObjectCopy;
+    // if (valueObject instanceof Cloneable) {
+    //     valueObjectCopy = ((Cloneable) valueObject).clone();
+    // }
+
+    // Copy the TLV byte array.
+    byte[] tlvCopy = new byte[tlv.length];
+    System.arraycopy(tlv, 0, tlvCopy, 0, tlv.length);
+
+    // Copy the JSON object.
+    JSONObject jsonCopy = new JSONObject(json.toString());
+
+    return new EventState(eventNumber, priorityLevel, timestampType, timestampValue, null, tlvCopy, jsonCopy);
+}
 }

--- a/src/controller/java/src/chip/devicecontroller/model/NodeState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/NodeState.java
@@ -26,8 +26,8 @@ import javax.annotation.Nullable;
 public final class NodeState {
   private Map<Integer, EndpointState> endpoints;
 
-  public NodeState(Map<Integer, EndpointState> endpoints) {
-    this.endpoints = endpoints;
+  public NodeState() {
+    this.endpoints = new HashMap<>();
   }
 
   public Map<Integer, EndpointState> getEndpointStates() {
@@ -60,7 +60,7 @@ public final class NodeState {
     }
 
     // This will overwrite previous attributes.
-    clusterState.getAttributeStates().put(attributeId, attributeStateToAdd);
+    clusterState.getAttributeStates().put(attributeId, attributeStateToAdd.clone());
   }
 
   private void addEvent(int endpointId, long clusterId, long eventId, EventState eventStateToAdd) {
@@ -79,7 +79,7 @@ public final class NodeState {
     if (!clusterState.getEventStates().containsKey(eventId)) {
       clusterState.getEventStates().put(eventId, new ArrayList<EventState>());
     }
-    clusterState.getEventStates().get(eventId).add(eventStateToAdd);
+    clusterState.getEventStates().get(eventId).add(eventStateToAdd.clone());
   }
 
   @Override


### PR DESCRIPTION
LocalReference leaks happens in AttributeState and EventState when pass them from JNI to Java.
Before releasing them, we need to deepcopy its value in Java layer.
We also need add clone method in generated ChipStruct and ChipEventStruct for ValueObject.
https://github.com/project-chip/connectedhomeip/issues/29069
