### PR TITLE
[Linux] Convert possible glib objects to GAutoPtr

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -92,6 +92,12 @@ struct GAutoPtrDeleter<char>
 };
 
 template <>
+struct GAutoPtrDeleter<const char *>
+{
+    using deleter = GFree;
+};
+
+template <>
 struct GAutoPtrDeleter<GBytes>
 {
     using deleter = GBytesDeleter;

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -65,6 +65,11 @@ struct GVariantDeleter
     void operator()(GVariant * object) { g_variant_unref(object); }
 };
 
+struct GVariantDictDeleter
+{
+    void operator()(GVariantDict * object) { g_variant_dict_unref(object); }
+};
+
 struct GVariantIterDeleter
 {
     void operator()(GVariantIter * object) { g_variant_iter_free(object); }
@@ -114,6 +119,12 @@ template <>
 struct GAutoPtrDeleter<GVariant>
 {
     using deleter = GVariantDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<GVariantDict>
+{
+    using deleter = GVariantDictDeleter;
 };
 
 template <>

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -65,11 +65,6 @@ struct GVariantDeleter
     void operator()(GVariant * object) { g_variant_unref(object); }
 };
 
-struct GVariantDictDeleter
-{
-    void operator()(GVariantDict * object) { g_variant_dict_unref(object); }
-};
-
 struct GVariantIterDeleter
 {
     void operator()(GVariantIter * object) { g_variant_iter_free(object); }
@@ -125,12 +120,6 @@ template <>
 struct GAutoPtrDeleter<GVariant>
 {
     using deleter = GVariantDeleter;
-};
-
-template <>
-struct GAutoPtrDeleter<GVariantDict>
-{
-    using deleter = GVariantDictDeleter;
 };
 
 template <>

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1557,11 +1557,11 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt.get(), nullptr);
-        const gchar ** keyMgmtsForFree = keyMgmts;
-        uint8_t res                    = 0;
-        for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;
-             keyMgmtVal               = *(++keyMgmts))
+        GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        const gchar ** keyMgmtsHendle = keyMgmts.get();
+        uint8_t res                   = 0;
+        for (const gchar * keyMgmtVal = (keyMgmtsHendle != nullptr ? *keyMgmtsHendle : nullptr); keyMgmtVal != nullptr;
+             keyMgmtVal               = *(++keyMgmtsHendle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-none") == 0)
             {
@@ -1572,7 +1572,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
                 res |= (kEAP);
             }
         }
-        g_free(keyMgmtsForFree);
+
         return res;
     };
     auto IsNetworkWPA2PSK = [](GVariant * rsn) -> uint8_t {
@@ -1585,11 +1585,11 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt.get(), nullptr);
-        const gchar ** keyMgmtsForFree = keyMgmts;
-        uint8_t res                    = 0;
-        for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;
-             keyMgmtVal               = *(++keyMgmts))
+        GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
+        const gchar ** keyMgmtsHendle = keyMgmts.get();
+        uint8_t res                   = 0;
+        for (const gchar * keyMgmtVal = (keyMgmtsHendle != nullptr ? *keyMgmtsHendle : nullptr); keyMgmtVal != nullptr;
+             keyMgmtVal               = *(++keyMgmtsHendle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-psk-sha256") == 0 ||
                 g_strcasecmp(keyMgmtVal, "wpa-ft-psk") == 0)
@@ -1608,7 +1608,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
                 res |= (1 << 4); // SecurityType::WPA3_PERSONAL
             }
         }
-        g_free(keyMgmtsForFree);
+
         return res;
     };
     auto GetNetworkSecurityType = [IsNetworkWPAPSK, IsNetworkWPA2PSK](WpaFiW1Wpa_supplicant1BSSProxy * proxy) -> uint8_t {

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -21,6 +21,7 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/ConnectivityUtils.h>
 #include <platform/Linux/DiagnosticDataProviderImpl.h>
 #include <platform/Linux/NetworkCommissioningDriver.h>
@@ -279,14 +280,14 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
 
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        GError * err = nullptr;
-        wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface, nullptr, &err);
+        GAutoPtr<GError> err;
+        wpa_fi_w1_wpa_supplicant1_interface_call_remove_all_networks_sync(mWpaSupplicant.iface, nullptr,
+                                                                          &MakeUniquePointerReceiver(err).Get());
 
         if (err != nullptr)
         {
             ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to remove all networks with error: %s",
                             err ? err->message : "unknown error");
