### PR TITLE
[Darwin] MTRDeviceTests test017 - fix resubscription expectation

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -679,7 +679,7 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
 /**
  *  Check whether concrete attribute path is an "existent attribute path" in spec terms.
  *  @param[in]    aPath                 The concrete path of the data being read.
- *  @retval  boolean   true if the concrete attribute path indicates a single existing instance on the node
+ *  @retval  boolean   true if the concrete attribute path indicates an attribute that exists on the node.
  */
 bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -679,7 +679,7 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
 /**
  *  Check whether concrete attribute path is an "existent attribute path" in spec terms.
  *  @param[in]    aPath                 The concrete path of the data being read.
- *  @retval  boolean
+ *  @retval  boolean   true if the concrete attribute path indicates a single existing instance on the node
  */
 bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath);
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
@@ -57,7 +57,7 @@
     CFErrorRef error = NULL;
     const NSDictionary * keygenParams = @{
         (__bridge NSString *) kSecAttrKeyClass : (__bridge NSString *) kSecAttrKeyClassPrivate,
-        (__bridge NSString *) kSecAttrKeyType : (__bridge NSNumber *) kSecAttrKeyTypeECSECPrimeRandom,
+        (__bridge NSString *) kSecAttrKeyType : (__bridge NSString *) kSecAttrKeyTypeECSECPrimeRandom,
         (__bridge NSString *) kSecAttrKeySizeInBits : @(keySizeInBits),
         (__bridge NSString *) kSecAttrIsPermanent : @(NO)
     };


### PR DESCRIPTION
Fixes #29365 

This PR makes MTRDeviceTests `test017_TestMTRDeviceBasics` test use the `-unitTestReportEndForDevice:` callback.

I also fixed some warnings that was causing local unit test compilation to fail.