### PR TITLE
Stop using ResolverProxy for resolving node lookups

### DIFF
--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -268,7 +268,7 @@ function run_test() {
     fi
 
     set +e
-    pytest --json-report --json-report-summary --json-report-file="$EXAMPLE_TEST_PATH"/test_report_"$EXAMPLE".json --binaryPath="$EXAMPLE_EXE_PATH" --fvp="$FVP_BIN" --fvpConfig="$FVP_CONFIG_FILE" "${TEST_OPTIONS[@]}" "$EXAMPLE_TEST_PATH"/test_app.py
+    pytest --log-level=INFO --json-report --json-report-summary --json-report-file="$EXAMPLE_TEST_PATH"/test_report_"$EXAMPLE".json --binaryPath="$EXAMPLE_EXE_PATH" --fvp="$FVP_BIN" --fvpConfig="$FVP_CONFIG_FILE" "${TEST_OPTIONS[@]}" "$EXAMPLE_TEST_PATH"/test_app.py
     set -e
 
     if [[ ! -f $EXAMPLE_TEST_PATH/test_report_$EXAMPLE.json ]]; then

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -645,12 +645,6 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId)
     service.mProtocol    = DnssdServiceProtocol::kDnssdProtocolTcp;
     service.mAddressType = Inet::IPAddressType::kAny;
 
-    // mDelegate is a ResolverDelegateProxy
-    //    - that is just created fully
-    //    - callback seems to use it somehow
-    // TODO:
-    //    - figure out what OperationalNodeResolved and others do ....
-
     return ChipDnssdResolve(&service, Inet::InterfaceId::Null(), HandleNodeIdResolve, this);
 }
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -55,70 +55,6 @@ static void HandleNodeResolve(void * context, DnssdService * result, const Span<
     proxy->Release();
 }
 
-static void HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses, CHIP_ERROR error)
-{
-    ResolverDelegateProxy * proxy = static_cast<ResolverDelegateProxy *>(context);
-    if (CHIP_NO_ERROR != error)
-    {
-        proxy->OnOperationalNodeResolutionFailed(PeerId(), error);
-        proxy->Release();
-        return;
-    }
-
-    VerifyOrDie(proxy != nullptr);
-
-    if (result == nullptr)
-    {
-        proxy->OnOperationalNodeResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
-        proxy->Release();
-        return;
-    }
-
-    VerifyOrDie(proxy != nullptr);
-
-    PeerId peerId;
-    error = ExtractIdFromInstanceName(result->mName, &peerId);
-    if (CHIP_NO_ERROR != error)
-    {
-        proxy->OnOperationalNodeResolutionFailed(PeerId(), error);
-        proxy->Release();
-        return;
-    }
-
-    VerifyOrDie(proxy != nullptr);
-
-    ResolvedNodeData nodeData;
-    Platform::CopyString(nodeData.resolutionData.hostName, result->mHostName);
-    nodeData.resolutionData.interfaceId = result->mInterface;
-    nodeData.resolutionData.port        = result->mPort;
-    nodeData.operationalData.peerId     = peerId;
-
-    size_t addressesFound = 0;
-    for (auto & ip : addresses)
-    {
-        if (addressesFound == ArraySize(nodeData.resolutionData.ipAddress))
-        {
-            // Out of space.
-            ChipLogProgress(Discovery, "Can't add more IPs to ResolvedNodeData");
-            break;
-        }
-        nodeData.resolutionData.ipAddress[addressesFound] = ip;
-        ++addressesFound;
-    }
-    nodeData.resolutionData.numIPs = addressesFound;
-
-    for (size_t i = 0; i < result->mTextEntrySize; ++i)
-    {
-        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
-        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, nodeData.resolutionData);
-    }
-
-    nodeData.LogNodeIdResolved();
-    proxy->OnOperationalNodeResolved(nodeData);
-    proxy->Release();
-}
-
 static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, bool finalBrowse, CHIP_ERROR error)
 {
     ResolverDelegateProxy * proxy = static_cast<ResolverDelegateProxy *>(context);
@@ -335,6 +271,67 @@ CHIP_ERROR AddTxtRecord(TxtFieldKey key, TextEntry * entries, size_t & entriesCo
 }
 
 } // namespace
