### PR TITLE
[MatterYamlTests][darwin-framework-tool] Ensure that WaitForCommissio…

### DIFF
--- a/examples/darwin-framework-tool/commands/delay/WaitForCommissioneeCommand.h
+++ b/examples/darwin-framework-tool/commands/delay/WaitForCommissioneeCommand.h
@@ -22,24 +22,15 @@
 #include <app/OperationalSessionSetup.h>
 #include <lib/core/CHIPCallback.h>
 
-NS_ASSUME_NONNULL_BEGIN
-@interface MTRDeviceTestDelegate : NSObject <MTRDeviceDelegate>
-@property CHIPCommandBridge * commandBridge;
-- (instancetype)initWithCommandBridge:(CHIPCommandBridge *)commandBridge;
-- (instancetype)init NS_UNAVAILABLE;
-@end
-NS_ASSUME_NONNULL_END
-
-class WaitForCommissioneeCommand : public CHIPCommandBridge {
+class WaitForCommissioneeCommand : public CHIPCommandBridge
+{
 public:
-    WaitForCommissioneeCommand()
-        : CHIPCommandBridge("wait-for-commissionee")
-        , mDeviceDelegate([[MTRDeviceTestDelegate alloc] initWithCommandBridge:this])
+    WaitForCommissioneeCommand() : CHIPCommandBridge("wait-for-commissionee")
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("expire-existing-session", 0, 1, &mExpireExistingSession);
-        AddArgument(
-            "timeout", 0, UINT64_MAX, &mTimeoutSecs, "Time, in seconds, before this command is considered to have timed out.");
+        AddArgument("timeout", 0, UINT64_MAX, &mTimeoutSecs,
+                    "Time, in seconds, before this command is considered to have timed out.");
     }
 
     /////////// CHIPCommandBridge Interface /////////
@@ -53,5 +44,4 @@ private:
     chip::NodeId mNodeId;
     chip::Optional<uint16_t> mTimeoutSecs;
     chip::Optional<bool> mExpireExistingSession;
-    id<MTRDeviceDelegate> _Nullable mDeviceDelegate;
 };

--- a/examples/darwin-framework-tool/commands/delay/WaitForCommissioneeCommand.mm
+++ b/examples/darwin-framework-tool/commands/delay/WaitForCommissioneeCommand.mm
@@ -20,43 +20,10 @@
 
 #import "MTRDevice_Externs.h"
 
-@implementation MTRDeviceTestDelegate
-- (instancetype)initWithCommandBridge:(CHIPCommandBridge *)commandBridge
-{
-    if (!(self = [super init])) {
-        return nil;
-    }
-
-    _commandBridge = commandBridge;
-    return self;
-}
-
-- (void)device:(MTRDevice *)device stateChanged:(MTRDeviceState)state
-{
-    if (state == MTRDeviceStateReachable) {
-        _commandBridge->SetCommandExitStatus(CHIP_NO_ERROR);
-    } else if (state == MTRDeviceStateUnreachable) {
-        _commandBridge->SetCommandExitStatus(CHIP_ERROR_NOT_FOUND);
-    } else if (state == MTRDeviceStateUnknown) {
-        _commandBridge->SetCommandExitStatus(CHIP_ERROR_NOT_FOUND);
-    } else {
-        // This should not happens.
-        chipDie();
-    }
-}
-
-- (void)device:(MTRDevice *)device receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
-{
-}
-
-- (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport
-{
-}
-@end
-
 CHIP_ERROR WaitForCommissioneeCommand::RunCommand()
 {
     MTRDeviceController * commissioner = CurrentCommissioner();
+    VerifyOrReturnError(nil != commissioner, CHIP_ERROR_INCORRECT_STATE);
 
     auto * base_device = [MTRBaseDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
     VerifyOrReturnError(base_device != nil, CHIP_ERROR_INCORRECT_STATE);
@@ -64,13 +31,7 @@ CHIP_ERROR WaitForCommissioneeCommand::RunCommand()
     if (mExpireExistingSession.ValueOr(true)) {
         [base_device invalidateCASESession];
     }
-    base_device = nil;
 
-    auto * device = [MTRDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
-    VerifyOrReturnError(device != nil, CHIP_ERROR_INCORRECT_STATE);
-
-    auto queue = dispatch_queue_create("com.chip.wait_for_commissionee", DISPATCH_QUEUE_SERIAL);
-    [device setDelegate:mDeviceDelegate queue:queue];
-
+    SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
…nee works after a reboot

#### Problem

When using `darwin-framework-tool` as a backend to run YAML tests, 'WaitForCommissionee' does not works as expected after an accessory reboot. 