-            g_error_free(err);
         }
     }
 }
@@ -397,28 +398,27 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
     if (g_variant_n_children(changed_properties) > 0)
     {
-        GVariantIter * iter;
+        GAutoPtr<GVariantIter> iter;
         const gchar * key;
         GVariant * value;
 
         WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
 
-        g_variant_get(changed_properties, "a{sv}", &iter);
+        g_variant_get(changed_properties, "a{sv}", &MakeUniquePointerReceiver(iter).Get());
 
-        while (g_variant_iter_loop(iter, "{&sv}", &key, &value))
+        while (g_variant_iter_loop(iter.get(), "{&sv}", &key, &value))
         {
-            gchar * value_str;
-            value_str = g_variant_print(value, TRUE);
+            GAutoPtr<gchar> value_str(g_variant_print(value, TRUE));
             ChipLogProgress(DeviceLayer, "wpa_supplicant:PropertiesChanged:key:%s -> %s", StringOrNullMarker(key),
-                            StringOrNullMarker(value_str));
+                            StringOrNullMarker(value_str.get()));
 
             if (g_strcmp0(key, "State") == 0)
             {
-                if (g_strcmp0(value_str, "\'associating\'") == 0)
+                if (g_strcmp0(value_str.get(), "\'associating\'") == 0)
                 {
                     mAssociationStarted = true;
                 }
-                else if (g_strcmp0(value_str, "\'disconnected\'") == 0)
+                else if (g_strcmp0(value_str.get(), "\'disconnected\'") == 0)
                 {
                     gint reason = wpa_fi_w1_wpa_supplicant1_interface_get_disconnect_reason(mWpaSupplicant.iface);
 
@@ -471,7 +471,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     mAssociationStarted = false;
                 }
-                else if (g_strcmp0(value_str, "\'associated\'") == 0)
+                else if (g_strcmp0(value_str.get(), "\'associated\'") == 0)
                 {
                     if (delegate)
                     {
@@ -480,7 +480,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
                 }
-                else if (g_strcmp0(value_str, "\'completed\'") == 0)
+                else if (g_strcmp0(value_str.get(), "\'completed\'") == 0)
                 {
                     if (mAssociationStarted)
                     {
@@ -496,11 +496,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                     mAssociationStarted = false;
                 }
             }
-
-            g_free(value_str);
         }
-
-        g_variant_iter_free(iter);
     }
 }
 
@@ -510,11 +506,12 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
     // all D-Bus signals will be delivered to the GLib global default main context.
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
-    GError * err = nullptr;
+    GAutoPtr<GError> err;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    WpaFiW1Wpa_supplicant1Interface * iface = wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus_finish(res, &err);
+    WpaFiW1Wpa_supplicant1Interface * iface =
+        wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus_finish(res, &MakeUniquePointerReceiver(err).Get());
 
     if (mWpaSupplicant.iface)
     {
@@ -547,9 +544,6 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
             ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %s", ErrorStr(errInner));
         }
     });
-
-    if (err != nullptr)
-        g_error_free(err);
 }
 
 void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
@@ -558,11 +552,12 @@ void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyn
     // all D-Bus signals will be delivered to the GLib global default main context.
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
-    GError * err = nullptr;
+    GAutoPtr<GError> err;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    WpaFiW1Wpa_supplicant1BSS * bss = wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus_finish(res, &err);
+    WpaFiW1Wpa_supplicant1BSS * bss =
+        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus_finish(res, &MakeUniquePointerReceiver(err).Get());
 
     if (mWpaSupplicant.bss)
     {
@@ -570,7 +565,7 @@ void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyn
         mWpaSupplicant.bss = nullptr;
     }
 
