### PR TITLE
Fix not usable in a constant expression build error

### DIFF
--- a/src/credentials/tests/CHIPAttCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPAttCert_test_vectors.cpp
@@ -4289,7 +4289,7 @@ constexpr uint8_t sTestCert_PAI_FFF2_NoPID_Resigned_SKID_Array[] = {
 
 extern const ByteSpan sTestCert_PAI_FFF2_NoPID_Resigned_SKID = ByteSpan(sTestCert_PAI_FFF2_NoPID_Resigned_SKID_Array);
 
-extern constexpr Span<const ByteSpan> kTestAttestationTrustStoreRoots((const ByteSpan[]){
+extern const Span<const ByteSpan> kTestAttestationTrustStoreRoots((const ByteSpan[]){
     sTestCert_PAA_FFF1_Cert,
     sTestCert_PAA_NoVID_Cert,
 });


### PR DESCRIPTION
Building failed with error

```
extern constexpr Span<const ByteSpan> kTestAttestationTrustStoreRoots((const ByteSpan[])
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/credentials/tests/CHIPAttCert_test_vectors.cpp:4295:2: error: the value of ‘chip::TestCerts::sTestCert_PAA_FFF1_Cert’ is not usable in a constant expression
 4295 | });
      |  ^

```
It looks its value is not commutable at compile time in certain case