### PR TITLE
app: Fix undef error for CHIP_CONFIG_ENABLE_READ_CLIENT

### DIFF
--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/DataVersionFilter.h>
 #include <app/util/basic-types.h>

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -21,6 +21,7 @@
 #include "lib/core/TLV.h"
 #include "system/SystemPacketBuffer.h"
 #include "system/TLVPacketBufferBackingStore.h"
+#include <app/AppBuildConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/ReadClient.h>
 #include <vector>

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -21,6 +21,7 @@
 #include "lib/core/CHIPError.h"
 #include "system/SystemPacketBuffer.h"
 #include "system/TLVPacketBufferBackingStore.h"
+#include <app/AppBuildConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ReadClient.h>

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -29,6 +29,7 @@
 
 #include "access/RequestPath.h"
 #include "access/SubjectDescriptor.h"
+#include <app/AppBuildConfig.h>
 #include <app/RequiredPrivilege.h>
 #include <app/util/af-types.h>
 #include <app/util/endpoint-config-api.h>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <access/AccessControl.h>
+#include <app/AppBuildConfig.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <lib/core/CHIPCore.h>

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -24,6 +24,7 @@
 
 #pragma once
 #include "system/SystemClock.h"
+#include <app/AppBuildConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/EventHeader.h>

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "app/ConcreteCommandPath.h"
+#include <app/AppBuildConfig.h>
 #include <app/DeviceProxy.h>
 #include <app/util/error-mapping.h>
 #include <controller/InvokeInteraction.h>

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/CASEClientPool.h>
 #include <app/CASESessionManager.h>
 #include <app/ClusterStateCache.h>

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadPrepareParams.h>

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/data-model/Decode.h>


### PR DESCRIPTION
We were checking CHIP_CONFIG_ENABLE_READ_CLIENT without including the config header that defines it.

Fixes #29213