-    if (bss != nullptr && err == nullptr)
+    if (bss != nullptr && err.get() == nullptr)
     {
         mWpaSupplicant.bss = bss;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant bss proxy");
@@ -580,9 +575,6 @@ void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyn
         ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant bss proxy %s: %s",
                         mWpaSupplicant.interfacePath, err ? err->message : "unknown error");
     }
-
-    if (err != nullptr)
-        g_error_free(err);
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
@@ -591,12 +583,12 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
     // all D-Bus signals will be delivered to the GLib global default main context.
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
-    GError * err = nullptr;
+    GAutoPtr<GError> err;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    gboolean result =
-        wpa_fi_w1_wpa_supplicant1_call_get_interface_finish(mWpaSupplicant.proxy, &mWpaSupplicant.interfacePath, res, &err);
+    gboolean result = wpa_fi_w1_wpa_supplicant1_call_get_interface_finish(mWpaSupplicant.proxy, &mWpaSupplicant.interfacePath, res,
+                                                                          &MakeUniquePointerReceiver(err).Get());
     if (result)
     {
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
@@ -611,7 +603,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
     }
     else
     {
-        GError * error  = nullptr;
+        GAutoPtr<GError> error;
         GVariant * args = nullptr;
         GVariantBuilder builder;
 
@@ -625,7 +617,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         args = g_variant_builder_end(&builder);
 
         result = wpa_fi_w1_wpa_supplicant1_call_create_interface_sync(mWpaSupplicant.proxy, args, &mWpaSupplicant.interfacePath,
-                                                                      nullptr, &error);
+                                                                      nullptr, &MakeUniquePointerReceiver(error).Get());
 
         if (result)
         {
@@ -654,13 +646,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
                 mWpaSupplicant.interfacePath = nullptr;
             }
         }
-
-        if (error != nullptr)
-            g_error_free(error);
     }
-
-    if (err != nullptr)
-        g_error_free(err);
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
@@ -736,12 +722,12 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
     // all D-Bus signals will be delivered to the GLib global default main context.
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
-    GError * err = nullptr;
+    GAutoPtr<GError> err;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    mWpaSupplicant.proxy = wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus_finish(res, &err);
-    if (mWpaSupplicant.proxy != nullptr && err == nullptr)
+    mWpaSupplicant.proxy = wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus_finish(res, &MakeUniquePointerReceiver(err).Get());
+    if (mWpaSupplicant.proxy != nullptr && err.get() == nullptr)
     {
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant proxy");
@@ -758,9 +744,6 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
                         err ? err->message : "unknown error");
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
     }
-
-    if (err != nullptr)
-        g_error_free(err);
 }
 
 void ConnectivityManagerImpl::StartWiFiManagement()
@@ -860,10 +843,10 @@ void ConnectivityManagerImpl::DriveAPState()
             {
                 if (mWpaSupplicant.networkPath)
                 {
-                    GError * error = nullptr;
+                    GAutoPtr<GError> error(nullptr);
 
                     gboolean result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(
-                        mWpaSupplicant.iface, mWpaSupplicant.networkPath, nullptr, &error);
+                        mWpaSupplicant.iface, mWpaSupplicant.networkPath, nullptr, &MakeUniquePointerReceiver(error).Get());
 
                     if (result)
                     {
@@ -878,9 +861,6 @@ void ConnectivityManagerImpl::DriveAPState()
                                         error ? error->message : "unknown error");
                         err = CHIP_ERROR_INTERNAL;
                     }
-
-                    if (error != nullptr)
-                        g_error_free(error);
                 }
             }
         }
