### PR TITLE
Enforce backwards protocol compatibility in controller-clusters.matter

### DIFF
--- a/.github/workflows/protocol_compatibility.yaml
+++ b/.github/workflows/protocol_compatibility.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2020-2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Backwards compatibility check
+on:
+  pull_request:
+    paths:
+      - "src/controller/data_model/controller-clusters.matter"
+
+jobs:
+  check_clusters_matter:
+    name: Check controller-clusters.matter backwards compatibility
+    runs-on: ubuntu-latest
+    if: github.event.pull_request && !(contains(github.event.pull_request.labels.*.name, 'skip-protocol-compatibility'))
+
+    steps:
+       - name: Checkout
+         uses: actions/checkout@v3
+       - name: Setup python
+         uses: actions/setup-python@v4
+         with:
+           python-version: 3.11
+       - name: Install dependencies
+         run: |
+           python -m pip install --upgrade pip
+           pip install click coloredlogs lark
+       - name: Create old/new copies
+         run: |
+           mkdir -p out
+           cp src/controller/data_model/controller-clusters.matter out/new_version.matter
+           wget '${{github.event.pull_request.diff_url}}' --output-document out/patch.diff
+           patch -p1 --reverse <out/patch.diff
+           cp src/controller/data_model/controller-clusters.matter out/old_version.matter
+           patch -p1 <out/patch.diff
+       - name: Check backwards compatibility
+         run: |
+           scripts/backwards_compatibility_checker.py out/old_version.matter out/new_version.matter
+


### PR DESCRIPTION
Creates a workflow that validates backwards compatibility in matter using controller-clusters.matter (on the assumption that this always contains every possible cluster on the client side)