### PR TITLE
[ESP32] Fix the threading issue in nimble

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -258,6 +258,12 @@ enum InternalEventTypes
     kCHIPoBLEUnsubscribe,
     kCHIPoBLEWriteReceived,
     kCHIPoBLEIndicateConfirm,
+
+    /**
+     * Post this event in case of a BLE connection error. This event should be posted
+     * if the BLE central disconnects without unsubscribing from the BLE characteristic.
+     * This event should populate CHIPoBLEConnectionError structure.
+     */
     kCHIPoBLEConnectionError,
     kCHIPoBLENotifyConfirm
 };

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1288,7 +1288,12 @@ CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(struct ble_gap_event * gapEvent)
             disconReason = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
             break;
         }
-        HandleConnectionError(gapEvent->disconnect.conn.conn_handle, disconReason);
+
+        ChipDeviceEvent connectionErrorEvent;
+        connectionErrorEvent.Type                           = DeviceEventType::kCHIPoBLEConnectionError;
+        connectionErrorEvent.CHIPoBLEConnectionError.ConId  = gapEvent->disconnect.conn.conn_handle;
+        connectionErrorEvent.CHIPoBLEConnectionError.Reason = disconReason;
+        ReturnErrorOnFailure(PlatformMgr().PostEvent(&connectionErrorEvent));
     }
 
     ChipDeviceEvent disconnectEvent;

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1273,6 +1273,8 @@ CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(struct ble_gap_event * gapEvent)
     peer_delete(gapEvent->disconnect.conn.conn_handle);
 #endif
 
+    // There can be a case where the BLE central disconnects without unsubscribing from the BLE characteristic.
+    // In such situations, it is necessary to clear the subscription and post a connection error event.
     if (UnsetSubscribed(gapEvent->disconnect.conn.conn_handle))
     {
         CHIP_ERROR disconReason;


### PR DESCRIPTION
#### Problem
When handling BLE disconnection, `CancelTimer` is being called from NimBLE thread, causing the assert described in #28142.

#### Change Overview
Scheduling the code which causes assert on the chip stack.
Fixes #28142

#### Tests
Commissioned all-cluster-app for target C3 and ESP32-M5Stack, using Linux/Mac chip-tool. Device did not crash.