@@ -896,8 +876,8 @@ exit:
 
 CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 {
-    CHIP_ERROR ret  = CHIP_NO_ERROR;
-    GError * err    = nullptr;
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+    GAutoPtr<GError> err;
     GVariant * args = nullptr;
     GVariantBuilder builder;
 
@@ -930,17 +910,17 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     g_variant_builder_add(&builder, "{sv}", "frequency", g_variant_new_int32(channel));
     args = g_variant_builder_end(&builder);
 
-    gboolean result = wpa_fi_w1_wpa_supplicant1_interface_call_add_network_sync(mWpaSupplicant.iface, args,
-                                                                                &mWpaSupplicant.networkPath, nullptr, &err);
+    gboolean result = wpa_fi_w1_wpa_supplicant1_interface_call_add_network_sync(
+        mWpaSupplicant.iface, args, &mWpaSupplicant.networkPath, nullptr, &MakeUniquePointerReceiver(err).Get());
 
     if (result)
     {
-        GError * error = nullptr;
+        GAutoPtr<GError> error;
 
         ChipLogProgress(DeviceLayer, "wpa_supplicant: added network: SSID: %s: %s", ssid, mWpaSupplicant.networkPath);
 
         result = wpa_fi_w1_wpa_supplicant1_interface_call_select_network_sync(mWpaSupplicant.iface, mWpaSupplicant.networkPath,
-                                                                              nullptr, &error);
+                                                                              nullptr, &MakeUniquePointerReceiver(error).Get());
         if (result)
         {
             ChipLogProgress(DeviceLayer, "wpa_supplicant: succeeded to start softAP: SSID: %s", ssid);
@@ -952,9 +932,6 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
             ret = CHIP_ERROR_INTERNAL;
         }
-
-        if (error != nullptr)
-            g_error_free(error);
     }
     else
     {
@@ -968,9 +945,6 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
         ret = CHIP_ERROR_INTERNAL;
     }
-
-    if (err != nullptr)
-        g_error_free(err);
 
     return ret;
 }
@@ -993,8 +967,8 @@ CHIP_ERROR
 ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credentials,
                                                  NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * apCallback)
 {
-    CHIP_ERROR ret  = CHIP_NO_ERROR;
-    GError * err    = nullptr;
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+    GAutoPtr<GError> err;
     GVariant * args = nullptr;
     GVariantBuilder builder;
     gboolean result;
@@ -1015,9 +989,10 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     // wpa_supplicant DBus API: if network path of current network is not "/", means we have already selected some network.
     if (strcmp(networkPath, "/") != 0)
     {
-        GError * error = nullptr;
+        GAutoPtr<GError> error;
 
-        result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(mWpaSupplicant.iface, networkPath, nullptr, &error);
+        result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(mWpaSupplicant.iface, networkPath, nullptr,
+                                                                              &MakeUniquePointerReceiver(error).Get());
 
         if (result)
         {
@@ -1035,9 +1010,6 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
             ret = CHIP_ERROR_INTERNAL;
         }
 
-        if (error != nullptr)
-            g_error_free(error);
-
         SuccessOrExit(ret);
     }
 
@@ -1050,7 +1022,7 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     args = g_variant_builder_end(&builder);
 
     result = wpa_fi_w1_wpa_supplicant1_interface_call_add_network_sync(mWpaSupplicant.iface, args, &mWpaSupplicant.networkPath,
-                                                                       nullptr, &err);
+                                                                       nullptr, &MakeUniquePointerReceiver(err).Get());
 
     if (result)
     {
@@ -1078,9 +1050,6 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     }
 
 exit:
-    if (err != nullptr)
-        g_error_free(err);
-
     return ret;
 }
 
@@ -1110,20 +1079,16 @@ void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_
             return;
         }
 
-        GError * gerror = nullptr;
-
-        result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr, &gerror);
+        result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr,
+                                                                           &MakeUniquePointerReceiver(err).Get());
         if (result)
         {
             ChipLogProgress(DeviceLayer, "wpa_supplicant: save config succeeded!");
         }
         else
         {
-            ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to save config: %s", gerror ? gerror->message : "unknown error");
+            ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to save config: %s", err ? err->message : "unknown error");
         }
-
-        if (gerror != nullptr)
-            g_error_free(gerror);
     }
 }
 
