### PR TITLE
Fix CHIPConfig.h not including InetConfig.h.

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -75,6 +75,7 @@ source_set("chip_config_header") {
   public_deps = [
     ":chip_buildconfig",
     "${chip_root}/src/ble:ble_config_header",
+    "${chip_root}/src/inet:inet_config_header",
     "${chip_root}/src/system:system_config_header",
   ]
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -42,8 +42,8 @@
 #include <ble/BleConfig.h>
 #include <system/SystemConfig.h>
 
-/* COMING SOON: making the INET Layer optional entails making this inclusion optional. */
-// #include "InetConfig.h"
+#include <inet/InetConfig.h>
+
 /*
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL <= 0
 #error "chip SDK requires INET_TCP_IDLE_CHECK_INTERVAL > 0"

--- a/src/lib/core/CHIPCore.h
+++ b/src/lib/core/CHIPCore.h
@@ -31,14 +31,6 @@
 
 #include <ble/BleConfig.h>
 
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-#include <inet/TCPEndPoint.h>
-#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
-
-#if INET_CONFIG_ENABLE_UDP_ENDPOINT
-#include <inet/UDPEndPoint.h>
-#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
-
 #if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BleLayer.h>
 #endif // CONFIG_NETWORK_LAYER_BLE


### PR DESCRIPTION
We had various things that were testing config bits that InetConfig.h would pull in that never actually included InetConfig.h, because CHIPConfig.h did not include it.
