### PR TITLE
tv-casting-app: Added WakeOnLAN support

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DiscoveredNodeData.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DiscoveredNodeData.java
@@ -106,6 +106,19 @@ public class DiscoveredNodeData {
     this.numIPs = 1;
   }
 
+  public DiscoveredNodeData(VideoPlayer player) {
+    this.connectableVideoPlayer = player;
+    this.instanceName = player.getInstanceName();
+    this.hostName = player.getHostName();
+    this.deviceName = player.getDeviceName();
+    this.deviceType = player.getDeviceType();
+    this.vendorId = player.getVendorId();
+    this.productId = player.getProductId();
+    this.numIPs = player.getNumIPs();
+    this.ipAddresses = player.getIpAddresses();
+    this.port = player.getPort();
+  }
+
   void setConnectableVideoPlayer(VideoPlayer videoPlayer) {
     this.connectableVideoPlayer = videoPlayer;
   }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdResolveListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdResolveListener.java
@@ -149,6 +149,9 @@ public class NsdResolveListener implements NsdManager.ResolveListener {
               TAG,
               "Matching Video Player with the following information found for DiscoveredNodeData"
                   + videoPlayer);
+          long currentUnixTimeMS = System.currentTimeMillis();
+          Log.d(TAG, "Updating discovery timestamp for VideoPlayer to " + currentUnixTimeMS);
+          videoPlayer.setLastDiscoveredMs(currentUnixTimeMS);
           discoveredNodeData.setConnectableVideoPlayer(videoPlayer);
           return;
         }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -29,8 +29,13 @@ import chip.platform.DiagnosticDataProviderImpl;
 import chip.platform.NsdManagerServiceBrowser;
 import chip.platform.NsdManagerServiceResolver;
 import chip.platform.PreferencesKeyValueStoreManager;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class TvCastingApp {
   private static final String TAG = TvCastingApp.class.getSimpleName();
@@ -38,12 +43,18 @@ public class TvCastingApp {
   private static final List<Long> DISCOVERY_TARGET_DEVICE_TYPE_FILTER =
       Arrays.asList(35L); // Video player = 35;
 
+  // delay before which we assume undiscovered cached players may be in STR mode
+  private static final long CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC = 5;
+
   private static TvCastingApp sInstance;
   private Context applicationContext;
   private ChipAppServer chipAppServer;
   private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
   private boolean discoveryStarted = false;
   private Object discoveryLock = new Object();
+
+  private List<DiscoveredNodeData> discoveredPlayers;
+  private ScheduledFuture<?> reportSleepingVideoPlayerCommissionersFuture;
 
   private WifiManager.MulticastLock multicastLock;
   private NsdManager nsdManager;
@@ -136,22 +147,126 @@ public class TvCastingApp {
       multicastLock.acquire();
 
       nsdManager = (NsdManager) applicationContext.getSystemService(Context.NSD_SERVICE);
+      discoveredPlayers = new ArrayList<>();
       nsdDiscoveryListener =
           new NsdDiscoveryListener(
               nsdManager,
               DISCOVERY_TARGET_SERVICE_TYPE,
               DISCOVERY_TARGET_DEVICE_TYPE_FILTER,
               preCommissionedVideoPlayers,
-              discoverySuccessCallback,
+              new SuccessCallback<DiscoveredNodeData>() {
+                @Override
+                public void handle(DiscoveredNodeData commissioner) {
+                  Log.d(TAG, "Discovered commissioner added " + commissioner);
+                  discoveredPlayers.add(commissioner);
+                  discoverySuccessCallback.handle(commissioner);
+                }
+              },
               discoveryFailureCallback,
               nsdManagerResolverAvailState);
 
       nsdManager.discoverServices(
           DISCOVERY_TARGET_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, nsdDiscoveryListener);
       Log.d(TAG, "TvCastingApp.discoverVideoPlayerCommissioners started");
+
+      /**
+       * Surface players (as DiscoveredNodeData objects on discoverySuccessCallback) that we
+       * previously connected to and received their WakeOnLAN MACAddress, but could not discover
+       * over DNS-SD this time in CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC. This API will also
+       * ensure that the reported players were previously discoverable within
+       * CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS.
+       *
+       * <p>The DiscoveredNodeData object for such players will have the IsAsleep attribute set to
+       * true, which can optionally be used for any special UX treatment when displaying them.
+       *
+       * <p>Surfacing such players as discovered will allow displaying them to the user, who may
+       * want to cast to them. In such a case, the VerifyOrEstablishConnection API will turn them on
+       * over WakeOnLan.
+       */
+      this.reportSleepingVideoPlayerCommissionersFuture =
+          Executors.newScheduledThreadPool(1)
+              .schedule(
+                  () -> {
+                    Log.d(
+                        TAG,
+                        "Scheduling reportSleepingCommissioners with commissioner count "
+                            + (preCommissionedVideoPlayers != null
+                                ? preCommissionedVideoPlayers.size()
+                                : 0));
+                    reportSleepingVideoPlayerCommissioners(
+                        preCommissionedVideoPlayers, discoverySuccessCallback);
+                  },
+                  CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC * 1000,
+                  TimeUnit.MILLISECONDS);
+
       this.discoveryStarted = true;
     }
   }
+
+  private void reportSleepingVideoPlayerCommissioners(
+      List<VideoPlayer> cachedVideoPlayers,
+      SuccessCallback<DiscoveredNodeData> discoverySuccessCallback) {
+    Log.d(
+        TAG,
+        "TvCastingApp.reportSleepingVideoPlayerCommissioners called with commissioner count "
+            + (cachedVideoPlayers != null ? cachedVideoPlayers.size() : 0));
+    if (cachedVideoPlayers == null) {
+      Log.d(TAG, "No cached video players available.");
+      return;
+    }
+
+    for (VideoPlayer player : cachedVideoPlayers) {
+      Log.d(TAG, "Cached Video Player: " + player);
+      // do NOT surface this cached Player if we don't have its MACAddress
+      if (player.getMACAddress() == null) {
+        Log.d(
+            TAG,
+            "TvCastingApp.reportSleepingVideoPlayerCommissioners Skipping Player with hostName"
+                + player.getHostName()
+                + " but no MACAddress");
+        continue;
+      }
+
+      // do NOT surface this cached Player if it has not been discoverable recently (in
+      // CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS)
+      if (!WasRecentlyDiscoverable(player)) {
+        Log.d(
+            TAG,
+            "TvCastingApp.reportSleepingVideoPlayerCommissioners Skipping Player with hostName"
+                + player.getHostName()
+                + " that has not been discovered recently");
+        continue;
+      }
+
+      // do NOT surface this cached Player if it was just discovered right now (in this discovery
+      // call)
+      boolean justDiscovered =
+          discoveredPlayers
+              .stream()
+              .anyMatch(
+                  new Predicate<DiscoveredNodeData>() {
+                    @Override
+                    public boolean test(DiscoveredNodeData discoveredNodeData) {
+                      return player.getHostName().equals(discoveredNodeData.getHostName());
+                    }
+                  });
+      if (justDiscovered) {
+        Log.d(
+            TAG,
+            "TvCastingApp.reportSleepingVideoPlayerCommissioners Skipping Player with hostName"
+                + player.getHostName()
+                + " that was just discovered");
+        continue;
+      }
+
+      // DO surface this cached Player (as asleep)
+      Log.d(TAG, "Reporting sleeping player with hostName " + player.getHostName());
+      player.setIsAsleep(true);
+      discoverySuccessCallback.handle(new DiscoveredNodeData(player));
+    }
+  }
+
+  private native boolean WasRecentlyDiscoverable(VideoPlayer player);
 
   public void stopVideoPlayerDiscovery() {
     synchronized (discoveryLock) {
@@ -172,6 +287,10 @@ public class TvCastingApp {
 
         if (multicastLock.isHeld()) {
           multicastLock.release();
+        }
+
+        if (reportSleepingVideoPlayerCommissionersFuture != null) {
+          reportSleepingVideoPlayerCommissionersFuture.cancel(false);
         }
         this.discoveryStarted = false;
       }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/VideoPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/VideoPlayer.java
@@ -38,6 +38,11 @@ public class VideoPlayer {
   private int numIPs;
   private List<InetAddress> ipAddresses;
   private String hostName;
+  private String instanceName;
+  private long lastDiscoveredMs;
+  private String MACAddress;
+  private boolean isAsleep = false;
+  private int port;
 
   private boolean isInitialized = false;
 
@@ -52,6 +57,11 @@ public class VideoPlayer {
       int numIPs,
       List<InetAddress> ipAddresses,
       String hostName,
+      String instanceName,
+      int port,
+      long lastDiscoveredMs,
+      String MACAddress,
+      boolean isAsleep,
       boolean isConnected) {
     this.nodeId = nodeId;
     this.fabricIndex = fabricIndex;
@@ -64,6 +74,11 @@ public class VideoPlayer {
     this.numIPs = numIPs;
     this.ipAddresses = ipAddresses;
     this.hostName = hostName;
+    this.MACAddress = MACAddress;
+    this.lastDiscoveredMs = lastDiscoveredMs;
+    this.instanceName = instanceName;
+    this.port = port;
+    this.isAsleep = isAsleep;
     this.isInitialized = true;
   }
 
@@ -116,8 +131,8 @@ public class VideoPlayer {
     return Objects.hash(super.hashCode(), nodeId, fabricIndex);
   }
 
-  @java.lang.Override
-  public java.lang.String toString() {
+  @Override
+  public String toString() {
     return "VideoPlayer{"
         + "nodeId="
         + nodeId
@@ -140,10 +155,22 @@ public class VideoPlayer {
         + numIPs
         + ", ipAddresses="
         + ipAddresses
-        + ", isInitialized="
         + ", hostName='"
         + hostName
         + '\''
+        + ", instanceName='"
+        + instanceName
+        + '\''
+        + ", lastDiscoveredMs="
+        + lastDiscoveredMs
+        + ", MACAddress='"
+        + MACAddress
+        + '\''
+        + ", isAsleep="
+        + isAsleep
+        + ", port="
+        + port
+        + ", isInitialized="
         + isInitialized
         + '}';
   }
@@ -178,6 +205,46 @@ public class VideoPlayer {
 
   public int getDeviceType() {
     return deviceType;
+  }
+
+  public int getNumIPs() {
+    return numIPs;
+  }
+
+  public List<InetAddress> getIpAddresses() {
+    return ipAddresses;
+  }
+
+  public String getHostName() {
+    return hostName;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public long getLastDiscoveredMs() {
+    return lastDiscoveredMs;
+  }
+
+  public void setLastDiscoveredMs(long lastDiscoveredMs) {
+    this.lastDiscoveredMs = lastDiscoveredMs;
+  }
+
+  public String getMACAddress() {
+    return MACAddress;
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public void setIsAsleep(boolean asleep) {
+    isAsleep = asleep;
+  }
+
+  public boolean isAsleep() {
+    return isAsleep;
   }
 
   public boolean isInitialized() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -162,17 +162,21 @@ CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, Targe
 
     jfieldID getInstanceNameField = env->GetFieldID(jVideoPlayerClass, "instanceName", "Ljava/lang/String;");
     jstring jInstanceName         = static_cast<jstring>(env->GetObjectField(videoPlayer, getInstanceNameField));
-    const char * instanceName     = env->GetStringUTFChars(jInstanceName, 0);
+    const char * instanceName     = {};
+    if (jInstanceName != nullptr)
+    {
+        instanceName = env->GetStringUTFChars(jInstanceName, 0);
+    }
 
     jfieldID jLastDiscoveredMs = env->GetFieldID(jVideoPlayerClass, "lastDiscoveredMs", "J");
     long lastDiscoveredMs      = static_cast<long>(env->GetLongField(videoPlayer, jLastDiscoveredMs));
 
     jfieldID getMACAddressField = env->GetFieldID(jVideoPlayerClass, "MACAddress", "Ljava/lang/String;");
     jstring jMACAddress         = static_cast<jstring>(env->GetObjectField(videoPlayer, getMACAddressField));
-    const char * MACAddress     = env->GetStringUTFChars(jMACAddress, 0);
+    const char * MACAddress     = jMACAddress == nullptr ? nullptr : env->GetStringUTFChars(jMACAddress, 0);
 
     jfieldID jIsAsleep = env->GetFieldID(jVideoPlayerClass, "isAsleep", "Z");
-    bool isAsleep      = static_cast<bool>(env->GetLongField(videoPlayer, jIsAsleep));
+    bool isAsleep      = static_cast<bool>(env->GetBooleanField(videoPlayer, jIsAsleep));
 
     outTargetVideoPlayerInfo.Initialize(nodeId, fabricIndex, nullptr, nullptr, vendorId, productId, deviceType, deviceName,
                                         hostName, 0, nullptr, port, instanceName, chip::System::Clock::Timestamp(lastDiscoveredMs));

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -223,9 +223,9 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
         jclass jVideoPlayerClass;
         ReturnErrorOnFailure(
             chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
-        jmethodID jVideoPlayerConstructor = env->GetMethodID(
-            jVideoPlayerClass, "<init>",
-            "(JBLjava/lang/String;IIILjava/util/List;ILjava/util/List;Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Z)V");
+        jmethodID jVideoPlayerConstructor = env->GetMethodID(jVideoPlayerClass, "<init>",
+                                                             "(JBLjava/lang/String;IIILjava/util/List;ILjava/util/List;Ljava/lang/"
+                                                             "String;Ljava/lang/String;IJLjava/lang/String;ZZ)V");
 
         jobject jContentAppList        = nullptr;
         TargetEndpointInfo * endpoints = targetVideoPlayerInfo->GetEndpoints();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -21,6 +21,8 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
+#include <string.h>
+#include <system/SystemClock.h>
 
 CHIP_ERROR convertJAppParametersToCppAppParams(jobject appParameters, AppParams & outAppParams)
 {
@@ -155,8 +157,33 @@ CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, Targe
     jstring jHostName         = static_cast<jstring>(env->GetObjectField(videoPlayer, getHostNameField));
     const char * hostName     = env->GetStringUTFChars(jHostName, 0);
 
+    jfieldID jPort = env->GetFieldID(jVideoPlayerClass, "port", "I");
+    uint16_t port  = static_cast<uint16_t>(env->GetIntField(videoPlayer, jPort));
+
+    jfieldID getInstanceNameField = env->GetFieldID(jVideoPlayerClass, "instanceName", "Ljava/lang/String;");
+    jstring jInstanceName         = static_cast<jstring>(env->GetObjectField(videoPlayer, getInstanceNameField));
+    const char * instanceName     = env->GetStringUTFChars(jInstanceName, 0);
+
+    jfieldID jLastDiscoveredMs = env->GetFieldID(jVideoPlayerClass, "lastDiscoveredMs", "J");
+    long lastDiscoveredMs      = static_cast<long>(env->GetLongField(videoPlayer, jLastDiscoveredMs));
+
+    jfieldID getMACAddressField = env->GetFieldID(jVideoPlayerClass, "MACAddress", "Ljava/lang/String;");
+    jstring jMACAddress         = static_cast<jstring>(env->GetObjectField(videoPlayer, getMACAddressField));
+    const char * MACAddress     = env->GetStringUTFChars(jMACAddress, 0);
+
+    jfieldID jIsAsleep = env->GetFieldID(jVideoPlayerClass, "isAsleep", "Z");
+    bool isAsleep      = static_cast<bool>(env->GetLongField(videoPlayer, jIsAsleep));
+
     outTargetVideoPlayerInfo.Initialize(nodeId, fabricIndex, nullptr, nullptr, vendorId, productId, deviceType, deviceName,
-                                        hostName);
+                                        hostName, 0, nullptr, port, instanceName, chip::System::Clock::Timestamp(lastDiscoveredMs));
+
+    if (MACAddress != nullptr)
+    {
+        chip::CharSpan MACAddressSpan(MACAddress, strlen(MACAddress) - 1);
+        outTargetVideoPlayerInfo.SetMACAddress(MACAddressSpan);
+    }
+
+    outTargetVideoPlayerInfo.SetIsAsleep(isAsleep);
 
     jfieldID jContentAppsField = env->GetFieldID(jVideoPlayerClass, "contentApps", "Ljava/util/List;");
     jobject jContentApps       = env->GetObjectField(videoPlayer, jContentAppsField);
@@ -197,7 +224,8 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
         ReturnErrorOnFailure(
             chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
         jmethodID jVideoPlayerConstructor = env->GetMethodID(
-            jVideoPlayerClass, "<init>", "(JBLjava/lang/String;IIILjava/util/List;ILjava/util/List;Ljava/lang/String;Z)V");
+            jVideoPlayerClass, "<init>",
+            "(JBLjava/lang/String;IIILjava/util/List;ILjava/util/List;Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Z)V");
 
         jobject jContentAppList        = nullptr;
         TargetEndpointInfo * endpoints = targetVideoPlayerInfo->GetEndpoints();
@@ -217,6 +245,20 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
 
         jstring hostName =
             targetVideoPlayerInfo->GetHostName() == nullptr ? nullptr : env->NewStringUTF(targetVideoPlayerInfo->GetHostName());
+
+        jstring instanceName = targetVideoPlayerInfo->GetInstanceName() == nullptr
+            ? nullptr
+            : env->NewStringUTF(targetVideoPlayerInfo->GetInstanceName());
+
+        jstring MACAddress = nullptr;
+        if (targetVideoPlayerInfo->GetMACAddress() != nullptr && targetVideoPlayerInfo->GetMACAddress()->data() != nullptr)
+        {
+            char MACAddressWithNil[2 * chip::DeviceLayer::ConfigurationManager::kMaxMACAddressLength + 1];
+            strncpy(MACAddressWithNil, targetVideoPlayerInfo->GetMACAddress()->data(),
+                    targetVideoPlayerInfo->GetMACAddress()->size());
+            MACAddressWithNil[targetVideoPlayerInfo->GetMACAddress()->size()] = '\0';
+            MACAddress                                                        = env->NewStringUTF(MACAddressWithNil);
+        }
 
         jobject jIPAddressList                    = nullptr;
         const chip::Inet::IPAddress * ipAddresses = targetVideoPlayerInfo->GetIpAddresses();
@@ -240,11 +282,12 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
             }
         }
 
-        outVideoPlayer = env->NewObject(jVideoPlayerClass, jVideoPlayerConstructor, targetVideoPlayerInfo->GetNodeId(),
-                                        targetVideoPlayerInfo->GetFabricIndex(), deviceName, targetVideoPlayerInfo->GetVendorId(),
-                                        targetVideoPlayerInfo->GetProductId(), targetVideoPlayerInfo->GetDeviceType(),
-                                        jContentAppList, targetVideoPlayerInfo->GetNumIPs(), jIPAddressList, hostName,
-                                        targetVideoPlayerInfo->GetOperationalDeviceProxy() != nullptr);
+        outVideoPlayer = env->NewObject(
+            jVideoPlayerClass, jVideoPlayerConstructor, targetVideoPlayerInfo->GetNodeId(), targetVideoPlayerInfo->GetFabricIndex(),
+            deviceName, targetVideoPlayerInfo->GetVendorId(), targetVideoPlayerInfo->GetProductId(),
+            targetVideoPlayerInfo->GetDeviceType(), jContentAppList, targetVideoPlayerInfo->GetNumIPs(), jIPAddressList, hostName,
+            instanceName, targetVideoPlayerInfo->GetPort(), targetVideoPlayerInfo->GetLastDiscovered().count(), MACAddress,
+            targetVideoPlayerInfo->IsAsleep(), targetVideoPlayerInfo->GetOperationalDeviceProxy() != nullptr);
     }
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -243,13 +243,13 @@ JNI_METHOD(jobject, readCachedVideoPlayers)(JNIEnv * env, jobject)
     return jVideoPlayerList;
 }
 
-JNI_METHOD(jboolean, verifyOrEstablishConnection)
+JNI_METHOD(jboolean, _1verifyOrEstablishConnection)
 (JNIEnv * env, jobject, jobject videoPlayer, jobject jOnConnectionSuccessHandler, jobject jOnConnectionFailureHandler,
  jobject jOnNewOrUpdatedEndpointHandler)
 {
     chip::DeviceLayer::StackLock lock;
 
-    ChipLogProgress(AppServer, "JNI_METHOD verifyOrEstablishConnection called");
+    ChipLogProgress(AppServer, "JNI_METHOD _1verifyOrEstablishConnection called");
 
     TargetVideoPlayerInfo targetVideoPlayerInfo;
     CHIP_ERROR err = convertJVideoPlayerToTargetVideoPlayerInfo(videoPlayer, targetVideoPlayerInfo);
@@ -276,10 +276,29 @@ JNI_METHOD(jboolean, verifyOrEstablishConnection)
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getOnConnectionFailureHandler(true).Handle(err); },
         [](TargetEndpointInfo * endpoint) { TvCastingAppJNIMgr().getOnNewOrUpdatedEndpointHandler(true).Handle(endpoint); });
     VerifyOrExit(CHIP_NO_ERROR == err,
-                 ChipLogError(AppServer, "CastingServer::verifyOrEstablishConnection failed: %" CHIP_ERROR_FORMAT, err.Format()));
+                 ChipLogError(AppServer, "CastingServer::_1verifyOrEstablishConnection failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
     return (err == CHIP_NO_ERROR);
+}
+
+JNI_METHOD(jboolean, WasRecentlyDiscoverable)
+(JNIEnv * env, jobject, jobject videoPlayer)
+{
+    chip::DeviceLayer::StackLock lock;
+
+    ChipLogProgress(AppServer, "JNI_METHOD WasRecentlyDiscoverable called");
+
+    TargetVideoPlayerInfo targetVideoPlayerInfo;
+    CHIP_ERROR err = convertJVideoPlayerToTargetVideoPlayerInfo(videoPlayer, targetVideoPlayerInfo);
+    VerifyOrExit(err == CHIP_NO_ERROR,
+                 ChipLogError(AppServer,
+                              "Conversion from jobject VideoPlayer to TargetVideoPlayerInfo * failed: %" CHIP_ERROR_FORMAT,
+                              err.Format()));
+    return targetVideoPlayerInfo.WasRecentlyDiscoverable();
+
+exit:
+    return false; // default to false
 }
 
 JNI_METHOD(void, shutdownAllSubscriptions)(JNIEnv * env, jobject)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -243,13 +243,13 @@ JNI_METHOD(jobject, readCachedVideoPlayers)(JNIEnv * env, jobject)
     return jVideoPlayerList;
 }
 
-JNI_METHOD(jboolean, _1verifyOrEstablishConnection)
+JNI_METHOD(jboolean, verifyOrEstablishConnection)
 (JNIEnv * env, jobject, jobject videoPlayer, jobject jOnConnectionSuccessHandler, jobject jOnConnectionFailureHandler,
  jobject jOnNewOrUpdatedEndpointHandler)
 {
     chip::DeviceLayer::StackLock lock;
 
-    ChipLogProgress(AppServer, "JNI_METHOD _1verifyOrEstablishConnection called");
+    ChipLogProgress(AppServer, "JNI_METHOD verifyOrEstablishConnection called");
 
     TargetVideoPlayerInfo targetVideoPlayerInfo;
     CHIP_ERROR err = convertJVideoPlayerToTargetVideoPlayerInfo(videoPlayer, targetVideoPlayerInfo);
@@ -276,7 +276,7 @@ JNI_METHOD(jboolean, _1verifyOrEstablishConnection)
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getOnConnectionFailureHandler(true).Handle(err); },
         [](TargetEndpointInfo * endpoint) { TvCastingAppJNIMgr().getOnNewOrUpdatedEndpointHandler(true).Handle(endpoint); });
     VerifyOrExit(CHIP_NO_ERROR == err,
-                 ChipLogError(AppServer, "CastingServer::_1verifyOrEstablishConnection failed: %" CHIP_ERROR_FORMAT, err.Format()));
+                 ChipLogError(AppServer, "CastingServer::verifyOrEstablishConnection failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
     return (err == CHIP_NO_ERROR);

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
@@ -21,6 +21,7 @@
 
 #import "ConversionUtils.hpp"
 #include <controller/DeviceDiscoveryDelegate.h>
+#include <system/SystemClock.h>
 
 class CommissionerDiscoveryDelegateImpl : public chip::Controller::DeviceDiscoveryDelegate {
 public:
@@ -31,6 +32,33 @@ public:
         mClientQueue = clientQueue;
         mObjCDiscoveredCommissionerHandler = objCDiscoveredCommissionerHandler;
         mCachedTargetVideoPlayerInfos = cachedTargetVideoPlayerInfos;
+        mDiscoveredCommissioners.clear();
+
+        /**
+         * Surface players (as DiscoveredNodeData objects on discoverySuccessCallback) that we previously
+         * connected to and received their WakeOnLAN MACAddress, but could not discover over DNS-SD this time in
+         * CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC. This API will also ensure that the reported players
+         * were previously discoverable within CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS.
+         *
+         * The DiscoveredNodeData object for such players will have the IsAsleep attribute set to true,
+         * which can optionally be used for any special UX treatment when displaying them.
+         *
+         * Surfacing such players as discovered will allow displaying them to the user, who may want to
+         * cast to them. In such a case, the VerifyOrEstablishConnection API will turn them on over
+         * WakeOnLan.
+         */
+        chip::DeviceLayer::SystemLayer().CancelTimer(
+            ReportSleepingCommissioners, this); // cancel preexisting timer for ReportSleepingCommissioners, if any
+        if (mCachedTargetVideoPlayerInfos != nullptr && mCachedTargetVideoPlayerInfos[0].IsInitialized()) {
+            chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(
+#ifdef CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC
+                                                            CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC
+#else
+                                                            0
+#endif
+                                                            * 1000),
+                ReportSleepingCommissioners, this);
+        }
     }
 
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
@@ -39,11 +67,20 @@ public:
         __block const chip::Dnssd::DiscoveredNodeData cppNodeData = nodeData;
         dispatch_async(mClientQueue, ^{
             DiscoveredNodeData * objCDiscoveredNodeData = [ConversionUtils convertToObjCDiscoveredNodeDataFrom:&cppNodeData];
+            mDiscoveredCommissioners.push_back(objCDiscoveredNodeData); // add to the list of discovered commissioners
 
             // set associated connectable video player from cache, if any
             if (mCachedTargetVideoPlayerInfos != nullptr) {
                 for (size_t i = 0; i < kMaxCachedVideoPlayers && mCachedTargetVideoPlayerInfos[i].IsInitialized(); i++) {
                     if (mCachedTargetVideoPlayerInfos[i].IsSameAs(&cppNodeData)) {
+                        chip::System::Clock::Timestamp currentUnixTimeMS = chip::System::Clock::kZero;
+                        chip::System::SystemClock().GetClock_RealTimeMS(currentUnixTimeMS);
+                        ChipLogProgress(AppServer, "Updating discovery timestamp for VideoPlayer %lu",
+                            static_cast<unsigned long>(currentUnixTimeMS.count()));
+                        mCachedTargetVideoPlayerInfos[i].SetLastDiscovered(currentUnixTimeMS); // add discovery timestamp
+                        CastingServer::GetInstance()->AddVideoPlayer(
+                            &mCachedTargetVideoPlayerInfos[i]); // write updated video player to cache
+
                         VideoPlayer * connectableVideoPlayer =
                             [ConversionUtils convertToObjCVideoPlayerFrom:&mCachedTargetVideoPlayerInfos[i]];
                         [objCDiscoveredNodeData setConnectableVideoPlayer:connectableVideoPlayer];
@@ -57,6 +94,64 @@ public:
     }
 
 private:
+    static void ReportSleepingCommissioners(chip::System::Layer * _Nonnull aSystemLayer, void * _Nullable context)
+    {
+        ChipLogProgress(AppServer, "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() called");
+        CommissionerDiscoveryDelegateImpl * thiz = (CommissionerDiscoveryDelegateImpl *) context;
+        if (thiz == nullptr || thiz->mCachedTargetVideoPlayerInfos == nullptr) {
+            ChipLogProgress(
+                AppServer, "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() found no cached video players");
+            return;
+        }
+        for (size_t i = 0; i < kMaxCachedVideoPlayers && thiz->mCachedTargetVideoPlayerInfos[i].IsInitialized(); i++) {
+            // do NOT surface this cached Player if we don't have its MACAddress
+            if (thiz->mCachedTargetVideoPlayerInfos[i].GetMACAddress() == nullptr
+                && thiz->mCachedTargetVideoPlayerInfos[i].GetMACAddress()->size() == 0) {
+                ChipLogProgress(NotSpecified,
+                    "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() Skipping Player with hostName %s but no "
+                    "MACAddress",
+                    thiz->mCachedTargetVideoPlayerInfos[i].GetHostName());
+                continue;
+            }
+
+            // do NOT surface this cached Player if it has not been discoverable recently
+            if (!thiz->mCachedTargetVideoPlayerInfos[i].WasRecentlyDiscoverable()) {
+                ChipLogProgress(NotSpecified,
+                    "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() Skipping Player with hostName %s that "
+                    "has not been discovered recently",
+                    thiz->mCachedTargetVideoPlayerInfos[i].GetHostName());
+                continue;
+            }
+
+            // do NOT surface this cached Player if it was just discovered right now (in this discovery call)
+            bool justDiscovered = false;
+            for (DiscoveredNodeData * discoveredCommissioner : thiz->mDiscoveredCommissioners) {
+                if (strcmp(
+                        (char *) [discoveredCommissioner.hostName UTF8String], thiz->mCachedTargetVideoPlayerInfos[i].GetHostName())
+                    == 0) {
+                    justDiscovered = true;
+                    break;
+                }
+            }
+            if (justDiscovered) {
+                ChipLogProgress(NotSpecified,
+                    "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() Skipping Player with hostName %s that "
+                    "was just discovered",
+                    thiz->mCachedTargetVideoPlayerInfos[i].GetHostName());
+                continue;
+            }
+
+            // DO surface this cached Player (as asleep)
+            DiscoveredNodeData * objCDiscoveredNodeData =
+                [ConversionUtils convertToDiscoveredNodeDataFrom:&thiz->mCachedTargetVideoPlayerInfos[i]];
+            objCDiscoveredNodeData.getConnectableVideoPlayer.isAsleep = true;
+            ChipLogProgress(AppServer, "CommissionerDiscoveryDelegateImpl().ReportSleepingCommissioners() with hostName %s",
+                thiz->mCachedTargetVideoPlayerInfos[i].GetHostName());
+            thiz->mObjCDiscoveredCommissionerHandler(objCDiscoveredNodeData);
+        }
+    }
+
+    std::vector<DiscoveredNodeData *> mDiscoveredCommissioners;
     void (^_Nonnull mObjCDiscoveredCommissionerHandler)(DiscoveredNodeData * _Nonnull);
     dispatch_queue_t _Nonnull mClientQueue;
     TargetVideoPlayerInfo * _Nullable mCachedTargetVideoPlayerInfos;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.hpp
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.hpp
@@ -55,6 +55,11 @@
 
 + (VideoPlayer * _Nonnull)convertToObjCVideoPlayerFrom:(TargetVideoPlayerInfo * _Nonnull)cppTargetVideoPlayerInfo;
 
+/**
+ * @brief inter-object converters
+ */
++ (DiscoveredNodeData * _Nonnull)convertToDiscoveredNodeDataFrom:(TargetVideoPlayerInfo * _Nonnull)cppTargetVideoPlayerInfo;
+
 @end
 
 #endif /* ConversionUtils_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/VideoPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/VideoPlayer.h
@@ -42,6 +42,18 @@
 
 @property uint16_t deviceType;
 
+@property NSString * hostName;
+
+@property NSString * instanceName;
+
+@property uint16_t port;
+
+@property NSString * MACAddress;
+
+@property uint64_t lastDiscoveredMs;
+
+@property bool isAsleep;
+
 /**
  @brief true, if all the required fields are initialized, false otherwise
  */
@@ -54,7 +66,12 @@
                     deviceName:(NSString *)deviceName
                       vendorId:(uint16_t)vendorId
                      productId:(uint16_t)productId
-                    deviceType:(uint16_t)deviceType;
+                    deviceType:(uint16_t)deviceType
+                      hostName:(NSString *)hostName
+                  instanceName:(NSString *)instanceName
+                          port:(uint16_t)port
+                    MACAddress:(NSString *)MACAddress
+              lastDiscoveredMs:(uint64_t)lastDiscoveredMs;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/VideoPlayer.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/VideoPlayer.m
@@ -36,7 +36,12 @@
                     deviceName:(NSString *)deviceName
                       vendorId:(uint16_t)vendorId
                      productId:(uint16_t)productId
-                    deviceType:(uint16_t)deviceType;
+                    deviceType:(uint16_t)deviceType
+                      hostName:(NSString *)hostName
+                  instanceName:(NSString *)instanceName
+                          port:(uint16_t)port
+                    MACAddress:(NSString *)MACAddress
+              lastDiscoveredMs:(uint64_t)lastDiscoveredMs
 {
     if (self = [super init]) {
         _nodeId = nodeId;
@@ -47,6 +52,12 @@
         _vendorId = vendorId;
         _productId = productId;
         _deviceType = deviceType;
+        _hostName = hostName;
+        _instanceName = instanceName;
+        _port = port;
+        _MACAddress = MACAddress;
+        _lastDiscoveredMs = lastDiscoveredMs;
+        _isAsleep = false;
         _isInitialized = true;
     }
     return self;

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -100,7 +100,8 @@ void InitCommissioningFlow(intptr_t commandArg)
             CastingServer::GetInstance()->GetDiscoveredCommissioner(i, associatedConnectableVideoPlayer);
         if (commissioner != nullptr)
         {
-            ChipLogProgress(AppServer, "Discovered Commissioner #%d", commissionerCount++);
+            ChipLogProgress(AppServer, "Discovered Commissioner #%d", commissionerCount);
+            commissionerCount++;
             commissioner->LogDetail();
             if (associatedConnectableVideoPlayer.HasValue())
             {

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -58,6 +58,7 @@ chip_data_model("tv-casting-common") {
     "include/CastingServer.h",
     "include/Channel.h",
     "include/ContentLauncher.h",
+    "include/ConversionUtils.h",
     "include/KeypadInput.h",
     "include/LevelControl.h",
     "include/MediaBase.h",
@@ -70,11 +71,13 @@ chip_data_model("tv-casting-common") {
     "include/TargetEndpointInfo.h",
     "include/TargetNavigator.h",
     "include/TargetVideoPlayerInfo.h",
+    "include/WakeOnLan.h",
     "src/AppParams.cpp",
     "src/ApplicationLauncher.cpp",
     "src/CastingServer.cpp",
     "src/Channel.cpp",
     "src/ContentLauncher.cpp",
+    "src/ConversionUtils.cpp",
     "src/KeypadInput.cpp",
     "src/LevelControl.cpp",
     "src/MediaPlayback.cpp",
@@ -83,6 +86,7 @@ chip_data_model("tv-casting-common") {
     "src/TargetEndpointInfo.cpp",
     "src/TargetNavigator.cpp",
     "src/TargetVideoPlayerInfo.cpp",
+    "src/WakeOnLan.cpp",
   ]
 
   # Add simplified casting API files here

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -65,6 +65,15 @@
 
 #define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT 4
 
+// cached players that were seen before this window (in hours) will not be surfaced as "discovered"
+#define CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS 7 * 24
+
+// time (in sec) assumed to be required for player to wake up after sending WoL magic packet
+#define CHIP_DEVICE_CONFIG_STR_WAKE_UP_DELAY_SEC 10
+
+// delay (in sec) before which we assume undiscovered cached players may be in STR mode
+#define CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC 5
+
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first
 #include <CHIPProjectConfig.h>

--- a/examples/tv-casting-app/tv-casting-common/include/ConversionUtils.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ConversionUtils.h
@@ -1,0 +1,23 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "TargetVideoPlayerInfo.h"
+
+#include <lib/dnssd/Resolver.h>
+
+CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::Dnssd::DiscoveredNodeData & outNodeData);

--- a/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
+++ b/examples/tv-casting-app/tv-casting-common/include/PersistenceManager.h
@@ -34,6 +34,8 @@ public:
 
     CHIP_ERROR PurgeVideoPlayerCache();
 
+    CHIP_ERROR DeleteVideoPlayer(TargetVideoPlayerInfo * targetVideoPlayerInfo);
+
 private:
     CHIP_ERROR WriteAllVideoPlayers(TargetVideoPlayerInfo videoPlayers[]);
 
@@ -55,6 +57,10 @@ private:
         kVideoPlayerNumIPsTag,
         kVideoPlayerIPAddressTag,
         kIpAddressesContainerTag,
+        kVideoPlayerLastDiscoveredTag,
+        kVideoPlayerMACAddressTag,
+        kVideoPlayerInstanceNameTag,
+        kVideoPlayerPortTag,
 
         kContextTagMaxNum = UINT8_MAX
     };

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -25,6 +25,10 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 
+#include <string.h>
+#include <system/SystemClock.h>
+#include <system/SystemLayer.h>
+
 inline constexpr size_t kMaxNumberOfEndpoints = 5;
 
 class TargetVideoPlayerInfo;
@@ -84,6 +88,34 @@ public:
     bool IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData);
     bool IsSameAs(const char * hostName, const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses);
 
+    uint16_t GetPort() const { return mPort; }
+    const char * GetInstanceName() const { return mInstanceName; }
+    chip::CharSpan * GetMACAddress() { return &mMACAddress; }
+    void SetIsAsleep(bool isAsleep) { mIsAsleep = isAsleep; }
+    bool IsAsleep() { return mIsAsleep; }
+    void SetMACAddress(chip::CharSpan MACAddress)
+    {
+        memcpy(mMACAddressBuf, MACAddress.data(), MACAddress.size());
+        mMACAddress = chip::CharSpan(mMACAddressBuf, MACAddress.size());
+    }
+    chip::System::Clock::Timestamp GetLastDiscovered() { return mLastDiscovered; }
+    void SetLastDiscovered(chip::System::Clock::Timestamp lastDiscovered) { mLastDiscovered = lastDiscovered; }
+    bool WasRecentlyDiscoverable()
+    {
+#ifdef CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS
+        // it was recently discoverable if its mLastDiscovered.count is within
+        // CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS of current time
+        chip::System::Clock::Timestamp currentUnixTimeMS = chip::System::Clock::kZero;
+        chip::System::SystemClock().GetClock_RealTimeMS(currentUnixTimeMS);
+        ChipLogProgress(AppServer, "WasRecentlyDiscoverable currentUnixTimeMS: %lu mLastDiscovered: %lu",
+                        static_cast<unsigned long>(currentUnixTimeMS.count()), static_cast<unsigned long>(mLastDiscovered.count()));
+        return mLastDiscovered.count() >
+            currentUnixTimeMS.count() - CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS * 60 * 60 * 1000;
+#else
+        return true;
+#endif // CHIP_DEVICE_CONFIG_STR_CACHE_LAST_DISCOVERED_HOURS
+    }
+
     chip::OperationalDeviceProxy * GetOperationalDeviceProxy()
     {
         if (mDeviceProxy != nullptr && mDeviceProxy->ConnectionReady())
@@ -97,7 +129,9 @@ public:
                           std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                           std::function<void(CHIP_ERROR)> onConnectionFailure, uint16_t vendorId = 0, uint16_t productId = 0,
                           chip::DeviceTypeId deviceType = 0, const char * deviceName = {}, const char * hostName = {},
-                          size_t numIPs = 0, chip::Inet::IPAddress * ipAddressList = nullptr);
+                          size_t numIPs = 0, chip::Inet::IPAddress * ipAddressList = nullptr, uint16_t port = 0,
+                          const char * instanceName                     = {},
+                          chip::System::Clock::Timestamp lastDiscovered = chip::System::Clock::kZero);
     CHIP_ERROR FindOrEstablishCASESession(std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                                           std::function<void(CHIP_ERROR)> onConnectionFailure);
     TargetEndpointInfo * GetOrAddEndpoint(chip::EndpointId endpointId);
@@ -174,5 +208,11 @@ private:
     char mHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t mNumIPs                                       = 0; // number of valid IP addresses
     chip::Inet::IPAddress mIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
+    char mInstanceName[chip::Dnssd::Commission::kInstanceNameMaxLength + 1];
+    uint16_t mPort;
+    chip::CharSpan mMACAddress;
+    char mMACAddressBuf[2 * chip::DeviceLayer::ConfigurationManager::kMaxMACAddressLength];
+    chip::System::Clock::Timestamp mLastDiscovered;
+    bool mIsAsleep    = false;
     bool mInitialized = false;
 };

--- a/examples/tv-casting-app/tv-casting-common/include/WakeOnLan.h
+++ b/examples/tv-casting-app/tv-casting-common/include/WakeOnLan.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "MediaReadBase.h"
+
+#include <controller/CHIPCluster.h>
+
+#include <app-common/zap-generated/cluster-objects.h>
+
+// READER CLASSES
+
+class MACAddressReader : public MediaReadBase<chip::app::Clusters::WakeOnLan::Attributes::MACAddress::TypeInfo>
+{
+public:
+    MACAddressReader() : MediaReadBase(chip::app::Clusters::WakeOnLan::Id) {}
+};
+
+CHIP_ERROR SendWakeOnLanPacket(chip::CharSpan * MACAddress);

--- a/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ConversionUtils.h"
+
+CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::Dnssd::DiscoveredNodeData & outNodeData)
+{
+    if (inPlayer == nullptr)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+
+    outNodeData.commissionData.vendorId   = inPlayer->GetVendorId();
+    outNodeData.commissionData.productId  = static_cast<uint16_t>(inPlayer->GetProductId());
+    outNodeData.commissionData.deviceType = inPlayer->GetDeviceType();
+    outNodeData.resolutionData.numIPs     = inPlayer->GetNumIPs();
+
+    const chip::Inet::IPAddress * ipAddresses = inPlayer->GetIpAddresses();
+    if (ipAddresses != nullptr)
+    {
+        for (size_t i = 0; i < outNodeData.resolutionData.numIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
+        {
+            outNodeData.resolutionData.ipAddress[i] = ipAddresses[i];
+        }
+    }
+
+    chip::Platform::CopyString(outNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+                               inPlayer->GetDeviceName());
+    chip::Platform::CopyString(outNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1, inPlayer->GetHostName());
+
+    return CHIP_NO_ERROR;
+}

--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -20,6 +20,8 @@
 
 #include <lib/core/TLV.h>
 #include <platform/KeyValueStoreManager.h>
+#include <system/SystemClock.h>
+#include <system/SystemLayer.h>
 
 using namespace chip;
 
@@ -64,6 +66,47 @@ CHIP_ERROR PersistenceManager::AddVideoPlayer(TargetVideoPlayerInfo * targetVide
     return WriteAllVideoPlayers(cachedVideoPlayers);
 }
 
+CHIP_ERROR PersistenceManager::DeleteVideoPlayer(TargetVideoPlayerInfo * targetVideoPlayerInfo)
+{
+    ChipLogProgress(AppServer, "PersistenceManager::DeleteVideoPlayer called");
+    VerifyOrReturnError(targetVideoPlayerInfo != nullptr && targetVideoPlayerInfo->IsInitialized(), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Read cache for video players targetted in previous runs
+    TargetVideoPlayerInfo cachedVideoPlayers[kMaxCachedVideoPlayers];
+    CHIP_ERROR err = ReadAllVideoPlayers(cachedVideoPlayers);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer,
+                     "PersistenceManager::DeleteVideoPlayer status of reading previously cached video players %" CHIP_ERROR_FORMAT,
+                     err.Format());
+        return err;
+    }
+
+    size_t i;
+    bool found = false;
+    for (i = 0; i < kMaxCachedVideoPlayers && cachedVideoPlayers[i].IsInitialized(); i++)
+    {
+        if (cachedVideoPlayers[i] == *targetVideoPlayerInfo) // found the video player, delete it
+        {
+            ChipLogProgress(AppServer, "PersistenceManager::DeleteVideoPlayer found video player in cache at position: %lu",
+                            static_cast<unsigned long>(i));
+            found = true;
+            break;
+        }
+    }
+    if (found)
+    {
+        while (i + 1 < kMaxCachedVideoPlayers && cachedVideoPlayers[i + 1].IsInitialized())
+        {
+            cachedVideoPlayers[i] = cachedVideoPlayers[i + 1];
+            i++;
+        }
+        cachedVideoPlayers[i].Reset();
+        return WriteAllVideoPlayers(cachedVideoPlayers);
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR PersistenceManager::WriteAllVideoPlayers(TargetVideoPlayerInfo videoPlayers[])
 {
     ChipLogProgress(AppServer, "PersistenceManager::WriteAllVideoPlayers called");
@@ -101,6 +144,18 @@ CHIP_ERROR PersistenceManager::WriteAllVideoPlayers(TargetVideoPlayerInfo videoP
             ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kVideoPlayerHostNameTag),
                                                     (const uint8_t *) videoPlayer->GetHostName(),
                                                     static_cast<uint32_t>(strlen(videoPlayer->GetHostName()) + 1)));
+            ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kVideoPlayerInstanceNameTag),
+                                                    (const uint8_t *) videoPlayer->GetInstanceName(),
+                                                    static_cast<uint32_t>(strlen(videoPlayer->GetInstanceName()) + 1)));
+            ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kVideoPlayerPortTag), videoPlayer->GetPort()));
+            ReturnErrorOnFailure(
+                tlvWriter.Put(TLV::ContextTag(kVideoPlayerLastDiscoveredTag), videoPlayer->GetLastDiscovered().count()));
+            if (videoPlayer->GetMACAddress() != nullptr && videoPlayer->GetMACAddress()->size() > 0)
+            {
+                ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kVideoPlayerMACAddressTag),
+                                                        (const uint8_t *) videoPlayer->GetMACAddress()->data(),
+                                                        static_cast<uint32_t>(videoPlayer->GetMACAddress()->size())));
+            }
 
             ReturnErrorOnFailure(
                 tlvWriter.Put(TLV::ContextTag(kVideoPlayerNumIPsTag), static_cast<uint64_t>(videoPlayer->GetNumIPs())));