+
+void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses, CHIP_ERROR error)
+{
+    DiscoveryImplPlatform *impl = static_cast<DiscoveryImplPlatform*>(context);
+
+    if (impl->mOperationalDelegate == nullptr) {
+        ChipLogError(Discovery, "No delegate to handle node resolution data.");
+        return;
+    }
+
+    if (CHIP_NO_ERROR != error)
+    {
+        impl->mOperationalDelegate->OnOperationalNodeResolutionFailed(PeerId(), error);
+        return;
+    }
+
+    if (result == nullptr)
+    {
+        impl->mOperationalDelegate->OnOperationalNodeResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
+        return;
+    }
+
+    PeerId peerId;
+    error = ExtractIdFromInstanceName(result->mName, &peerId);
+    if (CHIP_NO_ERROR != error)
+    {
+        impl->mOperationalDelegate->OnOperationalNodeResolutionFailed(PeerId(), error);
+        return;
+    }
+
+    ResolvedNodeData nodeData;
+    Platform::CopyString(nodeData.resolutionData.hostName, result->mHostName);
+    nodeData.resolutionData.interfaceId = result->mInterface;
+    nodeData.resolutionData.port        = result->mPort;
+    nodeData.operationalData.peerId     = peerId;
+
+    size_t addressesFound = 0;
+    for (auto & ip : addresses)
+    {
+        if (addressesFound == ArraySize(nodeData.resolutionData.ipAddress))
+        {
+            // Out of space.
+            ChipLogProgress(Discovery, "Can't add more IPs to ResolvedNodeData");
+            break;
+        }
+        nodeData.resolutionData.ipAddress[addressesFound] = ip;
+        ++addressesFound;
+    }
+    nodeData.resolutionData.numIPs = addressesFound;
+
+    for (size_t i = 0; i < result->mTextEntrySize; ++i)
+    {
+        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
+        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
+        FillNodeDataFromTxt(key, val, nodeData.resolutionData);
+    }
+
+    nodeData.LogNodeIdResolved();
+    impl->mOperationalDelegate->OnOperationalNodeResolved(nodeData);
+}
+
 
 void DnssdService::ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData)
 {
@@ -633,15 +630,33 @@ bool DiscoveryImplPlatform::IsInitialized()
 
 CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId)
 {
-    ReturnErrorOnFailure(InitImpl());
-    return mResolverProxy.ResolveNodeId(peerId);
+    // Resolve requests can only be issued once DNSSD is initialized and there is
+    // no caching currently
+    VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+
+    ChipLogProgress(Discovery, "Resolving " ChipLogFormatX64 ":" ChipLogFormatX64 " ...",
+                    ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
+
+    DnssdService service;
+
+    ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), peerId));
+    Platform::CopyString(service.mType, kOperationalServiceName);
+    service.mProtocol    = DnssdServiceProtocol::kDnssdProtocolTcp;
+    service.mAddressType = Inet::IPAddressType::kAny;
+
+    // mDelegate is a ResolverDelegateProxy
+    //    - that is just created fully
+    //    - callback seems to use it somehow
+    // TODO:
+    //    - figure out what OperationalNodeResolved and others do ....
+
+    return ChipDnssdResolve(&service, Inet::InterfaceId::Null(), HandleNodeIdResolve, this);
 }
 
 void DiscoveryImplPlatform::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
 {
     char name[Common::kInstanceNameMaxLength + 1];
     ReturnOnFailure(MakeInstanceName(name, sizeof(name), peerId));
-
     ChipDnssdResolveNoLongerNeeded(name);
 }
 
@@ -682,38 +697,6 @@ ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()
 Resolver & chip::Dnssd::Resolver::Instance()
 {
     return DiscoveryImplPlatform::GetInstance();
-}
-
-CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
-{
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    ChipLogProgress(Discovery, "Resolving " ChipLogFormatX64 ":" ChipLogFormatX64 " ...",
-                    ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
-
-    DnssdService service;
-
-    ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), peerId));
-    Platform::CopyString(service.mType, kOperationalServiceName);
-    service.mProtocol    = DnssdServiceProtocol::kDnssdProtocolTcp;
-    service.mAddressType = Inet::IPAddressType::kAny;
-
-    mDelegate->Retain();
-
-    CHIP_ERROR err = ChipDnssdResolve(&service, Inet::InterfaceId::Null(), HandleNodeIdResolve, mDelegate);
-    if (err != CHIP_NO_ERROR)
-    {
-        mDelegate->Release();
-    }
-    return err;
-}
-
-void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
-{
-    char name[Common::kInstanceNameMaxLength + 1];
-    ReturnOnFailure(MakeInstanceName(name, sizeof(name), peerId));
-
-    ChipDnssdResolveNoLongerNeeded(name);
 }
 
 ResolverProxy::~ResolverProxy()

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -272,11 +272,13 @@ CHIP_ERROR AddTxtRecord(TxtFieldKey key, TextEntry * entries, size_t & entriesCo
 
 } // namespace
 
