### PR TITLE
Remove mInfo field from Cancelable by default.

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -64,6 +64,7 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_CONFIG_TRANSPORT_PW_TRACE_ENABLED=${chip_enable_transport_pw_trace}",
     "CHIP_CONFIG_MINMDNS_DYNAMIC_OPERATIONAL_RESPONDER_LIST=${chip_config_minmdns_dynamic_operational_responder_list}",
     "CHIP_CONFIG_MINMDNS_MAX_PARALLEL_RESOLVES=${chip_config_minmdns_max_parallel_resolves}",
+    "CHIP_CONFIG_CANCELABLE_HAS_INFO_STRING_FIELD=${chip_config_cancelable_has_info_string_field}",
   ]
 }
 

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -26,6 +26,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <lib/core/CHIPConfig.h>
+
 namespace chip {
 
 namespace Callback {
@@ -49,7 +51,13 @@ public:
      */
     Cancelable * mNext;
     Cancelable * mPrev;
+
+    // CHIP_CONFIG_CANCELABLE_HAS_INFO_STRING_FIELD allows consumers that were
+    // using this field to opt into having it (and the resulting memory bloat)
+    // while allowing everyone else to save the memory.
+#if CHIP_CONFIG_CANCELABLE_HAS_INFO_STRING_FIELD
     alignas(uint64_t) char mInfo[24];
+#endif // CHIP_CONFIG_CANCELABLE_HAS_INFO_STRING_FIELD
 
     /**
      * @brief when non-null, indicates the Callback is registered with

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -84,6 +84,10 @@ declare_args() {
 
   # When using minmdns, set the number of parallel resolves
   chip_config_minmdns_max_parallel_resolves = 2
+
+  # If set to true, adds a string "info" field to Cancelable.
+  # Only here for backwards compat.  Generally should not be set to true.
+  chip_config_cancelable_has_info_string_field = false
 }
 
 if (chip_target_style == "") {

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -86,7 +86,7 @@ declare_args() {
   chip_config_minmdns_max_parallel_resolves = 2
 
   # If set to true, adds a string "info" field to Cancelable.
-  # Only here for backwards compat.  Generally should not be set to true.
+  # Only here for backwards compat.  Generally, THIS SHOULD NOT BE SET TO TRUE.
   chip_config_cancelable_has_info_string_field = false
 }
 


### PR DESCRIPTION
It's big, and totally unused.

The opt-in to enable it is for backwards compat.  If we care about preserving compat while also ensuring that some internal Cancelable uses never have this field, that is also possible, but more complicated.
