### PR TITLE
Bump cloudbuild for chef to double the time (10h now) since a lot of …

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -72,7 +72,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 18000s
+timeout: 36000s
 queueTtl: 21600s
 
 artifacts:


### PR DESCRIPTION
…examples were added and 5h seems to timeout. This may be a temporary fix until we determine what we really want to build

Hotfix since CI cannot validate cloudbuild.

