### PR TITLE
Remove use of CHIP_MINMDNS_HIGH_VERBOSITY from shared resolve code.

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -400,10 +400,7 @@ void Resolver::ReArmTimer()
 
     if (nextTimeout == kInvalidTimeout)
     {
-#if CHIP_MINMDNS_HIGH_VERBOSITY
         // Generally this is only expected when no active lookups exist
-        ChipLogProgress(Discovery, "Discovery does not require any more timeouts");
-#endif
         return;
     }
 


### PR DESCRIPTION
That define is only available when doing minmdns.

Fixes https://github.com/project-chip/connectedhomeip/issues/29215
