### PR TITLE
[Silabs]Fix some build issues with wifi-ncp combos

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
+++ b/examples/platform/silabs/efr32/rs911x/wfx_rsi_host.c
@@ -203,11 +203,7 @@ sl_status_t wfx_connect_to_ap(void)
  ***********************************************************************/
 sl_status_t wfx_power_save()
 {
-    if (wfx_rsi_power_save() != RSI_ERROR_NONE)
-    {
-        return SL_STATUS_FAIL;
-    }
-    return SL_STATUS_OK;
+    return (wfx_rsi_power_save() ? SL_STATUS_FAIL : SL_STATUS_OK);
 }
 #endif /* SL_ICD_ENABLED */
 

--- a/src/platform/silabs/rs911x/rsi_ble_config.h
+++ b/src/platform/silabs/rs911x/rsi_ble_config.h
@@ -20,6 +20,7 @@
 
 #include "rsi_ble_apis.h"
 #if (SIWX_917 | EXP_BOARD)
+#include "rsi_bt_common_apis.h"
 #include "rsi_user.h"
 #else
 #include <rsi_data_types.h>


### PR DESCRIPTION
 Some wifi-ncp builds were failing with some options with the latest wifi-sdk
- Missing include for si917 using its on-chip ble
- Conflicting enum location between si917 and rs9116. Just check for a non 0 result