### PR TITLE
lock chip build version for cirque

### DIFF
--- a/integrations/docker/images/stage-2/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-cirque/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=latest
+ARG VERSION=15
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 


### PR DESCRIPTION
Currently the flow for updating docker images in Matter is as below
Update image, bump version.
Merge that PR.
Jump through the multi-day hoops to get the updated images actually uploaded.
Start using the new version.

Cirque is using latest version, which could lead to the CI failure because of multiple-day delay on latest image uploading.
Now we just lock down the fixed version, and then update the version manually as needed.