### PR TITLE
[Bouffalolab] Extract lwipopts.h from SDK

### DIFF
--- a/examples/lighting-app/bouffalolab/bl702/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702/BUILD.gn
@@ -92,6 +92,10 @@ bl_iot_sdk("sdk") {
 
   defines += [ "CHIP_DEVICE_CONFIG_ENABLE_ETHERNET=${chip_enable_ethernet}" ]
 
+  if (chip_enable_wifi || chip_enable_ethernet) {
+    include_dirs += [ "${examples_plat_dir}/bl702/lwipopts" ]
+  }
+
   if (chip_enable_ethernet) {
     defines += [ "CHIP_SYSTEM_CRYPTO_HEADER_RESERVE_SIZE=48" ]
   }

--- a/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
@@ -8,31 +8,31 @@
  * critical regions during buffer allocation, deallocation and memory
  * allocation and deallocation.
  */
-#define SYS_LIGHTWEIGHT_PROT    1
+#define SYS_LIGHTWEIGHT_PROT 1
 
-#define LWIP_NETIF_HOSTNAME     1
-#define ETHARP_TRUST_IP_MAC     0
-#define IP_REASSEMBLY           0
-#define IP_FRAG                 0
-#define ARP_QUEUEING            0
-#define LWIP_NETIF_API          1
+#define LWIP_NETIF_HOSTNAME 1
+#define ETHARP_TRUST_IP_MAC 0
+#define IP_REASSEMBLY 0
+#define IP_FRAG 0
+#define ARP_QUEUEING 0
+#define LWIP_NETIF_API 1
 
-#define LWIP_MDNS_RESPONDER     1
-#define LWIP_IGMP               1
+#define LWIP_MDNS_RESPONDER 1
+#define LWIP_IGMP 1
 
-#define LWIP_NUM_NETIF_CLIENT_DATA      1
+#define LWIP_NUM_NETIF_CLIENT_DATA 1
 
-#define LWIP_ALTCP                      1
-#define LWIP_ALTCP_TLS                  1
+#define LWIP_ALTCP 1
+#define LWIP_ALTCP_TLS 1
 /**
  * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
  * use lwIP facilities.
  */
-#define NO_SYS                  0
+#define NO_SYS 0
 
-#define LWIP_TIMEVAL_PRIVATE    0
+#define LWIP_TIMEVAL_PRIVATE 0
 
-#define LWIP_HAVE_LOOPIF           1
+#define LWIP_HAVE_LOOPIF 1
 
 /**
  * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
@@ -42,82 +42,82 @@
  * ATTENTION: this does not work when tcpip_input() is called from
  * interrupt context!
  */
-#define LWIP_TCPIP_CORE_LOCKING_INPUT   1
+#define LWIP_TCPIP_CORE_LOCKING_INPUT 1
 
 /* ---------- Memory options ---------- */
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */
-#define MEM_ALIGNMENT           4
+#define MEM_ALIGNMENT 4
 
 /* MEM_SIZE: the size of the heap memory. If the application will send
 a lot of data that needs to be copied, this should be set high. */
-#define MEM_SIZE                (12*1024)
+#define MEM_SIZE (12 * 1024)
 
 /* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
    sends a lot of data out of ROM (or other static memory), this
    should be set high. */
-#define MEMP_NUM_PBUF           26
+#define MEMP_NUM_PBUF 26
 
 /* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
    per active UDP "connection". */
-#define MEMP_NUM_UDP_PCB        8
+#define MEMP_NUM_UDP_PCB 8
 
 /* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
    connections. */
-#define MEMP_NUM_TCP_PCB        10
+#define MEMP_NUM_TCP_PCB 10
 /* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
    connections. */
 #define MEMP_NUM_TCP_PCB_LISTEN 5
 /* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
    segments. */
-#define MEMP_NUM_TCP_SEG        32
+#define MEMP_NUM_TCP_SEG 32
 
 /* NUM of sys_timeout pool*/
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
+#define MEMP_NUM_SYS_TIMEOUT (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
 
-#define MEMP_NUM_NETCONN    (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
+#define MEMP_NUM_NETCONN (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
 
 /* ---------- Pbuf options ---------- */
 /* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
-#define PBUF_POOL_SIZE          20
+#define PBUF_POOL_SIZE 20
 
 /* ---------- TCP options ---------- */
-#define LWIP_TCP                1
-#define IP_DEFAULT_TTL          64
+#define LWIP_TCP 1
+#define IP_DEFAULT_TTL 64
 
 /* Controls if TCP should queue segments that arrive out of
    order. Define to 0 if your device is low on memory. */
-#define TCP_QUEUE_OOSEQ         1
+#define TCP_QUEUE_OOSEQ 1
 
 /* TCP Maximum segment size. */
-#define TCP_MSS                 (1500 - 40)	  /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
+#define TCP_MSS (1500 - 40) /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
 
 /* TCP sender buffer space (bytes). */
-#define TCP_SND_BUF             (3*TCP_MSS)
+#define TCP_SND_BUF (3 * TCP_MSS)
 
 /*  TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
   as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work. */
 
-#define TCP_SND_QUEUELEN        ((2 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS))
+#define TCP_SND_QUEUELEN ((2 * (TCP_SND_BUF) + (TCP_MSS - 1)) / (TCP_MSS))
 
-#define MEMP_NUM_TCPIP_MSG_INPKT        (32)
+#define MEMP_NUM_TCPIP_MSG_INPKT (32)
 
 /**
  * TCP_SNDQUEUELOWAT: TCP writable bufs (pbuf count). This must be less
  * than TCP_SND_QUEUELEN. If the number of pbufs queued on a pcb drops below
  * this number, select returns writable (combined with TCP_SNDLOWAT).
  */
-#define TCP_SNDQUEUELOWAT               ((TCP_SND_QUEUELEN)/2)
+#define TCP_SNDQUEUELOWAT ((TCP_SND_QUEUELEN) / 2)
 
 /* TCP receive window. */
-#define TCP_WND                 (3*TCP_MSS)
+#define TCP_WND (3 * TCP_MSS)
 
 /**
  * TCP_WND_UPDATE_THRESHOLD: difference in window to trigger an
  * explicit window update
  */
-#define TCP_WND_UPDATE_THRESHOLD   LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
+#define TCP_WND_UPDATE_THRESHOLD LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
 
 /**
  * By default, TCP socket/netconn close waits 20 seconds max to send the FIN
@@ -128,28 +128,24 @@ a lot of data that needs to be copied, this should be set high. */
  * LWIP_SO_SNDTIMEO==1: Enable send timeout for sockets/netconns and
  * SO_SNDTIMEO processing.
  */
-#define LWIP_SO_SNDTIMEO                1
+#define LWIP_SO_SNDTIMEO 1
 /**
  * LWIP_SO_RCVTIMEO==1: Enable receive timeout for sockets/netconns and
  * SO_RCVTIMEO processing.
  */
-#define LWIP_SO_RCVTIMEO                1
-
+#define LWIP_SO_RCVTIMEO 1
 
 /* ---------- ICMP options ---------- */
-#define LWIP_ICMP                       1
-
+#define LWIP_ICMP 1
 
 /* ---------- DHCP options ---------- */
 /* Define LWIP_DHCP to 1 if you want DHCP configuration of
    interfaces. DHCP is not implemented in lwIP 0.5.1, however, so
    turning this on does currently not work. */
-#define LWIP_DHCP               1
-
+#define LWIP_DHCP 1
 
 /* ---------- UDP options ---------- */
-#define LWIP_UDP                1
-
+#define LWIP_UDP 1
 
 /* ---------- Statistics options ---------- */
 #define LWIP_STATS 1
@@ -161,41 +157,40 @@ a lot of data that needs to be copied, this should be set high. */
    --------------------------------------
 */
 
-#define LWIP_CHECKSUM_ON_COPY            1
-#define LWIP_NETIF_TX_SINGLE_PBUF    1
+#define LWIP_CHECKSUM_ON_COPY 1
+#define LWIP_NETIF_TX_SINGLE_PBUF 1
 
 #ifdef CHECKSUM_BY_HARDWARE
-  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
-  #define CHECKSUM_GEN_IP                 0
-  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
-  #define CHECKSUM_GEN_UDP                0
-  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
-  #define CHECKSUM_GEN_TCP                0
-  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
-  #define CHECKSUM_CHECK_IP               0
-  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
-  #define CHECKSUM_CHECK_UDP              0
-  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
-  #define CHECKSUM_CHECK_TCP              0
-  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
-  #define CHECKSUM_GEN_ICMP               0
+/* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+#define CHECKSUM_GEN_IP 0
+/* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+#define CHECKSUM_GEN_UDP 0
+/* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+#define CHECKSUM_GEN_TCP 0
+/* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+#define CHECKSUM_CHECK_IP 0
+/* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+#define CHECKSUM_CHECK_UDP 0
+/* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+#define CHECKSUM_CHECK_TCP 0
+/* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+#define CHECKSUM_GEN_ICMP 0
 #else
-  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
-  #define CHECKSUM_GEN_IP                 1
-  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
-  #define CHECKSUM_GEN_UDP                1
-  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
-  #define CHECKSUM_GEN_TCP                1
-  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
-  #define CHECKSUM_CHECK_IP               1
-  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
-  #define CHECKSUM_CHECK_UDP              1
-  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
-  #define CHECKSUM_CHECK_TCP              1
-  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
-  #define CHECKSUM_GEN_ICMP               1
+/* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+#define CHECKSUM_GEN_IP 1
+/* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+#define CHECKSUM_GEN_UDP 1
+/* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+#define CHECKSUM_GEN_TCP 1
+/* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+#define CHECKSUM_CHECK_IP 1
+/* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+#define CHECKSUM_CHECK_UDP 1
+/* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+#define CHECKSUM_CHECK_TCP 1
+/* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+#define CHECKSUM_GEN_ICMP 1
 #endif
-
 
 /*
    ----------------------------------------------
@@ -207,7 +202,7 @@ a lot of data that needs to be copied, this should be set high. */
 /**
  * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
  */
-#define LWIP_NETCONN                    1
+#define LWIP_NETCONN 1
 
 /*
    ------------------------------------
@@ -217,7 +212,7 @@ a lot of data that needs to be copied, this should be set high. */
 /**
  * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
  */
-#define LWIP_SOCKET                     1
+#define LWIP_SOCKET 1
 
 /*
    -----------------------------------
@@ -233,48 +228,48 @@ a lot of data that needs to be copied, this should be set high. */
    ---------------------------------
 */
 
-#define TCPIP_THREAD_NAME              "TCP/IP"
-#define TCPIP_THREAD_STACKSIZE          1536
-#define TCPIP_MBOX_SIZE                 50
-#define DEFAULT_UDP_RECVMBOX_SIZE       50
-#define DEFAULT_TCP_RECVMBOX_SIZE       50
-#define DEFAULT_ACCEPTMBOX_SIZE         50
-#define DEFAULT_THREAD_STACKSIZE        500
-#define TCPIP_THREAD_PRIO               (configMAX_PRIORITIES - 2)
+#define TCPIP_THREAD_NAME "TCP/IP"
+#define TCPIP_THREAD_STACKSIZE 1536
+#define TCPIP_MBOX_SIZE 50
+#define DEFAULT_UDP_RECVMBOX_SIZE 50
+#define DEFAULT_TCP_RECVMBOX_SIZE 50
+#define DEFAULT_ACCEPTMBOX_SIZE 50
+#define DEFAULT_THREAD_STACKSIZE 500
+#define TCPIP_THREAD_PRIO (configMAX_PRIORITIES - 2)
 
-#define LWIP_COMPAT_MUTEX               0
-#define LWIP_TCPIP_CORE_LOCKING         1
-#define LWIP_NETCONN_SEM_PER_THREAD     0
-#define LWIP_SOCKET_SET_ERRNO           1
-#define SO_REUSE                        1
-#define LWIP_TCP_KEEPALIVE              1
+#define LWIP_COMPAT_MUTEX 0
+#define LWIP_TCPIP_CORE_LOCKING 1
+#define LWIP_NETCONN_SEM_PER_THREAD 0
+#define LWIP_SOCKET_SET_ERRNO 1
+#define SO_REUSE 1
+#define LWIP_TCP_KEEPALIVE 1
 
 /*Enable Status callback and link callback*/
-#define LWIP_NETIF_STATUS_CALLBACK      1
-#define LWIP_NETIF_LINK_CALLBACK        1
+#define LWIP_NETIF_STATUS_CALLBACK 1
+#define LWIP_NETIF_LINK_CALLBACK 1
 
 /*Enable dns*/
-#define LWIP_DNS                        1
-#define LWIP_DNS_SECURE                 0
+#define LWIP_DNS 1
+#define LWIP_DNS_SECURE 0
 
-#define MEMP_MEM_MALLOC                 0
-#define LWIP_SUPPORT_CUSTOM_PBUF        1
+#define MEMP_MEM_MALLOC 0
+#define LWIP_SUPPORT_CUSTOM_PBUF 1
 
-#define PBUF_LINK_ENCAPSULATION_HLEN    48u
+#define PBUF_LINK_ENCAPSULATION_HLEN 48u
 
-#define LWIP_RAW                        1
+#define LWIP_RAW 1
 
-#define LWIP_IPV4                       1
-#define LWIP_IPV6_DHCP6                 1
-#define LWIP_AUTOIP                     1
-#define LWIP_IPV6_MLD                   1
-#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
-#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
+#define LWIP_IPV4 1
+#define LWIP_IPV6_DHCP6 1
+#define LWIP_AUTOIP 1
+#define LWIP_IPV6_MLD 1
+#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS 1
+#define LWIP_HOOK_FILENAME "bl_lwip_hooks.h"
 
-#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+#define LWIP_NETIF_EXT_STATUS_CALLBACK 1
 
 /* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
-#define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
+#define PBUF_POOL_BUFSIZE LWIP_MEM_ALIGN_SIZE(TCP_MSS + 40 + PBUF_LINK_ENCAPSULATION_HLEN + PBUF_LINK_HLEN)
 
 /*
    ---------------------------------
@@ -299,6 +294,6 @@ extern int * __errno(void);
  */
 
 #define LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS 1
-#define LWIP_RAND() ((u32_t)bl_rand())
+#define LWIP_RAND() ((u32_t) bl_rand())
 
 #endif /* __LWIPOPTS_H__ */

--- a/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
@@ -54,14 +54,14 @@
 a lot of data that needs to be copied, this should be set high. */
 #define MEM_SIZE                (12*1024)
 
-
 /* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
    sends a lot of data out of ROM (or other static memory), this
    should be set high. */
 #define MEMP_NUM_PBUF           26
+
 /* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
    per active UDP "connection". */
-#define MEMP_NUM_UDP_PCB        6
+#define MEMP_NUM_UDP_PCB        8
 
 /* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
    connections. */
@@ -80,7 +80,7 @@ a lot of data that needs to be copied, this should be set high. */
 
 /* ---------- Pbuf options ---------- */
 /* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
-#define PBUF_POOL_SIZE          0
+#define PBUF_POOL_SIZE          20
 
 /* ---------- TCP options ---------- */
 #define LWIP_TCP                1
@@ -154,12 +154,6 @@ a lot of data that needs to be copied, this should be set high. */
 /* ---------- Statistics options ---------- */
 #define LWIP_STATS 1
 #define LWIP_PROVIDE_ERRNO 1
-
-/* ---------- link callback options ---------- */
-/* LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
- * whenever the link changes (i.e., link down)
- */
-#define LWIP_NETIF_LINK_CALLBACK        1
 
 /*
    --------------------------------------
@@ -258,6 +252,7 @@ a lot of data that needs to be copied, this should be set high. */
 /*Enable Status callback and link callback*/
 #define LWIP_NETIF_STATUS_CALLBACK      1
 #define LWIP_NETIF_LINK_CALLBACK        1
+
 /*Enable dns*/
 #define LWIP_DNS                        1
 #define LWIP_DNS_SECURE                 0
@@ -271,7 +266,6 @@ a lot of data that needs to be copied, this should be set high. */
 
 #define LWIP_IPV4                       1
 #define LWIP_IPV6_DHCP6                 1
-#define LWIP_IPV6_SCOPES                1
 #define LWIP_AUTOIP                     1
 #define LWIP_IPV6_MLD                   1
 #define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
@@ -279,10 +273,9 @@ a lot of data that needs to be copied, this should be set high. */
 
 #define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 
-#define LWIP_PBUF_FROM_CUSTOM_RAM_HEAP  1
-
 /* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
 #define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
+
 /*
    ---------------------------------
    ---------- MISC. options ----------

--- a/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
@@ -1,0 +1,311 @@
+#ifndef __LWIPOPTS_H__
+#define __LWIPOPTS_H__
+
+#include "stdbool.h"
+
+/**
+ * SYS_LIGHTWEIGHT_PROT==1: if you want inter-task protection for certain
+ * critical regions during buffer allocation, deallocation and memory
+ * allocation and deallocation.
+ */
+#define SYS_LIGHTWEIGHT_PROT    1
+
+#define LWIP_NETIF_HOSTNAME     1
+#define ETHARP_TRUST_IP_MAC     0
+#define IP_REASSEMBLY           0
+#define IP_FRAG                 0
+#define ARP_QUEUEING            0
+#define LWIP_NETIF_API          1
+
+#define LWIP_MDNS_RESPONDER     1
+#define LWIP_IGMP               1
+
+#define LWIP_NUM_NETIF_CLIENT_DATA      1
+
+#define LWIP_ALTCP                      1
+#define LWIP_ALTCP_TLS                  1
+/**
+ * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
+ * use lwIP facilities.
+ */
+#define NO_SYS                  0
+
+#define LWIP_TIMEVAL_PRIVATE    0
+
+#define LWIP_HAVE_LOOPIF           1
+
+/**
+ * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
+ * this lets tcpip_input() grab the mutex for input packets as well,
+ * instead of allocating a message and passing it to tcpip_thread.
+ *
+ * ATTENTION: this does not work when tcpip_input() is called from
+ * interrupt context!
+ */
+#define LWIP_TCPIP_CORE_LOCKING_INPUT   1
+
+/* ---------- Memory options ---------- */
+/* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
+   lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
+   byte alignment -> define MEM_ALIGNMENT to 2. */
+#define MEM_ALIGNMENT           4
+
+/* MEM_SIZE: the size of the heap memory. If the application will send
+a lot of data that needs to be copied, this should be set high. */
+#define MEM_SIZE                (12*1024)
+
+
+/* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
+   sends a lot of data out of ROM (or other static memory), this
+   should be set high. */
+#define MEMP_NUM_PBUF           26
+/* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
+   per active UDP "connection". */
+#define MEMP_NUM_UDP_PCB        6
+
+/* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB        10
+/* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB_LISTEN 5
+/* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
+   segments. */
+#define MEMP_NUM_TCP_SEG        32
+
+/* NUM of sys_timeout pool*/
+#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
+
+#define MEMP_NUM_NETCONN    (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
+
+/* ---------- Pbuf options ---------- */
+/* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
+#define PBUF_POOL_SIZE          0
+
+/* ---------- TCP options ---------- */
+#define LWIP_TCP                1
+#define IP_DEFAULT_TTL          64
+
+/* Controls if TCP should queue segments that arrive out of
+   order. Define to 0 if your device is low on memory. */
+#define TCP_QUEUE_OOSEQ         1
+
+/* TCP Maximum segment size. */
+#define TCP_MSS                 (1500 - 40)	  /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
+
+/* TCP sender buffer space (bytes). */
+#define TCP_SND_BUF             (3*TCP_MSS)
+
+/*  TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
+  as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work. */
+
+#define TCP_SND_QUEUELEN        ((2 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS))
+
+#define MEMP_NUM_TCPIP_MSG_INPKT        (32)
+
+/**
+ * TCP_SNDQUEUELOWAT: TCP writable bufs (pbuf count). This must be less
+ * than TCP_SND_QUEUELEN. If the number of pbufs queued on a pcb drops below
+ * this number, select returns writable (combined with TCP_SNDLOWAT).
+ */
+#define TCP_SNDQUEUELOWAT               ((TCP_SND_QUEUELEN)/2)
+
+/* TCP receive window. */
+#define TCP_WND                 (3*TCP_MSS)
+
+/**
+ * TCP_WND_UPDATE_THRESHOLD: difference in window to trigger an
+ * explicit window update
+ */
+#define TCP_WND_UPDATE_THRESHOLD   LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
+
+/**
+ * By default, TCP socket/netconn close waits 20 seconds max to send the FIN
+ */
+#define LWIP_TCP_CLOSE_TIMEOUT_MS_DEFAULT 5000
+
+/**
+ * LWIP_SO_SNDTIMEO==1: Enable send timeout for sockets/netconns and
+ * SO_SNDTIMEO processing.
+ */
+#define LWIP_SO_SNDTIMEO                1
+/**
+ * LWIP_SO_RCVTIMEO==1: Enable receive timeout for sockets/netconns and
+ * SO_RCVTIMEO processing.
+ */
+#define LWIP_SO_RCVTIMEO                1
+
+
+/* ---------- ICMP options ---------- */
+#define LWIP_ICMP                       1
+
+
+/* ---------- DHCP options ---------- */
+/* Define LWIP_DHCP to 1 if you want DHCP configuration of
+   interfaces. DHCP is not implemented in lwIP 0.5.1, however, so
+   turning this on does currently not work. */
+#define LWIP_DHCP               1
+
+
+/* ---------- UDP options ---------- */
+#define LWIP_UDP                1
+
+
+/* ---------- Statistics options ---------- */
+#define LWIP_STATS 1
+#define LWIP_PROVIDE_ERRNO 1
+
+/* ---------- link callback options ---------- */
+/* LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
+ * whenever the link changes (i.e., link down)
+ */
+#define LWIP_NETIF_LINK_CALLBACK        1
+
+/*
+   --------------------------------------
+   ---------- Checksum options ----------
+   --------------------------------------
+*/
+
+#define LWIP_CHECKSUM_ON_COPY            1
+#define LWIP_NETIF_TX_SINGLE_PBUF    1
+
+#ifdef CHECKSUM_BY_HARDWARE
+  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 0
+  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                0
+  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                0
+  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               0
+  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              0
+  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              0
+  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               0
+#else
+  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 1
+  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                1
+  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                1
+  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               1
+  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              1
+  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              1
+  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               1
+#endif
+
+
+/*
+   ----------------------------------------------
+   ---------- Sequential layer options ----------
+   ----------------------------------------------
+*/
+#define LWIP_CHKSUM_ALGORITHM 3
+
+/**
+ * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
+ */
+#define LWIP_NETCONN                    1
+
+/*
+   ------------------------------------
+   ---------- Socket options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
+ */
+#define LWIP_SOCKET                     1
+
+/*
+   -----------------------------------
+   ---------- DEBUG options ----------
+   -----------------------------------
+*/
+
+//#define LWIP_DEBUG                      0
+
+/*
+   ---------------------------------
+   ---------- OS options ----------
+   ---------------------------------
+*/
+
+#define TCPIP_THREAD_NAME              "TCP/IP"
+#define TCPIP_THREAD_STACKSIZE          1536
+#define TCPIP_MBOX_SIZE                 50
+#define DEFAULT_UDP_RECVMBOX_SIZE       50
+#define DEFAULT_TCP_RECVMBOX_SIZE       50
+#define DEFAULT_ACCEPTMBOX_SIZE         50
+#define DEFAULT_THREAD_STACKSIZE        500
+#define TCPIP_THREAD_PRIO               (configMAX_PRIORITIES - 2)
+
+#define LWIP_COMPAT_MUTEX               0
+#define LWIP_TCPIP_CORE_LOCKING         1
+#define LWIP_NETCONN_SEM_PER_THREAD     0
+#define LWIP_SOCKET_SET_ERRNO           1
+#define SO_REUSE                        1
+#define LWIP_TCP_KEEPALIVE              1
+
+/*Enable Status callback and link callback*/
+#define LWIP_NETIF_STATUS_CALLBACK      1
+#define LWIP_NETIF_LINK_CALLBACK        1
+/*Enable dns*/
+#define LWIP_DNS                        1
+#define LWIP_DNS_SECURE                 0
+
+#define MEMP_MEM_MALLOC                 0
+#define LWIP_SUPPORT_CUSTOM_PBUF        1
+
+#define PBUF_LINK_ENCAPSULATION_HLEN    48u
+
+#define LWIP_RAW                        1
+
+#define LWIP_IPV4                       1
+#define LWIP_IPV6_DHCP6                 1
+#define LWIP_IPV6_SCOPES                1
+#define LWIP_AUTOIP                     1
+#define LWIP_IPV6_MLD                   1
+#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
+#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
+
+#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+
+#define LWIP_PBUF_FROM_CUSTOM_RAM_HEAP  1
+
+/* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
+#define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
+/*
+   ---------------------------------
+   ---------- MISC. options ----------
+   ---------------------------------
+*/
+
+#if defined(__cplusplus)
+extern "C" int bl_rand(void);
+extern "C" int * __errno(void);
+#else
+extern int bl_rand(void);
+extern int * __errno(void);
+#endif
+
+#define errno (*__errno())
+
+/**
+ * LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS==1: randomize the local port for the first
+ * local TCP/UDP pcb (default==0). This can prevent creating predictable port
+ * numbers after booting a device.
+ */
+
+#define LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS 1
+#define LWIP_RAND() ((u32_t)bl_rand())
+
+#endif /* __LWIPOPTS_H__ */

--- a/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
@@ -8,31 +8,31 @@
  * critical regions during buffer allocation, deallocation and memory
  * allocation and deallocation.
  */
-#define SYS_LIGHTWEIGHT_PROT    1
+#define SYS_LIGHTWEIGHT_PROT 1
 
-#define LWIP_NETIF_HOSTNAME     1
-#define ETHARP_TRUST_IP_MAC     0
-#define IP_REASSEMBLY           0
-#define IP_FRAG                 0
-#define ARP_QUEUEING            0
-#define LWIP_NETIF_API          1
+#define LWIP_NETIF_HOSTNAME 1
+#define ETHARP_TRUST_IP_MAC 0
+#define IP_REASSEMBLY 0
+#define IP_FRAG 0
+#define ARP_QUEUEING 0
+#define LWIP_NETIF_API 1
 
-#define LWIP_MDNS_RESPONDER     1
-#define LWIP_IGMP               1
+#define LWIP_MDNS_RESPONDER 1
+#define LWIP_IGMP 1
 
-#define LWIP_NUM_NETIF_CLIENT_DATA      1
+#define LWIP_NUM_NETIF_CLIENT_DATA 1
 
-#define LWIP_ALTCP                      1
-#define LWIP_ALTCP_TLS                  1
+#define LWIP_ALTCP 1
+#define LWIP_ALTCP_TLS 1
 /**
  * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
  * use lwIP facilities.
  */
-#define NO_SYS                  0
+#define NO_SYS 0
 
-#define LWIP_TIMEVAL_PRIVATE    0
+#define LWIP_TIMEVAL_PRIVATE 0
 
-#define LWIP_HAVE_LOOPIF           1
+#define LWIP_HAVE_LOOPIF 1
 
 /**
  * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
@@ -42,90 +42,90 @@
  * ATTENTION: this does not work when tcpip_input() is called from
  * interrupt context!
  */
-#define LWIP_TCPIP_CORE_LOCKING_INPUT   1
+#define LWIP_TCPIP_CORE_LOCKING_INPUT 1
 
 /* ---------- Memory options ---------- */
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */
-#define MEM_ALIGNMENT           4
+#define MEM_ALIGNMENT 4
 
 /* MEM_SIZE: the size of the heap memory. If the application will send
 a lot of data that needs to be copied, this should be set high. */
-#define MEM_SIZE                (12*1024)
+#define MEM_SIZE (12 * 1024)
 
 /* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
    sends a lot of data out of ROM (or other static memory), this
    should be set high. */
-#define MEMP_NUM_PBUF           26
+#define MEMP_NUM_PBUF 26
 
 /* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
    per active UDP "connection". */
-#define MEMP_NUM_UDP_PCB        8
+#define MEMP_NUM_UDP_PCB 8
 
 /* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
    connections. */
-#define MEMP_NUM_TCP_PCB        10
+#define MEMP_NUM_TCP_PCB 10
 /* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
    connections. */
 #define MEMP_NUM_TCP_PCB_LISTEN 5
 /* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
    segments. */
-#define MEMP_NUM_TCP_SEG        32
+#define MEMP_NUM_TCP_SEG 32
 
 /* NUM of sys_timeout pool*/
-#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
+#define MEMP_NUM_SYS_TIMEOUT (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
 
-#define MEMP_NUM_NETCONN    (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
+#define MEMP_NUM_NETCONN (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
 
 /* ---------- Pbuf options ---------- */
 /* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
-#define PBUF_POOL_SIZE          20
+#define PBUF_POOL_SIZE 20
 
 /* ---------- TCP options ---------- */
-#define LWIP_TCP                1
-#define IP_DEFAULT_TTL          64
+#define LWIP_TCP 1
+#define IP_DEFAULT_TTL 64
 
 /* Controls if TCP should queue segments that arrive out of
    order. Define to 0 if your device is low on memory. */
-#define TCP_QUEUE_OOSEQ         1
+#define TCP_QUEUE_OOSEQ 1
 
 /* TCP Maximum segment size. */
-#define TCP_MSS                 (1500 - 40)	  /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
+#define TCP_MSS (1500 - 40) /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
 
 /* TCP sender buffer space (bytes). */
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-#define TCP_SND_BUF              (6*TCP_MSS)
+#define TCP_SND_BUF (6 * TCP_MSS)
 #else
-#define TCP_SND_BUF              (3*TCP_MSS)
+#define TCP_SND_BUF (3 * TCP_MSS)
 #endif
 
 /*  TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
   as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work. */
 
-#define TCP_SND_QUEUELEN        ((2 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS))
+#define TCP_SND_QUEUELEN ((2 * (TCP_SND_BUF) + (TCP_MSS - 1)) / (TCP_MSS))
 
-#define MEMP_NUM_TCPIP_MSG_INPKT        (32)
+#define MEMP_NUM_TCPIP_MSG_INPKT (32)
 
 /**
  * TCP_SNDQUEUELOWAT: TCP writable bufs (pbuf count). This must be less
  * than TCP_SND_QUEUELEN. If the number of pbufs queued on a pcb drops below
  * this number, select returns writable (combined with TCP_SNDLOWAT).
  */
-#define TCP_SNDQUEUELOWAT               ((TCP_SND_QUEUELEN)/2)
+#define TCP_SNDQUEUELOWAT ((TCP_SND_QUEUELEN) / 2)
 
 /* TCP receive window. */
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-#define TCP_WND                 (6*TCP_MSS)
+#define TCP_WND (6 * TCP_MSS)
 #else
-#define TCP_WND                 (3*TCP_MSS)
+#define TCP_WND (3 * TCP_MSS)
 #endif
 
 /**
  * TCP_WND_UPDATE_THRESHOLD: difference in window to trigger an
  * explicit window update
  */
-#define TCP_WND_UPDATE_THRESHOLD   LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
+#define TCP_WND_UPDATE_THRESHOLD LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
 
 /**
  * By default, TCP socket/netconn close waits 20 seconds max to send the FIN
@@ -136,28 +136,24 @@ a lot of data that needs to be copied, this should be set high. */
  * LWIP_SO_SNDTIMEO==1: Enable send timeout for sockets/netconns and
  * SO_SNDTIMEO processing.
  */
-#define LWIP_SO_SNDTIMEO                1
+#define LWIP_SO_SNDTIMEO 1
 /**
  * LWIP_SO_RCVTIMEO==1: Enable receive timeout for sockets/netconns and
  * SO_RCVTIMEO processing.
  */
-#define LWIP_SO_RCVTIMEO                1
-
+#define LWIP_SO_RCVTIMEO 1
 
 /* ---------- ICMP options ---------- */
-#define LWIP_ICMP                       1
-
+#define LWIP_ICMP 1
 
 /* ---------- DHCP options ---------- */
 /* Define LWIP_DHCP to 1 if you want DHCP configuration of
    interfaces. DHCP is not implemented in lwIP 0.5.1, however, so
    turning this on does currently not work. */
-#define LWIP_DHCP               1
-
+#define LWIP_DHCP 1
 
 /* ---------- UDP options ---------- */
-#define LWIP_UDP                1
-
+#define LWIP_UDP 1
 
 /* ---------- Statistics options ---------- */
 #define LWIP_STATS 1
@@ -169,45 +165,44 @@ a lot of data that needs to be copied, this should be set high. */
    --------------------------------------
 */
 
-#define LWIP_CHECKSUM_ON_COPY            1
+#define LWIP_CHECKSUM_ON_COPY 1
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-#define LWIP_NETIF_TX_SINGLE_PBUF    0
+#define LWIP_NETIF_TX_SINGLE_PBUF 0
 #else
-#define LWIP_NETIF_TX_SINGLE_PBUF    1
+#define LWIP_NETIF_TX_SINGLE_PBUF 1
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_ETHERNET */
 
 #ifdef CHECKSUM_BY_HARDWARE
-  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
-  #define CHECKSUM_GEN_IP                 0
-  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
-  #define CHECKSUM_GEN_UDP                0
-  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
-  #define CHECKSUM_GEN_TCP                0
-  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
-  #define CHECKSUM_CHECK_IP               0
-  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
-  #define CHECKSUM_CHECK_UDP              0
-  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
-  #define CHECKSUM_CHECK_TCP              0
-  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
-  #define CHECKSUM_GEN_ICMP               0
+/* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+#define CHECKSUM_GEN_IP 0
+/* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+#define CHECKSUM_GEN_UDP 0
+/* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+#define CHECKSUM_GEN_TCP 0
+/* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+#define CHECKSUM_CHECK_IP 0
+/* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+#define CHECKSUM_CHECK_UDP 0
+/* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+#define CHECKSUM_CHECK_TCP 0
+/* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+#define CHECKSUM_GEN_ICMP 0
 #else
-  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
-  #define CHECKSUM_GEN_IP                 1
-  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
-  #define CHECKSUM_GEN_UDP                1
-  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
-  #define CHECKSUM_GEN_TCP                1
-  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
-  #define CHECKSUM_CHECK_IP               1
-  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
-  #define CHECKSUM_CHECK_UDP              1
-  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
-  #define CHECKSUM_CHECK_TCP              1
-  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
-  #define CHECKSUM_GEN_ICMP               1
+/* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+#define CHECKSUM_GEN_IP 1
+/* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+#define CHECKSUM_GEN_UDP 1
+/* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+#define CHECKSUM_GEN_TCP 1
+/* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+#define CHECKSUM_CHECK_IP 1
+/* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+#define CHECKSUM_CHECK_UDP 1
+/* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+#define CHECKSUM_CHECK_TCP 1
+/* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+#define CHECKSUM_GEN_ICMP 1
 #endif
-
 
 /*
    ----------------------------------------------
@@ -219,7 +214,7 @@ a lot of data that needs to be copied, this should be set high. */
 /**
  * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
  */
-#define LWIP_NETCONN                    1
+#define LWIP_NETCONN 1
 
 /*
    ------------------------------------
@@ -229,7 +224,7 @@ a lot of data that needs to be copied, this should be set high. */
 /**
  * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
  */
-#define LWIP_SOCKET                     1
+#define LWIP_SOCKET 1
 
 /*
    -----------------------------------
@@ -245,48 +240,48 @@ a lot of data that needs to be copied, this should be set high. */
    ---------------------------------
 */
 
-#define TCPIP_THREAD_NAME              "TCP/IP"
-#define TCPIP_THREAD_STACKSIZE          1536
-#define TCPIP_MBOX_SIZE                 50
-#define DEFAULT_UDP_RECVMBOX_SIZE       50
-#define DEFAULT_TCP_RECVMBOX_SIZE       50
-#define DEFAULT_ACCEPTMBOX_SIZE         50
-#define DEFAULT_THREAD_STACKSIZE        500
-#define TCPIP_THREAD_PRIO               (configMAX_PRIORITIES - 2)
+#define TCPIP_THREAD_NAME "TCP/IP"
+#define TCPIP_THREAD_STACKSIZE 1536
+#define TCPIP_MBOX_SIZE 50
+#define DEFAULT_UDP_RECVMBOX_SIZE 50
+#define DEFAULT_TCP_RECVMBOX_SIZE 50
+#define DEFAULT_ACCEPTMBOX_SIZE 50
+#define DEFAULT_THREAD_STACKSIZE 500
+#define TCPIP_THREAD_PRIO (configMAX_PRIORITIES - 2)
 
-#define LWIP_COMPAT_MUTEX               0
-#define LWIP_TCPIP_CORE_LOCKING         1
-#define LWIP_NETCONN_SEM_PER_THREAD     0
-#define LWIP_SOCKET_SET_ERRNO           1
-#define SO_REUSE                        1
-#define LWIP_TCP_KEEPALIVE              1
+#define LWIP_COMPAT_MUTEX 0
+#define LWIP_TCPIP_CORE_LOCKING 1
+#define LWIP_NETCONN_SEM_PER_THREAD 0
+#define LWIP_SOCKET_SET_ERRNO 1
+#define SO_REUSE 1
+#define LWIP_TCP_KEEPALIVE 1
 
 /*Enable Status callback and link callback*/
-#define LWIP_NETIF_STATUS_CALLBACK      1
-#define LWIP_NETIF_LINK_CALLBACK        1
+#define LWIP_NETIF_STATUS_CALLBACK 1
+#define LWIP_NETIF_LINK_CALLBACK 1
 
 /*Enable dns*/
-#define LWIP_DNS                        1
-#define LWIP_DNS_SECURE                 0
+#define LWIP_DNS 1
+#define LWIP_DNS_SECURE 0
 
-#define MEMP_MEM_MALLOC                 0
-#define LWIP_SUPPORT_CUSTOM_PBUF        1
+#define MEMP_MEM_MALLOC 0
+#define LWIP_SUPPORT_CUSTOM_PBUF 1
 
-#define PBUF_LINK_ENCAPSULATION_HLEN    48u
+#define PBUF_LINK_ENCAPSULATION_HLEN 48u
 
-#define LWIP_RAW                        1
+#define LWIP_RAW 1
 
-#define LWIP_IPV4                       1
-#define LWIP_IPV6_DHCP6                 1
-#define LWIP_AUTOIP                     1
-#define LWIP_IPV6_MLD                   1
-#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
-#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
+#define LWIP_IPV4 1
+#define LWIP_IPV6_DHCP6 1
+#define LWIP_AUTOIP 1
+#define LWIP_IPV6_MLD 1
+#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS 1
+#define LWIP_HOOK_FILENAME "bl_lwip_hooks.h"
 
-#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+#define LWIP_NETIF_EXT_STATUS_CALLBACK 1
 
 /* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
-#define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
+#define PBUF_POOL_BUFSIZE LWIP_MEM_ALIGN_SIZE(TCP_MSS + 40 + PBUF_LINK_ENCAPSULATION_HLEN + PBUF_LINK_HLEN)
 
 /*
    ---------------------------------
@@ -311,6 +306,6 @@ extern int * __errno(void);
  */
 
 #define LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS 1
-#define LWIP_RAND() ((u32_t)bl_rand())
+#define LWIP_RAND() ((u32_t) bl_rand())
 
 #endif /* __LWIPOPTS_H__ */

--- a/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
@@ -1,0 +1,337 @@
+#ifndef __LWIPOPTS_H__
+#define __LWIPOPTS_H__
+
+#include "stdbool.h"
+
+/**
+ * SYS_LIGHTWEIGHT_PROT==1: if you want inter-task protection for certain
+ * critical regions during buffer allocation, deallocation and memory
+ * allocation and deallocation.
+ */
+#define SYS_LIGHTWEIGHT_PROT    1
+
+#define LWIP_NETIF_HOSTNAME     1
+#define ETHARP_TRUST_IP_MAC     0
+#define IP_REASSEMBLY           0
+#define IP_FRAG                 0
+#define ARP_QUEUEING            0
+#define LWIP_NETIF_API          1
+
+#define LWIP_MDNS_RESPONDER     1
+#define LWIP_IGMP               1
+
+#define LWIP_NUM_NETIF_CLIENT_DATA      1
+
+#define LWIP_ALTCP                      1
+#define LWIP_ALTCP_TLS                  1
+/**
+ * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
+ * use lwIP facilities.
+ */
+#define NO_SYS                  0
+
+#define LWIP_TIMEVAL_PRIVATE    0
+
+#define LWIP_HAVE_LOOPIF           1
+
+/**
+ * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
+ * this lets tcpip_input() grab the mutex for input packets as well,
+ * instead of allocating a message and passing it to tcpip_thread.
+ *
+ * ATTENTION: this does not work when tcpip_input() is called from
+ * interrupt context!
+ */
+#define LWIP_TCPIP_CORE_LOCKING_INPUT   1
+
+/* ---------- Memory options ---------- */
+/* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
+   lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
+   byte alignment -> define MEM_ALIGNMENT to 2. */
+#define MEM_ALIGNMENT           4
+
+/* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
+   sends a lot of data out of ROM (or other static memory), this
+   should be set high. */
+#define MEMP_NUM_PBUF           26
+
+/* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB        10
+/* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB_LISTEN 5
+/* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
+   segments. */
+#define MEMP_NUM_TCP_SEG        32
+
+/* NUM of sys_timeout pool*/
+#define MEMP_NUM_SYS_TIMEOUT            (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 8 + 3)
+
+#define MEMP_NUM_NETCONN    (MEMP_NUM_TCP_PCB + MEMP_NUM_UDP_PCB + MEMP_NUM_TCP_PCB_LISTEN)
+
+/* ---------- Pbuf options ---------- */
+/* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
+#define PBUF_POOL_SIZE          0
+
+/* ---------- TCP options ---------- */
+#define LWIP_TCP                1
+#define IP_DEFAULT_TTL          64
+
+/* Controls if TCP should queue segments that arrive out of
+   order. Define to 0 if your device is low on memory. */
+#define TCP_QUEUE_OOSEQ         1
+
+/* TCP Maximum segment size. */
+#define TCP_MSS                 (1500 - 40)	  /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
+
+/* TCP sender buffer space (bytes). */
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#define TCP_SND_BUF              (6*TCP_MSS)
+#else
+#define TCP_SND_BUF              (3*TCP_MSS)
+#endif
+
+/*  TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
+  as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work. */
+
+#define TCP_SND_QUEUELEN        ((2 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS))
+
+#define MEMP_NUM_TCPIP_MSG_INPKT        (32)
+
+/**
+ * TCP_SNDQUEUELOWAT: TCP writable bufs (pbuf count). This must be less
+ * than TCP_SND_QUEUELEN. If the number of pbufs queued on a pcb drops below
+ * this number, select returns writable (combined with TCP_SNDLOWAT).
+ */
+#define TCP_SNDQUEUELOWAT               ((TCP_SND_QUEUELEN)/2)
+
+/* TCP receive window. */
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#define TCP_WND                 (6*TCP_MSS)
+#else
+#define TCP_WND                 (3*TCP_MSS)
+#endif
+
+/**
+ * TCP_WND_UPDATE_THRESHOLD: difference in window to trigger an
+ * explicit window update
+ */
+#define TCP_WND_UPDATE_THRESHOLD   LWIP_MIN((TCP_WND / 2), (TCP_MSS * 6))
+
+/**
+ * By default, TCP socket/netconn close waits 20 seconds max to send the FIN
+ */
+#define LWIP_TCP_CLOSE_TIMEOUT_MS_DEFAULT 5000
+
+/**
+ * LWIP_SO_SNDTIMEO==1: Enable send timeout for sockets/netconns and
+ * SO_SNDTIMEO processing.
+ */
+#define LWIP_SO_SNDTIMEO                1
+/**
+ * LWIP_SO_RCVTIMEO==1: Enable receive timeout for sockets/netconns and
+ * SO_RCVTIMEO processing.
+ */
+#define LWIP_SO_RCVTIMEO                1
+
+
+/* ---------- ICMP options ---------- */
+#define LWIP_ICMP                       1
+
+
+/* ---------- DHCP options ---------- */
+/* Define LWIP_DHCP to 1 if you want DHCP configuration of
+   interfaces. DHCP is not implemented in lwIP 0.5.1, however, so
+   turning this on does currently not work. */
+#define LWIP_DHCP               1
+
+
+/* ---------- UDP options ---------- */
+#define LWIP_UDP                1
+
+
+/* ---------- Statistics options ---------- */
+#define LWIP_STATS 1
+#define LWIP_PROVIDE_ERRNO 1
+
+/* ---------- link callback options ---------- */
+/* LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
+ * whenever the link changes (i.e., link down)
+ */
+#define LWIP_NETIF_LINK_CALLBACK        1
+
+/*
+   --------------------------------------
+   ---------- Checksum options ----------
+   --------------------------------------
+*/
+
+#define LWIP_CHECKSUM_ON_COPY            1
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#define LWIP_NETIF_TX_SINGLE_PBUF    0
+#else
+#define LWIP_NETIF_TX_SINGLE_PBUF    1
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_ETHERNET */
+
+#ifdef CHECKSUM_BY_HARDWARE
+  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 0
+  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                0
+  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                0
+  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               0
+  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              0
+  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              0
+  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               0
+#else
+  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 1
+  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                1
+  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                1
+  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               1
+  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              1
+  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              1
+  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               1
+#endif
+
+
+/*
+   ----------------------------------------------
+   ---------- Sequential layer options ----------
+   ----------------------------------------------
+*/
+#define LWIP_CHKSUM_ALGORITHM 3
+
+/**
+ * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
+ */
+#define LWIP_NETCONN                    1
+
+/*
+   ------------------------------------
+   ---------- Socket options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
+ */
+#define LWIP_SOCKET                     1
+
+/*
+   -----------------------------------
+   ---------- DEBUG options ----------
+   -----------------------------------
+*/
+
+//#define LWIP_DEBUG                      0
+
+/*
+   ---------------------------------
+   ---------- OS options ----------
+   ---------------------------------
+*/
+
+#define TCPIP_THREAD_NAME              "TCP/IP"
+#define TCPIP_THREAD_STACKSIZE          1536
+#define TCPIP_MBOX_SIZE                 50
+#define DEFAULT_UDP_RECVMBOX_SIZE       50
+#define DEFAULT_TCP_RECVMBOX_SIZE       50
+#define DEFAULT_ACCEPTMBOX_SIZE         50
+#define DEFAULT_THREAD_STACKSIZE        500
+#define TCPIP_THREAD_PRIO               (configMAX_PRIORITIES - 2)
+
+#define LWIP_COMPAT_MUTEX               0
+#define LWIP_TCPIP_CORE_LOCKING         1
+#define LWIP_NETCONN_SEM_PER_THREAD     0
+#define LWIP_SOCKET_SET_ERRNO           1
+#define SO_REUSE                        1
+#define LWIP_TCP_KEEPALIVE              1
+
+/*Enable Status callback and link callback*/
+#define LWIP_NETIF_STATUS_CALLBACK      1
+#define LWIP_NETIF_LINK_CALLBACK        1
+/*Enable dns*/
+#define LWIP_DNS                        1
+#define LWIP_DNS_SECURE                 0
+
+#define MEMP_MEM_MALLOC                 0
+#define LWIP_SUPPORT_CUSTOM_PBUF        1
+
+#define PBUF_LINK_ENCAPSULATION_HLEN    48u
+
+#define LWIP_RAW                        1
+
+#define LWIP_IPV4                       1
+#define LWIP_IPV6_DHCP6                 1
+#define LWIP_AUTOIP                     1
+#define LWIP_IPV6_MLD                   1
+#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
+#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+
+#define LWIP_PBUF_FROM_CUSTOM_RAM_HEAP  1
+
+/* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
+#define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
+
+#if ENABLE_OPENTHREAD_BORDER_ROUTER
+#define LWIP_IPV6_SCOPES                0
+
+#define MEMP_NUM_MLD6_GROUP  300
+#define LWIP_SOCKET_MAX_MEMBERSHIPS  300
+#define LWIP_MULTICAST_PING  1
+#define LWIP_NETBUF_RECVINFO  1
+#define LWIP_IPV6_FORWARD  1
+#define LWIP_IPV6_NUM_ADDRESSES  20
+#define DEFAULT_RAW_RECVMBOX_SIZE  64
+#define MEMP_NUM_NETBUF  16
+#define OPENTHREAD_BORDER_ROUTER
+
+#define MEM_SIZE                (32*1024)
+#define MEMP_NUM_UDP_PCB        24
+#define LWIP_HOOK_FILENAME              "otbr_lwip_hooks.h"
+#else
+#define LWIP_IPV6_SCOPES                1
+
+#define MEM_SIZE                (8*1024)
+#define MEMP_NUM_UDP_PCB        8
+#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
+#endif
+
+/*
+   ---------------------------------
+   ---------- MISC. options ----------
+   ---------------------------------
+*/
+
+#if defined(__cplusplus)
+extern "C" int bl_rand(void);
+extern "C" int * __errno(void);
+#else
+extern int bl_rand(void);
+extern int * __errno(void);
+#endif
+
+#define errno (*__errno())
+
+/**
+ * LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS==1: randomize the local port for the first
+ * local TCP/UDP pcb (default==0). This can prevent creating predictable port
+ * numbers after booting a device.
+ */
+
+#define LWIP_RANDOMIZE_INITIAL_LOCAL_PORTS 1
+#define LWIP_RAND() ((u32_t)bl_rand())
+
+#endif /* __LWIPOPTS_H__ */

--- a/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl702/lwipopts/lwipopts.h
@@ -50,10 +50,18 @@
    byte alignment -> define MEM_ALIGNMENT to 2. */
 #define MEM_ALIGNMENT           4
 
+/* MEM_SIZE: the size of the heap memory. If the application will send
+a lot of data that needs to be copied, this should be set high. */
+#define MEM_SIZE                (12*1024)
+
 /* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
    sends a lot of data out of ROM (or other static memory), this
    should be set high. */
 #define MEMP_NUM_PBUF           26
+
+/* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
+   per active UDP "connection". */
+#define MEMP_NUM_UDP_PCB        8
 
 /* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
    connections. */
@@ -72,7 +80,7 @@
 
 /* ---------- Pbuf options ---------- */
 /* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
-#define PBUF_POOL_SIZE          0
+#define PBUF_POOL_SIZE          20
 
 /* ---------- TCP options ---------- */
 #define LWIP_TCP                1
@@ -154,12 +162,6 @@
 /* ---------- Statistics options ---------- */
 #define LWIP_STATS 1
 #define LWIP_PROVIDE_ERRNO 1
-
-/* ---------- link callback options ---------- */
-/* LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
- * whenever the link changes (i.e., link down)
- */
-#define LWIP_NETIF_LINK_CALLBACK        1
 
 /*
    --------------------------------------
@@ -262,6 +264,7 @@
 /*Enable Status callback and link callback*/
 #define LWIP_NETIF_STATUS_CALLBACK      1
 #define LWIP_NETIF_LINK_CALLBACK        1
+
 /*Enable dns*/
 #define LWIP_DNS                        1
 #define LWIP_DNS_SECURE                 0
@@ -278,36 +281,12 @@
 #define LWIP_AUTOIP                     1
 #define LWIP_IPV6_MLD                   1
 #define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  1
-#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
+#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
 
-#define LWIP_PBUF_FROM_CUSTOM_RAM_HEAP  1
+#define LWIP_NETIF_EXT_STATUS_CALLBACK  1
 
 /* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
 #define PBUF_POOL_BUFSIZE               LWIP_MEM_ALIGN_SIZE(TCP_MSS+40+PBUF_LINK_ENCAPSULATION_HLEN+PBUF_LINK_HLEN)
-
-#if ENABLE_OPENTHREAD_BORDER_ROUTER
-#define LWIP_IPV6_SCOPES                0
-
-#define MEMP_NUM_MLD6_GROUP  300
-#define LWIP_SOCKET_MAX_MEMBERSHIPS  300
-#define LWIP_MULTICAST_PING  1
-#define LWIP_NETBUF_RECVINFO  1
-#define LWIP_IPV6_FORWARD  1
-#define LWIP_IPV6_NUM_ADDRESSES  20
-#define DEFAULT_RAW_RECVMBOX_SIZE  64
-#define MEMP_NUM_NETBUF  16
-#define OPENTHREAD_BORDER_ROUTER
-
-#define MEM_SIZE                (32*1024)
-#define MEMP_NUM_UDP_PCB        24
-#define LWIP_HOOK_FILENAME              "otbr_lwip_hooks.h"
-#else
-#define LWIP_IPV6_SCOPES                1
-
-#define MEM_SIZE                (8*1024)
-#define MEMP_NUM_UDP_PCB        8
-#define LWIP_HOOK_FILENAME              "bl_lwip_hooks.h"
-#endif
 
 /*
    ---------------------------------

--- a/examples/platform/bouffalolab/common/route_hook/bl_lwip_hooks.h
+++ b/examples/platform/bouffalolab/common/route_hook/bl_lwip_hooks.h
@@ -1,0 +1,17 @@
+#ifndef _LWIP_DEFAULT_HOOKS_H_
+#define _LWIP_DEFAULT_HOOKS_H_
+#include "lwip/arch.h"
+#include "lwip/err.h"
+#include "lwip/ip_addr.h"
+
+#if BL616_ENABLE
+#include "lwiphooks.h"
+#endif
+
+extern struct netif * lwip_hook_ip6_route(const ip6_addr_t * src, const ip6_addr_t * dest);
+#define LWIP_HOOK_IP6_ROUTE lwip_hook_ip6_route
+
+extern const ip6_addr_t * lwip_hook_nd6_get_gw(struct netif * netif, const ip6_addr_t * dest);
+#define LWIP_HOOK_ND6_GET_GW lwip_hook_nd6_get_gw
+
+#endif /* _LWIP_DEFAULT_HOOKS_H_ */

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -261,5 +261,5 @@ class BouffalolabBuilder(GnBuilder):
         os.system("cp " + ota_images_image + " " + ota_images_dev_image)
 
         logging.info("PostBuild:")
-        logging.info("Bouffalo Lab OTA format image without signature: " +
+        logging.info("Bouffalo Lab unsigned OTA image: " +
                      self.app.AppNamePrefix(self.chip_name) + ".bin.xz.hash is generated.")

--- a/src/inet/TCPEndPointImplLwIP.cpp
+++ b/src/inet/TCPEndPointImplLwIP.cpp
@@ -39,10 +39,8 @@
 
 static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
 
-#if !(CHIP_DEVICE_LAYER_TARGET_BL602 || CHIP_DEVICE_LAYER_TARGET_BL702 || CHIP_DEVICE_LAYER_TARGET_BL702L)
 // TODO: Update to use RunOnTCPIP.
 static_assert(LWIP_TCPIP_CORE_LOCKING, "CHIP requires config LWIP_TCPIP_CORE_LOCKING enabled");
-#endif
 
 namespace chip {
 namespace Inet {

--- a/src/platform/bouffalolab/BL602/wifi_mgmr_portable.c
+++ b/src/platform/bouffalolab/BL602/wifi_mgmr_portable.c
@@ -1,14 +1,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdbool.h>
 
 #include <FreeRTOS.h>
-#include <task.h>
 #include <aos/yloop.h>
 #include <bl60x_wifi_driver/wifi_mgmr.h>
 #include <bl60x_wifi_driver/wifi_mgmr_api.h>
 #include <bl60x_wifi_driver/wifi_mgmr_profile.h>
+#include <task.h>
 
 #include <supplicant_api.h>
 
@@ -174,7 +173,7 @@ void wifi_start_firmware_task(void)
     netif_add_ext_callback(&netifExtCallback, network_netif_ext_callback);
 
     bl_pm_init();
-    xTaskCreateStatic(wifi_main, (char*)"fw", WIFI_STACK_SIZE, NULL, 30, wifi_fw_stack, &wifi_fw_task);
+    xTaskCreateStatic(wifi_main, (char *) "fw", WIFI_STACK_SIZE, NULL, 30, wifi_fw_stack, &wifi_fw_task);
 
     aos_post_event(EV_WIFI, CODE_WIFI_ON_INIT_DONE, 0);
 }

--- a/src/platform/bouffalolab/BL602/wifi_mgmr_portable.c
+++ b/src/platform/bouffalolab/BL602/wifi_mgmr_portable.c
@@ -1,12 +1,15 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdbool.h>
 
+#include <FreeRTOS.h>
+#include <task.h>
 #include <aos/yloop.h>
 #include <bl60x_wifi_driver/wifi_mgmr.h>
 #include <bl60x_wifi_driver/wifi_mgmr_api.h>
 #include <bl60x_wifi_driver/wifi_mgmr_profile.h>
-#include <hal_wifi.h>
+
 #include <supplicant_api.h>
 
 #include <wpa_supplicant/src/utils/common.h>
@@ -163,10 +166,15 @@ static void wifi_event_handler_raw(input_event_t * event, void * private_data)
 
 void wifi_start_firmware_task(void)
 {
-    aos_register_event_filter(EV_WIFI, wifi_event_handler_raw, NULL);
+#define WIFI_STACK_SIZE 1552
+    static StackType_t wifi_fw_stack[WIFI_STACK_SIZE];
+    static StaticTask_t wifi_fw_task;
 
+    aos_register_event_filter(EV_WIFI, wifi_event_handler_raw, NULL);
     netif_add_ext_callback(&netifExtCallback, network_netif_ext_callback);
 
-    hal_wifi_start_firmware_task();
+    bl_pm_init();
+    xTaskCreateStatic(wifi_main, (char*)"fw", WIFI_STACK_SIZE, NULL, 30, wifi_fw_stack, &wifi_fw_task);
+
     aos_post_event(EV_WIFI, CODE_WIFI_ON_INIT_DONE, 0);
 }

--- a/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.h
@@ -19,7 +19,6 @@
 
 #include <pkg_protocol.h>
 #include <platform/NetworkCommissioning.h>
-#include <pkg_protocol.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.h
@@ -19,6 +19,7 @@
 
 #include <pkg_protocol.h>
 #include <platform/NetworkCommissioning.h>
+#include <pkg_protocol.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/third_party/bouffalolab/bl602/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl602/bl_iot_sdk.gni
@@ -843,7 +843,6 @@ template("bl_iot_sdk") {
 
   config("${sdk_target_name}_config_lwip") {
     include_dirs = [
-      "${bl_iot_sdk_root}/components/network/lwip/lwip-port/config",
       "${bl_iot_sdk_root}/components/network/lwip/src/include",
       "${bl_iot_sdk_root}/components/network/lwip/src/include/lwip/apps",
       "${bl_iot_sdk_root}/components/network/lwip/lwip-port",
@@ -852,19 +851,7 @@ template("bl_iot_sdk") {
     ]
 
     defines = [
-      "LWIP_IPV6=1",
-      "LWIP_IPV4=1",
-      "LWIP_IPV6_DHCP6=1",
-      "LWIP_IPV6_SCOPES=0",
-      "LWIP_AUTOIP=1",
-      "LWIP_IPV6_MLD=1",
-      "LWIP_ND6_RDNSS_MAX_DNS_SERVERS=1",
-      "MEMP_NUM_MLD6_GROUP=10",
-      "PBUF_POOL_SIZE=20",
-      "PBUF_POOL_BUFSIZE=1600",
-      "MEMP_NUM_UDP_PCB=8",
-      "LWIP_NETIF_EXT_STATUS_CALLBACK",
-      "LWIP_HOOK_FILENAME=\"bl_route_hook.h\"",
+      "LWIP_IPV6=1"
     ]
   }
 

--- a/third_party/bouffalolab/bl602/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl602/bl_iot_sdk.gni
@@ -850,9 +850,7 @@ template("bl_iot_sdk") {
       "${bl_iot_sdk_root}/components/network/lwip/lwip-port/hook",
     ]
 
-    defines = [
-      "LWIP_IPV6=1"
-    ]
+    defines = [ "LWIP_IPV6=1" ]
   }
 
   source_set("${sdk_target_name}_lwip") {
@@ -969,8 +967,9 @@ template("bl_iot_sdk") {
       ":${sdk_target_name}_wifi",
     ]
 
-    if (defined(invoker.chip_enable_factory_data) && invoker.chip_enable_factory_data) {
-        public_deps += [":${sdk_target_name}_factory_data"]
+    if (defined(invoker.chip_enable_factory_data) &&
+        invoker.chip_enable_factory_data) {
+      public_deps += [ ":${sdk_target_name}_factory_data" ]
     }
   }
 }

--- a/third_party/bouffalolab/bl602/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl602/bl_iot_sdk.gni
@@ -957,7 +957,6 @@ template("bl_iot_sdk") {
       ":${sdk_target_name}_bl602_freertos",
       ":${sdk_target_name}_blcrypto_suite",
       ":${sdk_target_name}_ble",
-      ":${sdk_target_name}_factory_data",
       ":${sdk_target_name}_fs",
       ":${sdk_target_name}_hosal",
       ":${sdk_target_name}_libc",
@@ -969,5 +968,9 @@ template("bl_iot_sdk") {
       ":${sdk_target_name}_utils",
       ":${sdk_target_name}_wifi",
     ]
+
+    if (defined(invoker.chip_enable_factory_data) && invoker.chip_enable_factory_data) {
+        public_deps += [":${sdk_target_name}_factory_data"]
+    }
   }
 }

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -835,9 +835,7 @@ template("bl_iot_sdk") {
   }
 
   config("${sdk_target_name}_config_lwip") {
-    include_dirs = [
-      "${bl_iot_sdk_root}/components/network/lwip/lwip-port",
-    ]
+    include_dirs = [ "${bl_iot_sdk_root}/components/network/lwip/lwip-port" ]
 
     include_dirs += [
       "${bl_iot_sdk_root}/components/network/lwip/src/include",
@@ -847,9 +845,7 @@ template("bl_iot_sdk") {
       "${bl_iot_sdk_root}/components/network/lwip/lwip-port/hook",
     ]
 
-    defines = [
-      "LWIP_IPV6=1",
-    ]
+    defines = [ "LWIP_IPV6=1" ]
   }
 
   source_set("${sdk_target_name}_lwip") {

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -837,7 +837,6 @@ template("bl_iot_sdk") {
   config("${sdk_target_name}_config_lwip") {
     include_dirs = [
       "${bl_iot_sdk_root}/components/network/lwip/lwip-port",
-      "${bl_iot_sdk_root}/components/network/lwip/lwip-port/config",
     ]
 
     include_dirs += [
@@ -849,16 +848,7 @@ template("bl_iot_sdk") {
     ]
 
     defines = [
-      "CFG_ETHERNET_ENABLE=1",
       "LWIP_IPV6=1",
-      "LWIP_IPV4=1",
-      "LWIP_IPV6_DHCP6=1",
-      "LWIP_IPV6_SCOPES=0",
-      "PBUF_POOL_SIZE=20",
-      "PBUF_POOL_BUFSIZE=1600",
-      "MEMP_NUM_UDP_PCB=8",
-      "LWIP_NETIF_EXT_STATUS_CALLBACK",
-      "LWIP_HOOK_FILENAME=\"bl_route_hook.h\"",
     ]
   }
 


### PR DESCRIPTION
- Extract lwipopts.h from SDK for bl602 wifi and bl706 wifi/ethernet platform currently
- Enable LWIP_TCPIP_CORE_LOCKING for bl602 wifi and bl706 wifi/ethernet platform
- Enable LWIP_TCPIP_CORE_LOCKING check assert for bouffalolab platform 