### PR TITLE
[Bouffalolab] Don't factory reset if reboot with a pending failSafeArmed

### DIFF
--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
@@ -48,7 +48,6 @@ bool ConfigurationManagerImpl::IsFullyProvisioned()
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
-    bool failSafeArmed;
     uint32_t rebootCount = 0;
 
     err = Internal::GenericConfigurationManagerImpl<BLConfig>::Init();
@@ -72,12 +71,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
-    }
     err = CHIP_NO_ERROR;
 
 exit:


### PR DESCRIPTION
Remove factory reset when reboot with a pending failSafeArmed to fix #29142.

Since Matter Stack from #16497 had already handled the reboot with a pending failSafeArmed.
