### PR TITLE
Darwin: Improve MTRAsyncWorkQueue logging by tracking unique item ids

### DIFF
--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
@@ -107,6 +107,10 @@ MTR_TESTABLE
 /// Creates a work item that will run on the specified dispatch queue.
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 
+/// A unique (modulo overflow) ID automatically assigned to each work item for
+/// the purpose of correlating log messages from the work queue.
+@property (readonly, nonatomic) NSUInteger uniqueID;
+
 /// Called by the work queue to start this work item.
 ///
 /// Will be called on the dispatch queue associated with this item.

--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
@@ -109,7 +109,7 @@ MTR_TESTABLE
 
 /// A unique (modulo overflow) ID automatically assigned to each work item for
 /// the purpose of correlating log messages from the work queue.
-@property (readonly, nonatomic) NSUInteger uniqueID;
+@property (readonly, nonatomic) uint64_t uniqueID;
 
 /// Called by the work queue to start this work item.
 ///

--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
@@ -30,6 +30,12 @@ typedef NS_ENUM(NSInteger, MTRAsyncWorkOutcome) {
 /// being cancelled).
 typedef BOOL (^MTRAsyncWorkCompletionBlock)(MTRAsyncWorkOutcome outcome);
 
+typedef NS_ENUM(NSInteger, MTRBatchingOutcome) {
+    MTRNotBatched = 0,
+    MTRBatchedPartially, // some work was batched but the source item has work remaining
+    MTRBatchedFully, // the source item is now empty and can be dropped from the queue
+};
+
 /// An optional handler that controls batching of MTRAsyncWorkItem.
 ///
 /// When a work item is dequeued to run, if it is of a type that can be
@@ -47,15 +53,16 @@ typedef BOOL (^MTRAsyncWorkCompletionBlock)(MTRAsyncWorkOutcome outcome);
 /// `opaqueDataNext` is the data for the next item. The `fullyMerged` parameter
 /// will be initialized to NO by the caller.
 ///
-/// The handler is expected to mutate the data as needed to achieve batching.
-///
-/// If after the data mutations opaqueDataNext no longer requires any work, the
-/// handler should set `fullyMerged` to YES to indicate that the next item can
-/// be dropped from the queue. In this case, the handler may be called again to
-/// possibly also batch the work item after the one that was dropped.
+/// The handler is expected to mutate the data as needed to achieve batching,
+/// and return an `MTRBatchingOutcome` to indicate if any or all of the work
+/// from the next item was merged into the current item. A return value of
+/// `MTRBatchedFully` indicates that `opaqueDataNext` no longer requires any
+/// work and should be dropped from the queue. In this case, the handler may be
+/// called again to possibly also batch the work item after the one that was
+/// dropped.
 ///
 /// @see MTRAsyncWorkItem
-typedef void (^MTRAsyncWorkBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext, BOOL * fullyMerged);
+typedef MTRBatchingOutcome (^MTRAsyncWorkBatchingHandler)(id opaqueDataCurrent, id opaqueDataNext);
 
 /// An optional handler than enables duplicate checking for MTRAsyncWorkItem.
 ///
@@ -187,6 +194,14 @@ MTR_TESTABLE
 /// no further modifications may be made to it. Work item objects cannot be
 /// re-used.
 - (void)enqueueWorkItem:(MTRAsyncWorkItem<ContextType> *)item;
+
+/// Same as `enqueueWorkItem:` but includes the description in queue logging.
+- (void)enqueueWorkItem:(MTRAsyncWorkItem<ContextType> *)item
+            description:(nullable NSString *)description;
+
+/// Convenience for `enqueueWorkItem:description:` with a formatted string.
+- (void)enqueueWorkItem:(MTRAsyncWorkItem<ContextType> *)item
+    descriptionWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 /// Checks whether the queue already contains a work item matching the provided
 /// details. A client may call this method to avoid enqueueing duplicate work.

--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.mm
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.mm
@@ -321,7 +321,7 @@ MTR_DIRECT_MEMBERS
     }
 
     if (!context.reference) {
-        MTR_LOG_ERROR("MTRAsyncWorkQueue<%@> context has been lost, dropping queued work items", (id)nil);
+        MTR_LOG_ERROR("MTRAsyncWorkQueue<%@> context has been lost, dropping queued work items", (id) nil);
         [_items removeAllObjects];
         return;
     }

--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.mm
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.mm
@@ -45,11 +45,6 @@ struct ContextSnapshot {
 };
 
 MTR_DIRECT_MEMBERS
