### PR TITLE
Use progress-level logging for MRP resends.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -168,10 +168,10 @@ void ReliableMessageMgr::ExecuteActions()
         }
 
         entry->sendCount++;
-        ChipLogDetail(ExchangeManager,
-                      "Retransmitting MessageCounter:" ChipLogFormatMessageCounter " on exchange " ChipLogFormatExchange
-                      " Send Cnt %d",
-                      messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
+        ChipLogProgress(ExchangeManager,
+                        "Retransmitting MessageCounter:" ChipLogFormatMessageCounter " on exchange " ChipLogFormatExchange
+                        " Send Cnt %d",
+                        messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
 
         // Choose active/idle timeout from PeerActiveMode of session per 4.11.2.1. Retransmissions.
         System::Clock::Timestamp baseTimeout = entry->ec->GetSessionHandle()->GetMRPBaseTimeout();


### PR DESCRIPTION
Helps to figure out how many are happening in settings that do not capture detail logs.
