### PR TITLE
Log more information when "darwin-framework-tool tests list" fails.

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -15,6 +15,7 @@
 #
 
 import json
+import logging
 import os
 import subprocess
 from dataclasses import dataclass
@@ -246,8 +247,13 @@ def tests_with_command(chip_tool: str, is_manual: bool):
     if is_manual:
         cmd += "-manual"
 
-    result = subprocess.run([chip_tool, "tests", cmd], capture_output=True)
-    result.check_returncode()
+    cmd = [chip_tool, "tests", cmd]
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8")
+    if result.returncode != 0:
+        logging.error(f'Failed to run {cmd}:')
+        logging.error('STDOUT: ' + result.stdout)
+        logging.error('STDERR: ' + result.stderr)
+        result.check_returncode()
 
     test_tags = set()
     if is_manual:
@@ -255,7 +261,7 @@ def tests_with_command(chip_tool: str, is_manual: bool):
 
     in_development_tests = [s.replace(".yaml", "") for s in _GetInDevelopmentTests()]
 
-    for name in result.stdout.decode("utf8").split("\n"):
+    for name in result.stdout.split("\n"):
         if not name:
             continue
 


### PR DESCRIPTION
Logs for `subprocess.CalledProcessError` only contain the exit code and this makes it hard to debug (just saying 'exit code 1'). Print out stderr, stdout as well.