### PR TITLE
[Silabs] Adds build fix for MG12 + SiWx917 NCP all apps

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/hal/sl_board_configuration.h
+++ b/examples/platform/silabs/efr32/rs911x/hal/sl_board_configuration.h
@@ -28,19 +28,22 @@ typedef struct
     (sl_pin_t) { .port = gpioPort##port_id, .pin = pin_id }
 
 #define PACKET_PENDING_INT_PRI 3
-
-#if defined(EFR32MG24_BRD4186C) || defined(BRD4186C)
+#if defined(EFR32MG12_BRD4161A) || defined(BRD4161A) || defined(EFR32MG12_BRD4162A) || defined(BRD4162A) ||                        \
+    defined(EFR32MG12_BRD4163A) || defined(BRD4163A) || defined(EFR32MG12_BRD4164A) || defined(BRD4164A) ||                        \
+    defined(EFR32MG12_BRD4170A) || defined(BRD4170A)
+// BRD4161-63-64 are pin to pin compatible for SPI
+#include "brd4161a.h"
+#elif defined(EFR32MG24_BRD4186C) || defined(BRD4186C)
 #include "brd4186c.h"
 #elif defined(EFR32MG24_BRD4187C) || defined(BRD4187C)
 #include "brd4187c.h"
 #else
 #error "Need SPI Pins"
-#endif /* EFR32MG12_BRD4161A */
-#if EXP_BOARD && (defined(EFR32MG24_BRD4187C) || defined(BRD4187C) || defined(EFR32MG24_BRD4186C) || defined(BRD4186C))
+#endif
+#if EXP_BOARD
 #define RESET_PIN PIN(A, 6)
 #define INTERRUPT_PIN PIN(A, 7)
 #define SLEEP_CONFIRM_PIN PIN(A, 5) /* Exp hdr 7 */
-#define SL_WFX_HOST_PINOUT_SPI_IRQ 5
 #endif
 
 #define NETWORK_INTERFACE_VALID(x) (x == SL_NET_DEFAULT_WIFI_CLIENT_INTERFACE) || (x == SL_NET_DEFAULT_WIFI_AP_INTERFACE)


### PR DESCRIPTION
Added conditon based file for all MG12 Board variants in **sl_board_configuration.h**.
Removed one define which is redefined in other file.