### PR TITLE
Timesync: Force call to delegate so we get time source

### DIFF
--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -464,13 +464,10 @@ void TimeSynchronizationServer::Init()
     {
         ClearDSTOffset();
     }
-    System::Clock::Microseconds64 utcTime;
 
-    if (System::SystemClock().GetClock_RealTime(utcTime) == CHIP_NO_ERROR &&
-        !RuntimeOptionsProvider::Instance().GetSimulateNoInternalTime())
-    {
-        mGranularity = GranularityEnum::kMinutesGranularity;
-    }
+    // Set the granularity to none for now - this will force us to go to the delegate so it can
+    // properly report the time source
+    mGranularity = GranularityEnum::kNoTimeGranularity;
 
     // This can error, but it's not clear what should happen in this case. For now, just ignore it because we still
     // want time sync even if we can't register the deletgate here.


### PR DESCRIPTION
The initial time source does not get set correctly currently. Rather than guessing, if we just call the delegate, it will call the appropriate callback to set the granularity and time source correctly.

