### PR TITLE
Switch compileSdkVersion to 31 in remaining gradle files

### DIFF
--- a/examples/android/CHIPTest/app/build.gradle
+++ b/examples/android/CHIPTest/app/build.gradle
@@ -8,7 +8,7 @@ println 'matterBuildSrcDir='+matterBuildSrcDir
 println 'matterUTestLib='+matterUTestLib
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
     ndkPath System.getenv("ANDROID_NDK_HOME")
 

--- a/examples/android/CHIPTool/chip-library/build.gradle
+++ b/examples/android/CHIPTool/chip-library/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "../../../../third_party/android_deps/android_deps.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 24


### PR DESCRIPTION
We have `examples/android/CHIPTool/app/build.gradle` already being version 31 since #23090, so may as well upgrade all so we do not have gradle pulling in more SDKs during CI since each is 100-200MB unpacked.