### PR TITLE
yamltest: chip-repl: Make commissioning DUT flag more correct

### DIFF
--- a/scripts/tests/yaml/runner.py
+++ b/scripts/tests/yaml/runner.py
@@ -344,7 +344,10 @@ def chip_repl(parser_group: ParserGroup, adapter: str, stop_on_error: bool, stop
     runner_hooks = TestRunnerLogger(show_adapter_logs, show_adapter_logs_on_error, use_test_harness_log_format)
     runner_config = TestRunnerConfig(adapter, parser_group.pseudo_clusters, runner_options, runner_hooks)
 
-    runner = __import__(runner, fromlist=[None]).Runner(repl_storage_path, commission_on_network_dut)
+    node_id_to_commission = None
+    if commission_on_network_dut:
+        node_id_to_commission = parser_group.builder_config.parser_config.config_override['nodeId']
+    runner = __import__(runner, fromlist=[None]).Runner(repl_storage_path, node_id_to_commission=node_id_to_commission)
     loop = asyncio.get_event_loop()
     return loop.run_until_complete(runner.run(parser_group.builder_config, runner_config))
 


### PR DESCRIPTION
Problem:
* We assumed that the node id we should commission was the default one provided to yamltests (0x12344321). This ignored that you can provide command line arguments to override the default.
* If you provided flag to commission device, but were reusing chip-repl storage that already has certs it would not commission new device no network at all.

Fixes:
* Commission with the known DUT nodeId test is expected to use (when flagged to commission device)
* Simplify logic such that if flag `--commission_on_network_dut true` is provided that we try to commission the device. Unfortunately python doesn't have a nice way to make sure that we are not trying to commission a device with a nodeId that already exists on the fabric.

Test:
* CI passes
* Confirmed `./scripts/tests/yaml/runner.py --use_default_pseudo_clusters 0 Test_TC_OO_1_1 chip-repl --commission_on_network_dut true` work when chip-repl has new storage or old storage.