### PR TITLE
Add Span.h to a source_set that tracks its dependencies.

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -89,6 +89,7 @@ static_library("chip-tool-utils") {
     sources += [ "commands/interactive/InteractiveCommands.cpp" ]
     deps += [
       "${chip_root}/examples/common/websocket-server",
+      "${chip_root}/src/platform/logging:headers",
       "${editline_root}:editline",
     ]
   }

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -217,6 +217,7 @@ executable("darwin-framework-tool") {
 
     deps += [
       "${chip_root}/examples/common/websocket-server",
+      "${chip_root}/src/platform/logging:headers",
       "${editline_root}:editline",
     ]
   }

--- a/examples/pigweed-app/ameba/chip_main.cmake
+++ b/examples/pigweed-app/ameba/chip_main.cmake
@@ -60,6 +60,7 @@ target_include_directories(
     ${pigweed_dir}/pw_rpc/nanopb/public
 
     ${chip_dir_output}/gen/include
+    ${chip_dir}/third_party/nlassert/repo/include/
 )
 
 target_link_libraries(${chip_main} PUBLIC

--- a/examples/placeholder/linux/BUILD.gn
+++ b/examples/placeholder/linux/BUILD.gn
@@ -46,6 +46,7 @@ executable("chip-${chip_tests_zap_config}") {
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/support:testing",  # For sleepMillis. TODO: this is
                                              # odd and should be fixed
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/third_party/jsoncpp",
   ]
 

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -134,16 +134,7 @@ source_set("test_paa_store") {
     "attestation_verifier/TestPAAStore.h",
   ]
 
-  public_deps = [
-    "${chip_root}/src/lib/core:chip_config_header",  # for lib/support/Span.h
-    "${nlassert_root}:nlassert",  # for lib/support/Span.h
-  ]
-  if (chip_pw_tokenizer_logging) {
-    import("//build_overrides/pigweed.gni")
-    public_deps += [
-      "${dir_pw_tokenizer}",  # for /lib/support/Span.h
-    ]
-  }
+  public_deps = [ "${chip_root}/src/lib/support:span" ]
 }
 
 static_library("default_attestation_verifier") {

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -107,6 +107,49 @@ source_set("memory") {
   ]
 }
 
