### PR TITLE
Remove include_yamltests arg, and always install the whl for python tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -184,7 +184,7 @@ jobs:
                     "
             - name: Build Apps
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv --include_yamltests'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -207,11 +207,12 @@ if [ -n "$install_virtual_env" ]; then
     if [ "$install_pytest_requirements" = "yes" ]; then
         YAMLTESTS_GN_LABEL="//scripts:matter_yamltests_distribution._build_wheel"
         # Add wheels from pw_python_package or pw_python_distribution templates.
-        WHEEL+=(
+        YAMLTEST_WHEEL=(
             "$(ls -tr "$(wheel_output_dir "$YAMLTESTS_GN_LABEL")"/*.whl | head -n 1)"
         )
 
         echo_blue "Installing python test dependencies ..."
+        "$ENVIRONMENT_ROOT"/bin/pip install --upgrade "${YAMLTEST_WHEEL[@]}"
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/tests/requirements.txt"
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/src/python_testing/requirements.txt"
     fi

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -183,7 +183,6 @@ else
     WHEEL=("$OUTPUT_ROOT"/controller/python/chip*.whl)
 fi
 
-
 if [ -n "$extra_packages" ]; then
     WHEEL+=("$extra_packages")
 fi

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -68,7 +68,6 @@ Input Options:
                                                             src/python_testing scripts.
                                                             Defaults to yes.
   --extra_packages PACKAGES                                 Install extra Python packages from PyPI
-  --include_yamltests                                       Whether to install the matter_yamltests wheel.
   -z --pregen_dir DIRECTORY                                 Directory where generated zap files have been pre-generated.
 "
 }
@@ -129,9 +128,6 @@ while (($#)); do
             extra_packages=$2
             shift
             ;;
-        --include_yamltests)
-            include_yamltests="yes"
-            ;;
         --pregen_dir | -z)
             pregen_dir=$2
             shift
@@ -187,14 +183,6 @@ else
     WHEEL=("$OUTPUT_ROOT"/controller/python/chip*.whl)
 fi
 
-if [ -n "$include_yamltests" ]; then
-    YAMLTESTS_GN_LABEL="//scripts:matter_yamltests_distribution._build_wheel"
-
-    # Add wheels from pw_python_package or pw_python_distribution templates.
-    WHEEL+=(
-        "$(ls -tr "$(wheel_output_dir "$YAMLTESTS_GN_LABEL")"/*.whl | head -n 1)"
-    )
-fi
 
 if [ -n "$extra_packages" ]; then
     WHEEL+=("$extra_packages")
@@ -217,6 +205,12 @@ if [ -n "$install_virtual_env" ]; then
     "$ENVIRONMENT_ROOT"/bin/pip install --upgrade "${WHEEL[@]}"
 
     if [ "$install_pytest_requirements" = "yes" ]; then
+        YAMLTESTS_GN_LABEL="//scripts:matter_yamltests_distribution._build_wheel"
+        # Add wheels from pw_python_package or pw_python_distribution templates.
+        WHEEL+=(
+            "$(ls -tr "$(wheel_output_dir "$YAMLTESTS_GN_LABEL")"/*.whl | head -n 1)"
+        )
+
         echo_blue "Installing python test dependencies ..."
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/tests/requirements.txt"
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/src/python_testing/requirements.txt"


### PR DESCRIPTION
Prior to #27437, some build scripts were installing the python packages into the build environment located at `.environment/pigweed-venv/`. This cause all sort of at the time, and the issues were reduced by installing the yamltest python whl only if there was a need. Now that we always have a separate python environment, we shouldn't run into the same issues we previously were, and we can remove `include_yamltests `.

This somewhat reduces number of arguments that developers need to keep track, at the cost of less then 4 seconds for the additional `pip install` command to run. (Less then 4 seconds is based on running `time time pip install --upgrade out/python_lib/<path_to_yamltest_whl>` in my local environment). Note that the yamltest wheel was already being compiled it is just that we are now always installing it into the provided `--install_virtual_env`

Test: CI pass
