### PR TITLE
Remove CHIP_SYSTEM_CONFIG_USE_TIMER_POOL bits.

### DIFF
--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -79,11 +79,6 @@ void UpdateSnapshot(Snapshot & aSnapshot)
     memcpy(&aSnapshot.mResourcesInUse, &sResourcesInUse, sizeof(aSnapshot.mResourcesInUse));
     memcpy(&aSnapshot.mHighWatermarks, &sHighWatermarks, sizeof(aSnapshot.mHighWatermarks));
 
-#if CHIP_SYSTEM_CONFIG_USE_TIMER_POOL
-    chip::System::Timer::GetStatistics(aSnapshot.mResourcesInUse[kSystemLayer_NumTimers],
-                                       aSnapshot.mHighWatermarks[kSystemLayer_NumTimers]);
-#endif // CHIP_SYSTEM_CONFIG_USE_TIMER_POOL
-
     SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS();
 }
 


### PR DESCRIPTION
This is not a config macro we have anymore, and the code it guards does not compile, since System::Timer has no GetStatistics method.