-void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses, CHIP_ERROR error)
+void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses,
+                                                CHIP_ERROR error)
 {
-    DiscoveryImplPlatform *impl = static_cast<DiscoveryImplPlatform*>(context);
+    DiscoveryImplPlatform * impl = static_cast<DiscoveryImplPlatform *>(context);
 
-    if (impl->mOperationalDelegate == nullptr) {
+    if (impl->mOperationalDelegate == nullptr)
+    {
         ChipLogError(Discovery, "No delegate to handle node resolution data.");
         return;
     }
@@ -331,7 +333,6 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * r
     nodeData.LogNodeIdResolved();
     impl->mOperationalDelegate->OnOperationalNodeResolved(nodeData);
 }
-
 
 void DnssdService::ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData)
 {

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -91,15 +91,15 @@ private:
                               size_t subTypeSize, uint16_t port, Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
                               DnssdServiceProtocol procotol, PeerId peerId);
 
-    static void HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses, CHIP_ERROR error);
+    static void HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses,
+                                    CHIP_ERROR error);
 
     State mState = State::kUninitialized;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
     ResolverProxy mResolverProxy;
-    OperationalResolveDelegate *mOperationalDelegate = nullptr;
+    OperationalResolveDelegate * mOperationalDelegate = nullptr;
 
     static DiscoveryImplPlatform sManager;
-
 };
 
 } // namespace Dnssd

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -50,7 +50,7 @@ public:
     CHIP_ERROR UpdateCommissionableInstanceName() override;
 
     // Members that implement Resolver interface.
-    void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mResolverProxy.SetOperationalDelegate(delegate); }
+    void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override
     {
         mResolverProxy.SetCommissioningDelegate(delegate);
@@ -91,11 +91,15 @@ private:
                               size_t subTypeSize, uint16_t port, Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
                               DnssdServiceProtocol procotol, PeerId peerId);
 
+    static void HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & addresses, CHIP_ERROR error);
+
     State mState = State::kUninitialized;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
     ResolverProxy mResolverProxy;
+    OperationalResolveDelegate *mOperationalDelegate = nullptr;
 
     static DiscoveryImplPlatform sManager;
+
 };
 
 } // namespace Dnssd

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -158,7 +158,7 @@ public:
 
     // TODO: ResolverProxy should not be used anymore to implement operational node resolution
     //       This method still here because Resolver interface requires it
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId) override {return CHIP_ERROR_NOT_IMPLEMENTED;}
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
 
 private:

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -23,8 +23,7 @@
 namespace chip {
 namespace Dnssd {
 
-class ResolverDelegateProxy : public ReferenceCounted<ResolverDelegateProxy>,
-                              public CommissioningResolveDelegate
+class ResolverDelegateProxy : public ReferenceCounted<ResolverDelegateProxy>, public CommissioningResolveDelegate
 
 {
 public:
@@ -77,10 +76,10 @@ public:
 
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override
     {
-       /// Unfortunately cannot remove this method since it is in a Resolver interface.
-       ChipLogError(Discovery, "!!! Operational proxy does NOT support operational discovery");
-       ChipLogError(Discovery, "!!! Please use AddressResolver or DNSSD Resolver directly");
-       chipDie();  // force detection of invalid usages.
+        /// Unfortunately cannot remove this method since it is in a Resolver interface.
+        ChipLogError(Discovery, "!!! Operational proxy does NOT support operational discovery");
+        ChipLogError(Discovery, "!!! Please use AddressResolver or DNSSD Resolver directly");
+        chipDie(); // force detection of invalid usages.
     }
 
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -151,12 +151,15 @@ public:
         mDelegate = nullptr;
     }
 
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
-    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
+
+    // TODO: ResolverProxy should not be used anymore to implement operational node resolution
+    //       This method still here because Resolver interface requires it
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId) override {return CHIP_ERROR_NOT_IMPLEMENTED;}
+    void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
 
 private:
     ResolverDelegateProxy * mDelegate                            = nullptr;

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -748,25 +748,6 @@ ResolverProxy::~ResolverProxy()
     Shutdown();
 }
 
