### PR TITLE
[Silabs] RTT I/O stream support added.

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -291,23 +291,27 @@ standard names. */
 #define SysTick_Handler xPortSysTickHandler
 
 /* Thread local storage pointers used by the SDK */
-#ifdef PERFORMANCE_TEST_ENABLED
-// ot_debug_channel component uses thread-local storage
-#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
+
 #ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 0
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
-    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS)
+#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 2
 #endif
-#else /* PERFORMANCE_TEST_ENABLED */
+
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
+#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
 #endif
-#endif /* PERFORMANCE_TEST_ENABLED */
+
+#ifndef configNUM_THREAD_LOCAL_STORAGE_POINTERS
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
+    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS + 1)
+#endif
 
 #if defined(__GNUC__)
 /* For the linker. */
 #define fabs __builtin_fabs
+#endif
+
+#ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
+#error RC-FRTOS
 #endif
 
 #ifdef __cplusplus

--- a/examples/platform/silabs/args.gni
+++ b/examples/platform/silabs/args.gni
@@ -20,6 +20,9 @@ chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_inet_project_config_include = "<CHIPProjectConfig.h>"
 chip_system_project_config_include = "<CHIPProjectConfig.h>"
 
+segger_rtt_buffer_size_up = 1024
+segger_rtt_buffer_size_down = 1024
+
 declare_args() {
   app_data_model = ""
 }

--- a/examples/platform/silabs/matter-platform.slcp
+++ b/examples/platform/silabs/matter-platform.slcp
@@ -63,6 +63,7 @@ component:
 - {id: mbedtls_base64}
 - {id: ot_psa_crypto}
 - {id: bluetooth_crypto}
+- {id: iostream_rtt}
 # Necessary componenets for ot coap cert lib
 # - {id: mbedtls_dtls} # Requried by COAP lib
 # - {id: mbedtls_tls_server} # Requried by COAP lib

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -13,14 +13,10 @@
 #endif
 
 #include "AppConfig.h"
-#include <FreeRTOS.h>
-#include <queue.h>
 #include <stdio.h>
 #include <string.h>
-#include <task.h>
 
 #ifndef BRD4325A
-#include "rail_types.h"
 
 #ifdef RAIL_ASSERT_DEBUG_STRING
 #include "rail_assert_error_codes.h"

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <functional>
+#include <platform/CHIPDeviceError.h>
 
 #include "nvm3.h"
 #include "nvm3_hal_flash.h"
@@ -176,6 +177,7 @@ public:
 
     // Configuration methods used by the GenericConfigurationManagerImpl<> template.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
@@ -183,6 +185,7 @@ public:
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen, size_t offset);
     static CHIP_ERROR ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val);
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);

--- a/src/test_driver/efr32/include/FreeRTOSConfig.h
+++ b/src/test_driver/efr32/include/FreeRTOSConfig.h
@@ -285,8 +285,17 @@ standard names. */
 #define SysTick_Handler xPortSysTickHandler
 
 /* Thread local storage pointers used by the SDK */
+#ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
+#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 2
+#endif
+
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 0
+#define configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS 2
+#endif
+
+#ifndef configNUM_THREAD_LOCAL_STORAGE_POINTERS
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS                                                                                    \
+    (configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS + configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS + 1)
 #endif
 
 #if defined(__GNUC__)

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -157,6 +157,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/service/device_init/inc",
       "${efr32_sdk_root}/platform/service/hfxo_manager/inc",
       "${efr32_sdk_root}/platform/service/hfxo_manager/src",
+      "${efr32_sdk_root}/platform/service/iostream/inc",
       "${efr32_sdk_root}/platform/service/mpu/inc",
       "${efr32_sdk_root}/platform/service/power_manager/inc/",
       "${efr32_sdk_root}/platform/service/power_manager/src/",
@@ -584,6 +585,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/bootloader/api/btl_interface_storage.c",
       "${efr32_sdk_root}/platform/bootloader/security/sha/crypto_sha.c",
       "${efr32_sdk_root}/platform/common/src/sl_slist.c",
+      "${efr32_sdk_root}/platform/common/src/sli_cmsis_os2_ext_task_register.c",
       "${efr32_sdk_root}/platform/emdrv/dmadrv/src/dmadrv.c",
       "${efr32_sdk_root}/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c",
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_default.c",
@@ -626,6 +628,8 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/service/device_init/src/sl_device_init_lfrco.c",
       "${efr32_sdk_root}/platform/service/device_init/src/sl_device_init_nvic.c",
       "${efr32_sdk_root}/platform/service/hfxo_manager/src/sl_hfxo_manager.c",
+      "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream.c",
+      "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream_rtt.c",
       "${efr32_sdk_root}/platform/service/mpu/src/sl_mpu.c",
       "${efr32_sdk_root}/platform/service/power_manager/src/sl_power_manager.c",
       "${efr32_sdk_root}/platform/service/power_manager/src/sl_power_manager_debug.c",
@@ -711,6 +715,7 @@ template("efr32_sdk") {
       "${silabs_gen_folder}/autogen/sl_board_default_init.c",
       "${silabs_gen_folder}/autogen/sl_device_init_clocks.c",
       "${silabs_gen_folder}/autogen/sl_event_handler.c",
+      "${silabs_gen_folder}/autogen/sl_iostream_handles.c",
     ]
     if (enable_dic) {
       sources += [

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -48,6 +48,9 @@ declare_args() {
 
   # Disable UART log forwarding by default
   sl_uart_log_output = false
+
+  # Self-provision enabled
+  use_provision_channel = false
 }
 
 declare_args() {


### PR DESCRIPTION
Added support for RTT I/O Stream on Silicon Labs products. Required for the upcoming Provision Channel feature.

Tested on BRD4164A, BRD4166A, BRD4187C.
