### PR TITLE
Impove CD validation

### DIFF
--- a/src/credentials/CertificationDeclaration.cpp
+++ b/src/credentials/CertificationDeclaration.cpp
@@ -143,6 +143,7 @@ CHIP_ERROR DecodeCertificationElements(const ByteSpan & encodedCertElements, Cer
     certElements.ProductIdsCount = 0;
     while ((err = reader.Next(AnonymousTag())) == CHIP_NO_ERROR)
     {
+        VerifyOrReturnError(certElements.ProductIdsCount < kMaxProductIdsCount, CHIP_ERROR_INVALID_ARGUMENT);
         ReturnErrorOnFailure(reader.Get(certElements.ProductIds[certElements.ProductIdsCount++]));
     }
     VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
@@ -194,6 +195,7 @@ CHIP_ERROR DecodeCertificationElements(const ByteSpan & encodedCertElements, Cer
         while ((err = reader.Next(kTLVType_ByteString, AnonymousTag())) == CHIP_NO_ERROR)
         {
             VerifyOrReturnError(reader.GetLength() == kKeyIdentifierLength, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+            VerifyOrReturnError(certElements.AuthorizedPAAListCount < kMaxAuthorizedPAAListCount, CHIP_ERROR_INVALID_ARGUMENT);
 
             ReturnErrorOnFailure(
                 reader.GetBytes(certElements.AuthorizedPAAList[certElements.AuthorizedPAAListCount++], kKeyIdentifierLength));


### PR DESCRIPTION
We currently peform validation against PAA checks in encoding.  In decoding, we check for cryptographic validity, but do not perform the same checks againts the data.  This commit brings the encoding and decoding into parity.
