### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-15 : [Silabs] Adds fix for SLC CLI path
+16 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=31278e7f9a0103e369e9255f921e04986eb57eb3
+ARG ZEPHYR_REVISION=5e5f3cfde3fb5070b2e6cfb8ab08bc688b5aa3d4
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \


### PR DESCRIPTION
**Change overview**

- soc: riscv: telink_b9x: Add malloc() failed hook
- drivers: usb: device: b9x: enabled IRQ for USP_EP
- soc: riscv: telink_b9x: Update MbedTLS configuration
- soc: riscv: telink_b9x: Kconfig: Enable libc heap by default
- west.yml: update west.yml (Update B91 Library)
- drivers: ieee802154: b9x: Removed duplicated RF PWR table

**Testing**
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully