### PR TITLE
[Silabs] Add hooks into the Silabs performance testing functionality

### DIFF
--- a/docs/guides/silabs_efr32_software_update.md
+++ b/docs/guides/silabs_efr32_software_update.md
@@ -42,8 +42,8 @@ all of the EFR32 example applications.
 -   In a terminal start the Provider app passing to it the path to the Matter
     OTA file created in the previous step:
 
-           rm -r /tmp/chip_*
-           ./out/debug/chip-ota-provider-app -f chip-efr32-lighting-example.ota
+           rm -r /tmp/chip_kvs_provider
+           ./out/debug/chip-ota-provider-app --KVS /tmp/chip_kvs_provider -f chip-efr32-lighting-example.ota
 
 -   In a separate terminal run the chip-tool commands to provision the Provider:
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -312,7 +312,7 @@ combination with JLinkRTTClient as follows:
     ```
     chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
 
-    chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [<chip-tool-node-id>], "targets": null }{"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [1], "targets": null }]' <lighting-node-id> 0
+    chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [<chip-tool-node-id>], "targets": null },{"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [1], "targets": null }]' <lighting-node-id> 0
 
     chip-tool binding write binding '[{"fabricIndex": 1, "node": <lighting-node-id>, "endpoint": 1, "cluster":6}]' 1 1
     ```

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -65,6 +65,10 @@
 #include "dic_control.h"
 #endif // DIC_ENABLE
 
+#ifdef PERFORMANCE_TEST_ENABLED
+#include <performance_test_commands.h>
+#endif // PERFORMANCE_TEST_ENABLED
+
 /**********************************************************
  * Defines and Constants
  *********************************************************/
@@ -247,6 +251,10 @@ CHIP_ERROR BaseApplication::Init()
     ConfigurationMgr().LogDeviceConfig();
 
     OutputQrCode(true /*refreshLCD at init*/);
+
+#ifdef PERFORMANCE_TEST_ENABLED
+    RegisterPerfTestCommands();
+#endif // PERFORMANCE_TEST_ENABLED
 
     PlatformMgr().AddEventHandler(OnPlatformEvent, 0);
 #ifdef SL_WIFI

--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -285,9 +285,19 @@ standard names. */
 #define SysTick_Handler xPortSysTickHandler
 
 /* Thread local storage pointers used by the SDK */
+#ifdef PERFORMANCE_TEST_ENABLED
+// ot_debug_channel component uses thread-local storage
+#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
+#ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
+#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS \
+           + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
+#endif
+#else /* PERFORMANCE_TEST_ENABLED */
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
 #define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
 #endif
+#endif/* PERFORMANCE_TEST_ENABLED */
 
 #if defined(__GNUC__)
 /* For the linker. */

--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -290,14 +290,14 @@ standard names. */
 #define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
 #ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
 #define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 0
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS \
-           + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
+    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
 #endif
 #else /* PERFORMANCE_TEST_ENABLED */
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
 #define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
 #endif
-#endif/* PERFORMANCE_TEST_ENABLED */
+#endif /* PERFORMANCE_TEST_ENABLED */
 
 #if defined(__GNUC__)
 /* For the linker. */

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -70,7 +70,7 @@ static chip::DeviceLayer::Internal::Efr32PsaOperationalKeystore gOperationalKeys
 
 #include <lib/support/BytesToHex.h>
 
-#ifdef PERFORMANCE_TEST_ENABLED 
+#ifdef PERFORMANCE_TEST_ENABLED
 #include <performance_test_commands.h>
 #endif
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -70,6 +70,10 @@ static chip::DeviceLayer::Internal::Efr32PsaOperationalKeystore gOperationalKeys
 
 #include <lib/support/BytesToHex.h>
 
+#ifdef PERFORMANCE_TEST_ENABLED 
+#include <performance_test_commands.h>
+#endif
+
 #if CHIP_ENABLE_OPENTHREAD
 #include <inet/EndPointStateOpenThread.h>
 #include <openthread/cli.h>
@@ -224,6 +228,12 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     // instead of the default (insecure) one.
     gOperationalKeystore.Init();
     initParams.operationalKeystore = &gOperationalKeystore;
+#endif
+
+#ifdef PERFORMANCE_TEST_ENABLED
+    // Set up Test Event Trigger command of the General Diagnostics cluster. Used only in performace testing
+    static SilabsTestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
 #endif
 
     // Initialize the remaining (not overridden) providers to the SDK example defaults

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -231,7 +231,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #endif
 
 #ifdef PERFORMANCE_TEST_ENABLED
-    // Set up Test Event Trigger command of the General Diagnostics cluster. Used only in performace testing
+    // Set up Test Event Trigger command of the General Diagnostics cluster. Used only in performance testing
     static SilabsTestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
 #endif


### PR DESCRIPTION
Add hooks into the Silabs performance testing functionality, back-end is implemented in the Silabs SDK. 
Unrelated to the above: Minor updates to documentation fixing syntax