### PR TITLE
[MatterYamlTests][darwin-framework-tool] Get GetCommissionerNodeId method to work and update TestAccessControlConstraints.yaml to use it

### DIFF
--- a/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.h
+++ b/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.h
@@ -31,5 +31,6 @@ CHIP_ERROR LogAttributeAsJSON(NSNumber * endpointId, NSNumber * clusterId, NSNum
 CHIP_ERROR LogCommandAsJSON(NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, id result);
 CHIP_ERROR LogAttributeErrorAsJSON(NSNumber * endpointId, NSNumber * clusterId, NSNumber * attributeId, NSError * error);
 CHIP_ERROR LogCommandErrorAsJSON(NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, NSError * error);
+CHIP_ERROR LogGetCommissionerNodeId(NSNumber * nodeId);
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate);
 }; // namespace RemoteDataModelLogger

--- a/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.mm
+++ b/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.mm
@@ -34,6 +34,7 @@ constexpr char kCommandIdKey[] = "commandId";
 constexpr char kErrorIdKey[] = "error";
 constexpr char kClusterErrorIdKey[] = "clusterError";
 constexpr char kValueKey[] = "value";
+constexpr char kNodeIdKey[] = "nodeId";
 
 constexpr char kBase64Header[] = "base64:";
 
@@ -189,6 +190,18 @@ CHIP_ERROR LogCommandErrorAsJSON(NSNumber * endpointId, NSNumber * clusterId, NS
     auto err = MTRErrorToCHIPErrorCode(error);
     auto status = chip::app::StatusIB(err);
     return LogError(value, status);
+}
+
+CHIP_ERROR LogGetCommissionerNodeId(NSNumber * value)
+{
+    VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
+
+    Json::Value rootValue;
+    rootValue[kValueKey] = Json::Value();
+    rootValue[kValueKey][kNodeIdKey] = [value unsignedLongLongValue];
+
+    auto valueStr = JsonToString(rootValue);
+    return gDelegate->LogJSON(valueStr.c_str());
 }
 
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate) { gDelegate = delegate; }

--- a/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/GetCommissionerNodeIdCommand.mm
@@ -19,15 +19,17 @@
 #import <Matter/Matter.h>
 
 #include "GetCommissionerNodeIdCommand.h"
+#include "RemoteDataModelLogger.h"
 
 CHIP_ERROR GetCommissionerNodeIdCommand::RunCommand()
 {
     auto * controller = CurrentCommissioner();
     VerifyOrReturnError(nil != controller, CHIP_ERROR_INCORRECT_STATE);
 
-    ChipLogProgress(
-        chipTool, "Commissioner Node Id 0x" ChipLogFormatX64, ChipLogValueX64(controller.controllerNodeId.unsignedLongLongValue));
+    auto controllerNodeId = controller.controllerNodeId;
+    ChipLogProgress(chipTool, "Commissioner Node Id 0x" ChipLogFormatX64, ChipLogValueX64(controllerNodeId.unsignedLongLongValue));
 
+    ReturnErrorOnFailure(RemoteDataModelLogger::LogGetCommissionerNodeId(controllerNodeId));
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
 }

--- a/src/app/tests/suites/TestAccessControlConstraints.yaml
+++ b/src/app/tests/suites/TestAccessControlConstraints.yaml
@@ -28,6 +28,14 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Read the commissioner node ID from the alpha fabric"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdAlpha
+
     - label: "Constraint error: PASE reserved for future (TC-ACL-2.4 step 29)"
       cluster: "Access Control"
       command: "writeAttribute"
@@ -35,14 +43,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3,
                       AuthMode: 1, # PASE
                       Subjects: [],
@@ -61,14 +69,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 3, # Group
                       Subjects: [],
@@ -89,14 +97,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 6,
                       AuthMode: 2,
                       Subjects: null,
@@ -113,14 +121,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3,
                       AuthMode: 4, # INVALID
                       Subjects: [],
@@ -137,14 +145,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: [0],
@@ -161,14 +169,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
@@ -189,14 +197,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
@@ -215,14 +223,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 6, # INVALID
                       AuthMode: 2, # CASE
                       Subjects: null,
@@ -241,14 +249,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3, # Operate
                       AuthMode: 2, # CASE
                       Subjects: ["18446744073709551615"],
@@ -269,14 +277,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3, # Operate
                       AuthMode: 2, # CASE
                       Subjects: ["18446744060824649728"],
@@ -295,14 +303,14 @@ tests:
       arguments:
           value: [
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 5, # Administer
                       AuthMode: 2, # CASE
-                      Subjects: [112233],
+                      Subjects: [commissionerNodeIdAlpha],
                       Targets: null,
                   },
                   {
-                      FabricIndex: 1,
+                      FabricIndex: 0,
                       Privilege: 3, # Operate
                       AuthMode: 2, # CASE
                       Subjects: ["18446744073709486080"],


### PR DESCRIPTION
#### Problem

When using `darwin-framework-tool` as a backend to run YAML tests, `GetCommissionerNodeId` command does not work since it is not implemented.

This PR implements it and also update `TestAccessControlConstraints` to use it.
