### PR TITLE
Fix MATTER_TRACING_ENABLED checks.

### DIFF
--- a/src/tracing/registry.h
+++ b/src/tracing/registry.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <matter/tracing/build_config.h>
 #include <tracing/backend.h>
 
 namespace chip {


### PR DESCRIPTION
We were checking MATTTER_TRACING_ENABLED without including the config header that defines it.

Fixes https://github.com/project-chip/connectedhomeip/issues/29214
