### PR TITLE
Fix LwIP PBUF_RAM configuration

### DIFF
--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -123,7 +123,7 @@ public:
     /**
      * The maximum size buffer an application can allocate with no protocol header reserve.
      */
-#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
     static constexpr uint16_t kMaxSizeWithoutReserve = LWIP_MEM_ALIGN_SIZE(PBUF_POOL_BUFSIZE);
 #else
     static constexpr uint16_t kMaxSizeWithoutReserve = CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX;


### PR DESCRIPTION
Missed a case of CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_RAM, as there are no in-tree builds using this configuration. (Before #29208, this case had used CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE .)

Fixes #29282
