### PR TITLE
Increment used TCPEndPoint count during incoming connection.

### DIFF
--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -225,6 +225,10 @@ private:
      */
     CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
 
+    // Release an active connection(corresponding to the passed TCPEndPoint)
+    // from the pool.
+    void ReleaseActiveConnection(Inet::TCPEndPoint * endPoint);
+
     // Callback handler for TCPEndPoint. TCP message receive handler.
     // @see TCPEndpoint::OnDataReceivedFunct
     static CHIP_ERROR OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBufferHandle && buffer);

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -225,7 +225,7 @@ private:
      */
     CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
 
-    // Release an active connection(corresponding to the passed TCPEndPoint)
+    // Release an active connection (corresponding to the passed TCPEndPoint)
     // from the pool.
     void ReleaseActiveConnection(Inet::TCPEndPoint * endPoint);
 


### PR DESCRIPTION
Due to this issue, subsequent incoming connections were failing to connect as the value was getting decremented from zero resulting in a check failing.

Also, remove duplicate code for freeing an active connection and move it into a separate function.
