### PR TITLE
Include the peer address in "Msg TX" logs.

### DIFF
--- a/src/messaging/README.md
+++ b/src/messaging/README.md
@@ -16,7 +16,7 @@ will be expanded are denoted with `$` .
 Unless specified, numerical values are represented in decimal notation.
 
 ```
-<<< [E:$exchange_id S:$session_id M:$msg_id (Ack: $ack_msg_id)] ($msg_category) Msg TX to $fabric_index:$destination [$compressed_fabric_id] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name)
+<<< [E:$exchange_id S:$session_id M:$msg_id (Ack: $ack_msg_id)] ($msg_category) Msg TX to $fabric_index:$destination [$compressed_fabric_id] [$peer_address] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name)
 ```
 
 | Field                | Description                                                                                                                            |
@@ -29,6 +29,7 @@ Unless specified, numerical values are represented in decimal notation.
 | fabric_index         | Fabric index on the sending side                                                                                                       |
 | destination          | 64-bit Node Identifier that can represent both group, operational and temporary node identifiers depending on `$msg_category` (in hex) |
 | compressed_fabric_id | If present and valid, lower 16-bits of the compressed fabric ID (in hex). Otherwise, it will be set to 0000.                           |
+| peer_address         | The peer address (IP and port) for the session                                                                                         |
 | protocol_id          | 16-bit Protocol ID within the common vendor namespace (in hex)                                                                         |
 | msg_type             | 8-bit message type ID (in hex)                                                                                                         |
 | protocol_name        | If available, a logical name for the protocol                                                                                          |

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -309,16 +309,21 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
     char addressStr[Transport::PeerAddress::kMaxToStringSize] = { 0 };
     destination_address.ToString(addressStr);
 
+    // Work around pigweed not allowing more than 14 format args in a log
+    // message when using tokenized logs.
+    char typeStr[4 + 1 + 2 + 1];
+    snprintf(typeStr, sizeof(typeStr), "%04X:%02X", payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetMessageType());
+
     //
     // Legend that can be used to decode this log line can be found in messaging/README.md
     //
     ChipLogProgress(ExchangeManager,
                     "<<< [E:" ChipLogFormatExchangeId " S:%u M:" ChipLogFormatMessageCounter
-                    "%s] (%s) Msg TX to %u:" ChipLogFormatX64 " [%04X] [%s] --- Type %04X:%02X (%s:%s)",
+                    "%s] (%s) Msg TX to %u:" ChipLogFormatX64 " [%04X] [%s] --- Type %s (%s:%s)",
                     ChipLogValueExchangeIdFromSentHeader(payloadHeader), sessionHandle->SessionIdForLogging(),
                     packetHeader.GetMessageCounter(), ackBuf, Transport::GetSessionTypeString(sessionHandle), fabricIndex,
-                    ChipLogValueX64(destination), static_cast<uint16_t>(compressedFabricId), addressStr,
-                    payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetMessageType(), protocolName, msgTypeName);
+                    ChipLogValueX64(destination), static_cast<uint16_t>(compressedFabricId), addressStr, typeStr, protocolName,
+                    msgTypeName);
 #endif
 
     ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));


### PR DESCRIPTION
We had our logging split up into a "Msg TX" log that listed all sorts of info but not the peer address and some "Sending msg" logs that listed the peer address for group and unauthenticated messages, but not secure ones.  In the secure case the "Sending msg" log showed no information that was not also shown by the "Msg TX" log.

The "Sending msg" log did get shown for MRP retransmits, but those are also logged with "Retransmitting MessageCounter:" logs that allow them to be correlated with the relevant initial "Msg TX" log.

The fix here is:

1) Add peer address info in the "Msg TX" logs.
2) Remove the now-redunant "Sending msg" logs.
