### PR TITLE
Make ReadClient::Callback non-movable

### DIFF
--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -71,6 +71,14 @@ public:
     class Callback : public ReadClient::Callback
     {
     public:
+        Callback() = default;
+
+        // Callbacks are not expected to be copyable or movable.
+        Callback(const Callback &) = delete;
+        Callback(Callback &&)      = delete;
+        Callback & operator=(const Callback &) = delete;
+        Callback & operator=(Callback &&) = delete;
+
         /*
          * Called anytime an attribute value has changed in the cache
          */
@@ -102,6 +110,11 @@ public:
     {
         mHighestReceivedEventNumber = highestReceivedEventNumber;
     }
+
+    ClusterStateCache(const ClusterStateCache &) = delete;
+    ClusterStateCache(ClusterStateCache &&)      = delete;
+    ClusterStateCache & operator=(const ClusterStateCache &) = delete;
+    ClusterStateCache & operator=(ClusterStateCache &&) = delete;
 
     void SetHighestReceivedEventNumber(EventNumber highestReceivedEventNumber)
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -45,7 +45,6 @@ ReadClient::ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeM
     mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 {
     mpExchangeMgr    = apExchangeMgr;
-    mpCallback       = apCallback;
     mInteractionType = aInteractionType;
 
     mpImEngine = apImEngine;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -72,6 +72,14 @@ public:
     class Callback
     {
     public:
+        Callback() = default;
+
+        // Callbacks are not expected to be copyable or movable.
+        Callback(const Callback &) = delete;
+        Callback(Callback &&)      = delete;
+        Callback & operator=(const Callback &) = delete;
+        Callback & operator=(Callback &&) = delete;
+
         virtual ~Callback() = default;
 
         /**


### PR DESCRIPTION
The purpose of this interface is be called polymorphically through a pointer. Moving it will invalidate the original instance and is very likely to be a bug.

Make this type non-movable; this will fail compilation if a derived class is stored in an inappropriate container that moves its elements.

As an example, ClusterStateCache is also currently movable, but moving it retains a pointer to the moved-from instance via mBufferedReader, so any further usage is likely to result in a invalid memory access.