### PR TITLE
PacketBufferHandle::CloneData: Only copy the valid data

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -681,7 +681,7 @@ PacketBufferHandle PacketBufferHandle::CloneData() const
 
     for (PacketBuffer * original = mBuffer; original != nullptr; original = original->ChainedBuffer())
     {
-        uint16_t originalDataSize     = original->MaxDataLength();
+        uint16_t originalDataSize     = original->DataLength();
         uint16_t originalReservedSize = original->ReservedSize();
 
         if (originalDataSize + originalReservedSize > PacketBuffer::kMaxSizeWithoutReserve)


### PR DESCRIPTION
When cloning a packet buffer, only copy the actual data, not max data length. The source buffer may not in fact be that big so the copy can go off into the weeds. The destination is big enough so there's usually no harm done but it trips up ASAN.
