### PR TITLE
Fix MTROperationalCredentialsClusterAttestationResponseParams.attestationChallenge on Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -79,7 +79,12 @@ NS_ASSUME_NONNULL_BEGIN
  *                A structure-value is an NSArray object with NSDictionary objects as its elements. Each dictionary element will
  *                contain the following key values.
  *
- *                MTRContextTagKey : NSNumber object as context tag.
+ *                MTRContextTagKey : NSNumber object as context tag.  This can
+ *                                   actually be a fully-qualified profile tag,
+ *                                   but for compatibility it's using the same
+ *                                   key name.  The two types of tags can be
+ *                                   told apart by checking whether the value is
+ *                                   in the context tag range (0 <= tag <= 0xFF).
  *                MTRDataKey : Data-value NSDictionary object.
  *
  *                An array-value is an NSArray object with NSDictionary objects as its elements. Each dictionary element will

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -26,9 +26,25 @@
 #include <app/EventHeader.h>
 #include <app/EventLoggingTypes.h>
 #include <app/EventPathParams.h>
+#include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <lib/core/TLVTags.h>
 #include <system/SystemPacketBuffer.h>
 
 @class MTRDeviceController;
+
+// An AttestationResponse command needs to have an attestationChallenge
+// to make sense of the results.  Encode that with a profile-specific tag under
+// the Apple vendor id.  Let's select profile 0xFFFF just because, and use 0xFF
+// for the actual tag number, so that if someone accidentally casts it to a
+// uint8 (aka context tag) that will not collide with anything interesting.
+inline constexpr chip::TLV::Tag kAttestationChallengeTag = chip::TLV::ProfileTag(chip::VendorId::Apple, 0xFFFF, 0xFF);
+
+// We have no way to extract the tag value as a single thing, so just do it
+// manually.
+inline constexpr unsigned kProfileIdShift = 32;
+inline constexpr uint64_t kAttestationChallengeTagProfile = chip::TLV::ProfileIdFromTag(kAttestationChallengeTag);
+inline constexpr uint64_t kAttestationChallengeTagNumber = chip::TLV::TagNumFromTag(kAttestationChallengeTag);
+inline constexpr uint64_t kAttestationChallengeTagValue = (kAttestationChallengeTagProfile << kProfileIdShift) | kAttestationChallengeTagNumber;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
+++ b/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
@@ -20,17 +20,12 @@
 #import "MTRBaseDevice_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
-#import "NSDataSpanConversion.h"
 #import "zap-generated/MTRBaseClusters.h"
-#import "zap-generated/MTRCommandPayloads_Internal.h"
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/NullObject.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <transport/Session.h>
-
-#include <type_traits>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -152,23 +147,8 @@ using MTRActionBlockT = CHIP_ERROR (^)(chip::Messaging::ExchangeManager & exchan
 template <typename SuccessCallback>
 using MTRLocalActionBlockT = CHIP_ERROR (^)(SuccessCallback successCb, MTRErrorCallback failureCb);
 
-class NoAttestationChallenge {
-};
-
-class HaveAttestationChallenge {
-protected:
-    NSData * mAttestationChallenge;
-};
-
-namespace detail {
-using AttestationResponseCallback
-    = void (*)(void *, const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType &);
-} // namespace detail
-
 template <class T>
