### PR TITLE
Make reboot pw_rpc take a delay_ms argument

### DIFF
--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -45,9 +45,13 @@ message MetadataForProvider {
   bytes tlv = 1;
 }
 
+message RebootRequest {
+  uint32 delay_ms = 1;
+}
+
 service Device {
   rpc FactoryReset(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
-  rpc Reboot(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
+  rpc Reboot(RebootRequest) returns (pw.protobuf.Empty){}
   rpc TriggerOta(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
   rpc SetOtaMetadataForProvider(MetadataForProvider) returns (pw.protobuf.Empty){}
   rpc GetDeviceInfo(pw.protobuf.Empty) returns (DeviceInfo){}

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -217,7 +217,7 @@ public:
         return pw::OkStatus();
     }
 
-    virtual pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    virtual pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response)
     {
         return pw::Status::Unimplemented();
     }

--- a/examples/platform/ameba/Rpc.cpp
+++ b/examples/platform/ameba/Rpc.cpp
@@ -76,15 +76,21 @@ public:
 class AmebaDevice final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
-        mRebootTimer = xTimerCreateStatic("Reboot", kRebootTimerPeriodTicks, false, nullptr, RebootHandler, &mRebootTimerBuffer);
+        TickType_t delayMs = kRebootTimerPeriodMs;
+        if (request.delay_ms != 0) {
+            delayMs = request.delay_ms;
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(kRebootTimerPeriodMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
         xTimerStart(mRebootTimer, 0);
         return pw::OkStatus();
     }
 
 private:
-    static constexpr TickType_t kRebootTimerPeriodTicks = 1000;
+    static constexpr uint32_t kRebootTimerPeriodMs = 1000;
     TimerHandle_t mRebootTimer;
     StaticTimer_t mRebootTimerBuffer;
 

--- a/examples/platform/ameba/Rpc.cpp
+++ b/examples/platform/ameba/Rpc.cpp
@@ -79,12 +79,17 @@ public:
     pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         TickType_t delayMs = kRebootTimerPeriodMs;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delayMs = request.delay_ms;
-        } else {
-            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
         }
-        mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(kRebootTimerPeriodMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
+        else
+        {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms",
+                            static_cast<int>(kRebootTimerPeriodMs));
+        }
+        mRebootTimer =
+            xTimerCreateStatic("Reboot", pdMS_TO_TICKS(kRebootTimerPeriodMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
         xTimerStart(mRebootTimer, 0);
         return pw::OkStatus();
     }

--- a/examples/platform/bouffalolab/common/rpc/Rpc.cpp
+++ b/examples/platform/bouffalolab/common/rpc/Rpc.cpp
@@ -132,7 +132,7 @@ public:
 
 private:
     static constexpr uint32_t kRebootTimerPeriodMs = 1000;
-    TimerHandle_t mRebootTimer;
+    TimerHandle_t mRebootTimer = 0;
     StaticTimer_t mRebootTimerBuffer;
 
     static void RebootHandler(TimerHandle_t) { bl_sys_reset_por(); }

--- a/examples/platform/bouffalolab/common/rpc/Rpc.cpp
+++ b/examples/platform/bouffalolab/common/rpc/Rpc.cpp
@@ -96,12 +96,19 @@ class BouffaloDevice final : public Device
 public:
     pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
     {
-        if (!mRebootTimer)
+        if (mRebootTimer)
         {
-            mRebootTimer =
-                xTimerCreateStatic("Reboot", kRebootTimerPeriodTicks, false, nullptr, RebootHandler, &mRebootTimerBuffer);
-            xTimerStart(mRebootTimer, 0);
+            return pw::OkStatus();
         }
+
+        TickType_t delayMs = kRebootTimerPeriodMs;
+        if (request.delay_ms != 0) {
+            delayMs = request.delay_ms;
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
+        xTimerStart(mRebootTimer, 0);
         return pw::OkStatus();
     }
 
@@ -117,7 +124,7 @@ public:
     }
 
 private:
-    static constexpr TickType_t kRebootTimerPeriodTicks = 1000;
+    static constexpr uint32_t kRebootTimerPeriodMs = 1000;
     TimerHandle_t mRebootTimer;
     StaticTimer_t mRebootTimerBuffer;
 

--- a/examples/platform/bouffalolab/common/rpc/Rpc.cpp
+++ b/examples/platform/bouffalolab/common/rpc/Rpc.cpp
@@ -102,10 +102,14 @@ public:
         }
 
         TickType_t delayMs = kRebootTimerPeriodMs;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delayMs = request.delay_ms;
-        } else {
-            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms",
+                            static_cast<int>(kRebootTimerPeriodMs));
         }
         mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
         xTimerStart(mRebootTimer, 0);

