### PR TITLE
Fix incorrect PICS in `TC_RVCOPSTATE_2_1.py` and `TC_OPSTATE_2_1.py`

### DIFF
--- a/src/python_testing/TC_OPSTATE_2_1.py
+++ b/src/python_testing/TC_OPSTATE_2_1.py
@@ -175,7 +175,7 @@ class TC_OPSTATE_2_1(MatterBaseTest):
                 self.print_step("7e", "Manually put the device in the unable to complete operation error state")
                 input("Press Enter when done.\n")
                 await self.read_and_validate_operror(step="7f", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kUnableToCompleteOperation)
-            if self.check_pics("OPSTATE.S.M.ERR_COMMAND_INVALID_STATE"):
+            if self.check_pics("OPSTATE.S.M.ERR_COMMAND_INVALID_IN_STATE"):
                 self.print_step("7g", "Manually put the device in the command invalid error state")
                 input("Press Enter when done.\n")
                 await self.read_and_validate_operror(step="7h", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kCommandInvalidInState)

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -190,11 +190,11 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
                 self.print_step("7e", "Manually put the device in the unable to complete operation error state")
                 input("Press Enter when done.\n")
                 await self.read_and_validate_operror(step="7f", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kUnableToCompleteOperation)
-            if self.check_pics("RVCOPSTATE.S.M.ERR_COMMAND_INVALID_STATE"):
+            if self.check_pics("RVCOPSTATE.S.M.ERR_COMMAND_INVALID_IN_STATE"):
                 self.print_step("7g", "Manually put the device in the command invalid error state")
                 input("Press Enter when done.\n")
                 await self.read_and_validate_operror(step="7h", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kCommandInvalidInState)
-            if self.check_pics("RVCOPSTATE.S.M.ERR_FAILED_FIND_DOCK"):
+            if self.check_pics("RVCOPSTATE.S.M.ERR_FAILED_TO_FIND_CHARGING_DOCK"):
                 self.print_step("7i", "Manually put the device in the failed to find dock error state")
                 input("Press Enter when done.\n")
                 await self.read_and_validate_operror(step="7j", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kFailedToFindChargingDock)


### PR DESCRIPTION
`TC_RVCOPSTATE_2_1.py` has the wrong PICS.

```
if self.check_pics("RVCOPSTATE.S.M.ERR_COMMAND_INVALID_STATE"):
if self.check_pics("RVCOPSTATE.S.M.ERR_FAILED_FIND_DOCK"):
```

The PICS are:
```
RVCOPSTATE.S.M.ERR_COMMAND_INVALID_IN_STATE=1
RVCOPSTATE.S.M.ERR_FAILED_TO_FIND_CHARGING_DOCK=1
```

Fixes #29321