-// Minimal implementation does not support associating a context to a request (while platforms implementations do). So keep
-// updating the delegate that ends up being used by the server by calling 'SetOperationalDelegate'.
-// This effectively allow minimal to have multiple controllers issuing requests as long the requests are serialized, but
-// it won't work well if requests are issued in parallel.
-CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
-{
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    ChipLogProgress(Discovery, "Resolving " ChipLogFormatX64 ":" ChipLogFormatX64 " ...",
-                    ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
-    chip::Dnssd::Resolver::Instance().SetOperationalDelegate(mDelegate);
-    return chip::Dnssd::Resolver::Instance().ResolveNodeId(peerId);
-}
-
-void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId)
-{
-    return chip::Dnssd::Resolver::Instance().NodeIdResolutionNoLongerNeeded(peerId);
-}
-
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -68,13 +68,6 @@ ResolverProxy::~ResolverProxy()
     Shutdown();
 }
 
-CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId)
-{
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-void ResolverProxy::NodeIdResolutionNoLongerNeeded(const PeerId & peerId) {}
-
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/shell/commands/BUILD.gn
+++ b/src/lib/shell/commands/BUILD.gn
@@ -50,6 +50,7 @@ source_set("commands") {
 
   if (chip_device_platform != "none") {
     sources += [ "Dns.cpp" ]
+    public_deps += ["${chip_root}/src/lib/address_resolve" ]
   }
 
   if (chip_enable_ota_requestor && chip_device_platform != "none" &&
@@ -64,7 +65,7 @@ source_set("commands") {
     deps = [ "${chip_root}/src/controller/data_model:data_model_zapgen_files" ]
 
     configs +=
-        [ "${chip_root}/src/controller/data_model:data_model_zapgen_config" ]
+    [ "${chip_root}/src/controller/data_model:data_model_zapgen_config" ]
   }
 
   if (chip_system_config_provide_statistics) {

--- a/src/lib/shell/commands/BUILD.gn
+++ b/src/lib/shell/commands/BUILD.gn
@@ -50,7 +50,7 @@ source_set("commands") {
 
   if (chip_device_platform != "none") {
     sources += [ "Dns.cpp" ]
-    public_deps += ["${chip_root}/src/lib/address_resolve" ]
+    public_deps += [ "${chip_root}/src/lib/address_resolve" ]
   }
 
   if (chip_enable_ota_requestor && chip_device_platform != "none" &&
@@ -65,7 +65,7 @@ source_set("commands") {
     deps = [ "${chip_root}/src/controller/data_model:data_model_zapgen_files" ]
 
     configs +=
-    [ "${chip_root}/src/controller/data_model:data_model_zapgen_config" ]
+        [ "${chip_root}/src/controller/data_model:data_model_zapgen_config" ]
   }
 
   if (chip_system_config_provide_statistics) {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <inet/IPAddress.h>
+#include <lib/address_resolve/AddressResolve.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/PeerId.h>
 #include <lib/dnssd/Advertiser.h>
@@ -39,39 +40,37 @@ Shell::Engine sShellDnsBrowseSubcommands;
 Shell::Engine sShellDnsSubcommands;
 Dnssd::ResolverProxy sResolverProxy;
 
-class DnsShellResolverDelegate : public Dnssd::OperationalResolveDelegate, public Dnssd::CommissioningResolveDelegate
+class DnsShellResolverDelegate : public Dnssd::CommissioningResolveDelegate, public AddressResolve::NodeListener
 {
 public:
-    void OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeData) override
+    DnsShellResolverDelegate() { mSelfHandle.SetListener(this); }
+
+    void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override
     {
-        sResolverProxy.NodeIdResolutionNoLongerNeeded(nodeData.operationalData.peerId);
         streamer_printf(streamer_get(), "DNS resolve for " ChipLogFormatX64 "-" ChipLogFormatX64 " succeeded:\r\n",
-                        ChipLogValueX64(nodeData.operationalData.peerId.GetCompressedFabricId()),
-                        ChipLogValueX64(nodeData.operationalData.peerId.GetNodeId()));
-        streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.resolutionData.hostName);
-        for (size_t i = 0; i < nodeData.resolutionData.numIPs; ++i)
-        {
-            streamer_printf(streamer_get(), "   IP address: %s\r\n", nodeData.resolutionData.ipAddress[i].ToString(ipAddressBuf));
-        }
-        streamer_printf(streamer_get(), "   Port: %u\r\n", nodeData.resolutionData.port);
+                        ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
 
-        auto retryInterval = nodeData.resolutionData.GetMrpRetryIntervalIdle();
+        char addr_string[Transport::PeerAddress::kMaxToStringSize];
+        result.address.ToString(addr_string);
 
-        if (retryInterval.HasValue())
-            streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\r\n", retryInterval.Value());
-
-        retryInterval = nodeData.resolutionData.GetMrpRetryIntervalActive();
-
-        if (retryInterval.HasValue())
-            streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\r\n", retryInterval.Value());
-
-        streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.resolutionData.supportsTcp ? "yes" : "no");
+        streamer_printf(streamer_get(), "Resolve completed: %s\r\n", addr_string);
+        streamer_printf(streamer_get(), "   Supports TCP:                  %s\r\n", result.supportsTcp ? "YES" : "NO");
+        streamer_printf(streamer_get(), "   MRP IDLE retransmit timeout:   %u ms\r\n",
+                        result.mrpRemoteConfig.mIdleRetransTimeout.count());
+        streamer_printf(streamer_get(), "   MRP ACTIVE retransmit timeout: %u ms\r\n",
+                        result.mrpRemoteConfig.mActiveRetransTimeout.count());
+        streamer_printf(streamer_get(), "   MRP ACTIVE Threshold timet:    %u ms\r\n",
+                        result.mrpRemoteConfig.mActiveThresholdTime.count());
     }
 
-    void OnOperationalNodeResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason) override
     {
-        sResolverProxy.NodeIdResolutionNoLongerNeeded(peerId);
+        streamer_printf(streamer_get(),
+                        "DNS resolve for " ChipLogFormatX64 "-" ChipLogFormatX64 " failed: %" CHIP_ERROR_FORMAT "\r\n",
+                        ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()), reason.Format());
     }
+
+    AddressResolve::NodeLookupHandle & Handle() { return mSelfHandle; }
 
     void OnNodeDiscovered(const Dnssd::DiscoveredNodeData & nodeData) override
     {
@@ -118,6 +117,7 @@ public:
 
 private:
     char ipAddressBuf[Inet::IPAddress::kMaxStringLength];
+    AddressResolve::NodeLookupHandle mSelfHandle;
 };
 
 DnsShellResolverDelegate sDnsShellResolverDelegate;
@@ -126,13 +126,19 @@ CHIP_ERROR ResolveHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
+    if (sDnsShellResolverDelegate.Handle().IsActive())
+    {
+        streamer_printf(streamer_get(), "Cancelling previous resolve...\r\n");
+        LogErrorOnFailure(AddressResolve::Resolver::Instance().CancelLookup(sDnsShellResolverDelegate.Handle(),
+                                                                            AddressResolve::Resolver::FailureCallback::Call));
+    }
+
     streamer_printf(streamer_get(), "Resolving ...\r\n");
 
-    PeerId peerId;
-    peerId.SetCompressedFabricId(strtoull(argv[0], nullptr, 10));
-    peerId.SetNodeId(strtoull(argv[1], nullptr, 10));
+    AddressResolve::NodeLookupRequest request(
+        PeerId().SetCompressedFabricId(strtoull(argv[0], nullptr, 10)).SetNodeId(strtoull(argv[1], nullptr, 10)));
 
-    return sResolverProxy.ResolveNodeId(peerId);
+    return AddressResolve::Resolver::Instance().LookupNode(request, sDnsShellResolverDelegate.Handle());
 }
 
 bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)
@@ -230,7 +236,6 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
     }
 
     sResolverProxy.Init(DeviceLayer::UDPEndPointManager());
