### PR TITLE
Fix MaxMeasuredValue for all-clusters-app Flow Measurement cluster.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -7204,9 +7204,9 @@ endpoint 1 {
   }
 
   server cluster FlowMeasurement {
-    ram      attribute measuredValue;
-    ram      attribute minMeasuredValue;
-    ram      attribute maxMeasuredValue;
+    ram      attribute measuredValue default = 5;
+    ram      attribute minMeasuredValue default = 0;
+    ram      attribute maxMeasuredValue default = 100;
     ram      attribute tolerance default = 0;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 3;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -23526,7 +23526,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": "5",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -23542,7 +23542,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -23558,7 +23558,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": "100",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -35392,5 +35392,6 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }


### PR DESCRIPTION
Per spec, MaxMeasuredValue > MinMeasuredValue, but we were ending up with 0 for both.

Fixes https://github.com/project-chip/connectedhomeip/issues/27543