-class MTRCallbackBridge : public MTRCallbackBridgeBase,
-                          protected std::conditional<std::is_same_v<T, detail::AttestationResponseCallback>,
-                              HaveAttestationChallenge, NoAttestationChallenge>::type {
+class MTRCallbackBridge : public MTRCallbackBridgeBase {
 public:
     using MTRActionBlock = MTRActionBlockT<T>;
     using MTRLocalActionBlock = MTRLocalActionBlockT<T>;
@@ -253,10 +233,6 @@ public:
             return;
         }
 
-        if constexpr (HaveAttestationChallenge()) {
-            this->mAttestationChallenge = AsData(session.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge());
-        }
-
         CHIP_ERROR err = action(*exchangeManager, session.Value(), mSuccess, mFailure, this);
         if (err != CHIP_NO_ERROR) {
             ChipLogError(Controller, "Failure performing action. C++-mangled success callback type: '%s', error: %s",
@@ -277,18 +253,7 @@ protected:
 
     static void DispatchFailure(void * context, NSError * error) { DispatchCallbackResult(context, error, nil); }
 
-    template <typename ResponseType>
-    static void SetAttestationChallengeIfNeeded(void * context, ResponseType * _Nonnull response)
-    {
-        if constexpr (HaveAttestationChallenge()) {
-            auto * self = static_cast<MTRCallbackBridge *>(context);
-            response.attestationChallenge = self->mAttestationChallenge;
-        }
-    }
-
 private:
-    static constexpr bool HaveAttestationChallenge() { return std::is_same_v<T, detail::AttestationResponseCallback>; }
-
     static void DispatchCallbackResult(void * context, NSError * _Nullable error, id _Nullable value)
     {
         MTRCallbackBridge * callbackBridge = static_cast<MTRCallbackBridge *>(context);

--- a/src/darwin/Framework/CHIP/MTRCommandPayloadExtensions_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommandPayloadExtensions_Internal.h
@@ -1,0 +1,28 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+#import <Matter/MTRDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTROperationalCredentialsClusterAttestationResponseParams ()
+@property (nonatomic, copy) NSData * attestationChallenge;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -2,6 +2,7 @@
 
 #import "MTRCommandPayloadsObjc.h"
 #import "MTRCommandPayloads_Internal.h"
+#import "MTRCommandPayloadExtensions_Internal.h"
 #import "MTRBaseDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
@@ -97,6 +98,86 @@ NS_ASSUME_NONNULL_BEGIN
     err = chip::app::DataModel::Decode(reader, decodedStruct);
     if (err == CHIP_NO_ERROR) {
       err = [self _setFieldsFromDecodableStruct:decodedStruct];
+      {{#if (and (isStrEqual (asUpperCamelCase parent.name preserveAcronyms=true) "OperationalCredentials")
+                 (isStrEqual (asUpperCamelCase name preserveAcronyms=true) "AttestationResponse"))}}
+      if (err == CHIP_NO_ERROR) {
+        do {
+          // AttestationResponse has an extra attestationChallenge field.  Once we
+          // have some sort of more direct decoding from the responseValue, we can
+          // probably make this less hardcoded.
+          //
+          // It might be simpler to look for the right profile tag in the TLV, but let's stick to examining
+          // the responseValue we were handed.
+          id data = responseValue[MTRDataKey];
+          if (![data isKindOfClass:NSDictionary.class]) {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+            break;
+          }
+
+          NSDictionary * dataDictionary = data;
+          if (dataDictionary[MTRTypeKey] == nil ||
+              ![dataDictionary[MTRTypeKey] isKindOfClass:NSString.class] ||
+              ![dataDictionary[MTRTypeKey] isEqualToString:MTRStructureValueType]) {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+            break;
+          }
+
+          id value = dataDictionary[MTRValueKey];
+          if (value == nil || ![value isKindOfClass:NSArray.class]) {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+            break;
+          }
+
+          NSArray * valueArray = value;
+          for (id item in valueArray) {
+            if (![item isKindOfClass:NSDictionary.class]) {
+                err = CHIP_ERROR_INVALID_ARGUMENT;
+                break;
+            }
+
+            NSDictionary * itemDictionary = item;
+            id contextTag = itemDictionary[MTRContextTagKey];
+            if (contextTag == nil || ![contextTag isKindOfClass:NSNumber.class]) {
+              err = CHIP_ERROR_INVALID_ARGUMENT;
+              break;
+            }
+
+            NSNumber * contextTagNumber = contextTag;
+            if (![contextTagNumber isEqualToNumber:@(kAttestationChallengeTagValue)]) {
+              // Not the right field; keep going.
+              continue;
+            }
+
+            id data = itemDictionary[MTRDataKey];
+            if (data == nil || ![data isKindOfClass:NSDictionary.class]) {
+              err = CHIP_ERROR_INVALID_ARGUMENT;
+              break;
+            }
+
+            NSDictionary * dataDictionary = data;
+            id dataType = dataDictionary[MTRTypeKey];
+            id dataValue = dataDictionary[MTRValueKey];
+            if (dataType == nil || dataValue == nil ||
+                ![dataType isKindOfClass:NSString.class] ||
+                ![dataValue isKindOfClass:NSData.class]) {
+              err = CHIP_ERROR_INVALID_ARGUMENT;
+              break;
+            }
+
+            NSString * dataTypeString = dataType;
+            if (![dataTypeString isEqualToString:MTROctetStringValueType]) {
+              err = CHIP_ERROR_INVALID_ARGUMENT;
+              break;
+            }
+
+            self.attestationChallenge = dataValue;
+            break;
+          }
+
+          // Do not add code here without first checking whether err is success.
+        } while (0);
+      }
+      {{/if}}
       if (err == CHIP_NO_ERROR) {
         return self;
       }

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloads_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloads_Internal.zapt
@@ -1,14 +1,11 @@
 {{> header excludeZapComment=true}}
 
 #import <Matter/MTRDefines.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-@interface MTROperationalCredentialsClusterAttestationResponseParams ()
-@property (nonatomic, strong) NSData * attestationChallenge;
-@end
 
 {{#zcl_clusters}}
 {{#zcl_commands}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
@@ -15,15 +15,12 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRCommandPayloadsObjc.h>
 #import <Matter/MTRDefines.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-@interface MTROperationalCredentialsClusterAttestationResponseParams ()
-@property (nonatomic, strong) NSData * attestationChallenge;
-@end
 
 @interface MTRIdentifyClusterIdentifyParams (InternalMethods)
 

--- a/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
@@ -389,6 +389,9 @@ class MTRSwiftDeviceTests : XCTestCase {
         XCTAssertEqual(eventReportsReceived, 0);
     }
 
+    // Note: test027_AttestationChallenge is not implementable in Swift so far,
+    // because the attestationChallenge property is internal-only
+
     func test999_TearDown()
     {
         ResetCommissionee(sConnectedDevice, DispatchQueue.main, self, DeviceConstants.timeoutInSeconds)

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		51E95DFB2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */; };
 		51E95DFC2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */; };
 		51EF279F2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51FE72352ACDB40000437032 /* MTRCommandPayloads_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FE72342ACDB40000437032 /* MTRCommandPayloads_Internal.h */; };
+		51FE723F2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */; };
 		5A60370827EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */; };
 		5A6FEC9027B563D900F25F42 /* MTRDeviceControllerOverXPC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC8F27B563D900F25F42 /* MTRDeviceControllerOverXPC.mm */; };
 		5A6FEC9227B5669C00F25F42 /* MTRDeviceControllerOverXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC8D27B5624E00F25F42 /* MTRDeviceControllerOverXPC.h */; };
@@ -552,6 +554,8 @@
 		51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRSessionResumptionStorageBridge.h; sourceTree = "<group>"; };
 		51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRSessionResumptionStorageBridge.mm; sourceTree = "<group>"; };
 		51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBackwardsCompatShims.h; sourceTree = "<group>"; };
