### PR TITLE
[nrfconnect] Added erasing network credentials after the last fabric removal

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -194,7 +194,7 @@ endif # BOARD_NRF7002DK_NRF5340_CPUAPP
 
 # Enable extended discovery
 config CHIP_EXTENDED_DISCOVERY
-    default y
+    default n
 
 config NVS_LOOKUP_CACHE
     default y

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -230,4 +230,41 @@ config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
 	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
 	  within range [-JITTER; +JITTER].
 
+choice CHIP_LAST_FABRIC_REMOVED_ACTION
+	prompt "An action to perform after removing the last fabric"
+	default CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+
+	config CHIP_LAST_FABRIC_REMOVED_NONE
+	bool "After removing the last fabric do not perform any action"
+	help
+	  After removing the last fabric the device will not perform factory reset
+	  or reboot. The current state will be left as it is and the BLE advertising
+	  will not start automatically.
+
+	config CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+	bool "After removing the last fabric erase NVS and reboot"
+	help
+	  After removing the last fabric the device will perform the factory reset and
+	  then reboot. The current RAM state will be removed and the new commissioning to
+	  the new fabric will use the initial fabric index. This option is the most safe.
+
+	config CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
+	bool "After removing the last fabric erase NVS and start Bluetooth LE advertising"
+	help
+	  After removing the last fabric the device will perform the factory reset without 
+	  rebooting and start the Bluetooth LE advertisement automatically.
+	  The current RAM state will be saved and the new commissioning to the next 
+	  fabric will use the next possible fabric index. This option should not be used for
+	  devices that normally do not advertise Bluetooth LE on boot to keep their original 
+	  behavior.
+
+	config CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY
+	bool "After removing the last fabric erase NVS only"
+	help
+	  After removing the last fabric the device will perform the factory reset only without
+	  rebooting. The current RAM state will be saved and the new commissioning to the next 
+	  fabric will use the next possible fabric index.
+
+endchoice
+
 endif # CHIP

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -18,6 +18,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "binding-handler.h"
 
@@ -207,6 +208,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -34,10 +34,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -18,6 +18,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "binding-handler.h"
 
@@ -156,6 +157,7 @@ CHIP_ERROR AppTask::Init()
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);

--- a/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
@@ -34,10 +34,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -19,6 +19,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "BoardUtil.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "LightSwitch.h"
 
@@ -218,6 +219,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/light-switch-app/nrfconnect/main/include/AppTask.h
+++ b/examples/light-switch-app/nrfconnect/main/include/AppTask.h
@@ -37,10 +37,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance()
     {
         static AppTask sAppTask;

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -20,6 +20,7 @@
 
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "PWMDevice.h"
 
@@ -246,6 +247,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -42,10 +42,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance()
     {
         static AppTask sAppTask;

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -19,6 +19,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "BoltLockManager.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "LEDWidget.h"
 
@@ -212,6 +213,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -37,10 +37,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance()
     {
         static AppTask sAppTask;
@@ -67,8 +70,8 @@ private:
     static void FunctionHandler(const AppEvent & event);
     static void StartBLEAdvertisementAndLockActionEventHandler(const AppEvent & event);
     static void LockActionEventHandler(const AppEvent & event);
-    static void StartBLEAdvertisementHandler(const AppEvent & event);
     static void UpdateLedStateEventHandler(const AppEvent & event);
+    static void StartBLEAdvertisementHandler(const AppEvent & event);
 
     static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     static void ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged);

--- a/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
+++ b/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
@@ -1,0 +1,77 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "AppTask.h"
+
+#include <app/server/Server.h>
+#include <app/util/attribute-storage.h>
+#ifdef CONFIG_CHIP_WIFI
+#include <platform/nrfconnect/wifi/WiFiManager.h>
+#endif
+
+class AppFabricTableDelegate : public chip::FabricTable::Delegate
+{
+public:
+    ~AppFabricTableDelegate() { chip::Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this); }
+
+    /**
+     * @brief Initialize module and add a delegation to the Fabric Table.
+     *
+     * To use the OnFabricRemoved method defined within this class and allow to react on the last fabric removal
+     * this method should be called in the application code.
+     */
+    static void Init()
+    {
+#ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+        static AppFabricTableDelegate sAppFabricDelegate;
+        chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+    }
+
+private:
+    void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
+    {
+#ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+#ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+            chip::Server::GetInstance().ScheduleFactoryReset();
+#elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) || defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
+            chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
+                /* Erase Matter data */
+                chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
+                /* Erase Network credentials and disconnect */
+                chip::DeviceLayer::ConnectivityMgr().ErasePersistentInfo();
+#ifdef CONFIG_CHIP_WIFI
+                chip::DeviceLayer::WiFiManager::Instance().Disconnect();
+                chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
+#endif
+#ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
+                /* Start the New BLE advertising */
+                AppEvent event;
+                event.Handler = AppTask::StartBLEAdvertisementHandler;
+                AppTask::Instance().PostEvent(event);
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
+            });
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+        }
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+    }
+};

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -18,6 +18,7 @@
 
 #include "AppTask.h"
 #include "AppConfig.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "LEDWidget.h"
 #include "PumpManager.h"
@@ -189,6 +190,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/pump-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-app/nrfconnect/main/include/AppTask.h
@@ -36,10 +36,13 @@
 #endif
 
 struct k_timer;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -18,6 +18,7 @@
 
 #include "AppTask.h"
 #include "AppConfig.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "LEDWidget.h"
 #include "PumpManager.h"
@@ -187,6 +188,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
@@ -36,10 +36,13 @@
 #endif
 
 struct k_timer;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -18,6 +18,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "FabricTableDelegate.h"
 #include "LEDUtil.h"
 #include "WindowCovering.h"
 
@@ -191,6 +192,7 @@ CHIP_ERROR AppTask::Init()
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    AppFabricTableDelegate::Init();
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -34,10 +34,13 @@
 
 struct k_timer;
 struct Identify;
+class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
+    friend class AppFabricTableDelegate;
+
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;


### PR DESCRIPTION
Users can decide now what should happen after removing the last fabric:
- Do nothing.
- Erase the saved network credentials (Thread/WI-FI).
- Erase the saved network credentials and start Bluetooth LE advertising.
- Erase the saved network credentials and reboot the device.