@@ -1388,8 +1353,8 @@ CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::Sca
     VerifyOrReturnError(mpScanCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(ssid.size() <= sizeof(sInterestedSSID), CHIP_ERROR_INVALID_ARGUMENT);
 
-    CHIP_ERROR ret  = CHIP_NO_ERROR;
-    GError * err    = nullptr;
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+    GAutoPtr<GError> err;
     GVariant * args = nullptr;
     GVariantBuilder builder;
     gboolean result;
@@ -1401,7 +1366,8 @@ CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::Sca
     g_variant_builder_add(&builder, "{sv}", "Type", g_variant_new_string("active"));
     args = g_variant_builder_end(&builder);
 
-    result = wpa_fi_w1_wpa_supplicant1_interface_call_scan_sync(mWpaSupplicant.iface, args, nullptr, &err);
+    result = wpa_fi_w1_wpa_supplicant1_interface_call_scan_sync(mWpaSupplicant.iface, args, nullptr,
+                                                                &MakeUniquePointerReceiver(err).Get());
 
     if (result)
     {
@@ -1414,10 +1380,6 @@ CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::Sca
         ret = CHIP_ERROR_INTERNAL;
     }
 
-    if (err != nullptr)
-    {
-        g_error_free(err);
-    }
     return ret;
 }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1552,12 +1552,12 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
             return 0;
         }
 
-        GVariant * keyMgmt = g_variant_lookup_value(wpa, "KeyMgmt", nullptr);
+        GAutoPtr<GVariant> keyMgmt(g_variant_lookup_value(wpa, "KeyMgmt", nullptr));
         if (keyMgmt == nullptr)
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt, nullptr);
+        const gchar ** keyMgmts        = g_variant_get_strv(MakeUniquePointerReceiver(keyMgmt).Get(), nullptr);
         const gchar ** keyMgmtsForFree = keyMgmts;
         uint8_t res                    = 0;
         for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;
@@ -1572,7 +1572,6 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
                 res |= (kEAP);
             }
         }
-        g_variant_unref(keyMgmt);
         g_free(keyMgmtsForFree);
         return res;
     };
@@ -1581,12 +1580,12 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         {
             return 0;
         }
-        GVariant * keyMgmt = g_variant_lookup_value(rsn, "KeyMgmt", nullptr);
+        GAutoPtr<GVariant> keyMgmt(g_variant_lookup_value(rsn, "KeyMgmt", nullptr));
         if (keyMgmt == nullptr)
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt, nullptr);
+        const gchar ** keyMgmts        = g_variant_get_strv(MakeUniquePointerReceiver(keyMgmt).Get(), nullptr);
         const gchar ** keyMgmtsForFree = keyMgmts;
         uint8_t res                    = 0;
         for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;
@@ -1609,7 +1608,6 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
                 res |= (1 << 4); // SecurityType::WPA3_PERSONAL
             }
         }
-        g_variant_unref(keyMgmt);
         g_free(keyMgmtsForFree);
         return res;
     };

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1557,7 +1557,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(MakeUniquePointerReceiver(keyMgmt).Get(), nullptr);
+        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt.get(), nullptr);
         const gchar ** keyMgmtsForFree = keyMgmts;
         uint8_t res                    = 0;
         for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;
@@ -1585,7 +1585,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         {
             return 0;
         }