--- a/examples/platform/bouffalolab/common/rpc/Rpc.cpp
+++ b/examples/platform/bouffalolab/common/rpc/Rpc.cpp
@@ -132,7 +132,7 @@ public:
 
 private:
     static constexpr uint32_t kRebootTimerPeriodMs = 1000;
-    TimerHandle_t mRebootTimer = 0;
+    TimerHandle_t mRebootTimer                     = 0;
     StaticTimer_t mRebootTimerBuffer;
 
     static void RebootHandler(TimerHandle_t) { bl_sys_reset_por(); }

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -115,10 +115,14 @@ public:
     pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         TickType_t delayMs = kRebootTimerPeriodMs;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delayMs = request.delay_ms;
-        } else {
-            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms",
+                            static_cast<int>(kRebootTimerPeriodMs));
         }
         mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
 
@@ -131,9 +135,7 @@ private:
     TimerHandle_t mRebootTimer;
     StaticTimer_t mRebootTimerBuffer;
 
-    static void RebootHandler(TimerHandle_t) {
-        esp_restart();
-    }
+    static void RebootHandler(TimerHandle_t) { esp_restart(); }
 };
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
 

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -112,19 +112,28 @@ public:
 class Esp32Device final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
-        mRebootTimer = xTimerCreateStatic("Reboot", kRebootTimerPeriodTicks, false, nullptr, RebootHandler, &mRebootTimerBuffer);
+        TickType_t delayMs = kRebootTimerPeriodMs;
+        if (request.delay_ms != 0) {
+            delayMs = request.delay_ms;
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
+
         xTimerStart(mRebootTimer, 0);
         return pw::OkStatus();
     }
 
 private:
-    static constexpr TickType_t kRebootTimerPeriodTicks = 1000;
+    static constexpr uint32_t kRebootTimerPeriodMs = 1000;
     TimerHandle_t mRebootTimer;
     StaticTimer_t mRebootTimerBuffer;
 
-    static void RebootHandler(TimerHandle_t) { esp_restart(); }
+    static void RebootHandler(TimerHandle_t) {
+        esp_restart();
+    }
 };
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
 

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -95,9 +95,17 @@ K_TIMER_DEFINE(reboot_timer, reboot_timer_handler, NULL);
 class NrfDevice final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
-        k_timer_start(&reboot_timer, K_SECONDS(1), K_FOREVER);
+        k_timeout_t delay;
+        if (request.delay_ms != 0) {
+            delay = K_MSEC(request.delay_ms);
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
+            delay = K_SECONDS(1);
+        }
+
+        k_timer_start(&reboot_timer, delay, K_FOREVER);
         return pw::OkStatus();
     }
 };

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -98,9 +98,12 @@ public:
     pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         k_timeout_t delay;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delay = K_MSEC(request.delay_ms);
-        } else {
+        }
+        else
+        {
             ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
             delay = K_SECONDS(1);
         }

--- a/examples/platform/qpg/Rpc.cpp
+++ b/examples/platform/qpg/Rpc.cpp
@@ -67,9 +67,12 @@ public:
     {
         Clock::Timeout delay;
 
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delay = System::Clock::Milliseconds64(request.delay_ms);
-        } else {
+        }
+        else
+        {
             delay = System::Clock::Seconds32(1);
             ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
         }
@@ -82,10 +85,9 @@ public:
         TriggerOTAQuery();
         return pw::OkStatus();
     }
+
 private:
-    static void RebootImpl(System::Layer *, void *) {
-        qvCHIP_ResetSystem();
-    }
+    static void RebootImpl(System::Layer *, void *) { qvCHIP_ResetSystem(); }
 };
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
 

