### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-11 : [ESP32] Update IDF to release v5.1.1
+12 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=333abf31311e73def9db739026d217fca547a01f
+ARG ZEPHYR_REVISION=31278e7f9a0103e369e9255f921e04986eb57eb3
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \


### PR DESCRIPTION
**Change overview**

- drivers: bluetooth: hci_b9x: Fixed samples compilation
- boards: riscv: telink: Add support 4 buttons
- soc: riscv: telink_b9x: Fix retention functionality
- boards: riscv: telink: Move HEAP_MEM_POOL_SIZE into Kconfig
- soc: telink: b9x: Added RF calibration at startup
- west.yml: Update about fixed BT buffers
- west.yml: Update B92 Library
- west.yml: soc: riscv: update soc_b9x_init and soc_b9x_restore
- west.yml: Use B9X_BLE_CTRL_MAC_TYPE name for choice

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully