### PR TITLE
Fix handling of a response that comes after MRP resends end.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -79,6 +79,7 @@ bool ExchangeContext::IsResponseExpected() const
 void ExchangeContext::SetResponseExpected(bool inResponseExpected)
 {
     mFlags.Set(Flags::kFlagResponseExpected, inResponseExpected);
+    SetWaitingForResponseOrAck(inResponseExpected);
 }
 
 void ExchangeContext::UseSuggestedResponseTimeout(Timeout applicationProcessingTimeout)
@@ -489,6 +490,9 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
     }
 #endif // CONFIG_DEVICE_LAYER && CHIP_CONFIG_ENABLE_ICD_SERVER
 
+    // Grab the value of WaitingForResponseOrAck() before we mess with our state.
+    bool mrpTimedOut = WaitingForResponseOrAck();
+
     SetResponseExpected(false);
 
     // Hold a ref to ourselves so we can make calls into our delegate that might
@@ -502,9 +506,8 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
     {
         // If we timed out _after_ getting an ack for the message, that means
         // the session is probably fine (since our message and the ack got
-        // through), so don't mark the session defunct unless we have an
-        // un-acked message here.
-        if (IsMessageNotAcked())
+        // through), so don't mark the session defunct unless MRP also timed out.
+        if (mrpTimedOut)
         {
             if (mSession->IsSecureSession() && mSession->AsSecureSession()->IsCASESession())
             {
@@ -596,7 +599,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
         return CHIP_NO_ERROR;
     }
 
-    if (IsMessageNotAcked())
+    if (IsWaitingForAck())
     {
         // The only way we can get here is a spec violation on the other side:
         // we sent a message that needs an ack, and the other side responded

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -491,7 +491,7 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
 #endif // CONFIG_DEVICE_LAYER && CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // Grab the value of WaitingForResponseOrAck() before we mess with our state.
-    bool mrpTimedOut = WaitingForResponseOrAck();
+    bool gotMRPAck = !WaitingForResponseOrAck();
 
     SetResponseExpected(false);
 
@@ -506,8 +506,8 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
     {
         // If we timed out _after_ getting an ack for the message, that means
         // the session is probably fine (since our message and the ack got
-        // through), so don't mark the session defunct unless MRP also timed out.
-        if (mrpTimedOut)
+        // through), so don't mark the session defunct if we got an MRP ack.
+        if (!gotMRPAck)
         {
             if (mSession->IsSecureSession() && mSession->AsSecureSession()->IsCASESession())
             {

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -163,10 +163,24 @@ CHIP_ERROR MessagingContext::CreateSessionBobToAlice()
                                                         mBobFabricIndex, mAliceAddress, CryptoContext::SessionRole::kInitiator);
 }
 
+CHIP_ERROR MessagingContext::CreateCASESessionBobToAlice()
+{
+    return mSessionManager.InjectCaseSessionWithTestKey(mSessionBobToAlice, kBobKeyId, kAliceKeyId, GetBobFabric()->GetNodeId(),
+                                                        GetAliceFabric()->GetNodeId(), mBobFabricIndex, mAliceAddress,
+                                                        CryptoContext::SessionRole::kInitiator);
+}
+
 CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 {
     return mSessionManager.InjectPaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, GetBobFabric()->GetNodeId(), kBobKeyId,
                                                         mAliceFabricIndex, mBobAddress, CryptoContext::SessionRole::kResponder);
+}
+
+CHIP_ERROR MessagingContext::CreateCASESessionAliceToBob()
+{
+    return mSessionManager.InjectCaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, kBobKeyId, GetAliceFabric()->GetNodeId(),
+                                                        GetBobFabric()->GetNodeId(), mAliceFabricIndex, mBobAddress,
+                                                        CryptoContext::SessionRole::kResponder);
 }
 
 CHIP_ERROR MessagingContext::CreatePASESessionCharlieToDavid()

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -139,9 +139,11 @@ public:
     const FabricInfo * GetAliceFabric() { return mFabricTable.FindFabricWithIndex(mAliceFabricIndex); }
     const FabricInfo * GetBobFabric() { return mFabricTable.FindFabricWithIndex(mBobFabricIndex); }
 
-    CHIP_ERROR CreateSessionBobToAlice();
-    CHIP_ERROR CreateSessionAliceToBob();
-    CHIP_ERROR CreateSessionBobToFriends();
+    CHIP_ERROR CreateSessionBobToAlice(); // Creates PASE session
+    CHIP_ERROR CreateCASESessionBobToAlice();
+    CHIP_ERROR CreateSessionAliceToBob(); // Creates PASE session
+    CHIP_ERROR CreateCASESessionAliceToBob();
+    CHIP_ERROR CreateSessionBobToFriends(); // Creates PASE session
     CHIP_ERROR CreatePASESessionCharlieToDavid();
     CHIP_ERROR CreatePASESessionDavidToCharlie();
 


### PR DESCRIPTION
After #29173 we can get into the following situation:

1. A message is sent.
2. Before we get an ack or response, all MRP retries happen, MRP gives up, but the exchange response timer has not been hit yet.
3. We get an actual response.
4. Because our exchange is marked as having an un-acked message, but the incoming message is not treated as an ack (because the MRP state that would do that has been torn down), we do not clear our "have un-acked message" state and end up discarding the incoming message.

The fix is as follows:

* Rename things to make it clear that what we really have is "waiting for an ack" state, which in fact _does_ get cleared when we run out of MRP retries, not an "un-acked message" state.
* Have a separate state bit for tracking that we ran out of MRP retries on a message we sent.
