### PR TITLE
[Bouffalolab] Update docker image to upgrade flash-tool

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-12 : [Telink] Update Docker image (Zephyr update)
+13 : [Bouffalolab] Update bflb-iot-tool to 1.8.6

--- a/integrations/docker/images/stage-2/chip-build-bouffalolab/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-bouffalolab/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN apt update -y \
     && apt install vim -fy \
     && apt clean \
-    && pip3 install bflb-iot-tool \
+    && pip3 install bflb-iot-tool==1.8.6 \
     && : # last line
 
 COPY setup.sh /tmp

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -90,7 +90,7 @@ RUN set -x \
 
 # Required for the Bouffalolab platform
 RUN set -x \
-    && pip3 install bflb-iot-tool \
+    && pip3 install bflb-iot-tool==1.8.6 \
     && : # last line
 
 ENV PATH $PATH:/usr/lib/kotlinc/bin


### PR DESCRIPTION
Update docker image to upgrade flash-tool, bflb-iot-tool==1.8.6
