### PR TITLE
Save flash on command/event decodes

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -7,6 +7,41 @@ namespace app {
 namespace Clusters {
 
 namespace detail {
+
+CHIP_ERROR FlightCheckDecodeAndEnterStruct(TLV::TLVReader & reader, TLV::TLVType & outer)
+{
+    TLV::TLVReader temp_reader;
+
+    // Make a copy of the struct reader to do pre-checks.
+    temp_reader.Init(reader);
+
+    // Ensure we have a single struct and that it's properly bounded.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrReturnError(TLV::kTLVType_Structure == temp_reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(temp_reader.EnterContainer(outer));
+    while ((err = temp_reader.Next()) == CHIP_NO_ERROR)
+    {
+        if (!TLV::IsContextTag(temp_reader.GetTag()))
+        {
+            continue;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(temp_reader.ExitContainer(outer));
+
+    // Guaranteed to work due to prior checks.
+    VerifyOrDie(reader.EnterContainer(outer) == CHIP_NO_ERROR);
+    return CHIP_NO_ERROR;
+}
+
+void ExitStructAfterDecode(TLV::TLVReader & reader, TLV::TLVType & outer)
+{
+    // Ensure we exit the container. Will be OK since FlightCheckDecodeAndEnterStruct will have
+    // already been called, and generated code properly iterates over entire container.
+    VerifyOrDie(reader.Next() == CHIP_END_OF_TLV);
+    VerifyOrDie(reader.ExitContainer(outer) == CHIP_NO_ERROR);
+}
+
 // Structs shared across multiple clusters.
 namespace Structs {
 {{#zcl_structs}}
@@ -45,10 +80,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const{
 }
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR) {
         if (!TLV::IsContextTag(reader.GetTag()))
         {
@@ -66,8 +101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace {{asUpperCamelCase name}}.
@@ -109,10 +143,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const{
 }
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR) {
         if (!TLV::IsContextTag(reader.GetTag()))
         {
@@ -130,8 +164,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace {{asUpperCamelCase name}}.

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -24,6 +24,41 @@ namespace app {
 namespace Clusters {
 
 namespace detail {
+
+CHIP_ERROR FlightCheckDecodeAndEnterStruct(TLV::TLVReader & reader, TLV::TLVType & outer)
+{
+    TLV::TLVReader temp_reader;
+
+    // Make a copy of the struct reader to do pre-checks.
+    temp_reader.Init(reader);
+
+    // Ensure we have a single struct and that it's properly bounded.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrReturnError(TLV::kTLVType_Structure == temp_reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(temp_reader.EnterContainer(outer));
+    while ((err = temp_reader.Next()) == CHIP_NO_ERROR)
+    {
+        if (!TLV::IsContextTag(temp_reader.GetTag()))
+        {
+            continue;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(temp_reader.ExitContainer(outer));
+
+    // Guaranteed to work due to prior checks.
+    VerifyOrDie(reader.EnterContainer(outer) == CHIP_NO_ERROR);
+    return CHIP_NO_ERROR;
+}
+
+void ExitStructAfterDecode(TLV::TLVReader & reader, TLV::TLVType & outer)
+{
+    // Ensure we exit the container. Will be OK since FlightCheckDecodeAndEnterStruct will have
+    // already been called, and generated code properly iterates over entire container.
+    VerifyOrDie(reader.Next() == CHIP_END_OF_TLV);
+    VerifyOrDie(reader.ExitContainer(outer) == CHIP_NO_ERROR);
+}
+
 // Structs shared across multiple clusters.
 namespace Structs {
 namespace ModeTagStruct {
@@ -316,10 +351,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -336,8 +371,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Identify.
@@ -354,10 +388,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -377,8 +411,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TriggerEffect.
@@ -440,10 +473,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -463,8 +496,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddGroup.
@@ -481,10 +513,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -504,8 +536,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddGroupResponse.
@@ -521,10 +552,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -541,8 +572,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ViewGroup.
@@ -560,10 +590,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -586,8 +616,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ViewGroupResponse.
@@ -603,10 +632,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -623,8 +652,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetGroupMembership.
@@ -641,10 +669,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -664,8 +692,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetGroupMembershipResponse.
@@ -681,10 +708,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -701,8 +728,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveGroup.
@@ -719,10 +745,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -742,8 +768,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveGroupResponse.
@@ -758,10 +783,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -775,8 +800,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveAllGroups.
@@ -793,10 +817,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -816,8 +840,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddGroupIfIdentifying.
@@ -969,10 +992,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1001,8 +1024,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddScene.
@@ -1020,10 +1042,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1046,8 +1068,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddSceneResponse.
@@ -1064,10 +1085,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1087,8 +1108,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ViewScene.
@@ -1109,10 +1129,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1144,8 +1164,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ViewSceneResponse.
@@ -1162,10 +1181,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1185,8 +1204,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveScene.
@@ -1204,10 +1222,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1230,8 +1248,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveSceneResponse.
@@ -1247,10 +1264,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1267,8 +1284,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveAllScenes.
@@ -1285,10 +1301,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1308,8 +1324,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveAllScenesResponse.
@@ -1326,10 +1341,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1349,8 +1364,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StoreScene.
@@ -1368,10 +1382,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1394,8 +1408,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StoreSceneResponse.
@@ -1413,10 +1426,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1439,8 +1452,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RecallScene.
@@ -1456,10 +1468,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1476,8 +1488,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetSceneMembership.
@@ -1496,10 +1507,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1525,8 +1536,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetSceneMembershipResponse.
@@ -1546,10 +1556,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1578,8 +1588,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedAddScene.
@@ -1597,10 +1606,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1623,8 +1632,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedAddSceneResponse.
@@ -1641,10 +1649,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1664,8 +1672,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedViewScene.
@@ -1686,10 +1693,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1721,8 +1728,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedViewSceneResponse.
@@ -1742,10 +1748,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1774,8 +1780,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CopyScene.
@@ -1793,10 +1798,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1819,8 +1824,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CopySceneResponse.
@@ -1898,10 +1902,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1915,8 +1919,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Off.
@@ -1931,10 +1934,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1948,8 +1951,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace On.
@@ -1964,10 +1966,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -1981,8 +1983,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Toggle.
@@ -1999,10 +2000,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2022,8 +2023,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OffWithEffect.
@@ -2038,10 +2038,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2055,8 +2055,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OnWithRecallGlobalScene.
@@ -2074,10 +2073,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2100,8 +2099,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OnWithTimedOff.
@@ -2218,10 +2216,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2247,8 +2245,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToLevel.
@@ -2267,10 +2264,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2296,8 +2293,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Move.
@@ -2317,10 +2313,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2349,8 +2345,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Step.
@@ -2367,10 +2362,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2390,8 +2385,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Stop.
@@ -2410,10 +2404,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2439,8 +2433,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToLevelWithOnOff.
@@ -2459,10 +2452,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2488,8 +2481,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveWithOnOff.
@@ -2509,10 +2501,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2541,8 +2533,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StepWithOnOff.
@@ -2559,10 +2550,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2582,8 +2573,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StopWithOnOff.
@@ -2599,10 +2589,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -2619,8 +2609,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToClosestFrequency.
@@ -3328,10 +3317,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3360,8 +3349,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AccessControlEntryChanged.
@@ -3381,10 +3369,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3413,8 +3401,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AccessControlExtensionChanged.
@@ -3551,10 +3538,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3574,8 +3561,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace InstantAction.
@@ -3593,10 +3579,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3619,8 +3605,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace InstantActionWithTransition.
@@ -3637,10 +3622,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3660,8 +3645,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StartAction.
@@ -3679,10 +3663,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3705,8 +3689,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StartActionWithDuration.
@@ -3723,10 +3706,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3746,8 +3729,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StopAction.
@@ -3764,10 +3746,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3787,8 +3769,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PauseAction.
@@ -3806,10 +3787,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3832,8 +3813,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PauseActionWithDuration.
@@ -3850,10 +3830,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3873,8 +3853,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResumeAction.
@@ -3891,10 +3870,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3914,8 +3893,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnableAction.
@@ -3933,10 +3911,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -3959,8 +3937,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnableActionWithDuration.
@@ -3977,10 +3954,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4000,8 +3977,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DisableAction.
@@ -4019,10 +3995,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4045,8 +4021,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DisableActionWithDuration.
@@ -4107,10 +4082,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4133,8 +4108,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StateChanged.
@@ -4153,10 +4127,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4182,8 +4156,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ActionFailed.
@@ -4294,10 +4267,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4311,8 +4284,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MfgSpecificPing.
@@ -4425,10 +4397,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4445,8 +4417,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StartUp.
@@ -4461,10 +4432,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4478,8 +4449,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ShutDown.
@@ -4495,10 +4465,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4515,8 +4485,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Leave.
@@ -4532,10 +4501,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4552,8 +4521,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ReachableChanged.
@@ -4582,10 +4550,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4623,8 +4591,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace QueryImage.
@@ -4647,10 +4614,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4688,8 +4655,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace QueryImageResponse.
@@ -4706,10 +4672,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4729,8 +4695,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ApplyUpdateRequest.
@@ -4747,10 +4712,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4770,8 +4735,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ApplyUpdateResponse.
@@ -4788,10 +4752,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4811,8 +4775,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NotifyUpdateApplied.
@@ -4934,10 +4897,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -4966,8 +4929,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AnnounceOTAProvider.
@@ -5032,10 +4994,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5061,8 +5023,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StateTransition.
@@ -5079,10 +5040,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5102,8 +5063,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace VersionApplied.
@@ -5122,10 +5082,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5151,8 +5111,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DownloadError.
@@ -5611,10 +5570,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5634,8 +5593,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace WiredFaultChange.
@@ -5652,10 +5610,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5675,8 +5633,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BatFaultChange.
@@ -5693,10 +5650,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5716,8 +5673,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BatChargeFaultChange.
@@ -5788,10 +5744,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5811,8 +5767,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ArmFailSafe.
@@ -5829,10 +5784,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5852,8 +5807,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ArmFailSafeResponse.
@@ -5871,10 +5825,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5897,8 +5851,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetRegulatoryConfig.
@@ -5915,10 +5868,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5938,8 +5891,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetRegulatoryConfigResponse.
@@ -5954,10 +5906,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -5971,8 +5923,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CommissioningComplete.
@@ -5989,10 +5940,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6012,8 +5963,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CommissioningCompleteResponse.
@@ -6258,10 +6208,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6281,8 +6231,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ScanNetworks.
@@ -6301,10 +6250,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6330,8 +6279,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ScanNetworksResponse.
@@ -6349,10 +6297,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6375,8 +6323,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddOrUpdateWiFiNetwork.
@@ -6393,10 +6340,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6416,8 +6363,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddOrUpdateThreadNetwork.
@@ -6434,10 +6380,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6457,8 +6403,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveNetwork.
@@ -6476,10 +6421,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6502,8 +6447,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NetworkConfigResponse.
@@ -6520,10 +6464,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6543,8 +6487,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ConnectNetwork.
@@ -6562,10 +6505,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6588,8 +6531,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ConnectNetworkResponse.
@@ -6607,10 +6549,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6633,8 +6575,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ReorderNetwork.
@@ -6715,10 +6656,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6741,8 +6682,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RetrieveLogsRequest.
@@ -6761,10 +6701,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6790,8 +6730,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RetrieveLogsResponse.
@@ -6919,10 +6858,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -6942,8 +6881,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEventTrigger.
@@ -7024,10 +6962,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7047,8 +6985,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace HardwareFaultChange.
@@ -7065,10 +7002,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7088,8 +7025,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RadioFaultChange.
@@ -7106,10 +7042,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7129,8 +7065,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NetworkFaultChange.
@@ -7146,10 +7081,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7166,8 +7101,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BootReason.
@@ -7246,10 +7180,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7263,8 +7197,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetWatermarks.
@@ -7328,10 +7261,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7354,8 +7287,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SoftwareFault.
@@ -7674,10 +7606,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7691,8 +7623,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetCounts.
@@ -7931,10 +7862,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7951,8 +7882,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ConnectionStatus.
@@ -7969,10 +7899,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -7992,8 +7922,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NetworkFaultChange.
@@ -8014,10 +7943,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8031,8 +7960,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetCounts.
@@ -8121,10 +8049,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8141,8 +8069,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Disconnection.
@@ -8159,10 +8086,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8182,8 +8109,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AssociationFailure.
@@ -8199,10 +8125,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8219,8 +8145,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ConnectionStatus.
@@ -8241,10 +8166,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8258,8 +8183,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetCounts.
@@ -8533,10 +8457,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8559,8 +8483,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetUTCTime.
@@ -8576,10 +8499,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8596,8 +8519,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetTrustedTimeSource.
@@ -8613,10 +8535,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8633,8 +8555,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetTimeZone.
@@ -8650,10 +8571,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8670,8 +8591,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetTimeZoneResponse.
@@ -8687,10 +8607,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8707,8 +8627,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetDSTOffset.
@@ -8724,10 +8643,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8744,8 +8663,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetDefaultNTP.
@@ -8833,10 +8751,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8850,8 +8768,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DSTTableEmpty.
@@ -8867,10 +8784,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8887,8 +8804,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DSTStatus.
@@ -8905,10 +8821,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8928,8 +8844,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TimeZoneStatus.
@@ -8944,10 +8859,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8961,8 +8876,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TimeFailure.
@@ -8977,10 +8891,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -8994,8 +8908,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MissingTrustedTimeSource.
@@ -9144,10 +9057,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9164,8 +9077,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StartUp.
@@ -9180,10 +9092,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9197,8 +9109,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ShutDown.
@@ -9213,10 +9124,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9230,8 +9141,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Leave.
@@ -9247,10 +9157,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9267,8 +9177,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ReachableChanged.
@@ -9332,10 +9241,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9352,8 +9261,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SwitchLatched.
@@ -9369,10 +9277,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9389,8 +9297,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace InitialPress.
@@ -9406,10 +9313,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9426,8 +9333,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LongPress.
@@ -9443,10 +9349,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9463,8 +9369,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ShortRelease.
@@ -9480,10 +9385,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9500,8 +9405,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LongRelease.
@@ -9519,10 +9423,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9542,8 +9446,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MultiPressOngoing.
@@ -9561,10 +9464,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9584,8 +9487,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MultiPressComplete.
@@ -9611,10 +9513,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9643,8 +9545,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OpenCommissioningWindow.
@@ -9660,10 +9561,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9680,8 +9581,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OpenBasicCommissioningWindow.
@@ -9696,10 +9596,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9713,8 +9613,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RevokeCommissioning.
@@ -9921,10 +9820,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9941,8 +9840,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AttestationRequest.
@@ -9959,10 +9857,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -9982,8 +9880,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AttestationResponse.
@@ -9999,10 +9896,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10019,8 +9916,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CertificateChainRequest.
@@ -10036,10 +9932,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10056,8 +9952,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CertificateChainResponse.
@@ -10074,10 +9969,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10097,8 +9992,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CSRRequest.
@@ -10115,10 +10009,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10138,8 +10032,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace CSRResponse.
@@ -10159,10 +10052,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10191,8 +10084,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddNOC.
@@ -10209,10 +10101,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10232,8 +10124,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UpdateNOC.
@@ -10251,10 +10142,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10277,8 +10168,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NOCResponse.
@@ -10294,10 +10184,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10314,8 +10204,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UpdateFabricLabel.
@@ -10331,10 +10220,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10351,8 +10240,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RemoveFabric.
@@ -10368,10 +10256,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10388,8 +10276,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddTrustedRootCertificate.
@@ -10658,10 +10545,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10678,8 +10565,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetWrite.
@@ -10695,10 +10581,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10715,8 +10601,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetRead.
@@ -10732,10 +10617,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10752,8 +10637,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetReadResponse.
@@ -10769,10 +10653,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10789,8 +10673,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetRemove.
@@ -10805,10 +10688,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10822,8 +10705,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetReadAllIndices.
@@ -10839,10 +10721,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -10859,8 +10741,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace KeySetReadAllIndicesResponse.
@@ -11161,10 +11042,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11181,8 +11062,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StateChange.
@@ -11284,10 +11164,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11313,8 +11193,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RegisterClient.
@@ -11330,10 +11209,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11350,8 +11229,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RegisterClientResponse.
@@ -11368,10 +11246,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11391,8 +11269,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UnregisterClient.
@@ -11407,10 +11284,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11424,8 +11301,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StayActiveRequest.
@@ -11592,10 +11468,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11612,8 +11488,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -11687,10 +11562,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11707,8 +11582,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -11725,10 +11599,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11748,8 +11622,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToModeResponse.
@@ -11817,10 +11690,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11837,8 +11710,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -11855,10 +11727,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -11878,8 +11750,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToModeResponse.
@@ -11997,10 +11868,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12017,8 +11888,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -12035,10 +11905,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12058,8 +11928,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToModeResponse.
@@ -12127,10 +11996,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12147,8 +12016,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -12165,10 +12033,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12188,8 +12056,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToModeResponse.
@@ -12257,10 +12124,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12280,8 +12147,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetTemperature.
@@ -12399,10 +12265,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12428,8 +12294,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Notify.
@@ -12452,10 +12317,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12472,8 +12337,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToMode.
@@ -12490,10 +12354,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12513,8 +12377,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeToModeResponse.
@@ -12621,10 +12484,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12638,8 +12501,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SelfTestRequest.
@@ -12728,10 +12590,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12748,8 +12610,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SmokeAlarm.
@@ -12765,10 +12626,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12785,8 +12646,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace COAlarm.
@@ -12802,10 +12662,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12822,8 +12682,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LowBattery.
@@ -12838,10 +12697,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12855,8 +12714,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace HardwareFault.
@@ -12871,10 +12729,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12888,8 +12746,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EndOfService.
@@ -12904,10 +12761,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12921,8 +12778,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SelfTestComplete.
@@ -12937,10 +12793,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12954,8 +12810,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AlarmMuted.
@@ -12970,10 +12825,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -12987,8 +12842,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MuteEnded.
@@ -13004,10 +12858,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13024,8 +12878,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace InterconnectSmokeAlarm.
@@ -13041,10 +12894,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13061,8 +12914,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace InterconnectCOAlarm.
@@ -13077,10 +12929,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13094,8 +12946,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AllClear.
@@ -13117,10 +12968,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13137,8 +12988,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Reset.
@@ -13154,10 +13004,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13174,8 +13024,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ModifyEnabledAlarms.
@@ -13240,10 +13089,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13269,8 +13118,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Notify.
@@ -13292,10 +13140,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13309,8 +13157,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Pause.
@@ -13325,10 +13172,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13342,8 +13189,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Stop.
@@ -13358,10 +13204,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13375,8 +13221,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Start.
@@ -13391,10 +13236,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13408,8 +13253,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Resume.
@@ -13425,10 +13269,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13445,8 +13289,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationalCommandResponse.
@@ -13514,10 +13357,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13534,8 +13377,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationalError.
@@ -13553,10 +13395,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13579,8 +13421,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationCompletion.
@@ -13602,10 +13443,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13619,8 +13460,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Pause.
@@ -13635,10 +13475,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13652,8 +13492,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Stop.
@@ -13668,10 +13507,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13685,8 +13524,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Start.
@@ -13701,10 +13539,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13718,8 +13556,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Resume.
@@ -13735,10 +13572,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13755,8 +13592,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationalCommandResponse.
@@ -13824,10 +13660,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13844,8 +13680,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationalError.
@@ -13863,10 +13698,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13889,8 +13724,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace OperationCompletion.
@@ -13957,10 +13791,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -13974,8 +13808,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetCondition.
@@ -14093,10 +13926,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14110,8 +13943,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ResetCondition.
@@ -14230,10 +14062,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14250,8 +14082,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LockDoor.
@@ -14267,10 +14098,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14287,8 +14118,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UnlockDoor.
@@ -14305,10 +14135,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14328,8 +14158,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UnlockWithTimeout.
@@ -14351,10 +14180,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14389,8 +14218,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetWeekDaySchedule.
@@ -14407,10 +14235,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14430,8 +14258,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetWeekDaySchedule.
@@ -14454,10 +14281,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14495,8 +14322,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetWeekDayScheduleResponse.
@@ -14513,10 +14339,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14536,8 +14362,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearWeekDaySchedule.
@@ -14556,10 +14381,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14585,8 +14410,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetYearDaySchedule.
@@ -14603,10 +14427,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14626,8 +14450,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetYearDaySchedule.
@@ -14647,10 +14470,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14679,8 +14502,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetYearDayScheduleResponse.
@@ -14697,10 +14519,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14720,8 +14542,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearYearDaySchedule.
@@ -14740,10 +14561,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14769,8 +14590,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetHolidaySchedule.
@@ -14786,10 +14606,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14806,8 +14626,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetHolidaySchedule.
@@ -14827,10 +14646,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14859,8 +14678,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetHolidayScheduleResponse.
@@ -14876,10 +14694,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14896,8 +14714,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearHolidaySchedule.
@@ -14919,10 +14736,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14957,8 +14774,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetUser.
@@ -14974,10 +14790,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -14994,8 +14810,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetUser.
@@ -15020,10 +14835,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15067,8 +14882,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetUserResponse.
@@ -15084,10 +14898,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15104,8 +14918,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearUser.
@@ -15126,10 +14939,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15161,8 +14974,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetCredential.
@@ -15180,10 +14992,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15206,8 +15018,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetCredentialResponse.
@@ -15223,10 +15034,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15243,8 +15054,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetCredentialStatus.
@@ -15264,10 +15074,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15296,8 +15106,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetCredentialStatusResponse.
@@ -15313,10 +15122,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15333,8 +15142,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearCredential.
@@ -15350,10 +15158,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15370,8 +15178,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UnboltDoor.
@@ -15529,10 +15336,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15549,8 +15356,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DoorLockAlarm.
@@ -15566,10 +15372,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15586,8 +15392,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DoorStateChange.
@@ -15608,10 +15413,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15643,8 +15448,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LockOperation.
@@ -15666,10 +15470,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15704,8 +15508,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LockOperationError.
@@ -15727,10 +15530,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15765,8 +15568,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LockUserChange.
@@ -15787,10 +15589,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15804,8 +15606,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace UpOrOpen.
@@ -15820,10 +15621,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15837,8 +15638,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DownOrClose.
@@ -15853,10 +15653,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15870,8 +15670,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StopMotion.
@@ -15887,10 +15686,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15907,8 +15706,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GoToLiftValue.
@@ -15924,10 +15722,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15944,8 +15742,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GoToLiftPercentage.
@@ -15961,10 +15758,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -15981,8 +15778,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GoToTiltValue.
@@ -15998,10 +15794,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16018,8 +15814,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GoToTiltPercentage.
@@ -16140,10 +15935,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16160,8 +15955,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BarrierControlGoToPercent.
@@ -16176,10 +15970,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16193,8 +15987,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BarrierControlStop.
@@ -16380,10 +16173,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16397,8 +16190,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SupplyVoltageLow.
@@ -16413,10 +16205,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16430,8 +16222,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SupplyVoltageHigh.
@@ -16446,10 +16237,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16463,8 +16254,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PowerMissingPhase.
@@ -16479,10 +16269,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16496,8 +16286,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SystemPressureLow.
@@ -16512,10 +16301,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16529,8 +16318,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SystemPressureHigh.
@@ -16545,10 +16333,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16562,8 +16350,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace DryRunning.
@@ -16578,10 +16365,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16595,8 +16382,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MotorTemperatureHigh.
@@ -16611,10 +16397,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16628,8 +16414,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PumpMotorFatalFailure.
@@ -16644,10 +16429,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16661,8 +16446,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ElectronicTemperatureHigh.
@@ -16677,10 +16461,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16694,8 +16478,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PumpBlocked.
@@ -16710,10 +16493,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16727,8 +16510,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SensorFailure.
@@ -16743,10 +16525,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16760,8 +16542,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ElectronicNonFatalFailure.
@@ -16776,10 +16557,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16793,8 +16574,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ElectronicFatalFailure.
@@ -16809,10 +16589,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16826,8 +16606,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GeneralFault.
@@ -16842,10 +16621,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16859,8 +16638,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Leakage.
@@ -16875,10 +16653,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16892,8 +16670,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AirDetection.
@@ -16908,10 +16685,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -16925,8 +16702,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TurbineOperation.
@@ -16999,10 +16775,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17022,8 +16798,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetpointRaiseLower.
@@ -17043,10 +16818,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17072,8 +16847,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetWeeklyScheduleResponse.
@@ -17093,10 +16867,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17122,8 +16896,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SetWeeklySchedule.
@@ -17140,10 +16913,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17163,8 +16936,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetWeeklySchedule.
@@ -17179,10 +16951,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17196,8 +16968,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ClearWeeklySchedule.
@@ -17401,10 +17172,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17427,8 +17198,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Step.
@@ -17570,10 +17340,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17602,8 +17372,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToHue.
@@ -17622,10 +17391,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17651,8 +17420,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveHue.
@@ -17672,10 +17440,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17704,8 +17472,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StepHue.
@@ -17724,10 +17491,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17753,8 +17520,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToSaturation.
@@ -17773,10 +17539,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17802,8 +17568,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveSaturation.
@@ -17823,10 +17588,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17855,8 +17620,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StepSaturation.
@@ -17876,10 +17640,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17908,8 +17672,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToHueAndSaturation.
@@ -17929,10 +17692,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -17961,8 +17724,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToColor.
@@ -17981,10 +17743,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18010,8 +17772,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveColor.
@@ -18031,10 +17792,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18063,8 +17824,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StepColor.
@@ -18083,10 +17843,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18112,8 +17872,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveToColorTemperature.
@@ -18133,10 +17892,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18165,8 +17924,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedMoveToHue.
@@ -18185,10 +17943,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18214,8 +17972,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedMoveHue.
@@ -18235,10 +17992,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18267,8 +18024,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedStepHue.
@@ -18288,10 +18044,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18320,8 +18076,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace EnhancedMoveToHueAndSaturation.
@@ -18343,10 +18098,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18381,8 +18136,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ColorLoopSet.
@@ -18399,10 +18153,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18422,8 +18176,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StopMoveStep.
@@ -18446,10 +18199,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18481,8 +18234,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace MoveColorTemperature.
@@ -18506,10 +18258,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -18544,8 +18296,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StepColorTemperature.
@@ -20039,10 +19790,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20059,8 +19810,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeChannel.
@@ -20077,10 +19827,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20100,8 +19850,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeChannelResponse.
@@ -20118,10 +19867,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20141,8 +19890,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ChangeChannelByNumber.
@@ -20158,10 +19906,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20178,8 +19926,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SkipChannel.
@@ -20290,10 +20037,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20313,8 +20060,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NavigateTarget.
@@ -20331,10 +20077,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20354,8 +20100,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace NavigateTargetResponse.
@@ -20461,10 +20206,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20478,8 +20223,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Play.
@@ -20494,10 +20238,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20511,8 +20255,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Pause.
@@ -20527,10 +20270,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20544,8 +20287,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Stop.
@@ -20560,10 +20302,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20577,8 +20319,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StartOver.
@@ -20593,10 +20334,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20610,8 +20351,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Previous.
@@ -20626,10 +20366,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20643,8 +20383,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Next.
@@ -20659,10 +20398,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20676,8 +20415,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Rewind.
@@ -20692,10 +20430,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20709,8 +20447,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace FastForward.
@@ -20727,10 +20464,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20747,8 +20484,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SkipForward.
@@ -20765,10 +20501,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20785,8 +20521,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SkipBackward.
@@ -20803,10 +20538,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20826,8 +20561,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace PlaybackResponse.
@@ -20843,10 +20577,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -20863,8 +20597,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Seek.
@@ -20994,10 +20727,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21014,8 +20747,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SelectInput.
@@ -21030,10 +20762,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21047,8 +20779,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace ShowInputStatus.
@@ -21063,10 +20794,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21080,8 +20811,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace HideInputStatus.
@@ -21098,10 +20828,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21121,8 +20851,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RenameInput.
@@ -21182,10 +20911,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21199,8 +20928,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Sleep.
@@ -21255,10 +20983,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21275,8 +21003,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SendKey.
@@ -21292,10 +21019,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21312,8 +21039,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SendKeyResponse.
@@ -21660,10 +21386,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21686,8 +21412,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LaunchContent.
@@ -21705,10 +21430,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21731,8 +21456,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LaunchURL.
@@ -21749,10 +21473,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21772,8 +21496,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LauncherResponse.
@@ -21884,10 +21607,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21904,8 +21627,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SelectOutput.
@@ -21922,10 +21644,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -21945,8 +21667,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace RenameOutput.
@@ -22054,10 +21775,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22077,8 +21798,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LaunchApp.
@@ -22094,10 +21814,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22114,8 +21834,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace StopApp.
@@ -22131,10 +21850,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22151,8 +21870,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace HideApp.
@@ -22169,10 +21887,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22192,8 +21910,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace LauncherResponse.
@@ -22317,10 +22034,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22337,8 +22054,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetSetupPIN.
@@ -22354,10 +22070,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22374,8 +22090,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetSetupPINResponse.
@@ -22392,10 +22107,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22415,8 +22130,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Login.
@@ -22431,10 +22145,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22448,8 +22162,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Logout.
@@ -22507,10 +22220,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22536,8 +22249,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetProfileInfoResponseCommand.
@@ -22552,10 +22264,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22569,8 +22281,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetProfileInfoCommand.
@@ -22592,10 +22303,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22627,8 +22338,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetMeasurementProfileResponseCommand.
@@ -22646,10 +22356,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -22672,8 +22382,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace GetMeasurementProfileCommand.
@@ -23569,10 +23278,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23586,8 +23295,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Test.
@@ -23603,10 +23311,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23623,8 +23331,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestSpecificResponse.
@@ -23639,10 +23346,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23656,8 +23363,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestNotHandled.
@@ -23673,10 +23379,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23693,8 +23399,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestAddArgumentsResponse.
@@ -23709,10 +23414,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23726,8 +23431,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestSpecific.
@@ -23743,10 +23447,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23763,8 +23467,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestSimpleArgumentResponse.
@@ -23779,10 +23482,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23796,8 +23499,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestUnknownCommand.
@@ -23818,10 +23520,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23853,8 +23555,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestStructArrayArgumentResponse.
@@ -23871,10 +23572,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23894,8 +23595,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestAddArguments.
@@ -23911,10 +23611,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23931,8 +23631,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestListInt8UReverseResponse.
@@ -23948,10 +23647,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -23968,8 +23667,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestSimpleArgumentRequest.
@@ -23986,10 +23684,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24009,8 +23707,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEnumsResponse.
@@ -24031,10 +23728,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24066,8 +23763,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestStructArrayArgumentRequest.
@@ -24086,10 +23782,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24115,8 +23811,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestNullableOptionalResponse.
@@ -24132,10 +23827,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24152,8 +23847,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestStructArgumentRequest.
@@ -24207,10 +23901,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24308,8 +24002,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestComplexNullableOptionalResponse.
@@ -24325,10 +24018,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24345,8 +24038,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestNestedStructArgumentRequest.
@@ -24362,10 +24054,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24382,8 +24074,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace BooleanResponse.
@@ -24399,10 +24090,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24419,8 +24110,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestListStructArgumentRequest.
@@ -24436,10 +24126,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24456,8 +24146,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SimpleStructResponse.
@@ -24473,10 +24162,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24493,8 +24182,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestListInt8UArgumentRequest.
@@ -24510,10 +24198,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24530,8 +24218,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEmitTestEventResponse.
@@ -24547,10 +24234,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24567,8 +24254,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestNestedStructListArgumentRequest.
@@ -24584,10 +24270,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24604,8 +24290,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEmitTestFabricScopedEventResponse.
@@ -24621,10 +24306,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24641,8 +24326,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestListNestedStructListArgumentRequest.
@@ -24658,10 +24342,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24678,8 +24362,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestListInt8UReverseRequest.
@@ -24696,10 +24379,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24719,8 +24402,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEnumsRequest.
@@ -24736,10 +24418,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24756,8 +24438,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestNullableOptionalRequest.
@@ -24784,10 +24465,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24837,8 +24518,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestComplexNullableOptionalRequest.
@@ -24854,10 +24534,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24874,8 +24554,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace SimpleStructEchoRequest.
@@ -24890,10 +24569,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24907,8 +24586,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TimedInvokeRequest.
@@ -24924,10 +24602,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24944,8 +24622,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestSimpleOptionalArgumentRequest.
@@ -24963,10 +24640,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -24989,8 +24666,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEmitTestEventRequest.
@@ -25006,10 +24682,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25026,8 +24702,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEmitTestFabricScopedEventRequest.
@@ -25328,10 +25003,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25363,8 +25038,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestEvent.
@@ -25380,10 +25054,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25400,8 +25074,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace TestFabricScopedEvent.
@@ -25427,10 +25100,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25459,8 +25132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace FailAtFault.
@@ -25478,10 +25150,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25504,8 +25176,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace FailRandomlyAtFault.
@@ -25559,10 +25230,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25576,8 +25247,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace Ping.
@@ -25593,10 +25263,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25613,8 +25283,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddArgumentsResponse.
@@ -25631,10 +25300,10 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    ReturnErrorOnFailure(chip::app::Clusters::detail::FlightCheckDecodeAndEnterStruct(reader, outer));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         if (!TLV::IsContextTag(reader.GetTag()))
@@ -25654,8 +25323,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
     }
 
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    chip::app::Clusters::detail::ExitStructAfterDecode(reader, outer);
     return CHIP_NO_ERROR;
 }
 } // namespace AddArguments.


### PR DESCRIPTION
### Problem

Generated code has a lot of force-inlined repetition that did not get optimized-out, even in release.

### Changes

This PR:

- Removes some calls from every single command and event decoder and replaces them with combined function calls.
- Functionally, there should be no change.

### Testing done:

- Unit tests still pass
- Integration tests still pass

