### PR TITLE
fix(QPG): Enable -Wundef and fix any  errors for qpg based builds

### DIFF
--- a/examples/lighting-app/qpg/BUILD.gn
+++ b/examples/lighting-app/qpg/BUILD.gn
@@ -44,9 +44,7 @@ qpg_sdk("sdk") {
     "${qpg_project_dir}/include",
   ]
 
-  if (chip_enable_pw_rpc) {
-    defines = [ "PW_RPC_ENABLED" ]
-  }
+  defines = [ "PW_RPC_ENABLED=${chip_enable_pw_rpc}" ]
 }
 
 qpg_executable("lighting_app") {
@@ -92,7 +90,6 @@ qpg_executable("lighting_app") {
 
   if (chip_enable_pw_rpc) {
     defines += [
-      "PW_RPC_ENABLED",
       "PW_RPC_ATTRIBUTE_SERVICE=1",
       "PW_RPC_BUTTON_SERVICE=1",
       "PW_RPC_DEVICE_SERVICE=1",

--- a/examples/lighting-app/qpg/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/qpg/include/CHIPProjectConfig.h
@@ -114,6 +114,15 @@
 #endif
 
 /**
+ * @def CHIP_DEVICE_CONFIG_ENABLE_SSED
+ *
+ * @brief Defines if a matter device is acting as a Synchronized Sleepy End Device(SSED)
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_SSED
+#define CHIP_DEVICE_CONFIG_ENABLE_SSED 0
+#endif
+
+/**
  * @def CHIP_DEVICE_CONFIG_THREAD_FTD
  *
  * @brief Defines if a matter device is acting as Full Thread Device (FTD)

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -44,9 +44,7 @@ qpg_sdk("sdk") {
     "${qpg_project_dir}/include",
   ]
 
-  if (chip_enable_pw_rpc) {
-    defines = [ "PW_RPC_ENABLED" ]
-  }
+  defines = [ "PW_RPC_ENABLED=${chip_enable_pw_rpc}" ]
 }
 
 qpg_executable("lock_app") {
@@ -89,7 +87,6 @@ qpg_executable("lock_app") {
 
   if (chip_enable_pw_rpc) {
     defines += [
-      "PW_RPC_ENABLED",
       "PW_RPC_ATTRIBUTE_SERVICE=1",
       "PW_RPC_BUTTON_SERVICE=1",
       "PW_RPC_DEVICE_SERVICE=1",

--- a/examples/lock-app/qpg/include/CHIPProjectConfig.h
+++ b/examples/lock-app/qpg/include/CHIPProjectConfig.h
@@ -115,6 +115,20 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_SED 1
 #endif
 
+/**
+ * @def CHIP_DEVICE_CONFIG_ENABLE_SSED
+ *
+ * @brief Defines if a matter device is acting as a Synchronized Sleepy End Device(SSED)
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_SSED
+#define CHIP_DEVICE_CONFIG_ENABLE_SSED 0
+#endif
+
+/**
+ * @def CHIP_DEVICE_CONFIG_THREAD_FTD
+ *
+ * @brief Defines if a matter device is acting as Full Thread Device (FTD)
+ */
 #ifndef CHIP_DEVICE_CONFIG_THREAD_FTD
 #define CHIP_DEVICE_CONFIG_THREAD_FTD 0
 #endif

--- a/examples/platform/qpg/app/main.cpp
+++ b/examples/platform/qpg/app/main.cpp
@@ -45,11 +45,11 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#if PW_RPC_ENABLED
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
 #include "Rpc.h"
 #endif // PW_RPC_ENABLED
 
-#if ENABLE_CHIP_SHELL
+#if defined(ENABLE_CHIP_SHELL) && ENABLE_CHIP_SHELL
 #include "shell_common/shell.h"
 #endif // ENABLE_CHIP_SHELL
 
@@ -142,7 +142,7 @@ CHIP_ERROR CHIP_Init(void)
 {
     CHIP_ERROR ret = CHIP_NO_ERROR;
 
-#if PW_RPC_ENABLED
+#if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
     ret = (CHIP_ERROR) chip::rpc::Init();
     if (ret != CHIP_NO_ERROR)
     {
@@ -158,7 +158,7 @@ CHIP_ERROR CHIP_Init(void)
         goto exit;
     }
 
-#if ENABLE_CHIP_SHELL
+#if defined(ENABLE_CHIP_SHELL) && ENABLE_CHIP_SHELL
     ret = (CHIP_ERROR) ShellTask::Start();
     if (ret != CHIP_NO_ERROR)
     {
@@ -184,7 +184,7 @@ CHIP_ERROR CHIP_Init(void)
         goto exit;
     }
 
-#if CONFIG_CHIP_THREAD_SSED
+#if defined(CHIP_DEVICE_CONFIG_ENABLE_SSED) && CHIP_DEVICE_CONFIG_ENABLE_SSED
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SynchronizedSleepyEndDevice);
     qvIO_EnableSleep(true);
 #elif CHIP_DEVICE_CONFIG_ENABLE_SED

--- a/examples/platform/qpg/project_include/OpenThreadConfig.h
+++ b/examples/platform/qpg/project_include/OpenThreadConfig.h
@@ -72,6 +72,10 @@
 #define OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE 0
 #define OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE 0
 #define OPENTHREAD_CONFIG_TCP_ENABLE 0
+#define OPENTHREAD_CONFIG_TLS_ENABLE 0
+
+#define OPENTHREAD_ENABLE_VENDOR_EXTENSION 0
+#define OPENTHREAD_EXAMPLES_SIMULATION 0
 
 // Use the Qorvo-supplied default platform configuration for remainder
 // of OpenThread config options.

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1710,7 +1710,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
 
     // Enable automatic assignment of Thread advertised addresses.
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+#if defined(OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE) && OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
     otIp6SetSlaacEnabled(otInst, true);
 #endif
 

--- a/src/platform/qpg/Logging.cpp
+++ b/src/platform/qpg/Logging.cpp
@@ -19,10 +19,6 @@
 #include <openthread/platform/memory.h>
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-#ifdef PW_RPC_ENABLED
-#include "PigweedLogger.h"
-#endif
-
 constexpr uint8_t kPrintfModuleLwip       = 0x01;
 constexpr uint8_t kPrintfModuleOpenThread = 0x02;
 constexpr uint8_t kPrintfModuleLogging    = 0x03;

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -97,8 +97,11 @@ template("qpg_sdk") {
     } else {
       defines += [ "MBEDTLS_SW_ONLY" ]
     }
+    
+    #Wundef fix - to be updated in SDK
+    defines += ["GP_SCHED_NR_OF_IDLE_CALLBACKS=0"]
 
-    cflags = []
+    cflags = ["-Wundef"]
 
     # Allow warning due to mbedtls
     cflags += [

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -97,11 +97,11 @@ template("qpg_sdk") {
     } else {
       defines += [ "MBEDTLS_SW_ONLY" ]
     }
-    
-    #Wundef fix - to be updated in SDK
-    defines += ["GP_SCHED_NR_OF_IDLE_CALLBACKS=0"]
 
-    cflags = ["-Wundef"]
+    #Wundef fix - to be updated in SDK
+    defines += [ "GP_SCHED_NR_OF_IDLE_CALLBACKS=0" ]
+
+    cflags = [ "-Wundef" ]
 
     # Allow warning due to mbedtls
     cflags += [


### PR DESCRIPTION
#29591 uncovered errors raised by -Wundef.

This PR addresses all issues found by -Wundef.
Note -Wundef is not enabled by default yet in all builds - flag added to qpg specific gn configuration.

Tested:
- Added -Wundef in third_party/qpg_sdk/qpg_sdk.gni
- CI builds pass
