### PR TITLE
Be consistent about how we handle cluster names in config-data.yaml.

### DIFF
--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -22,20 +22,18 @@ CommandHandlerInterfaceOnlyClusters:
     # List of clusters that are implemented entirely with
     # CommandHandlerInterface and hence do not need generated command dispatch.
     # This uses asUpperCamelCase versions of the cluster name.
-    - NetworkCommissioning
+    - Network Commissioning
     - Scenes
-    - RvcRunMode
-    - RvcCleanMode
-    - DishwasherMode
-    - LaundryWasherMode
-    - RefrigeratorAndTemperatureControlledCabinetMode
-    - OperationalState
-    - ActivatedCarbonFilterMonitoring
-    - HepaFilterMonitoring
-    - RvcOperationalState
-    # cluster format should match ClustersWithInitFunctions et al
-    # See https://github.com/project-chip/connectedhomeip/issues/29186
-    - SampleMei
+    - RVC Run Mode
+    - RVC Clean Mode
+    - Dishwasher Mode
+    - Laundry Washer Mode
+    - Refrigerator And Temperature Controlled Cabinet Mode
+    - Operational State
+    - Activated Carbon Filter Monitoring
+    - HEPA Filter Monitoring
+    - RVC Operational State
+    - Sample MEI
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -113,7 +113,7 @@ void emberAf{{asUpperCamelCase label}}ClusterClientTickCallback(chip::EndpointId
 {{#zcl_clusters}}
 {{#zcl_commands}}
 {{#if (isClient source)}}
-{{#unless (isInConfigList (asUpperCamelCase parent.name) "CommandHandlerInterfaceOnlyClusters")}}
+{{#unless (isInConfigList parent.name "CommandHandlerInterfaceOnlyClusters")}}
 /**
  * @brief {{parent.name}} Cluster {{name}} Command callback (from {{source}})
  */

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -21,7 +21,7 @@ namespace app {
 namespace Clusters {
 
 {{#all_user_clusters_with_incoming_commands}}
-{{#unless (isInConfigList (asUpperCamelCase clusterName) "CommandHandlerInterfaceOnlyClusters")}}
+{{#unless (isInConfigList clusterName "CommandHandlerInterfaceOnlyClusters")}}
 {{#if (isServer clusterSide)}}
 namespace {{asUpperCamelCase clusterName}} {
 
@@ -71,7 +71,7 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
     switch (aCommandPath.mClusterId)
     {
     {{#all_user_clusters_with_incoming_commands}}
-    {{#unless (isInConfigList (asUpperCamelCase clusterName) "CommandHandlerInterfaceOnlyClusters")}}
+    {{#unless (isInConfigList clusterName "CommandHandlerInterfaceOnlyClusters")}}
     {{#if (isServer clusterSide)}}
     case Clusters::{{asUpperCamelCase clusterName}}::Id:
         Clusters::{{asUpperCamelCase clusterName}}::DispatchServerCommand(apCommandObj, aCommandPath, aReader);


### PR DESCRIPTION
Use the cluster name as it appears in the XML.

Fixes https://github.com/project-chip/connectedhomeip/issues/29186
