### PR TITLE
[Telink] Power down mode using ICD

### DIFF
--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -97,6 +97,7 @@ matter_add_gn_arg_bool  ("chip_error_logging"                     CONFIG_MATTER_
 matter_add_gn_arg_bool  ("chip_progress_logging"                  CONFIG_MATTER_LOG_LEVEL GREATER_EQUAL 3)
 matter_add_gn_arg_bool  ("chip_detail_logging"                    CONFIG_MATTER_LOG_LEVEL GREATER_EQUAL 4)
 matter_add_gn_arg_bool  ("chip_automation_logging"                FALSE)
+matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
 
 if (CONFIG_CHIP_FACTORY_DATA)
     matter_add_gn_arg_bool  ("chip_use_transitional_commissionable_data_provider"  "false")

--- a/examples/platform/telink/common/src/mainCommon.cpp
+++ b/examples/platform/telink/common/src/mainCommon.cpp
@@ -142,7 +142,7 @@ int main(void)
         goto exit;
     }
 
-#ifdef CONFIG_OPENTHREAD_MTD_SED
+#ifdef CONFIG_CHIP_ENABLE_ICD_SUPPORT
     err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
 #elif CONFIG_OPENTHREAD_MTD
     err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);


### PR DESCRIPTION
Enable power saving mode when ICD is enabled.
Feature touches only Telink platform

Tesed
manually using chip-tool commissioning process

