### PR TITLE
[Silabs] Logging: Unnecessary include removed.

### DIFF
--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -12,7 +12,6 @@
 #include <openthread/platform/logging.h>
 #endif
 
-#include "AppConfig.h"
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Removed AppConfig.h include. This included both unnecessary and misplaced.
Affects Silicon Labs boards only.

Tested on BRD4166A, BRD4164A and BRD4187C.



