### PR TITLE
[MatterYamlTests] Fix a bunch of typos in the yaml tests

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_3.yaml
@@ -745,7 +745,7 @@ tests:
     - label:
           "Step 10: Verify that the public Key extracted NOCValue of the AddNOC
           matches the Node Operational Public Key extracted from CSRResponse"
-      verifiaction: |
+      verification: |
           Not verifiable (out of scope)
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_OPSTATE_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPSTATE_2_2.yaml
@@ -25,7 +25,7 @@ config:
 
 tests:
     - label: "Note"
-      verifications: |
+      verification: |
           This is a simulated example log for instructional purposes only. In real scenarios, the actual log may vary depending on the feature implementation in Reference App.
       disabled: true
 

--- a/src/app/tests/suites/examples/Test_Example.yaml
+++ b/src/app/tests/suites/examples/Test_Example.yaml
@@ -18,7 +18,6 @@ tests:
       command: "ExamplesCommand"
       response: # Validates the response variables of the commands
           saveAs: nameOfSaveVariable
-          value: 0
           values:
               - name: "exampleResponseVariable"
                 value: 1


### PR DESCRIPTION
#### Problem

This is just some typos that I found while debugging the test with `darwin-framework-tool`
