### PR TITLE
fix: docs for additional payload

### DIFF
--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -727,7 +727,7 @@ Here, _<payload\>_ is the ID of the payload to be parsed.
 To parse additional data payload, use the following command pattern:
 
 ```
-$ ./chip-tool parse-additional-data-payload <payload>
+$ ./chip-tool payload parse-additional-data-payload <payload>
 ```
 
 In this command:


### PR DESCRIPTION
Fix `parse-additional-data-payload` command in chip tool guide docs