### PR TITLE
Fix silabs compile - `#elif` without a condition replaced with `#else`

### DIFF
--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -212,9 +212,11 @@ void SilabsLCD::SetScreen(Screen_e screen)
     case StatusScreen:
         WriteStatus();
         break;
+#ifdef QR_CODE_ENABLED
     case QRCodeScreen:
         WriteQRCode();
         break;
+#endif
     default:
         break;
     }
@@ -286,9 +288,9 @@ void SilabsLCD::SetQRCode(uint8_t * str, uint32_t size)
 void SilabsLCD::ShowQRCode(bool show)
 {
     if (mCurrentScreen != QRCodeScreen)
-    {
-        mCurrentScreen = QRCodeScreen;
-    }
+        {
+            mCurrentScreen = QRCodeScreen;
+        }
 
     WriteQRCode();
 }

--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -224,7 +224,7 @@ void SilabsLCD::CycleScreens(void)
 {
 #ifdef QR_CODE_ENABLED
     if (mCurrentScreen < QRCodeScreen)
-#elif
+#else
     if (mCurrentScreen < StatusScreen)
 #endif
     {

--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -288,9 +288,9 @@ void SilabsLCD::SetQRCode(uint8_t * str, uint32_t size)
 void SilabsLCD::ShowQRCode(bool show)
 {
     if (mCurrentScreen != QRCodeScreen)
-        {
-            mCurrentScreen = QRCodeScreen;
-        }
+    {
+        mCurrentScreen = QRCodeScreen;
+    }
 
     WriteQRCode();
 }

--- a/examples/platform/silabs/display/lcd.h
+++ b/examples/platform/silabs/display/lcd.h
@@ -74,7 +74,9 @@ private:
         bool protocol1 = false; /* data */
     } DemoState_t;
 
+#ifdef QR_CODE_ENABLED
     void WriteQRCode();
+#endif
     void WriteDemoUI();
     void WriteStatus();
 #ifdef QR_CODE_ENABLED

--- a/examples/platform/silabs/display/lcd.h
+++ b/examples/platform/silabs/display/lcd.h
@@ -37,7 +37,9 @@ public:
     {
         DemoScreen = 0,
         StatusScreen,
+#ifdef QR_CODE_ENABLED
         QRCodeScreen,
+#endif
         InvalidScreen,
     } Screen_e;
 

--- a/examples/platform/silabs/display/lcd.h
+++ b/examples/platform/silabs/display/lcd.h
@@ -74,15 +74,15 @@ private:
         bool protocol1 = false; /* data */
     } DemoState_t;
 
-#ifdef QR_CODE_ENABLED
-    void WriteQRCode();
-#endif
     void WriteDemoUI();
     void WriteStatus();
+
 #ifdef QR_CODE_ENABLED
+    void WriteQRCode();
     void LCDFillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h);
     char mQRCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
 #endif
+
     GLIB_Context_t glibContext;
 
 #ifdef SL_DEMO_NAME


### PR DESCRIPTION
Fixed compile bug after #29195 - conditional typo using `elif` without a condition.

Replaced it with else and checked that `efr32-brd4161a-lock-rpc` compiles now