### PR TITLE
Darwin: set is_debug=false for Release builds

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -107,7 +107,10 @@ declare -a args=(
     "mac_deployment_target=\"$LLVM_TARGET_TRIPLE_OS_VERSION$LLVM_TARGET_TRIPLE_SUFFIX\""
 )
 
-[[ $CONFIGURATION == Debug ]] && args+=('is_debug=true')
+case "$CONFIGURATION" in
+    Debug) args+=('is_debug=true') ;;
+    Release) args+=('is_debug=false') ;;
+esac
 
 [[ $PLATFORM_FAMILY_NAME != macOS ]] && {
     args+=(


### PR DESCRIPTION
Set `is_debug=false` for Release builds. Currently we just set `is_debug=true` for Debug, but that's already the default anyway.