### PR TITLE
Return ConnectionFailureException which contains the connection state (Part I)

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -320,6 +320,8 @@ private:
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     Optional<State> mStopHandshakeAtState = Optional<State>::Missing();
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+    SessionEstablishmentStage MapCASEStateToSessionEstablishmentStage(State caseState);
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -255,7 +255,7 @@ void PairingSession::Clear()
     mSessionManager = nullptr;
 }
 
-void PairingSession::NotifySessionEstablishmentError(CHIP_ERROR error)
+void PairingSession::NotifySessionEstablishmentError(CHIP_ERROR error, SessionEstablishmentStage stage)
 {
     if (mDelegate == nullptr)
     {
@@ -265,7 +265,7 @@ void PairingSession::NotifySessionEstablishmentError(CHIP_ERROR error)
 
     auto * delegate = mDelegate;
     mDelegate       = nullptr;
-    delegate->OnSessionEstablishmentError(error);
+    delegate->OnSessionEstablishmentError(error, stage);
 }
 
 void PairingSession::OnSessionReleased()

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -218,10 +218,14 @@ protected:
     void Clear();
 
     /**
-     * Notify our delegate about a session establishment error, if we have not
-     * notified it of an error or success before.
+     * Notify our delegate about a session establishment error and the stage when the error occurs
+     * if we have not already notified it of an error or success before.
+     *
+     * @param error The error code to report.
+     * @param stage The stage of the session when the error occurs, defaults to kNotInKeyExchange.
      */
-    void NotifySessionEstablishmentError(CHIP_ERROR error);
+    void NotifySessionEstablishmentError(CHIP_ERROR error,
+                                         SessionEstablishmentStage stage = SessionEstablishmentStage::kNotInKeyExchange);
 
 protected:
     CryptoContext::SessionRole mRole;

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -32,6 +32,18 @@
 
 namespace chip {
 
+enum class SessionEstablishmentStage : uint8_t
+{
+    kUnknown          = 0,
+    kNotInKeyExchange = 1,
+    kSentSigma1       = 2,
+    kReceivedSigma1   = 3,
+    kSentSigma2       = 4,
+    kReceivedSigma2   = 5,
+    kSentSigma3       = 6,
+    kReceivedSigma3   = 7,
+};
+
 class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
@@ -39,8 +51,21 @@ public:
      *   Called when session establishment fails with an error.  This will be
      *   called at most once per session establishment and will not be called if
      *   OnSessionEstablished is called.
+     *
+     *   This overload of OnSessionEstablishmentError is not called directly.  It's only called from the default
+     *.   implemetation of the two-argument overload.
      */
     virtual void OnSessionEstablishmentError(CHIP_ERROR error) {}
+
+    /**
+     *   Called when session establishment fails with an error and state at the
+     *   failure. This will be called at most once per session establishment and
+     *   will not be called if OnSessionEstablished is called.
+     */
+    virtual void OnSessionEstablishmentError(CHIP_ERROR error, SessionEstablishmentStage stage)
+    {
+        OnSessionEstablishmentError(error);
+    }
 
     /**
      *   Called on start of session establishment process


### PR DESCRIPTION
Move private enum State to public and rename it to CaseSessionState. 

This is to expose CaseSessionState to provide valuable debugging and metrics data, as well as improve the user experience by providing more detailed information about the connection failure.

