### PR TITLE
[Silabs] Build fixes for SiWx917 SoC

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -23,10 +23,6 @@
 #endif
 #endif // BRD4325A
 
-#ifdef BRD4325A // For SiWx917 Platform only
-#include "core_cm4.h"
-#endif
-
 #ifdef PW_RPC_ENABLED
 #include "PigweedLogger.h"
 #endif

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -205,7 +205,6 @@ template("siwx917_sdk") {
       if (silabs_board == "BRD4338A") {
         defines += [
           "SI917_RADIO_BOARD_V2=1",
-          "SL_BOARD_NAME=\"BRD4338A\"",
           "SL_BOARD_REV=\"A00\"",
           "SPI_MULTI_SLAVE=1",
           "SYSCALLS_WRITE=1",


### PR DESCRIPTION
917 SoC was not building on the CSA master due to the include of core_m4.h file which is no longer needed. Warning fix SL_BOARD_NAME was already in defines so added from this location. 