### PR TITLE
PersistentStorageOpCertStore: fix a clang-tidy warning

### DIFF
--- a/src/credentials/PersistentStorageOpCertStore.h
+++ b/src/credentials/PersistentStorageOpCertStore.h
@@ -36,7 +36,7 @@ namespace Credentials {
  *        to refactors to use `OperationalCertificateStore` and exists as a baseline example
  *        of how to use the interface.
  */
-class PersistentStorageOpCertStore : public OperationalCertificateStore
+class PersistentStorageOpCertStore final : public OperationalCertificateStore
 {
 public:
     PersistentStorageOpCertStore() {}


### PR DESCRIPTION
`~PersistentStorageOpCertStore` invokes `Finish()`, which invokes `RevertPendingOpCerts()` which is a virtual method.

In this case methods invoked belong to this class so as long as there are no descendants, it's ok. Make sure there are no descendants by declaring the class final.

Fixes https://github.com/project-chip/connectedhomeip/issues/29239