### PR TITLE
[ESP32] Add an API to get MAC address of ethernet device

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -31,6 +31,9 @@
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#include "esp_mac.h"
+#endif
 #include "esp_ota_ops.h"
 #include "esp_phy_init.h"
 #include "esp_wifi.h"
@@ -261,6 +264,31 @@ CHIP_ERROR ConfigurationManagerImpl::StoreCountryCode(const char * code, size_t 
     // CountryCode then we read from NVS
     return GenericConfigurationManagerImpl<ESP32Config>::StoreCountryCode(code, codeLen);
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan buf)
+{
+    if (GetPrimaryEthernetMACAddress(buf) == CHIP_NO_ERROR)
+    {
+        ChipLogDetail(DeviceLayer, "Using Ethernet MAC for hostname.");
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryEthernetMACAddress(MutableByteSpan buf)
+{
+    if (buf.size() < ConfigurationManager::kPrimaryMACAddressLength)
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+
+    memset(buf.data(), 0, buf.size());
+
+    esp_err_t err = esp_read_mac(buf.data(), ESP_MAC_ETH);
+    buf.reduce_size(ConfigurationManager::kPrimaryMACAddressLength);
+    return MapConfigError(err);
+}
+#endif
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -66,6 +66,10 @@ private:
     // ===== Members that implement the ConfigurationManager public interface.
 
     CHIP_ERROR Init(void) override;
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
+    CHIP_ERROR GetPrimaryEthernetMACAddress(MutableByteSpan buf);
+#endif
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;


### PR DESCRIPTION
- Ethernet device fails to get PrimaryMACAddress as there is no default implementation of `GetPrimaryMACAddress` in connectedhomeip for ethernet
- This PR adds the `GetPrimaryMACAddress` for ethernet