### PR TITLE
CastingDiscovery: fix snprintf warning

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -45,7 +45,7 @@ const int kIdMaxLength   = chip::Dnssd::kHostNameMaxLength + kPortMaxLength;
 class CastingPlayerAttributes
 {
 public:
-    char id[kIdMaxLength]                                  = {};
+    char id[kIdMaxLength + 1]                              = {};
     char deviceName[chip::Dnssd::kMaxDeviceNameLen + 1]    = {};
     char hostName[chip::Dnssd::kHostNameMaxLength + 1]     = {};
     char instanceName[chip::Dnssd::kHostNameMaxLength + 1] = {};

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -41,7 +41,7 @@ using DisconnectCallback = std::function<void(void)>;
 
 const int kPortMaxLength = 5; // port is uint16_t
 // +1 for the : between the hostname and the port.
-const int kIdMaxLength   = chip::Dnssd::kHostNameMaxLength + kPortMaxLength + 1;
+const int kIdMaxLength = chip::Dnssd::kHostNameMaxLength + kPortMaxLength + 1;
 
 class CastingPlayerAttributes
 {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -40,7 +40,8 @@ using ConnectCallback    = std::function<void(ConnectionError)>;
 using DisconnectCallback = std::function<void(void)>;
 
 const int kPortMaxLength = 5; // port is uint16_t
-const int kIdMaxLength   = chip::Dnssd::kHostNameMaxLength + kPortMaxLength;
+// +1 for the : between the hostname and the port.
+const int kIdMaxLength   = chip::Dnssd::kHostNameMaxLength + kPortMaxLength + 1;
 
 class CastingPlayerAttributes
 {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -81,7 +81,7 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
     CastingPlayerAttributes attributes;
     strcpy(attributes.id, nodeData.resolutionData.hostName);
 
-    char port[kPortMaxLength] = {};
+    char port[kPortMaxLength + 1] = {};
     snprintf(port, sizeof(port), "%u", nodeData.resolutionData.port);
     strcat(attributes.id, port);
 


### PR DESCRIPTION
snprintf appends a null terminator, as does strcat, so both buffers need to be upsized by 1 to accommodate that.

Fixes a build failing while running gn_build.sh

