### PR TITLE
[TI] Update CC2674 migration guide to include CC1354P10-1

### DIFF
--- a/docs/guides/ti/matter_cc2674_migration.md
+++ b/docs/guides/ti/matter_cc2674_migration.md
@@ -108,7 +108,6 @@ should be addressed from a SysConfig Editor.
    `RF_cmdIeeeRadioSetup` and add the following functions from the drop-down:
    `CMD_TX_TEST`,`CMD_IEEE_ED_SCAN`, `CMD_IEEE_CSMA`, and `CMD_IEEE_RX_ACK`.
 
-
 ## Building examples for the CC1354P10-1
 
 To migrate the CC1354P10-6 examples to the CC1354P10-1 platform, there are only
@@ -117,7 +116,7 @@ two steps:
 1. `examples/[application]/cc13x4_26x4/args.gni` should have
    `ti_simplelink_board` as `CC1354P10-1`
 2. `examples/[application]/cc13x4_26x4/chip.syscfg` opened with a Text Editor
-    should change `ble.radioConfig.codeExportConfig.$name` to
+   should change `ble.radioConfig.codeExportConfig.$name` to
    `ti_devices_radioconfig_code_export_param2` and `ble.rfDesign` to
    `LP_EM_CC1354P10_1`
 

--- a/docs/guides/ti/matter_cc2674_migration.md
+++ b/docs/guides/ti/matter_cc2674_migration.md
@@ -121,4 +121,4 @@ only two steps:
     `ti_devices_radioconfig_code_export_param2` and `ble.rfDesign` to
     `LP_EM_CC1354P10_1`
 
-After this, the example's readme can be followed to produce the executable needed.
+After this, the example's `README.md` instructions can be followed to produce the executable needed.

--- a/docs/guides/ti/matter_cc2674_migration.md
+++ b/docs/guides/ti/matter_cc2674_migration.md
@@ -111,14 +111,15 @@ should be addressed from a SysConfig Editor.
 
 ## Building examples for the CC1354P10-1
 
-To migrate the CC1354P10-6 examples to the CC1354P10-1 platform, there are
-only two steps:
+To migrate the CC1354P10-6 examples to the CC1354P10-1 platform, there are only
+two steps:
 
 1. `examples/[application]/cc13x4_26x4/args.gni` should have
    `ti_simplelink_board` as `CC1354P10-1`
-2.  `examples/[application]/cc13x4_26x4/chip.syscfg` opened with a Text Editor
+2. `examples/[application]/cc13x4_26x4/chip.syscfg` opened with a Text Editor
     should change `ble.radioConfig.codeExportConfig.$name` to
-    `ti_devices_radioconfig_code_export_param2` and `ble.rfDesign` to
-    `LP_EM_CC1354P10_1`
+   `ti_devices_radioconfig_code_export_param2` and `ble.rfDesign` to
+   `LP_EM_CC1354P10_1`
 
-After this, the example's `README.md` instructions can be followed to produce the executable needed.
+After this, the example's `README.md` instructions can be followed to produce
+the executable needed.

--- a/docs/guides/ti/matter_cc2674_migration.md
+++ b/docs/guides/ti/matter_cc2674_migration.md
@@ -107,3 +107,18 @@ should be addressed from a SysConfig Editor.
    Command Symbols_, change `CMD_RADIO_SETUP` from `RF_cmdRadioSetup` to
    `RF_cmdIeeeRadioSetup` and add the following functions from the drop-down:
    `CMD_TX_TEST`,`CMD_IEEE_ED_SCAN`, `CMD_IEEE_CSMA`, and `CMD_IEEE_RX_ACK`.
+
+
+## Building examples for the CC1354P10-1
+
+To migrate the CC1354P10-6 examples to the CC1354P10-1 platform, there are
+only two steps:
+
+1. `examples/[application]/cc13x4_26x4/args.gni` should have
+   `ti_simplelink_board` as `CC1354P10-1`
+2.  `examples/[application]/cc13x4_26x4/chip.syscfg` opened with a Text Editor
+    should change `ble.radioConfig.codeExportConfig.$name` to
+    `ti_devices_radioconfig_code_export_param2` and `ble.rfDesign` to
+    `LP_EM_CC1354P10_1`
+
+After this, the example's readme can be followed to produce the executable needed.


### PR DESCRIPTION
The current CC2674 migration guide does not have instructions to migrate from CC1354P10-6 to CC1354P10-1. This PR adds those updates. 
