### PR TITLE
Remove some unused CIPD packages before android compile.

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -59,6 +59,16 @@ jobs:
               with:
                 platform: android
 
+            - name: Cleanup pigweed CIPD packages
+              # This should not generally be needed, however android CI runs out of space
+              # We do not need pigweed cross compile here because we use android NDK
+              # compilers, so removing rust and arm compilers saves 2.5GB
+              run: |
+                du -sh .environment/cipd/packages/pigweed/rust \
+                       .environment/cipd/packages/arm
+
+                rm -rf .environment/cipd/packages/pigweed/rust \
+                       .environment/cipd/packages/arm
             - name: Build Android arm-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -48,6 +48,16 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: android
+            - name: Cleanup pigweed CIPD packages
+              # This should not generally be needed, however android CI runs out of space
+              # We do not need pigweed cross compile here because we use android NDK
+              # compilers, so removing rust and arm compilers saves 2.5GB
+              run: |
+                du -sh .environment/cipd/packages/pigweed/rust \
+                       .environment/cipd/packages/arm
+
+                rm -rf .environment/cipd/packages/pigweed/rust \
+                       .environment/cipd/packages/arm
 
             - name: Build Android CHIPTool and CHIPTest (ARM64)
               run: |


### PR DESCRIPTION
This should save about 2.5GB of space.
Ideally we should not download these in the first place, however I would have to figure out how to set that up.

For now tested locally that compile seems to pass because we use the NDK, however CI will fully validate this.