+source_set("text_only_logging") {
+  sources = [
+    "logging/TextOnlyLogging.cpp",
+    "logging/TextOnlyLogging.h",
+  ]
+
+  public_deps = [
+    ":attributes",
+    ":logging_constants",
+    ":verifymacros_no_logging",
+    "${chip_root}/src/lib/core:chip_config_header",
+  ]
+
+  if (chip_pw_tokenizer_logging) {
+    public_deps += [ "${dir_pw_tokenizer}" ]
+  }
+
+  deps = [
+    ":memory",
+    "${chip_root}/src/lib/core:chip_config_header",
+    "${chip_root}/src/platform/logging:headers",
+  ]
+}
+
+source_set("verifymacros") {
+  sources = [ "CodeUtils.h" ]
+
+  public_deps = [
+    ":attributes",
+    ":text_only_logging",
+    ":verifymacros_no_logging",
+    "${chip_root}/src/lib/core:chip_config_header",
+    "${chip_root}/src/lib/core:error",
+    "${nlassert_root}:nlassert",
+  ]
+}
+
+source_set("span") {
+  sources = [ "Span.h" ]
+
+  public_deps = [ ":verifymacros" ]
+}
+
 source_set("chip_version_header") {
   sources = get_target_outputs(":gen_chip_version")
 
@@ -132,7 +175,6 @@ static_library("support") {
     "CHIPArgParser.cpp",
     "CHIPCounter.h",
     "CHIPMemString.h",
-    "CodeUtils.h",
     "DLLUtil.h",
     "DefaultStorageKeyAllocator.h",
     "Defer.h",
@@ -172,8 +214,6 @@ static_library("support") {
     "logging/BinaryLogging.cpp",
     "logging/BinaryLogging.h",
     "logging/CHIPLogging.h",
-    "logging/TextOnlyLogging.cpp",
-    "logging/TextOnlyLogging.h",
     "verhoeff/Verhoeff.cpp",
     "verhoeff/Verhoeff.h",
     "verhoeff/Verhoeff10.cpp",
@@ -203,11 +243,13 @@ static_library("support") {
     ":logging_constants",
     ":memory",
     ":safeint",
+    ":span",
+    ":text_only_logging",
+    ":verifymacros",
     ":verifymacros_no_logging",
     "${chip_root}/src/lib/core:chip_config_header",
     "${chip_root}/src/lib/core:error",
     "${chip_root}/src/platform:platform_buildconfig",
-    "${chip_root}/src/platform/logging:headers",
     "${nlassert_root}:nlassert",
     "${nlio_root}:nlio",
   ]

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -155,23 +155,6 @@ constexpr inline const _T & max(const _T & a, const _T & b)
 } // namespace chip
 
 /**
- *  @def IgnoreUnusedVariable(aVariable)
- *
- *  @brief
- *    This casts the specified @a aVariable to void to quell any
- *    compiler-issued unused variable warnings or errors.
- *
- *  @code
- *  void foo (int err)
- *  {
- *      IgnoreUnusedVariable(err)
- *  }
- *  @endcode
- *
- */
-#define IgnoreUnusedVariable(aVariable) ((void) (aVariable))
-
-/**
  *  @def ReturnErrorOnFailure(expr)
  *
  *  @brief

--- a/src/lib/support/VerificationMacrosNoLogging.h
+++ b/src/lib/support/VerificationMacrosNoLogging.h
@@ -25,3 +25,20 @@
 #include <nlassert.h>
 
 #define VerifyOrDieWithoutLogging(aCondition) nlABORT(aCondition)
+
+/**
+ *  @def IgnoreUnusedVariable(aVariable)
+ *
+ *  @brief
+ *    This casts the specified @a aVariable to void to quell any
+ *    compiler-issued unused variable warnings or errors.
+ *
+ *  @code
+ *  void foo (int err)
+ *  {
+ *      IgnoreUnusedVariable(err)
+ *  }
+ *  @endcode
+ *
+ */
+#define IgnoreUnusedVariable(aVariable) ((void) (aVariable))

--- a/src/lib/support/logging/TextOnlyLogging.cpp
+++ b/src/lib/support/logging/TextOnlyLogging.cpp
@@ -24,9 +24,8 @@
 
 #include "TextOnlyLogging.h"
 
-#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
 
 #include <platform/logging/LogV.h>
 

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -38,6 +38,7 @@
 
 #include <lib/support/DLLUtil.h>
 #include <lib/support/EnforceFormat.h>
+#include <lib/support/VerificationMacrosNoLogging.h>
 #include <lib/support/logging/Constants.h>
 
 #include <inttypes.h>

--- a/src/platform/ASR/BUILD.gn
+++ b/src/platform/ASR/BUILD.gn
@@ -72,6 +72,7 @@ static_library("ASR") {
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 

--- a/src/platform/Ameba/BUILD.gn
+++ b/src/platform/Ameba/BUILD.gn
@@ -54,6 +54,7 @@ static_library("Ameba") {
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 

--- a/src/platform/Beken/BUILD.gn
+++ b/src/platform/Beken/BUILD.gn
@@ -52,6 +52,7 @@ static_library("Beken") {
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -98,6 +98,7 @@ static_library("Darwin") {
   deps = [
     ":logging",
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 
@@ -137,10 +138,9 @@ static_library("logging") {
   ]
 
   deps = [
-    "${chip_root}/src/lib/core:chip_config_header",  # for lib/support/Span.h
     "${chip_root}/src/lib/support:attributes",
     "${chip_root}/src/lib/support:logging_constants",
-    "${nlassert_root}:nlassert",  # for lib/support/Span.h
+    "${chip_root}/src/lib/support:span",
   ]
 
   configs += [ "${chip_root}/src:includes" ]

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -65,6 +65,7 @@ static_library("ESP32") {
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 

--- a/src/platform/Infineon/CYW30739/BUILD.gn
+++ b/src/platform/Infineon/CYW30739/BUILD.gn
@@ -63,7 +63,10 @@ static_library("CYW30739") {
     ]
   }
 
-  deps = [ "${chip_root}/src/crypto" ]
+  deps = [
+    "${chip_root}/src/crypto",
+    "${chip_root}/src/platform/logging:headers",
+  ]
 
   public = [
     "${chip_root}/src/credentials/DeviceAttestationCredsProvider.h",

--- a/src/platform/Infineon/PSOC6/BUILD.gn
+++ b/src/platform/Infineon/PSOC6/BUILD.gn
@@ -69,6 +69,7 @@ static_library("PSOC6") {
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
   ]
 

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -73,8 +73,11 @@ static_library("Linux") {
     "SystemTimeSupport.cpp",
   ]
 
+  deps = [ "${chip_root}/src/setup_payload" ]
+
   if (!chip_use_external_logging) {
     sources += [ "Logging.cpp" ]
+    deps += [ "${chip_root}/src/platform/logging:headers" ]
   }
 
   if (chip_enable_openthread) {
@@ -95,8 +98,6 @@ static_library("Linux") {
       "bluez/Types.h",
     ]
   }
-
-  deps = [ "${chip_root}/src/setup_payload" ]
 
   public_deps = [
     "${chip_root}/src/app/common:cluster-objects",

--- a/src/platform/Tizen/BUILD.gn
+++ b/src/platform/Tizen/BUILD.gn
@@ -63,7 +63,10 @@ static_library("Tizen") {
     "SystemTimeSupport.cpp",
   ]
 
-  deps = [ "${chip_root}/src/setup_payload" ]
+  deps = [
+    "${chip_root}/src/platform/logging:headers",
+    "${chip_root}/src/setup_payload",
+  ]
 
   public_deps = [
     "${chip_root}/src/platform:platform_base",

--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -52,6 +52,7 @@ static_library("Zephyr") {
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   if (chip_enable_openthread) {
     sources += [
@@ -66,7 +67,7 @@ static_library("Zephyr") {
         "../OpenThread/OpenThreadDnssdImpl.cpp",
         "../OpenThread/OpenThreadDnssdImpl.h",
       ]
-      deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+      deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
   }
 

--- a/src/platform/bouffalolab/BL602/BUILD.gn
+++ b/src/platform/bouffalolab/BL602/BUILD.gn
@@ -69,6 +69,7 @@ static_library("BL602") {
   deps = [
     "${chip_root}/src/credentials:credentials_header",
     "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/platform/logging:headers",
   ]
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 }

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -59,6 +59,8 @@ static_library("BL702") {
     ]
   }
 
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
+
   defines =
       [ "CONFIG_BOUFFALOLAB_FACTORY_DATA_ENABLE=${chip_enable_factory_data}" ]
   if (chip_enable_factory_data || chip_enable_factory_data_test) {
@@ -76,7 +78,7 @@ static_library("BL702") {
       "wifi_mgmr_portable.c",
     ]
 
-    deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+    deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
   }
 
   if (chip_enable_openthread) {
@@ -84,7 +86,7 @@ static_library("BL702") {
 
     import("//build_overrides/bouffalolab_iot_sdk.gni")
     import("${bouffalolab_iot_sdk_build_root}/bl702/bl_iot_sdk.gni")
-    deps = [ "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk" ]
+    deps += [ "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk" ]
 
     sources += [
       "../../OpenThread/OpenThreadUtils.cpp",
@@ -108,7 +110,7 @@ static_library("BL702") {
       "EthernetInterface.c",
     ]
 
-    deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+    deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
   }
 
   deps += [ "${chip_root}/src/credentials:credentials_header" ]

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -57,6 +57,8 @@ static_library("BL702L") {
     ]
   }
 
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
+
   defines =
       [ "CONFIG_BOUFFALOLAB_FACTORY_DATA_ENABLE=${chip_enable_factory_data}" ]
   if (chip_enable_factory_data || chip_enable_factory_data_test) {
@@ -71,7 +73,7 @@ static_library("BL702L") {
 
     import("//build_overrides/bouffalolab_iot_sdk.gni")
     import("${bouffalolab_iot_sdk_build_root}/bl702l/bl_iot_sdk.gni")
-    deps = [ "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk" ]
+    deps += [ "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk" ]
 
     sources += [
       "../../OpenThread/OpenThreadUtils.cpp",

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
@@ -46,7 +46,7 @@ static_library("cc13x2_26x2") {
     "SystemPlatformConfig.h",
   ]
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   public_deps = [
     "${chip_root}/src/crypto",

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
@@ -46,7 +46,7 @@ static_library("cc13x4_26x4") {
     "SystemPlatformConfig.h",
   ]
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   public_deps = [
     "${chip_root}/src/crypto",

--- a/src/platform/logging/BUILD.gn
+++ b/src/platform/logging/BUILD.gn
@@ -19,6 +19,7 @@ if (current_os == "android") {
       "${chip_root}/src/lib/support:attributes",
       "${chip_root}/src/lib/support:logging_constants",
       "${chip_root}/src/platform:platform_buildconfig",
+      "${chip_root}/src/platform/logging:headers",
     ]
 
     libs = [ "log" ]
@@ -43,6 +44,7 @@ static_library("stdio") {
     "${chip_root}/src/lib/support:attributes",
     "${chip_root}/src/lib/support:logging_constants",
     "${chip_root}/src/platform:platform_buildconfig",
+    "${chip_root}/src/platform/logging:headers",
   ]
 
   # Ensure we end up with the expected output file name

--- a/src/platform/mbed/BUILD.gn
+++ b/src/platform/mbed/BUILD.gn
@@ -40,6 +40,7 @@ static_library("mbed") {
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   if (chip_enable_wifi) {
     sources += [

--- a/src/platform/mt793x/BUILD.gn
+++ b/src/platform/mt793x/BUILD.gn
@@ -65,8 +65,7 @@ static_library("mt793x") {
 
   public_deps += [ "${chip_root}/third_party/mt793x_sdk/mDNSResponder" ]
 
-  deps = []
-  public_deps += []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   # mDNS
   if (chip_mdns == "platform") {

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -61,6 +61,7 @@ static_library("nrfconnect") {
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   if (chip_enable_factory_data) {
     sources += [
@@ -89,7 +90,7 @@ static_library("nrfconnect") {
         "../OpenThread/OpenThreadDnssdImpl.cpp",
         "../OpenThread/OpenThreadDnssdImpl.h",
       ]
-      deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+      deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
   }
 

--- a/src/platform/nxp/k32w/k32w0/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w0/BUILD.gn
@@ -104,7 +104,7 @@ static_library("k32w0") {
     }
   }
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 

--- a/src/platform/nxp/k32w/k32w1/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w1/BUILD.gn
@@ -86,7 +86,7 @@ static_library("k32w1") {
     public_deps += [ "${mbedtls_root}:mbedtls" ]
   }
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   if (chip_enable_openthread) {
     sources += [

--- a/src/platform/nxp/mw320/BUILD.gn
+++ b/src/platform/nxp/mw320/BUILD.gn
@@ -74,7 +74,7 @@ static_library("mw320") {
   # Use ethernet/wifi interface for network commissioning. Default: WiFi
   defines += [ "USE_ETHERNET_COMMISSION=0" ]
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 

--- a/src/platform/openiotsdk/BUILD.gn
+++ b/src/platform/openiotsdk/BUILD.gn
@@ -76,6 +76,8 @@ static_library("openiotsdk") {
     "${chip_root}/src/platform:platform_base",
   ]
 
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
+
   if (chip_enable_ota_requestor) {
     sources += [
       "OTAImageProcessorImpl.cpp",

--- a/src/platform/qpg/BUILD.gn
+++ b/src/platform/qpg/BUILD.gn
@@ -50,7 +50,7 @@ static_library("qpg") {
     "qpgConfig.h",
   ]
 
-  deps = []
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   public = [ "${chip_root}/src/credentials/DeviceAttestationCredsProvider.h" ]
 

--- a/src/platform/silabs/SiWx917/BUILD.gn
+++ b/src/platform/silabs/SiWx917/BUILD.gn
@@ -75,6 +75,7 @@ static_library("SiWx917") {
   }
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   # Add platform crypto implementation
   if (chip_crypto == "platform") {

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -85,6 +85,7 @@ static_library("efr32") {
   }
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   # Add platform crypto implementation
   if (chip_crypto == "platform") {
@@ -105,7 +106,7 @@ static_library("efr32") {
   if (chip_enable_openthread) {
     public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
 
-    deps = [ "${chip_root}/third_party/openthread:openthread_cli" ]
+    deps += [ "${chip_root}/third_party/openthread:openthread_cli" ]
 
     sources += [
       "${silabs_platform_dir}/ThreadStackManagerImpl.h",

--- a/src/platform/stm32/BUILD.gn
+++ b/src/platform/stm32/BUILD.gn
@@ -32,6 +32,8 @@ if (chip_enable_openthread) {
 }
 
 static_library("stm32") {
+  deps = [ "${chip_root}/src/setup_payload" ]
+
   if (stm32_board == "STM32WB5MM-DK") {
     sources = [
       "../FreeRTOS/SystemTimeSupport.cpp",
@@ -61,9 +63,10 @@ static_library("stm32") {
       "STM32FreeRtosHooks.h",
       "SystemPlatformConfig.h",
     ]
+
+    deps += [ "${chip_root}/src/platform/logging:headers" ]
   }
 
-  deps = [ "${chip_root}/src/setup_payload" ]
   public = [ "${chip_root}/src/credentials/DeviceAttestationCredsProvider.h" ]
   public_deps = [
     "${chip_root}/src/crypto",

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -56,6 +56,7 @@ static_library("telink") {
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/platform/logging:headers" ]
 
   defines = [ "CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>" ]
 
@@ -81,7 +82,7 @@ static_library("telink") {
         "../OpenThread/OpenThreadDnssdImpl.cpp",
         "../OpenThread/OpenThreadDnssdImpl.h",
       ]
-      deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+      deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
   }
 

--- a/src/platform/webos/BUILD.gn
+++ b/src/platform/webos/BUILD.gn
@@ -100,7 +100,10 @@ static_library("webos") {
     "SystemTimeSupport.cpp",
   ]
 
-  deps = [ "${chip_root}/src/setup_payload" ]
+  deps = [
+    "${chip_root}/src/platform/logging:headers",
+    "${chip_root}/src/setup_payload",
+  ]
 
   public_deps = [
     "${chip_root}/src/app/common:cluster-objects",


### PR DESCRIPTION
This requires that those dependencies be separate things that are not the entire "support" library, because some things need Span but can't depend on all of "support".  Maybe these should just all be lumped into "support_core"... but then why are these things in support/ and not core/ (which are very much "these are the same thing, but we are going to pretend the are not).

Fixes https://github.com/project-chip/connectedhomeip/issues/29490
