### PR TITLE
Correctly Clean out the generated jar and so files from android build

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -64,31 +64,31 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-chip-tool build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
             - name: Build Android arm-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-tv-casting-app build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/tv-casting-app/android/App/app/libs/jniLibs/* examples/tv-casting-app/android/App/app/libs/*.jar
             - name: Build Android arm-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-tv-server build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar
             - name: Build Android arm64-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/tv-casting-app/android/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
             - name: Build Android arm64-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-server build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar
             - name: Build Android arm64-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -98,7 +98,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
             # - name: Build Android Studio build (arm64 only)
             #   run: |
             #     ./scripts/run_in_build_env.sh \

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -58,12 +58,16 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/*
+              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
             - name: Build Android arm64-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
+            - name: Clean out build output
+              run: rm -rf ./out examples/tv-casting-app/android/App/app/libs/jniLibs/* examples/tv-casting-app/android/App/app/libs/*.jar                   
             - name: Build Android arm64-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-server build"
+            - name: Clean out build output
+              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar


### PR DESCRIPTION
TV-Server and TV-Casting app's jar and so are not located in examples/android/CHIPTool, previously CI cleans the wrong place and result sin 2gb + space waste in full-build, 1gb+ space waste in smoke build.
In addition,   indeed so files are stored in examples/.../app/libs/jniLibs/xxx, which needs to be removed, but we also need clean out the generated jar file in examples/.../app/libs/ 