### PR TITLE
Fix -Wundef issues in Linux example code.

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -137,6 +137,18 @@ DeviceLayer::NetworkCommissioning::DarwinWiFiDriver sWiFiDriver;
 DeviceLayer::NetworkCommissioning::DarwinEthernetDriver sEthernetDriver;
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 
+#ifndef CHIP_APP_MAIN_HAS_THREAD_DRIVER
+#define CHIP_APP_MAIN_HAS_THREAD_DRIVER 0
+#endif // CHIP_APP_MAIN_HAS_THREAD_DRIVER
+
+#ifndef CHIP_APP_MAIN_HAS_WIFI_DRIVER
+#define CHIP_APP_MAIN_HAS_WIFI_DRIVER 0
+#endif // CHIP_APP_MAIN_HAS_WIFI_DRIVER
+
+#ifndef CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+#define CHIP_APP_MAIN_HAS_ETHERNET_DRIVER 0
+#endif // CHIP_APP_MAIN_HAS_ETHERNET_DRIVER
+
 #if CHIP_APP_MAIN_HAS_THREAD_DRIVER
 app::Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(kRootEndpointId, &sThreadDriver);
 #endif // CHIP_APP_MAIN_HAS_THREAD_DRIVER

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -32,6 +32,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
 #include <lib/support/CHIPArgParser.hpp>
+#include <platform/CHIPDeviceConfig.h>
 #include <setup_payload/SetupPayload.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>


### PR DESCRIPTION
* Make sure to include CHIPDeviceConfig.h in Options.h, because it's testing some config vars that device config defines.
* Ensure the CHIP_APP_MAIN_HAS_*_DRIVER macros are always defined to a value.
