### PR TITLE
lwip: Add patch to fix RA LLADDR processing

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -789,6 +789,8 @@ LightingApp
 LightingColor
 LightingState
 LinkSoftwareAndDocumentationPack
+lladdr
+LLADDR
 LocalConfigDisabled
 localedef
 localhost

--- a/src/lwip/patches/README.md
+++ b/src/lwip/patches/README.md
@@ -21,8 +21,9 @@ recent API change on upstream LwIP. The previous version of this function is
 
 ### ND6 LLADDR fix
 
-This patch fixes a bug where the RA processing fails if the RA includes an LLADDR
-option with a hw address that is not the max length. This happens for thread devices.
+This patch fixes a bug where the RA processing fails if the RA includes an
+LLADDR option with a hw address that is not the max length. This happens for
+thread devices.
 
 -   patch file: nd6_lladdr_fix.patch
 

--- a/src/lwip/patches/README.md
+++ b/src/lwip/patches/README.md
@@ -19,6 +19,13 @@ Troubleshooting: The patch uses the `ip6_addr_net_eq` function, which is a
 recent API change on upstream LwIP. The previous version of this function is
 `ip6_addr_netcmp`, so this function call may need to be replaced on older forks.
 
+### ND6 LLADDR fix
+
+This patch fixes a bug where the RA processing fails if the RA includes an LLADDR
+option with a hw address that is not the max length. This happens for thread devices.
+
+-   patch file: nd6_lladdr_fix.patch
+
 ## Important upstream patches
 
 ### Malformed neighbor solicitation packet fix

--- a/src/lwip/patches/nd6_lladdr_fix.patch
+++ b/src/lwip/patches/nd6_lladdr_fix.patch
@@ -1,0 +1,25 @@
+diff --git a/src/core/ipv6/nd6.c b/src/core/ipv6/nd6.c
+index 55b5774f..7ab0d270 100644
+--- a/src/core/ipv6/nd6.c
++++ b/src/core/ipv6/nd6.c
+@@ -686,14 +686,15 @@ nd6_input(struct pbuf *p, struct netif *inp)
+       switch (option_type) {
+       case ND6_OPTION_TYPE_SOURCE_LLADDR:
+       {
+-        struct lladdr_option *lladdr_opt;
+-        if (option_len < (ND6_LLADDR_OPTION_MIN_LENGTH + inp->hwaddr_len)) {
++        const u8_t option_type_and_length_size = 1 + 1;
++        const u8_t *addr_cursor;
++        if (option_len < (option_type_and_length_size + inp->hwaddr_len)) {
+           goto lenerr_drop_free_return;
+         }
+-        lladdr_opt = (struct lladdr_option *)buffer;
++        addr_cursor = buffer + option_type_and_length_size;
+         if ((default_router_list[i].neighbor_entry != NULL) &&
+-            (default_router_list[i].neighbor_entry->state == ND6_INCOMPLETE)) {
+-          SMEMCPY(default_router_list[i].neighbor_entry->lladdr, lladdr_opt->addr, inp->hwaddr_len);
++           (default_router_list[i].neighbor_entry->state == ND6_INCOMPLETE)) {
++          SMEMCPY(default_router_list[i].neighbor_entry->lladdr, addr_cursor, inp->hwaddr_len);
+           default_router_list[i].neighbor_entry->state = ND6_REACHABLE;
+           default_router_list[i].neighbor_entry->counter.reachable_time = reachable_time;
+         }

--- a/src/lwip/patches/nd6_lladdr_fix.patch
+++ b/src/lwip/patches/nd6_lladdr_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ipv6/nd6.c b/src/core/ipv6/nd6.c
-index 55b5774f..7ab0d270 100644
+index 55b5774f..8559d69b 100644
 --- a/src/core/ipv6/nd6.c
 +++ b/src/core/ipv6/nd6.c
 @@ -686,14 +686,15 @@ nd6_input(struct pbuf *p, struct netif *inp)
@@ -16,9 +16,8 @@ index 55b5774f..7ab0d270 100644
 -        lladdr_opt = (struct lladdr_option *)buffer;
 +        addr_cursor = buffer + option_type_and_length_size;
          if ((default_router_list[i].neighbor_entry != NULL) &&
--            (default_router_list[i].neighbor_entry->state == ND6_INCOMPLETE)) {
+             (default_router_list[i].neighbor_entry->state == ND6_INCOMPLETE)) {
 -          SMEMCPY(default_router_list[i].neighbor_entry->lladdr, lladdr_opt->addr, inp->hwaddr_len);
-+           (default_router_list[i].neighbor_entry->state == ND6_INCOMPLETE)) {
 +          SMEMCPY(default_router_list[i].neighbor_entry->lladdr, addr_cursor, inp->hwaddr_len);
            default_router_list[i].neighbor_entry->state = ND6_REACHABLE;
            default_router_list[i].neighbor_entry->counter.reachable_time = reachable_time;


### PR DESCRIPTION
This an lwIP patch to fix an issue with RA processing related to LLADDR options where the LLADDR is thread and therefore is not the max size. This issue was brought to our attention by a partner company. Original fix from Tennessee, I've just updated the style to conform to lwIP style and added the patch here.

This patch applies and builds on top of current ToT lwIP, but there do not seem to be many changes in this area recently.

I will attempt to get this upstreamed, but for now let's share it within the SDK.





