### PR TITLE
[Darwin] Issue 26012 - MTRDevice should stream subscription reports

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -108,8 +108,6 @@ protected:
     // be immediately followed by OnDone and we want to do the deletion there.
     void ReportError(CHIP_ERROR aError, bool aCancelSubscription = true);
 
-    void ReportCurrentData();
-
     // Called at attribute/event report time to queue a block to report on the Matter queue so that for multi-packet reports, this
     // block is run and reports in batch. No-op if the block is already queued.
     void QueueInterimReport();

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -103,6 +103,10 @@ protected:
     // be immediately followed by OnDone and we want to do the deletion there.
     void ReportError(CHIP_ERROR aError, bool aCancelSubscription = true);
 
+    void ReportAttributes(NSArray * attributeReports);
+
+    void ReportEvents(NSArray * eventReports);
+
 private:
     void OnReportBegin() override;
 

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -58,26 +58,15 @@ void MTRBaseSubscriptionCallback::QueueInterimReport()
         return;
     }
 
-    //    __block auto * myself = this;
     mInterimReportBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
         mInterimReportBlock = nil;
         ReportData();
         // Allocate reports arrays to continue accumulation
         mAttributeReports = [NSMutableArray new];
         mEventReports = [NSMutableArray new];
-        //            myself->ReportCurrentData();
     });
 
     dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), mInterimReportBlock);
-}
-
-void MTRBaseSubscriptionCallback::ReportCurrentData()
-{
-    mInterimReportBlock = nil;
-    ReportData();
-    // Allocate reports arrays to continue accumulation
-    mAttributeReports = [NSMutableArray new];
-    mEventReports = [NSMutableArray new];
 }
 
 void MTRBaseSubscriptionCallback::OnReportEnd()

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -37,15 +37,25 @@ void MTRBaseSubscriptionCallback::ReportData()
 {
     __block NSArray * attributeReports = mAttributeReports;
     mAttributeReports = nil;
-    auto attributeCallback = mAttributeReportCallback;
 
     __block NSArray * eventReports = mEventReports;
     mEventReports = nil;
-    auto eventCallback = mEventReportCallback;
 
+    ReportAttributes(attributeReports);
+    ReportEvents(eventReports);
+}
+
+void MTRBaseSubscriptionCallback::ReportAttributes(NSArray * attributeReports)
+{
+    auto attributeCallback = mAttributeReportCallback;
     if (attributeCallback != nil && attributeReports.count) {
         attributeCallback(attributeReports);
     }
+}
+
+void MTRBaseSubscriptionCallback::ReportEvents(NSArray * eventReports)
+{
+    auto eventCallback = mEventReportCallback;
     if (eventCallback != nil && eventReports.count) {
         eventCallback(eventReports);
     }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -441,9 +441,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 // For unit testing only
 #ifdef DEBUG
     id delegate = _weakDelegate.strongObject;
-    if (delegate && [delegate respondsToSelector:@selector(unitTestReportEndForDevice:)]) {
+    if (delegate) {
         dispatch_async(_delegateQueue, ^{
-            [delegate unitTestReportEndForDevice:self];
+            if ([delegate respondsToSelector:@selector(unitTestReportEndForDevice:)]) {
+                [delegate unitTestReportEndForDevice:self];
+            }
         });
     }
 #endif

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -187,9 +187,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 @end
 
+// Declaring selector so compiler won't complain about testing and calling it in _handleReportEnd
+#ifdef DEBUG
 @protocol MTRDeviceUnitTestDelegate <MTRDeviceDelegate>
 - (void)unitTestReportEndForDevice:(MTRDevice *)device;
 @end
+#endif
 
 @implementation MTRDevice
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -409,9 +409,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     [self _changeState:MTRDeviceStateReachable];
 
     id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate && [delegate respondsToSelector:@selector(deviceBecameActive:)]) {
+    if (delegate) {
         dispatch_async(_delegateQueue, ^{
-            [delegate deviceBecameActive:self];
+            if ([delegate respondsToSelector:@selector(deviceBecameActive:)]) {
+                [delegate deviceBecameActive:self];
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #26012 

This PR makes the MTRDevice.mm's SubscriptionCallback reports attributes immediately without waiting for OnReportEnd.

This does mean that the `MTRDeviceDelegate` will be getting individual callbacks for each attribute and event, and so I have filed a separate issue for optimizing that part: https://github.com/project-chip/connectedhomeip/issues/29357