### PR TITLE
Update silabs unit test driver README

### DIFF
--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -110,7 +110,7 @@ Then the python wheels need to installed using pip3.
     pip3 install out/debug/chip_nl_test_runner_wheels/*.whl
     ```
 
-Other python libraries may need to be installed such as 
+Other python libraries may need to be installed such as
 
     ```
     pip3 install pyserial

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -70,7 +70,7 @@ OR use GN/Ninja directly
           cd ~/connectedhomeip/src/test_driver/efr32/
           git submodule update --init
           source third_party/connectedhomeip/scripts/activate.sh
-          export EFR32_BOARD=BRD4161A
+          export SILABS_BOARD=BRD4161A
           gn gen out/debug
           ninja -C out/debug
           ```
@@ -103,6 +103,18 @@ Or build using build script from the root
 
 The runner will be installed into the venv and python wheels will be packaged in
 the output folder for deploying.
+
+Then the python wheels need to installed using pip3.
+
+    ```
+    pip3 install out/debug/chip_nl_test_runner_wheels/*.whl
+    ```
+
+Other python libraries may need to be installed such as 
+
+    ```
+    pip3 install pyserial
+    ```
 
 -   To run the tests:
 


### PR DESCRIPTION
Updated the silabs unit test driver readme to mention installing python wheels, installing needed python libraries, and updating EFR32_BOARD to SILABS_BOARD

