### PR TITLE
Return custom status code in invoke response callback

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -832,7 +832,12 @@ void InvokeCallback::OnResponse(app::CommandSender * apCommandSender, const app:
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
 
     DeviceLayer::StackUnlock unlock;
-    env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj, static_cast<jlong>(aStatusIB.mStatus));
+    if (aStatusIB.mClusterStatus.HasValue()) {
+        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj, static_cast<jlong>(aStatusIB.mClusterStatus.Value()));
+    }
+    else {
+        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj, static_cast<jlong>(Protocols::InteractionModel::Status::Success));
+    }
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 }
 

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -832,11 +832,15 @@ void InvokeCallback::OnResponse(app::CommandSender * apCommandSender, const app:
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
 
     DeviceLayer::StackUnlock unlock;
-    if (aStatusIB.mClusterStatus.HasValue()) {
-        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj, static_cast<jlong>(aStatusIB.mClusterStatus.Value()));
+    if (aStatusIB.mClusterStatus.HasValue())
+    {
+        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj,
+                            static_cast<jlong>(aStatusIB.mClusterStatus.Value()));
     }
-    else {
-        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj, static_cast<jlong>(Protocols::InteractionModel::Status::Success));
+    else
+    {
+        env->CallVoidMethod(mJavaCallbackRef, onResponseMethod, invokeElementObj,
+                            static_cast<jlong>(Protocols::InteractionModel::Status::Success));
     }
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 }


### PR DESCRIPTION
onResponse description say if data in InvokeElment is null, successCode can be any success status,  including possibly a cluster-specific one.

But we always return Protocols::InteractionModel::Status::Success even tlv payload is not null, this is because OnResponse is only get called when statusIB.IsSuccess()

if (statusIB.IsSuccess())
{
  mpCallback->OnResponse(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
    hasDataResponse ? &commandDataReader : nullptr);
}
else
{
  mpCallback->OnError(this, statusIB.ToChipError());
}