-@interface MTRAsyncWorkItem ()
-@property (readonly, nonatomic) NSUInteger uniqueID;
-@end
-
-MTR_DIRECT_MEMBERS
 @implementation MTRAsyncWorkItem {
     dispatch_queue_t _queue;
     MTRAsyncWorkItemState _state; // protected by queue lock once enqueued

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -46,4 +46,14 @@
     _Pragma("clang diagnostic ignored \"-Wshadow\"")            \
     __strong typeof(local) _Nullable local = _mtr_weak_##local  \
     _Pragma("clang diagnostic pop")
+
+/// Declares an unused local of unspecified type, to prevent accidental
+/// references to a shadowed variable of the same name. Note that hiding
+/// `self` does not prevent implicit references to self due to ivar access.
+#define mtr_hide(local)                                         \
+    _Pragma("clang diagnostic push")                            \
+    _Pragma("clang diagnostic ignored \"-Wshadow\"")            \
+    __attribute__((unused)) _mtr_hidden local;                  \
+    _Pragma("clang diagnostic pop")
+typedef struct {} _mtr_hidden;
 // clang-format on

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -53,7 +53,7 @@
 #define mtr_hide(local)                                         \
     _Pragma("clang diagnostic push")                            \
     _Pragma("clang diagnostic ignored \"-Wshadow\"")            \
-    __attribute__((unused)) _mtr_hidden local;                  \
+    __attribute__((unused)) variable_hidden_by_mtr_hide local;  \
     _Pragma("clang diagnostic pop")
-typedef struct {} _mtr_hidden;
+typedef struct {} variable_hidden_by_mtr_hide;
 // clang-format on

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -893,7 +893,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
         // Create work item, set ready handler to perform task, then enqueue the work
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
-        NSUInteger workItemID = workItem.uniqueID; // capture only the ID, not the work item
+        uint64_t workItemID = workItem.uniqueID; // capture only the ID, not the work item
         [workItem setBatchingID:MTRDeviceWorkItemBatchingReadID data:readRequests handler:^(id opaqueDataCurrent, id opaqueDataNext) {
             mtr_hide(self); // don't capture self accidentally
             NSMutableArray<NSArray *> * readRequestsCurrent = opaqueDataCurrent;
@@ -903,14 +903,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             while (readRequestsNext.count) {
                 // Can only read up to 9 paths at a time, per spec
                 if (readRequestsCurrent.count >= 9) {
-                    MTR_LOG_INFO("Batching read attribute work %tu: cannot add more work, item is full", workItemID);
+                    MTR_LOG_INFO("Batching read attribute work item [%llu]: cannot add more work, item is full", workItemID);
                     return outcome;
                 }
 
                 // if params don't match then they cannot be merged
                 if (![readRequestsNext[0][MTRDeviceReadRequestFieldParamsIndex]
                         isEqual:readRequestsCurrent[0][MTRDeviceReadRequestFieldParamsIndex]]) {
-                    MTR_LOG_INFO("Batching read attribute work %tu: cannot add more work, parameter mismatch", workItemID);
+                    MTR_LOG_INFO("Batching read attribute work item [%llu]: cannot add more work, parameter mismatch", workItemID);
                     return outcome;
                 }
 
@@ -918,7 +918,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                 auto readItem = readRequestsNext.firstObject;
                 [readRequestsNext removeObjectAtIndex:0];
                 [readRequestsCurrent addObject:readItem];
-                MTR_LOG_INFO("Batching read attribute work %tu: added %@ (now %tu requests total)",
+                MTR_LOG_INFO("Batching read attribute work item [%llu]: added %@ (now %tu requests total)",
                     workItemID, readItem, readRequestsCurrent.count);
                 outcome = MTRBatchedPartially;
             }
@@ -929,7 +929,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             mtr_hide(self); // don't capture self accidentally
             for (NSArray * readItem in readRequests) {
                 if ([readItem isEqual:opaqueItemData]) {
-                    MTR_LOG_DEFAULT("Read attribute work %tu report duplicate %@", workItemID, readItem);
+                    MTR_LOG_DEFAULT("Read attribute work item [%llu] report duplicate %@", workItemID, readItem);
                     *isDuplicate = YES;
                     *stop = YES;
                     return;
@@ -940,7 +940,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         [workItem setReadyHandler:^(MTRDevice * self, NSInteger retryCount, MTRAsyncWorkCompletionBlock completion) {
             // Sanity check
             if (readRequests.count == 0) {
-                MTR_LOG_ERROR("Read attribute work %tu contained no read requests", workItemID);
+                MTR_LOG_ERROR("Read attribute work item [%llu] contained no read requests", workItemID);
                 completion(MTRAsyncWorkComplete);
                 return;
             }
@@ -965,16 +965,16 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                             if (values) {
                                 // Since the format is the same data-value dictionary, this looks like an
                                 // attribute report
-                                MTR_LOG_INFO("Read attribute work %tu result: %@", workItemID, values);
+                                MTR_LOG_INFO("Read attribute work item [%llu] result: %@", workItemID, values);
                                 [self _handleAttributeReport:values];
                             }
 
                             // TODO: better retry logic
                             if (error && (retryCount < 2)) {
-                                MTR_LOG_ERROR("Read attribute work %tu failed (will retry): %@", workItemID, error);
+                                MTR_LOG_ERROR("Read attribute work item [%llu] failed (will retry): %@", workItemID, error);
                                 completion(MTRAsyncWorkNeedsRetry);
                             } else {
-                                MTR_LOG_DEFAULT("Read attribute work %tu failed (giving up): %@", workItemID, error);
+                                MTR_LOG_DEFAULT("Read attribute work item [%llu] failed (giving up): %@", workItemID, error);
                                 completion(MTRAsyncWorkComplete);
                             }
                         }];
@@ -1007,7 +1007,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
               expectedValueID:&expectedValueID];
 
     MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
-    NSUInteger workItemID = workItem.uniqueID; // capture only the ID, not the work item
+    uint64_t workItemID = workItem.uniqueID; // capture only the ID, not the work item
     // The write operation will install a duplicate check handler, to return NO for "isDuplicate". Since a write operation may
     // change values, only read requests after this should be considered for duplicate requests.
     [workItem setDuplicateTypeID:MTRDeviceWorkItemDuplicateReadTypeID handler:^(id opaqueItemData, BOOL * isDuplicate, BOOL * stop) {
@@ -1025,7 +1025,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                                    queue:self.queue
                               completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                   if (error) {
-                                      MTR_LOG_ERROR("Write attribute work %tu failed: %@", workItemID, error);
+                                      MTR_LOG_ERROR("Write attribute work item [%llu] failed: %@", workItemID, error);
                                       [self removeExpectedValueForAttributePath:attributePath expectedValueID:expectedValueID];
                                   }
                                   completion(MTRAsyncWorkComplete);
@@ -1090,7 +1090,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         }
     }
     MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
-    NSUInteger workItemID = workItem.uniqueID; // capture only the ID, not the work item
+    uint64_t workItemID = workItem.uniqueID; // capture only the ID, not the work item
     // The command operation will install a duplicate check handler, to return NO for "isDuplicate". Since a command operation may
     // change values, only read requests after this should be considered for duplicate requests.
     [workItem setDuplicateTypeID:MTRDeviceWorkItemDuplicateReadTypeID handler:^(id opaqueItemData, BOOL * isDuplicate, BOOL * stop) {
@@ -1110,7 +1110,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                               completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                   // Log the data at the INFO level (not usually persisted permanently),
                                   // but make sure we log the work completion at the DEFAULT level.
-                                  MTR_LOG_INFO("Invoke work %tu received command response: %@ error: %@", workItemID, values, error);
+                                  MTR_LOG_INFO("Invoke work item [%llu] received command response: %@ error: %@", workItemID, values, error);
                                   dispatch_async(queue, ^{
                                       completion(values, error);
                                   });

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -894,7 +894,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         // Create work item, set ready handler to perform task, then enqueue the work
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
         [workItem setBatchingID:MTRDeviceWorkItemBatchingReadID data:readRequests handler:^(id opaqueDataCurrent, id opaqueDataNext) {
-            nullptr_t self; // don't capture self accidentally
+            mtr_hide(self); // don't capture self accidentally
             NSMutableArray<NSArray *> * readRequestsCurrent = opaqueDataCurrent;
             NSMutableArray<NSArray *> * readRequestsNext = opaqueDataNext;
 
@@ -923,7 +923,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             return MTRBatchedFully;
         }];
         [workItem setDuplicateTypeID:MTRDeviceWorkItemDuplicateReadTypeID handler:^(id opaqueItemData, BOOL * isDuplicate, BOOL * stop) {
-            nullptr_t self; // don't capture self accidentally
+            mtr_hide(self); // don't capture self accidentally
             for (NSArray * readItem in readRequests) {
                 if ([readItem isEqual:opaqueItemData]) {
                     MTR_LOG_DEFAULT("Read attribute duplicate check found %@ - report duplicate", readItem);


### PR DESCRIPTION
Also return more information from the batching handler so we can log both partial and full batching from the queue itself.