### PR TITLE
CHIPCryptoPALmbedTLS: Include mbedtls/version.h

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -37,6 +37,7 @@
 #include <mbedtls/pkcs5.h>
 #include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
+#include <mbedtls/version.h>
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 #include <mbedtls/x509_crt.h>
 #endif // defined(MBEDTLS_X509_CRT_PARSE_C)


### PR DESCRIPTION
`MBEDTLS_VERSION_NUMBER` is defined in version.h, include explicitly.