### PR TITLE
[Not ready for review] debug full android build

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -60,46 +60,6 @@ jobs:
               with:
                 platform: android
 
-            - name: Build Android arm-chip-tool
-              run: |
-                  df -h
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target android-arm-chip-tool build"
-            - name: Clean out build output
-              run:  git clean -dfx -e .environment -e build_overrides
-            - name: Build Android arm-tv-casting-app
-              run: |
-                  df -h
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target android-arm-tv-casting-app build"
-            - name: Clean out build output
-              run: |
-                  df -h
-                  git clean -dfx -e .environment -e build_overrides
-                  df -h
-                  git clean -dfx
-                  df -h
-            - name: Build Android arm-tv-server
-              run: |
-                  df -h
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target android-arm-tv-server build"
-            - name: Clean out build output
-              run: git clean -dfx -e .environment -e build_overrides
-            - name: Build Android arm64-tv-casting-app
-              run: |
-                  df -h
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
-            - name: Clean out build output
-              run: git clean -dfx -e .environment -e build_overrides
-            - name: Build Android arm64-tv-server
-              run: |
-                  df -h
-                  ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --target android-arm64-tv-server build"
-            - name: Clean out build output
-              run: git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm64-chip-tool
               run: |
                   df -h
@@ -110,7 +70,49 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test"
             - name: Clean out build output
-              run: git clean -dfx -e .environment -e build_overrides
+              run: |
+                  df -h
+                  git clean -dfx -e .environment -e build_overrides
+                  rm -rf /__w/_temp
+                  df -h
+            - name: Build Android arm-chip-tool
+              run: |
+                  df -h
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target android-arm-chip-tool build"
+            - name: Clean out build output
+              run: |
+                  git clean -dfx 
+            - name: Build Android arm-tv-casting-app
+              run: |
+                  df -h
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target android-arm-tv-casting-app build"
+            - name: Clean out build output
+              run: |
+                  df -h
+                  git clean -dfx 
+            - name: Build Android arm-tv-server
+              run: |
+                  df -h
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target android-arm-tv-server build"
+            - name: Clean out build output
+              run: git clean -dfx 
+            - name: Build Android arm64-tv-casting-app
+              run: |
+                  df -h
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
+            - name: Clean out build output
+              run: git clean -dfx 
+            - name: Build Android arm64-tv-server
+              run: |
+                  df -h
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target android-arm64-tv-server build"
+            - name: Clean out build output
+              run: git clean -dfx 
             # - name: Build Android Studio build (arm64 only)
             #   run: |
             #     ./scripts/run_in_build_env.sh \

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -15,6 +15,7 @@
 name: Full builds - Android
 
 on:
+    pull_request:
     push:
     workflow_dispatch:
 
@@ -61,36 +62,47 @@ jobs:
 
             - name: Build Android arm-chip-tool
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-chip-tool build"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
+              run:  git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm-tv-casting-app
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-tv-casting-app build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-casting-app/android/App/app/libs/jniLibs/* examples/tv-casting-app/android/App/app/libs/*.jar
+              run: |
+                  df -h
+                  git clean -dfx -e .environment -e build_overrides
+                  df -h
+                  git clean -dfx
+                  df -h
             - name: Build Android arm-tv-server
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm-tv-server build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm64-tv-casting-app
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-casting-app/android/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm64-tv-server
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-server build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm64-chip-tool
               run: |
+                  df -h
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-chip-tool build"
             - name: Run Android build rule tests
@@ -98,7 +110,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides
             # - name: Build Android Studio build (arm64 only)
             #   run: |
             #     ./scripts/run_in_build_env.sh \

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -58,16 +58,16 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test"
             - name: Clean out build output
-              run: rm -rf ./out examples/android/CHIPTool/app/libs/jniLibs/* examples/android/CHIPTool/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides
             - name: Build Android arm64-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-casting-app build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-casting-app/android/App/app/libs/jniLibs/* examples/tv-casting-app/android/App/app/libs/*.jar                   
+              run: git clean -dfx -e .environment -e build_overrides                 
             - name: Build Android arm64-tv-server
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target android-arm64-tv-server build"
             - name: Clean out build output
-              run: rm -rf ./out examples/tv-app/android/App/app/libs/jniLibs/* examples/tv-app/android/App/app/libs/*.jar
+              run: git clean -dfx -e .environment -e build_overrides


### PR DESCRIPTION
We still see 1.6g+ waste after android build and clean, use "git clean -dfx -e .environment  -e build_overrides" to bring the build back to the fully clean state.

Validated via presubmit for full android build.