### PR TITLE
Update python test CI: stop dirtying build env, cleanup build outputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -307,6 +307,7 @@ jobs:
                   scripts/run_in_build_env.sh "ninja -C ./out"
                   scripts/tests/gn_tests.sh
             - name: Setup test python environment
+              shell: bash
               run: |
                   scripts/run_in_build_env.sh 'virtualenv pyenv'
                   source pyenv/bin/activate
@@ -315,6 +316,7 @@ jobs:
                   pip3 install ./out/controller/python/chip_repl-0.0-py3-none-any.whl
 
             - name: Run Python tests
+              shell: bash
               run: |
                   source pyenv/bin/activate
                   cd src/controller/python/test/unit_tests/
@@ -322,6 +324,7 @@ jobs:
             - name: Clean previous outputs
               run: rm -rf out pyenv
             - name: Run Python Setup Payload Generator Test
+              shell: bash
               run: |
                   scripts/run_in_build_env.sh 'scripts/examples/gn_build_example.sh examples/chip-tool out/'
                   scripts/run_in_build_env.sh 'virtualenv pyenv'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -303,7 +303,7 @@ jobs:
 
             - name: Setup Build, Run Build and Run Tests
               run: |
-                  scripts/build/gn_gen.sh --args="enable_rtti=true enable_pylib=true chip_config_memory_debug_checks=false chip_config_memory_debug_dmalloc=false"
+                  scripts/build/gn_gen.sh --args="enable_rtti=true enable_pylib=true chip_config_memory_debug_checks=false chip_config_memory_debug_dmalloc=false chip_generate_link_map_file=false"
                   scripts/run_in_build_env.sh "ninja -C ./out"
                   scripts/tests/gn_tests.sh
             - name: Setup test python environment

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,18 +306,28 @@ jobs:
                   scripts/build/gn_gen.sh --args="enable_rtti=true enable_pylib=true chip_config_memory_debug_checks=false chip_config_memory_debug_dmalloc=false"
                   scripts/run_in_build_env.sh "ninja -C ./out"
                   scripts/tests/gn_tests.sh
-            - name: Run Python library specific unit tests
+            - name: Setup test python environment
               run: |
-                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl'
-                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_clusters-0.0-py3-none-any.whl'
-                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_repl-0.0-py3-none-any.whl'
-                  scripts/run_in_build_env.sh '(cd src/controller/python/test/unit_tests/ && python3 -m unittest -v)'
+                  virtualenv pyenv
+                  source pyenv/bin/activate
+                  pip3 install ./out/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl
+                  pip3 install ./out/controller/python/chip_clusters-0.0-py3-none-any.whl
+                  pip3 install ./out/controller/python/chip_repl-0.0-py3-none-any.whl
 
+            - name: Run Python tests
+              run: |
+                  source pyenv/bin/activate
+                  cd src/controller/python/test/unit_tests/
+                  python3 -m unittest -v
+            - name: Clean previous outputs
+              run: rm -rf out pyenv
             - name: Run Python Setup Payload Generator Test
               run: |
                   scripts/run_in_build_env.sh 'scripts/examples/gn_build_example.sh examples/chip-tool out/'
-                  scripts/run_in_build_env.sh 'pip3 install -r src/setup_payload/python/requirements.txt'
-                  scripts/run_in_build_env.sh 'python3 src/setup_payload/tests/run_python_setup_payload_gen_test.py out/chip-tool'
+                  virtualenv pyenv
+                  source pyenv/bin/activate
+                  pip3 install -r src/setup_payload/python/requirements.txt
+                  python3 src/setup_payload/tests/run_python_setup_payload_gen_test.py out/chip-tool
 
     build_darwin:
         name: Build on Darwin (clang, python_lib, simulated)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -308,7 +308,7 @@ jobs:
                   scripts/tests/gn_tests.sh
             - name: Setup test python environment
               run: |
-                  virtualenv pyenv
+                  scripts/run_in_build_env.sh 'virtualenv pyenv'
                   source pyenv/bin/activate
                   pip3 install ./out/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl
                   pip3 install ./out/controller/python/chip_clusters-0.0-py3-none-any.whl
@@ -324,7 +324,7 @@ jobs:
             - name: Run Python Setup Payload Generator Test
               run: |
                   scripts/run_in_build_env.sh 'scripts/examples/gn_build_example.sh examples/chip-tool out/'
-                  virtualenv pyenv
+                  scripts/run_in_build_env.sh 'virtualenv pyenv'
                   source pyenv/bin/activate
                   pip3 install -r src/setup_payload/python/requirements.txt
                   python3 src/setup_payload/tests/run_python_setup_payload_gen_test.py out/chip-tool

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -15,6 +15,14 @@
 import("//build_overrides/pigweed.gni")
 import("$dir_pw_toolchain/generate_toolchain.gni")
 
+declare_args() {
+  # Generate Linker map files. Can skip since they can
+  # be quite large.
+  #
+  # Note that toolchains can individually override this
+  chip_generate_link_map_file = true
+}
+
 template("gcc_toolchain") {
   invoker_toolchain_args = invoker.toolchain_args
 
@@ -42,6 +50,8 @@ template("gcc_toolchain") {
 
     if (defined(invoker.link_generate_map_file)) {
       link_generate_map_file = invoker.link_generate_map_file
+    } else {
+      link_generate_map_file = chip_generate_link_map_file
     }
 
     is_host_toolchain = invoker_toolchain_args.current_os == host_os


### PR DESCRIPTION
Previous python CI seems to use the build environment for tests and it runs out of space (like https://github.com/project-chip/connectedhomeip/actions/runs/6416647929/job/17420797300 saying `: Could not install packages due to an OSError: [Errno 28] No space left on device: '`

Changes:
- stop using the build environment to install extra packages. Create a separate one for testing
- do a build output clean after the build output is no longer needed.
- Add a config flag for 'generate map files during link' and disable it for this CI step. This seems to save about 2G of map files and may even speed up compilation.