### PR TITLE
[nrfconnect] Align nrf_power calls to new scheme

### DIFF
--- a/src/platform/nrfconnect/Reboot.cpp
+++ b/src/platform/nrfconnect/Reboot.cpp
@@ -42,7 +42,7 @@ SoftwareRebootReason GetSoftwareRebootReason()
 
 #else
 
-using RetainedReason = decltype(nrf_power_gpregret_get(NRF_POWER));
+using RetainedReason = decltype(nrf_power_gpregret_get(NRF_POWER, 0));
 
 constexpr RetainedReason EncodeReason(SoftwareRebootReason reason)
 {
@@ -61,7 +61,7 @@ void Reboot(SoftwareRebootReason reason)
     // set it manually.
 
 #ifdef CONFIG_SOC_SERIES_NRF53X
-    nrf_power_gpregret_set(NRF_POWER, retainedReason);
+    nrf_power_gpregret_set(NRF_POWER, 0, retainedReason);
 #endif
 
     sys_reboot(retainedReason);
@@ -69,10 +69,10 @@ void Reboot(SoftwareRebootReason reason)
 
 SoftwareRebootReason GetSoftwareRebootReason()
 {
-    switch (nrf_power_gpregret_get(NRF_POWER))
+    switch (nrf_power_gpregret_get(NRF_POWER, 0))
     {
     case EncodeReason(SoftwareRebootReason::kSoftwareUpdate):
-        nrf_power_gpregret_set(NRF_POWER, 0);
+        nrf_power_gpregret_set(NRF_POWER, 0, 0);
         return SoftwareRebootReason::kSoftwareUpdate;
     default:
         return SoftwareRebootReason::kOther;


### PR DESCRIPTION
Now the API to manage GPREGRET register is unified for all devices having one or more GPREGRET entries.

This PR is related to nrfx library update in Zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/63461
