### PR TITLE
Correct name of args variable

### DIFF
--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -107,7 +107,7 @@ elif (len(certificateAuthorityManager.activeCaList[0].adminList) == 0):
 
 caList = certificateAuthorityManager.activeCaList
 
-devCtrl = caList[0].adminList[0].NewController(paaTrustStorePath=args.trustStore)
+devCtrl = caList[0].adminList[0].NewController(paaTrustStorePath=args.trust_store)
 builtins.devCtrl = devCtrl
 
 atexit.register(StackShutdown)


### PR DESCRIPTION
Fixes: #29374

`argparse` is taking argument `--trust-store` which should be `args.trust_store` and not `args.trustStore`

Test: From a fresh repo
```
source scripts/bootstrap.sh
source scripts/activate.sh
scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv -d true'
source out/venv/bin/activate
chip-repl
```

Confirm no longer hitting error described in issue