### PR TITLE
[TC-DRLK-2.12] Bugfix: fix crash when testing against DUT that does not support PIN's

### DIFF
--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -144,8 +144,8 @@ class DRLK_COMMON:
             logging.info("Credential created at CredentialIndex %d, UserIndex %d." % (credentialIndex, ret.userIndex))
             self.createdCredential = credential
 
+        requirePinForRemoteOperation_dut = False
         if self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F07"):
-            requirePinForRemoteOperation_dut = False
             self.print_step("1", "TH writes the RequirePINforRemoteOperation attribute value as false on the DUT")
             attribute = attributes.RequirePINforRemoteOperation(False)
             if self.check_pics("DRLK.S.M.RequirePINForRemoteOperationAttributeWritable"):


### PR DESCRIPTION
[TC-DRLK-2.12] Bugfix: fix crash when testing against DUT that does not support PIN's

Fixes https://github.com/CHIP-Specifications/chip-test-scripts/issues/670