-        const gchar ** keyMgmts        = g_variant_get_strv(MakeUniquePointerReceiver(keyMgmt).Get(), nullptr);
+        const gchar ** keyMgmts        = g_variant_get_strv(keyMgmt.get(), nullptr);
         const gchar ** keyMgmtsForFree = keyMgmts;
         uint8_t res                    = 0;
         for (const gchar * keyMgmtVal = (keyMgmts != nullptr ? *keyMgmts : nullptr); keyMgmtVal != nullptr;

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1560,8 +1560,10 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHendle = keyMgmts.get();
         uint8_t res                   = 0;
-        for (const gchar * keyMgmtVal = (keyMgmtsHendle != nullptr ? *keyMgmtsHendle : nullptr); keyMgmtVal != nullptr;
-             keyMgmtVal               = *(++keyMgmtsHendle))
+
+        VerifyOrReturnError(keyMgmtsHendle != nullptr, res);
+
+        for (auto keyMgmtVal = *keyMgmtsHendle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHendle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-none") == 0)
             {
@@ -1588,8 +1590,10 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
         GAutoPtr<const char *> keyMgmts(g_variant_get_strv(keyMgmt.get(), nullptr));
         const gchar ** keyMgmtsHendle = keyMgmts.get();
         uint8_t res                   = 0;
-        for (const gchar * keyMgmtVal = (keyMgmtsHendle != nullptr ? *keyMgmtsHendle : nullptr); keyMgmtVal != nullptr;
-             keyMgmtVal               = *(++keyMgmtsHendle))
+
+        VerifyOrReturnError(keyMgmtsHendle != nullptr, res);
+
+        for (auto keyMgmtVal = *keyMgmtsHendle; keyMgmtVal != nullptr; keyMgmtVal = *(++keyMgmtsHendle))
         {
             if (g_strcasecmp(keyMgmtVal, "wpa-psk") == 0 || g_strcasecmp(keyMgmtVal, "wpa-psk-sha256") == 0 ||
                 g_strcasecmp(keyMgmtVal, "wpa-ft-psk") == 0)

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -19,6 +19,7 @@
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 
 namespace chip {
@@ -51,12 +52,12 @@ CHIP_ERROR AdapterIterator::Initialize(AdapterIterator * self)
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    GError * error = nullptr;
+    GAutoPtr<GError> error;
 
-    self->mManager = g_dbus_object_manager_client_new_for_bus_sync(G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
-                                                                   BLUEZ_INTERFACE, "/", bluez_object_manager_client_get_proxy_type,
-                                                                   nullptr /* unused user data in the Proxy Type Func */,
-                                                                   nullptr /*destroy notify */, nullptr /* cancellable */, &error);
+    self->mManager = g_dbus_object_manager_client_new_for_bus_sync(
+        G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/",
+        bluez_object_manager_client_get_proxy_type, nullptr /* unused user data in the Proxy Type Func */,
+        nullptr /*destroy notify */, nullptr /* cancellable */, &MakeUniquePointerReceiver(error).Get());
 
     VerifyOrExit(self->mManager != nullptr, ChipLogError(DeviceLayer, "Failed to get DBUS object manager for listing adapters.");
                  err = CHIP_ERROR_INTERNAL);
@@ -68,7 +69,6 @@ exit:
     if (error != nullptr)
     {
         ChipLogError(DeviceLayer, "DBus error: %s", error->message);
-        g_error_free(error);
     }
 
     return err;

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -376,7 +376,6 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
     char * errStr;
 #endif // CHIP_ERROR_LOGGING
     BluezConnection * conn = nullptr;
-    GAutoPtr<GVariantDict> options;
     GAutoPtr<GVariant> option_mtu;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
@@ -443,7 +442,6 @@ static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aCha
     char * errStr;
 #endif // CHIP_ERROR_LOGGING
     BluezConnection * conn = nullptr;
-    GAutoPtr<GVariantDict> options;
     GAutoPtr<GVariant> option_mtu;
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -50,6 +50,7 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 #include <ble/CHIPBleServiceData.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
 #include <cstdint>
@@ -187,7 +188,7 @@ struct BluezConnection
 struct ConnectionDataBundle
 {
     BluezConnection * mpConn;
-    GVariant * mpVal;
+    GAutoPtr<GVariant> mpVal;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -188,7 +188,7 @@ struct BluezConnection
 struct ConnectionDataBundle
 {
     BluezConnection * mpConn;
-    GAutoPtr<GVariant> mpVal;
+    GVariant * mpVal;
 };
 
 } // namespace Internal


### PR DESCRIPTION
### Problem
Linux still has explicit glib memory management. This is follow-up PRs (#28304) which will replace glib explicit memory management with  GAutoPtr<>.

### Changes
Changed explicit memory management of glib objects to GAutoPtr<> where possible for the Linux platform.

### Testing
CI will test for potential build breaks.

Valgrind test result for linux-x64-light target:
```==83428== LEAK SUMMARY:
==83428==    definitely lost: 0 bytes in 0 blocks
==83428==    indirectly lost: 0 bytes in 0 blocks
==83428==      possibly lost: 640 bytes in 2 blocks
==83428==    still reachable: 202,774 bytes in 2,898 blocks
==83428==         suppressed: 0 bytes in 0 blocks```