### PR TITLE
Fix android CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,6 +322,5 @@
 [submodule "third_party/st/STM32CubeWB"]
 	path = third_party/st/STM32CubeWB
 	url = https://github.com/STMicroelectronics/STM32CubeWB.git
-        branch = v1.17.0
-        platform = stm32
-
+	branch = v1.17.0
+	platforms = stm32


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/28889 accidentally adds STM32CubeWB across all platforms because of typo, which blow away the size for Android CI with limited unused storage.