-    sResolverProxy.SetOperationalDelegate(&sDnsShellResolverDelegate);
     sResolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -63,7 +63,7 @@ public:
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
 
         // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
-        SystemLayer().ScheduleLambda([this] {
+        DeviceLayer::SystemLayer().ScheduleLambda([this] {
             CHIP_ERROR err = AddressResolve::Resolver::Instance().TryNextResult(Handle());
             if (err != CHIP_NO_ERROR && err != CHIP_ERROR_WELL_EMPTY)
             {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -61,6 +61,15 @@ public:
                         result.mrpRemoteConfig.mActiveRetransTimeout.count());
         streamer_printf(streamer_get(), "   MRP ACTIVE Threshold timet:    %u ms\r\n",
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
+
+        // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
+        SystemLayer().ScheduleLambda([this] {
+            CHIP_ERROR err = AddressResolve::Resolver::Instance().TryNextResult(Handle());
+            if (err != CHIP_NO_ERROR && err != CHIP_ERROR_WELL_EMPTY)
+            {
+                ChipLogError(Discovery, "Failed to list next result: %" CHIP_ERROR_FORMAT, err.Format());
+            }
+        });
     }
 
     void OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason) override

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -853,9 +853,10 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     resolveContext->mAddressType = ToAvahiProtocol(addressType);
     resolveContext->mFullType    = GetFullType(type, protocol);
 
-    AvahiServiceResolver * resolver = avahi_service_resolver_new(
-        mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(), nullptr,
-        resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve, reinterpret_cast<void *>(resolveContext->mNumber));
+    AvahiServiceResolver * resolver =
+        avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
+                                   nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
+                                   reinterpret_cast<void *>(resolveContext->mNumber));
     // Otherwise the resolver will be freed in the callback
     if (resolver == nullptr)
     {
@@ -876,7 +877,8 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
     ResolveContext * context = sInstance.ResolveContextForHandle(handle);
     std::vector<TextEntry> textEntries;
 
-    if (context == nullptr) {
+    if (context == nullptr)
+    {
         ChipLogError(Discovery, "Invalid context for handling resolves: %ld", static_cast<long>(handle));
         return;
     }

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -156,6 +156,7 @@ private:
             if (mResolver != nullptr)
             {
                 avahi_service_resolver_free(mResolver);
+                mResolver = nullptr;
             }
         }
     };

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -116,7 +116,7 @@ public:
     CHIP_ERROR Resolve(const char * name, const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                        chip::Inet::IPAddressType transportType, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
-    void StopResolve(const char *name);
+    void StopResolve(const char * name);
 
     Poller & GetPoller() { return mPoller; }
 
@@ -139,7 +139,7 @@ private:
 
     struct ResolveContext
     {
-        size_t    mNumber; // unique number for this context
+        size_t mNumber; // unique number for this context
         MdnsAvahi * mInstance;
         DnssdResolveCallback mCallback;
         void * mContext;
@@ -148,11 +148,13 @@ private:
         AvahiProtocol mTransport;
         AvahiProtocol mAddressType;
         std::string mFullType;
-        uint8_t mAttempts = 0;
-        AvahiServiceResolver *mResolver = nullptr;
+        uint8_t mAttempts                = 0;
+        AvahiServiceResolver * mResolver = nullptr;
 
-        ~ResolveContext() {
-            if (mResolver != nullptr) {
+        ~ResolveContext()
+        {
+            if (mResolver != nullptr)
+            {
                 avahi_service_resolver_free(mResolver);
             }
         }
@@ -162,11 +164,11 @@ private:
     static MdnsAvahi sInstance;
 
     /// Allocates a new resolve context with a unique `mNumber`
-    ResolveContext *AllocateResolveContext();
+    ResolveContext * AllocateResolveContext();
 
-    ResolveContext *ResolveContextForHandle(size_t handle);
+    ResolveContext * ResolveContextForHandle(size_t handle);
     void FreeResolveContext(size_t handle);
-    void FreeResolveContext(const char *name);
+    void FreeResolveContext(const char * name);
 
     static void HandleClientState(AvahiClient * client, AvahiClientState state, void * context);
     void HandleClientState(AvahiClient * client, AvahiClientState state);

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <list>
 #include <map>
 #include <memory>
 #include <string>
@@ -115,6 +116,7 @@ public:
     CHIP_ERROR Resolve(const char * name, const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                        chip::Inet::IPAddressType transportType, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
+    void StopResolve(const char *name);
 
     Poller & GetPoller() { return mPoller; }
 
@@ -137,6 +139,7 @@ private:
 
     struct ResolveContext
     {
+        size_t    mNumber; // unique number for this context
         MdnsAvahi * mInstance;
         DnssdResolveCallback mCallback;
         void * mContext;
@@ -146,10 +149,24 @@ private:
         AvahiProtocol mAddressType;
         std::string mFullType;
         uint8_t mAttempts = 0;
+        AvahiServiceResolver *mResolver = nullptr;
+
+        ~ResolveContext() {
+            if (mResolver != nullptr) {
+                avahi_service_resolver_free(mResolver);
+            }
+        }
     };
 
     MdnsAvahi() : mClient(nullptr) {}
     static MdnsAvahi sInstance;
+
+    /// Allocates a new resolve context with a unique `mNumber`
+    ResolveContext *AllocateResolveContext();
+
+    ResolveContext *ResolveContextForHandle(size_t handle);
+    void FreeResolveContext(size_t handle);
+    void FreeResolveContext(const char *name);
 
     static void HandleClientState(AvahiClient * client, AvahiClientState state, void * context);
     void HandleClientState(AvahiClient * client, AvahiClientState state);
@@ -174,6 +191,10 @@ private:
     std::map<std::string, AvahiEntryGroup *> mPublishedGroups;
     Poller mPoller;
     static constexpr size_t kMaxBrowseRetries = 4;
+
+    // Handling of allocated resolves
+    size_t mResolveCount = 0;
+    std::list<ResolveContext *> mAllocatedResolves;
 };
 
 } // namespace Dnssd

--- a/src/test_driver/openiotsdk/integration-tests/common/utils.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/utils.py
@@ -72,6 +72,7 @@ def discover_device(devCtrl, setupPayload):
     if not res:
         log.info("Device not found")
         return None
+    log.info("Device found at %r" % res[0])
     return res[0]
 
 
@@ -87,6 +88,8 @@ def connect_device(devCtrl, setupPayload, commissionableDevice, nodeId=None):
     if nodeId is None:
         nodeId = random.randint(1, 1000000)
 
+    log.info("Connecting to device %d" % nodeId);
+
     pincode = int(setupPayload.attributes['SetUpPINCode'])
     try:
         res = devCtrl.CommissionOnNetwork(
@@ -95,7 +98,7 @@ def connect_device(devCtrl, setupPayload, commissionableDevice, nodeId=None):
         log.error("Commission discovered device failed {}".format(str(ex)))
         return None
     if not res:
-        log.info("Commission discovered device failed")
+        log.info("Commission discovered device failed (no response received)")
         return None
     return nodeId
 

--- a/src/test_driver/openiotsdk/integration-tests/common/utils.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/utils.py
@@ -88,7 +88,7 @@ def connect_device(devCtrl, setupPayload, commissionableDevice, nodeId=None):
     if nodeId is None:
         nodeId = random.randint(1, 1000000)
 
-    log.info("Connecting to device %d" % nodeId);
+    log.info("Connecting to device %d" % nodeId)
 
     pincode = int(setupPayload.attributes['SetUpPINCode'])
     try:

--- a/src/test_driver/openiotsdk/integration-tests/common/utils.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/utils.py
@@ -98,7 +98,7 @@ def connect_device(devCtrl, setupPayload, commissionableDevice, nodeId=None):
         log.error("Commission discovered device failed {}".format(str(ex)))
         return None
     if not res:
-        log.info("Commission discovered device failed (no response received)")
+        log.info("Commission discovered device failed: %r" % res)
         return None
     return nodeId
 


### PR DESCRIPTION
Fixes #28694 (memory leak because stopping resolution was not implemented).

We currently use AddressResolve to handle node resolution, so a separate singleton resolver proxy should not be needed for handling node resolution.

Actual changes:
  - remove implementation for ResolverProxy::ResolveNodeId
  - replace with inline code for PlatformDnsSd for resolverproxy. Made PlatformDnsSd maintain its own delegate for operational node discovery
  - Updated Avahi linux implementation to support "StopResolution" by kepping track of active resolutions and being able to free up memory outside avahi callbacks
  - Changed shell `Dns.cpp` to use AddressResolver interface instead of ResolverProxy for operational discovery.

## Tested

```
./out/linux-x64-address-resolve-tool-platform-mdns-asan/address-resolve-tool node 1 2
```

validated that node resolution still works when node is advertised (CI should also validate that) and that there are no memory leaks if we stop a resolution that does not find anything (i.e. cancel works and memory is freed up).

## TODO notes

- we may in general want to clean up ResolverProxy usage, especially since it now claims to implement an entire Resolver interface when in fact it does not implement operational node resolution. Maybe interfaces should be split