@@ -212,6 +267,12 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
     char hostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
     size_t numIPs                                       = 0;
     Inet::IPAddress ipAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
+    uint64_t lastDiscoveredMs                                                             = 0;
+    char MACAddressBuf[2 * chip::DeviceLayer::ConfigurationManager::kMaxMACAddressLength] = {};
+    uint32_t MACAddressLength                                                             = 0;
+    char instanceName[chip::Dnssd::Commission::kInstanceNameMaxLength + 1]                = {};
+    uint16_t port                                                                         = 0;
+
     CHIP_ERROR err;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
@@ -265,6 +326,33 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
             continue;
         }
 
+        if (videoPlayersContainerTagNum == kVideoPlayerInstanceNameTag)
+        {
+            ReturnErrorOnFailure(
+                reader.GetBytes(reinterpret_cast<uint8_t *>(instanceName), chip::Dnssd::Commission::kInstanceNameMaxLength + 1));
+            continue;
+        }
+
+        if (videoPlayersContainerTagNum == kVideoPlayerPortTag)
+        {
+            ReturnErrorOnFailure(reader.Get(port));
+            continue;
+        }
+
+        if (videoPlayersContainerTagNum == kVideoPlayerLastDiscoveredTag)
+        {
+            ReturnErrorOnFailure(reader.Get(lastDiscoveredMs));
+            continue;
+        }
+
+        if (videoPlayersContainerTagNum == kVideoPlayerMACAddressTag)
+        {
+            MACAddressLength = reader.GetLength();
+            ReturnErrorOnFailure(reader.GetBytes(reinterpret_cast<uint8_t *>(MACAddressBuf),
+                                                 2 * chip::DeviceLayer::ConfigurationManager::kMaxMACAddressLength));
+            continue;
+        }
+
         if (videoPlayersContainerTagNum == kVideoPlayerNumIPsTag)
         {
             ReturnErrorOnFailure(reader.Get(reinterpret_cast<uint64_t &>(numIPs)));
@@ -312,7 +400,14 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
         if (videoPlayersContainerTagNum == kContentAppEndpointsContainerTag)
         {
             outVideoPlayers[videoPlayerIndex].Initialize(nodeId, fabricIndex, nullptr, nullptr, vendorId, productId, deviceType,
-                                                         deviceName, hostName, numIPs, ipAddress);
+                                                         deviceName, hostName, numIPs, ipAddress, port, instanceName,
+                                                         chip::System::Clock::Timestamp(lastDiscoveredMs));
+            if (MACAddressLength > 0)
+            {
+                chip::CharSpan MACAddress(MACAddressBuf, MACAddressLength);
+                outVideoPlayers[videoPlayerIndex].SetMACAddress(MACAddress);
+            }
+
             // Entering Content App Endpoints container
             TLV::TLVType contentAppEndpointArrayContainerType = TLV::kTLVType_Array;
             ReturnErrorOnFailure(reader.EnterContainer(contentAppEndpointArrayContainerType));

--- a/examples/tv-casting-app/tv-casting-common/src/WakeOnLan.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/WakeOnLan.cpp
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "WakeOnLan.h"
+
+constexpr int kBroadcastOption    = 1;
+constexpr int kWoLMagicPacketSize = 102;
+
+CHIP_ERROR SendWakeOnLanPacket(chip::CharSpan * MACAddress)
+{
+    ChipLogProgress(AppServer, "SendWakeOnLanPacket called");
+    VerifyOrReturnError(MACAddress != nullptr && MACAddress->size() > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    const int kMACLength = chip::DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength;
+
+    // Create a socket
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (sockfd < 0)
+    {
+        ChipLogError(AppServer, "socket(): Could not create socket");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Enable broadcast option
+    if (setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, &kBroadcastOption, sizeof(kBroadcastOption)) < 0)
+    {
+        ChipLogError(AppServer, "setsockopt(): Could not enable broadcast option on socket");
+        close(sockfd);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Convert MAC Address to bytes
+    uint8_t MACBytes[kMACLength];
+    for (int i = 0; i < 2 * kMACLength; i += 2)
+    {
+        char byteString[3];
+        byteString[0]   = MACAddress->data()[i];
+        byteString[1]   = MACAddress->data()[i + 1];
+        byteString[2]   = '\0';
+        MACBytes[i / 2] = static_cast<uint8_t>(std::strtol(byteString, nullptr, 16));
+    }
+
+    // Create the Wake On LAN "magic" packet
+    char magicPacket[kWoLMagicPacketSize];
+    std::memset(magicPacket, 0xFF, kMACLength);
+    for (int i = kMACLength; i < kWoLMagicPacketSize; i += kMACLength)
+    {
+        std::memcpy(magicPacket + i, MACBytes, kMACLength);
+    }
+
+    // Set up the broadcast address
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(9);
+    addr.sin_addr.s_addr = INADDR_BROADCAST;
+
+    // Send the Wake On LAN packet
+    ssize_t bytesSent = sendto(sockfd, magicPacket, kWoLMagicPacketSize, 0, (struct sockaddr *) &addr, sizeof(addr));
+    if (bytesSent < 0)
+    {
+        ChipLogError(AppServer, "sendto(): Could not send WoL magic packet");
+        close(sockfd);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    ChipLogProgress(AppServer, "Broadcasted WoL magic packet with MACAddress %.*s", 2 * kMACLength, MACAddress->data());
+
+    close(sockfd);
+    return CHIP_NO_ERROR;
+}


### PR DESCRIPTION
Fixes #29442

### Overview

This is a new feature for the tv-casting-app to support "discovering," waking, and connecting to STR/WoL video players.

### Change Summary

1.  Added new fields MACAddress, lastDiscoveredMs, port and instanceName to TargetVideoPlayerInfo.h / VideoPlayer.mm/java and persisted them in the mobile app cache using PersistenceManager.
2.  On a discovery request, we now wait for CHIP\_DEVICE\_CONFIG\_STR\_DISCOVERY\_DELAY\_SEC and then surface, as discovery results, undiscovered video players from the cache that were otherwise recently discoverable (within CHIP\_DEVICE\_CONFIG\_STR\_CACHE\_LAST\_DISCOVERED\_HOURS) and returned MACAddresses. The VideoPlayer port and instanceName we started tracking in # 1 above allow us to convert the VideoPlayer object to the DiscoveredNodeData type used to surface the discovery results.
3.  After a CASE sesssion is established, CastingServer runs ReadMACAddress to get the MACAddress of the Video Player from its WakeOnLan cluster.
4.  When the user / client calls CastingServer.VerifyOrEstablishConnection, we now check if the video player is asleep. If it is, before calling FindOrEstablishCASE, we now broadcast a WakeOnLan magic packet if its MACAddress is known, and wait for CHIP\_DEVICE\_CONFIG\_STR\_WAKE\_UP\_DELAY\_SEC so it can turn on.

### Testing

Tested using the Android/iOS tv-casting-apps against the Linux tv-app running on a Raspi.