### PR TITLE
IPAddress: Fix zero-initialization of ip6_addr_t

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -194,7 +194,7 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 
 ip6_addr_t IPAddress::ToIPv6() const
 {
-    ip6_addr_t ipAddr = { 0 };
+    ip6_addr_t ipAddr = {};
     static_assert(sizeof(ipAddr.addr) == sizeof(Addr), "ip6_addr_t size mismatch");
     memcpy(&ipAddr.addr, Addr, sizeof(ipAddr.addr));
     return ipAddr;


### PR DESCRIPTION
C-style zero init produces compiler warnings, use C++-style zero init.