### PR TITLE
Fix IPAddress Type mismatch between echo-requester and echo-responder.

### DIFF
--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -217,6 +217,12 @@ int main(int argc, char * argv[])
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
+    if (gDestAddr.Type() != chip::Inet::IPAddressType::kIPv6)
+    {
+        printf("Echo Server IP address: %s is not of type IPv6\n", argv[1]);
+        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
     InitializeChip();
 
     if (gUseTCP)
@@ -264,6 +270,11 @@ int main(int argc, char * argv[])
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
     gUDPManager.Close();
+
+    if (gUseTCP)
+    {
+        gTCPManager.Disconnect(chip::Transport::PeerAddress::TCP(gDestAddr));
+    }
     gTCPManager.Close();
 
     Shutdown();

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -84,12 +84,7 @@ int main(int argc, char * argv[])
     if (useTCP)
     {
         err = gTCPManager.Init(chip::Transport::TcpListenParameters(chip::DeviceLayer::TCPEndPointManager())
-#if INET_CONFIG_ENABLE_IPV4
-                                   .SetAddressType(chip::Inet::IPAddressType::kIPv4)
-#else
-                                   .SetAddressType(chip::Inet::IPAddressType::kIPv6)
-#endif
-        );
+                                   .SetAddressType(chip::Inet::IPAddressType::kIPv6));
         SuccessOrExit(err);
 
         err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager, &gStorage,


### PR DESCRIPTION
When using TCP, the echo-server was listening over IPv4 while the echo-requester was getting configured for IPv6.

Normalize both sides to always use IPv6 over both TCP or MRP.