+		51FE72342ACDB40000437032 /* MTRCommandPayloads_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommandPayloads_Internal.h; sourceTree = "<group>"; };
+		51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommandPayloadExtensions_Internal.h; sourceTree = "<group>"; };
 		5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MTRClusterStateCacheContainer+XPC.h"; sourceTree = "<group>"; };
 		5A6FEC8B27B5609C00F25F42 /* MTRDeviceOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceOverXPC.h; sourceTree = "<group>"; };
 		5A6FEC8D27B5624E00F25F42 /* MTRDeviceControllerOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerOverXPC.h; sourceTree = "<group>"; };
@@ -984,6 +988,7 @@
 				7596A85228788557004DAE0E /* MTRClusters.mm */,
 				51B22C212740CB1D008D5055 /* MTRCommandPayloadsObjc.h */,
 				51B22C292740CB47008D5055 /* MTRCommandPayloadsObjc.mm */,
+				51FE72342ACDB40000437032 /* MTRCommandPayloads_Internal.h */,
 				7560FD1B27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm */,
 				51B22C1D2740CB0A008D5055 /* MTRStructsObjc.h */,
 				51B22C252740CB32008D5055 /* MTRStructsObjc.mm */,
@@ -1131,6 +1136,7 @@
 				5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */,
 				5ACDDD7C27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm */,
 				5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */,
+				51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */,
 				99D466E02798936D0089A18F /* MTRCommissioningParameters.h */,
 				99AECC7F2798A57E00B6355B /* MTRCommissioningParameters.mm */,
 				3DFCB32B29678C9500332B35 /* MTRConversion.h */,
@@ -1454,6 +1460,7 @@
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,
 				51E4D121291D0EB400C8C535 /* MTRBaseClusterUtils.h in Headers */,
+				51FE72352ACDB40000437032 /* MTRCommandPayloads_Internal.h in Headers */,
 				51E51FC0282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h in Headers */,
 				3DECCB702934AECD00585AEC /* MTRLogging.h in Headers */,
 				1E4D654E29C208DD00BC3478 /* MTRCommissionableBrowserResult.h in Headers */,
@@ -1463,6 +1470,7 @@
 				51565CB12A7AD77600469F18 /* MTRDeviceControllerDataStore.h in Headers */,
 				3D843713294977000070D20A /* NSDataSpanConversion.h in Headers */,
 				991DC08B247704DC00C13860 /* MTRLogging_Internal.h in Headers */,
+				51FE723F2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h in Headers */,
 				1E4D655029C208DD00BC3478 /* MTRCommissionableBrowserDelegate.h in Headers */,
 				7596A84828762783004DAE0E /* MTRAsyncCallbackWorkQueue.h in Headers */,
 				5A7947E527C0129F00434CF2 /* MTRDeviceController+XPC.h in Headers */,


### PR DESCRIPTION
This got broken because we had no tests.

Also makes attestationChallenge work when invoking via the MTRDevice/MTRBaseDevice interface, not just MTRCluster/MTRBaseCluster.
