### PR TITLE
[Tizen] Convert possible glib objects to GAutoPtr<> 

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -105,6 +105,12 @@ struct GAutoPtrDeleter<GError>
 };
 
 template <>
+struct GAutoPtrDeleter<GSource>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GVariant>
 {
     using deleter = GVariantDeleter;

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -58,6 +58,7 @@
 #include <platform/CHIPDeviceEvent.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ConfigurationManager.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
@@ -187,21 +188,19 @@ void BLEManagerImpl::ReadValueRequestedCb(const char * remoteAddress, int reques
 {
     int ret, len = 0;
     bt_gatt_type_e type;
-    char * uuid  = nullptr;
-    char * value = nullptr;
+    GAutoPtr<char> uuid;
+    GAutoPtr<char> value;
 
-    VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
+    VerifyOrReturn(__GetAttInfo(gattHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
-    ChipLogProgress(DeviceLayer, "Gatt read requested on %s: uuid=%s", __ConvertAttTypeToStr(type), StringOrNullMarker(uuid));
-    g_free(uuid);
+    ChipLogProgress(DeviceLayer, "Gatt read requested on %s: uuid=%s", __ConvertAttTypeToStr(type), StringOrNullMarker(uuid.get()));
 
-    ret = bt_gatt_get_value(gattHandle, &value, &len);
+    ret = bt_gatt_get_value(gattHandle, &MakeUniquePointerReceiver(value).Get(), &len);
     VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_get_value() failed. ret: %d", ret));
 
-    ChipLogByteSpan(DeviceLayer, ByteSpan(Uint8::from_const_char(value), len));
+    ChipLogByteSpan(DeviceLayer, ByteSpan(Uint8::from_const_char(value.get()), len));
 
-    ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_READ, offset, 0x00, value, len);
-    g_free(value);
+    ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_READ, offset, 0x00, value.get(), len);
     VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed. ret: %d", ret));
 }
 
@@ -209,19 +208,18 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
                                            bool responseNeeded, int offset, const char * value, int len, void * userData)
 {
     int ret;
-    char * uuid          = nullptr;
+    GAutoPtr<char> uuid;
     BLEConnection * conn = nullptr;
     bt_gatt_type_e type;
 
     conn = static_cast<BLEConnection *>(g_hash_table_lookup(sInstance.mConnectionMap, remoteAddress));
     VerifyOrReturn(conn != nullptr, ChipLogError(DeviceLayer, "Failed to find connection info"));
 
-    VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
+    VerifyOrReturn(__GetAttInfo(gattHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
     ChipLogProgress(DeviceLayer, "Gatt write requested on %s: uuid=%s len=%d", __ConvertAttTypeToStr(type),
-                    StringOrNullMarker(uuid), len);
+                    StringOrNullMarker(uuid.get()), len);
     ChipLogByteSpan(DeviceLayer, ByteSpan(Uint8::from_const_char(value), len));
-    g_free(uuid);
 
     ret = bt_gatt_set_value(gattHandle, value, len);
     VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
@@ -234,7 +232,7 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
 
 void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h gattHandle, void * userData)
 {
-    char * uuid          = nullptr;
+    GAutoPtr<char> uuid;
     BLEConnection * conn = nullptr;
     bt_gatt_type_e type;
     GHashTableIter iter;
@@ -250,12 +248,11 @@ void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h se
     }
 
     VerifyOrReturn(conn != nullptr, ChipLogError(DeviceLayer, "Failed to find connection info"));
-    VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
+    VerifyOrReturn(__GetAttInfo(gattHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
 
     ChipLogProgress(DeviceLayer, "Notification State Changed %d on %s: %s", notify, __ConvertAttTypeToStr(type),
-                    StringOrNullMarker(uuid));
-    g_free(uuid);
+                    StringOrNullMarker(uuid.get()));
     sInstance.NotifyBLESubscribed(notify ? true : false, conn);
 }
 
@@ -728,23 +725,22 @@ exit:
 static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle, void * data)
 {
     bt_gatt_type_e type;
-    char * uuid = nullptr;
-    auto conn   = static_cast<BLEConnection *>(data);
+    GAutoPtr<char> uuid;
+    auto conn = static_cast<BLEConnection *>(data);
 
-    VerifyOrExit(__GetAttInfo(charHandle, &uuid, &type) == BT_ERROR_NONE,
+    VerifyOrExit(__GetAttInfo(charHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from CHAR handle"));
 
-    if (strcasecmp(uuid, chip_ble_char_c1_tx_uuid) == 0)
+    if (strcasecmp(uuid.get(), chip_ble_char_c1_tx_uuid) == 0)
     {
-        ChipLogProgress(DeviceLayer, "CHIP Char C1 TX Found [%s]", StringOrNullMarker(uuid));
+        ChipLogProgress(DeviceLayer, "CHIP Char C1 TX Found [%s]", StringOrNullMarker(uuid.get()));
         conn->gattCharC1Handle = charHandle;
     }
-    else if (strcasecmp(uuid, chip_ble_char_c2_rx_uuid) == 0)
+    else if (strcasecmp(uuid.get(), chip_ble_char_c2_rx_uuid) == 0)
     {
-        ChipLogProgress(DeviceLayer, "CHIP Char C2 RX Found [%s]", StringOrNullMarker(uuid));
+        ChipLogProgress(DeviceLayer, "CHIP Char C2 RX Found [%s]", StringOrNullMarker(uuid.get()));
         conn->gattCharC2Handle = charHandle;
     }
-    g_free(uuid);
 
 exit:
     /* Try next Char UUID */
@@ -754,28 +750,24 @@ exit:
 static bool __GattClientForeachServiceCb(int total, int index, bt_gatt_h svcHandle, void * data)
 {
     bt_gatt_type_e type;
-    char * uuid = nullptr;
-    auto conn   = static_cast<BLEConnection *>(data);
+    GAutoPtr<char> uuid;
+    auto conn = static_cast<BLEConnection *>(data);
     ChipLogProgress(DeviceLayer, "__GattClientForeachServiceCb");
 
-    VerifyOrExit(__GetAttInfo(svcHandle, &uuid, &type) == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle"));
+    VerifyOrReturnValue(__GetAttInfo(svcHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE, true,
+                        ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle"));
 
-    if (strcasecmp(uuid, chip_ble_service_uuid) == 0)
+    if (strcasecmp(uuid.get(), chip_ble_service_uuid) == 0)
     {
-        ChipLogProgress(DeviceLayer, "CHIP Service UUID Found [%s]", StringOrNullMarker(uuid));
+        ChipLogProgress(DeviceLayer, "CHIP Service UUID Found [%s]", StringOrNullMarker(uuid.get()));
 
         if (bt_gatt_service_foreach_characteristics(svcHandle, __GattClientForeachCharCb, conn) == BT_ERROR_NONE)
             conn->isChipDevice = true;
 
         /* Got CHIP Device, no need to process further service */
-        g_free(uuid);
         return false;
     }
-    g_free(uuid);
 
-exit:
-    /* Try next Service UUID */
     return true;
 }
 

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -754,8 +754,8 @@ static bool __GattClientForeachServiceCb(int total, int index, bt_gatt_h svcHand
     auto conn = static_cast<BLEConnection *>(data);
     ChipLogProgress(DeviceLayer, "__GattClientForeachServiceCb");
 
-    VerifyOrReturnValue(__GetAttInfo(svcHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE, true,
-                        ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle"));
+    VerifyOrExit(__GetAttInfo(svcHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle"));
 
     if (strcasecmp(uuid.get(), chip_ble_service_uuid) == 0)
     {
@@ -768,6 +768,8 @@ static bool __GattClientForeachServiceCb(int total, int index, bt_gatt_h svcHand
         return false;
     }
 
+exit:
+    /* Try next Service UUID */
     return true;
 }
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -371,10 +371,9 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
         // with the NSD internal mutex locked, which is also locked by the
         // dnssd_create_remote_service() function called in the Resolve(), and
         // the Resolve() itself is called with the stack mutex locked.
-        auto * sourceIdle = g_idle_source_new();
-        g_source_set_callback(sourceIdle, OnResolveFinalize, rCtx, NULL);
-        g_source_attach(sourceIdle, g_main_context_get_thread_default());
-        g_source_unref(sourceIdle);
+        chip::GAutoPtr<GSource> sourceIdle(g_idle_source_new());
+        g_source_set_callback(sourceIdle.get(), OnResolveFinalize, rCtx, NULL);
+        g_source_attach(sourceIdle.get(), g_main_context_get_thread_default());
     }
 
     return;

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -38,6 +38,7 @@
 #include <lib/support/SafeInt.h>
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceConfig.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -186,31 +187,31 @@ void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)
     g_source_attach(source, g_main_context_get_thread_default());
     bCtx->mTimeoutSource = source;
 
-    char * type          = nullptr;
-    char * name          = nullptr;
-    char * ifaceName     = nullptr;
+    chip::GAutoPtr<char> type;
+    chip::GAutoPtr<char> name;
+    chip::GAutoPtr<char> ifaceName;
     uint32_t interfaceId = 0;
 
-    ret = dnssd_service_get_type(service, &type);
+    ret = dnssd_service_get_type(service, &MakeUniquePointerReceiver(type).Get());
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_type() failed. ret: %d", ret));
 
-    ret = dnssd_service_get_name(service, &name);
+    ret = dnssd_service_get_name(service, &MakeUniquePointerReceiver(name).Get());
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_name() failed. ret: %d", ret));
 
-    ret = dnssd_service_get_interface(service, &ifaceName);
+    ret = dnssd_service_get_interface(service, &MakeUniquePointerReceiver(ifaceName).Get());
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_interface() failed. ret: %d", ret));
 
-    interfaceId = if_nametoindex(ifaceName);
+    interfaceId = if_nametoindex(ifaceName.get());
     VerifyOrExit(interfaceId > 0, ChipLogError(DeviceLayer, "if_nametoindex() failed. errno: %d", errno);
                  ret = DNSSD_ERROR_OPERATION_FAILED);
 
     if (state == DNSSD_SERVICE_STATE_AVAILABLE)
     {
-        OnBrowseAdd(bCtx, type, name, interfaceId);
+        OnBrowseAdd(bCtx, type.get(), name.get(), interfaceId);
     }
     else
     {
-        OnBrowseRemove(bCtx, type, name, interfaceId);
+        OnBrowseRemove(bCtx, type.get(), name.get(), interfaceId);
     }
 
 exit:
@@ -223,10 +224,6 @@ exit:
         // After this point the context might be no longer valid
         bCtx->mInstance->RemoveContext(bCtx);
     }
-
-    g_free(type);
-    g_free(name);
-    g_free(ifaceName);
 }
 
 CHIP_ERROR BrowseAsync(chip::Dnssd::BrowseContext * bCtx)
@@ -310,46 +307,42 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
     ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto rCtx = reinterpret_cast<chip::Dnssd::ResolveContext *>(userData);
 
-    char * name      = nullptr;
-    char * ipv4      = nullptr;
-    char * ipv6      = nullptr;
+    chip::GAutoPtr<char> name;
+    chip::GAutoPtr<char> ipv4;
+    chip::GAutoPtr<char> ipv6;
     int port         = 0;
     char * interface = nullptr;
     chip::Inet::IPAddress ipAddr;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    int ret = dnssd_service_get_name(service, &name);
+    int ret = dnssd_service_get_name(service, &MakeUniquePointerReceiver(name).Get());
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_name() failed. ret: %d", ret));
 
-    chip::Platform::CopyString(rCtx->mResult.mName, name);
-    g_free(name);
+    chip::Platform::CopyString(rCtx->mResult.mName, name.get());
 
-    ret = dnssd_service_get_ip(service, &ipv4, &ipv6);
+    ret = dnssd_service_get_ip(service, &MakeUniquePointerReceiver(ipv4).Get(), &MakeUniquePointerReceiver(ipv6).Get());
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_ip() failed. ret: %d", ret));
 
     // If both IPv4 and IPv6 are set, IPv6 address has higher priority.
-    if (ipv6 != nullptr && strcmp(ipv6, kEmptyAddressIpv6) != 0)
+    if (ipv6.get() != nullptr && strcmp(ipv6.get(), kEmptyAddressIpv6) != 0)
     {
-        if (!chip::Inet::IPAddress::FromString(ipv6, ipAddr) || ipAddr.Type() != chip::Inet::IPAddressType::kIPv6)
+        if (!chip::Inet::IPAddress::FromString(ipv6.get(), ipAddr) || ipAddr.Type() != chip::Inet::IPAddressType::kIPv6)
         {
             ret = DNSSD_ERROR_OPERATION_FAILED;
         }
     }
 #if INET_CONFIG_ENABLE_IPV4
-    else if (ipv4 != nullptr)
+    else if (ipv4.get() != nullptr)
     {
-        if (!chip::Inet::IPAddress::FromString(ipv4, ipAddr) || ipAddr.Type() != chip::Inet::IPAddressType::kIPv4)
+        if (!chip::Inet::IPAddress::FromString(ipv4.get(), ipAddr) || ipAddr.Type() != chip::Inet::IPAddressType::kIPv4)
         {
             ret = DNSSD_ERROR_OPERATION_FAILED;
         }
     }
 #endif
 
-    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s, ret: %d", __func__, StringOrNullMarker(ipv4),
-                  StringOrNullMarker(ipv6), ret);
-
-    g_free(ipv4);
-    g_free(ipv6);
+    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s, ret: %d", __func__, StringOrNullMarker(ipv4.get()),
+                  StringOrNullMarker(ipv6.get()), ret);
 
     VerifyOrExit(ret == DNSSD_ERROR_NONE, );
 

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -37,6 +37,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/DeviceInstanceInfoProvider.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Tizen/DeviceInstanceInfoProviderImpl.h>
 
 #include "PosixConfig.h"
@@ -92,9 +93,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
         GLibMatterContextInvokeData invokeData{};
 
-        auto * idleSource = g_idle_source_new();
+        GAutoPtr<GSource> idleSource(g_idle_source_new());
         g_source_set_callback(
-            idleSource,
+            idleSource.get(),
             [](void * userData_) {
                 auto * data = reinterpret_cast<GLibMatterContextInvokeData *>(userData_);
                 std::unique_lock<std::mutex> lock(data->mDoneMutex);
@@ -103,8 +104,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
                 return G_SOURCE_REMOVE;
             },
             &invokeData, nullptr);
-        g_source_attach(idleSource, g_main_loop_get_context(mGLibMainLoop));
-        g_source_unref(idleSource);
+        g_source_attach(idleSource.get(), g_main_loop_get_context(mGLibMainLoop));
 
         std::unique_lock<std::mutex> lock(invokeData.mDoneMutex);
         invokeData.mDoneCond.wait(lock, [&invokeData]() { return invokeData.mDone; });


### PR DESCRIPTION
### Problem

Tizen still has explicit glib memory management. This is follow-up PRs (https://github.com/project-chip/connectedhomeip/pull/28304) which will replace glib explicit memory management with GAutoPtr<>.

### Changes

Changed explicit memory management of glib objects to GAutoPtr<> where possible for the Tizen platform.

### Testing

CI will test for potential build breaks.