### PR TITLE
[clang-tidy] Fix a bunch of style warnings

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -108,7 +108,7 @@ ip4_addr_t IPAddress::ToIPv4() const
 
 #endif // INET_CONFIG_ENABLE_IPV4
 
-ip_addr_t IPAddress::ToLwIPAddr(void) const
+ip_addr_t IPAddress::ToLwIPAddr() const
 {
     ip_addr_t ret;
 

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -216,7 +216,7 @@ bool InterfaceIterator::Next()
 #if defined(NETIF_FOREACH)
     NETIF_FOREACH(mCurNetif)
 #else
-    for (mCurNetif = netif_list; mCurNetif != NULL; mCurNetif = mCurNetif->next)
+    for (mCurNetif = netif_list; mCurNetif != nullptr; mCurNetif = mCurNetif->next)
 #endif
     {
         if (mCurNetif == prevNetif)
@@ -229,7 +229,7 @@ bool InterfaceIterator::Next()
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
-    return mCurNetif != NULL;
+    return mCurNetif != nullptr;
 }
 
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -322,13 +322,11 @@ CHIP_ERROR InterfaceAddressIterator::GetAddress(IPAddress & outIPAddress)
         return CHIP_NO_ERROR;
     }
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
-    else
-    {
-        outIPAddress = IPAddress(*netif_ip4_addr(curIntf));
-        return CHIP_NO_ERROR;
-    }
-#endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
+    outIPAddress = IPAddress(*netif_ip4_addr(curIntf));
+    return CHIP_NO_ERROR;
+#else
     return CHIP_ERROR_INTERNAL;
+#endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
 }
 
 uint8_t InterfaceAddressIterator::GetPrefixLength()
@@ -340,11 +338,8 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
             return 64;
         }
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
-        else
-        {
-            struct netif * curIntf = mIntfIter.GetInterfaceId().GetPlatformInterface();
-            return NetmaskToPrefixLength((const uint8_t *) netif_ip4_netmask(curIntf), 4);
-        }
+        struct netif * curIntf = mIntfIter.GetInterfaceId().GetPlatformInterface();
+        return NetmaskToPrefixLength((const uint8_t *) netif_ip4_netmask(curIntf), 4);
 #endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
     }
     return 0;

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -195,10 +195,7 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
             return udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort,
                                  intfId.GetPlatformInterface());
         }
-        else
-        {
-            return udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
-        }
+        return udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
     });
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
@@ -461,11 +458,8 @@ CHIP_ERROR UDPEndPointImplLwIP::IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInt
             return join ? igmp_joingroup_netif(lNetif, &lIPv4Address) //
                         : igmp_leavegroup_netif(lNetif, &lIPv4Address);
         }
-        else
-        {
-            return join ? igmp_joingroup(IP4_ADDR_ANY4, &lIPv4Address) //
-                        : igmp_leavegroup(IP4_ADDR_ANY4, &lIPv4Address);
-        }
+        return join ? igmp_joingroup(IP4_ADDR_ANY4, &lIPv4Address) //
+                    : igmp_leavegroup(IP4_ADDR_ANY4, &lIPv4Address);
     });
 
     if (lStatus == ERR_MEM)
@@ -496,11 +490,8 @@ CHIP_ERROR UDPEndPointImplLwIP::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInt
             return join ? mld6_joingroup_netif(lNetif, &lIPv6Address) //
                         : mld6_leavegroup_netif(lNetif, &lIPv6Address);
         }
-        else
-        {
-            return join ? mld6_joingroup(IP6_ADDR_ANY6, &lIPv6Address) //
-                        : mld6_leavegroup(IP6_ADDR_ANY6, &lIPv6Address);
-        }
+        return join ? mld6_joingroup(IP6_ADDR_ANY6, &lIPv6Address) //
+                    : mld6_leavegroup(IP6_ADDR_ANY6, &lIPv6Address);
     });
 
     if (lStatus == ERR_MEM)

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -167,7 +167,7 @@ DLL_EXPORT void FormatError(char * buf, uint16_t bufSize, const char * subsys, C
 {
 #if CHIP_CONFIG_SHORT_ERROR_STR
 
-    if (subsys == NULL)
+    if (subsys == nullptr)
     {
         (void) snprintf(buf, bufSize, "Error " CHIP_CONFIG_SHORT_FORM_ERROR_VALUE_FORMAT, err.AsInteger());
     }

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -108,7 +108,7 @@ bool FormatPOSIXError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     {
         const char * desc =
 #if CHIP_CONFIG_SHORT_ERROR_STR
-            NULL;
+            nullptr;
 #else
             DescribeErrorPOSIX(err);
 #endif
@@ -178,9 +178,9 @@ DLL_EXPORT const char * DescribeErrorLwIP(CHIP_ERROR aError)
 /**
  * Register a text error formatter for LwIP errors.
  */
-void RegisterLwIPErrorFormatter(void)
+void RegisterLwIPErrorFormatter()
 {
-    static ErrorFormatter sLwIPErrorFormatter = { FormatLwIPError, NULL };
+    static ErrorFormatter sLwIPErrorFormatter = { FormatLwIPError, nullptr };
 
     RegisterErrorFormatter(&sLwIPErrorFormatter);
 }
@@ -203,17 +203,14 @@ bool FormatLwIPError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     {
         const char * desc =
 #if CHIP_CONFIG_SHORT_ERROR_STR
-            NULL;
+            nullptr;
 #else
             DescribeErrorLwIP(err);
 #endif
         chip::FormatError(buf, bufSize, "LwIP", err, desc);
         return true;
     }
-    else
-    {
-        return false;
-    }
+    return false;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP


### PR DESCRIPTION
NULL -> nullptr and else after return, primarily.