--- a/examples/platform/qpg/Rpc.cpp
+++ b/examples/platform/qpg/Rpc.cpp
@@ -63,16 +63,28 @@ public:
 class QpgDevice final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response)
     {
-        qvCHIP_ResetSystem();
-        // WILL NOT RETURN
+        Clock::Timeout delay;
+
+        if (request.delay_ms != 0) {
+            delay = System::Clock::Milliseconds64(request.delay_ms);
+        } else {
+            delay = System::Clock::Seconds32(1);
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
+        }
+
+        DeviceLayer::SystemLayer().StartTimer(delay, RebootImpl, nullptr);
         return pw::OkStatus();
     }
     pw::Status TriggerOta(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
         TriggerOTAQuery();
         return pw::OkStatus();
+    }
+private:
+    static void RebootImpl(System::Layer *, void *) {
+        qvCHIP_ResetSystem();
     }
 };
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE

--- a/examples/platform/silabs/Rpc.cpp
+++ b/examples/platform/silabs/Rpc.cpp
@@ -92,7 +92,7 @@ public:
 class Efr32Device final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         TickType_t delayMs = kRebootTimerPeriodMs;
         if (request.delay_ms != 0) {

--- a/examples/platform/silabs/Rpc.cpp
+++ b/examples/platform/silabs/Rpc.cpp
@@ -94,13 +94,19 @@ class Efr32Device final : public Device
 public:
     pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
     {
-        mRebootTimer = xTimerCreateStatic("Reboot", kRebootTimerPeriodTicks, false, nullptr, RebootHandler, &mRebootTimerBuffer);
-        xTimerStart(mRebootTimer, pdMS_TO_TICKS(0));
+        TickType_t delayMs = kRebootTimerPeriodMs;
+        if (request.delay_ms != 0) {
+            delayMs = request.delay_ms;
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
+        xTimerStart(mRebootTimer, 0);
         return pw::OkStatus();
     }
 
 private:
-    static constexpr TickType_t kRebootTimerPeriodTicks = 1000;
+    static constexpr uint32_t kRebootTimerPeriodMs = 1000;
     TimerHandle_t mRebootTimer;
     StaticTimer_t mRebootTimerBuffer;
 

--- a/examples/platform/silabs/Rpc.cpp
+++ b/examples/platform/silabs/Rpc.cpp
@@ -95,10 +95,14 @@ public:
     pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         TickType_t delayMs = kRebootTimerPeriodMs;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delayMs = request.delay_ms;
-        } else {
-            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms", static_cast<int>(kRebootTimerPeriodMs));
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to %d ms",
+                            static_cast<int>(kRebootTimerPeriodMs));
         }
         mRebootTimer = xTimerCreateStatic("Reboot", pdMS_TO_TICKS(delayMs), false, nullptr, RebootHandler, &mRebootTimerBuffer);
         xTimerStart(mRebootTimer, 0);

--- a/examples/platform/telink/Rpc.cpp
+++ b/examples/platform/telink/Rpc.cpp
@@ -99,9 +99,12 @@ public:
     pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         k_timeout_t delay;
-        if (request.delay_ms != 0) {
+        if (request.delay_ms != 0)
+        {
             delay = K_MSEC(request.delay_ms);
-        } else {
+        }
+        else
+        {
             ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
             delay = K_SECONDS(1);
         }

--- a/examples/platform/telink/Rpc.cpp
+++ b/examples/platform/telink/Rpc.cpp
@@ -96,9 +96,17 @@ K_TIMER_DEFINE(reboot_timer, reboot_timer_handler, NULL);
 class TelinkDevice final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
-        k_timer_start(&reboot_timer, K_SECONDS(1), K_FOREVER);
+        k_timeout_t delay;
+        if (request.delay_ms != 0) {
+            delay = K_MSEC(request.delay_ms);
+        } else {
+            ChipLogProgress(NotSpecified, "Did not receive a reboot delay. Defaulting to 1s");
+            delay = K_SECONDS(1);
+        }
+
+        k_timer_start(&reboot_timer, delay, K_FOREVER);
         return pw::OkStatus();
     }
 };


### PR DESCRIPTION
Reboot delays were not consistent (using ticks for esp32, constants for others, qpg was not even delaying).

Changes:
  - add an input argument to Reboot to allow a ms delay
  - make use of this delay on all platforms. 0 delay is NOT allowed and we default to 1 second
  - Update QPG to use a timer for reboot, so that RPC replies can be processed

Testing
  - various delays on a devkitc-light-rpc app (running on a m5)
  - compile test efr32 and nrfconnect