### PR TITLE
Lock app: Remove duplicate generated command

### DIFF
--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -3937,16 +3937,6 @@
           "define": "GENERAL_DIAGNOSTICS_CLUSTER",
           "side": "server",
           "enabled": 1,
-          "commands": [
-            {
-              "name": "TestEventTrigger",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "incoming": 1,
-              "outgoing": 0
-            }
-          ],
           "attributes": [
             {
               "name": "NetworkInterfaces",


### PR DESCRIPTION
As in https://github.com/project-chip/connectedhomeip/pull/28890 this zap had a client side command on the server that was causing a duplicate in the generated command list.

