### PR TITLE
Add enable_tracing_support build parameter

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -44,6 +44,7 @@ declare case_retry_delta
 declare install_virtual_env
 declare clean_virtual_env=yes
 declare install_pytest_requirements=yes
+declare enable_tracing_support=true
 
 help() {
 
@@ -69,6 +70,7 @@ Input Options:
                                                             Defaults to yes.
   --extra_packages PACKAGES                                 Install extra Python packages from PyPI
   -z --pregen_dir DIRECTORY                                 Directory where generated zap files have been pre-generated.
+  --enable_tracing_support <true/false>                 Specify whether to enable tracing support.
 "
 }
 
@@ -132,6 +134,14 @@ while (($#)); do
             pregen_dir=$2
             shift
             ;;
+        --enable_tracing_support)
+            enable_tracing_support=$2
+            if [[ "$enable_tracing_support" != "true" && "$enable_tracing_support" != "false" ]]; then
+                echo "enable_tracing_support should have a true/false value, not '$enable_tracing_support'"
+                exit
+            fi
+            shift
+            ;;
         -*)
             help
             echo "Unknown Option \"$1\""
@@ -142,7 +152,7 @@ while (($#)); do
 done
 
 # Print input values
-echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings, chip_case_retry_delta=\"$chip_case_retry_delta\", pregen_dir=\"$pregen_dir\""
+echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings, chip_case_retry_delta=\"$chip_case_retry_delta\", pregen_dir=\"$pregen_dir\", enable_tracing_support = $enable_tracing_support"
 
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
@@ -153,7 +163,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 [[ -n "$pregen_dir" ]] && pregen_dir_arg="chip_code_pre_generated_directory=\"$pregen_dir\"" || pregen_dir_arg=""
 
 # Make all possible human redable tracing available.
-tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
+tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=$enable_tracing_support"
 
 gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg"
 


### PR DESCRIPTION
Add `enable_tracing_support` build parameter, by setting it to `false` you can solve the problem of not being able to compile when `enable_pybindings` is turned on.

Test using the following compile command.

First you need to activate the environment:
``` shell
source scripts/activate.sh
```

It fails by default:
``` shell
scripts/run_in_build_env.sh '. /scripts/build_python.sh -i out/venv -c no -p true'
```

And log shows below:
```
ubuntu@guoyuchao-vm:~/dev/csa/connectedhomeip$ scripts/run_in_build_env.sh './scripts/build_python.sh -i out/venv -c no -p true'

  WELCOME TO...

         █
         █
     ▄   █   ▄                                █     █
     ▀▀█████▀▀      ▄▀▀▀▄ ▄▀▀▀▄    ▄▀▀▀▀▄█  ▀▀█▀▀▀▀▀█▀▀   ▄▀▀▀▀▄    ▄▀▀
   ▀█▄       ▄█▀   █     █     █  █      █    █     █    █▄▄▄▄▄▄█  █   
     ▀█▄   ▄█▀     █     █     █  █      █    █     █    █         █   
  ▄██▀▀█   █▀▀██▄  █     █     █   ▀▄▄▄▄▀█    ▀▄▄   ▀▄▄   ▀▄▄▄▄▀   █   
 ▀▀    █   █    ▀▀

  ACTIVATOR! This sets your shell environment variables.

Activating environment (setting environment variables):

  Setting environment variables for CIPD package manager...done
  Setting environment variables for Project actions........skipped
  Setting environment variables for Python environment.....done
  Setting environment variables for pw packages............skipped
  Setting environment variables for Host tools.............done

Checking the environment:

20231010 06:06:42 INF Environment passes all checks!

Environment looks good, you are ready to go!

Executing in build environment: ./scripts/build_python.sh -i out/venv -c no -p true
Input values: chip_detail_logging = false , chip_mdns = "", enable_pybindings = true, chip_case_retry_delta="", pregen_dir="", enable_tracing_support = true

  WELCOME TO...

         █
         █
     ▄   █   ▄                                █     █
     ▀▀█████▀▀      ▄▀▀▀▄ ▄▀▀▀▄    ▄▀▀▀▀▄█  ▀▀█▀▀▀▀▀█▀▀   ▄▀▀▀▀▄    ▄▀▀
   ▀█▄       ▄█▀   █     █     █  █      █    █     █    █▄▄▄▄▄▄█  █   
     ▀█▄   ▄█▀     █     █     █  █      █    █     █    █         █   
  ▄██▀▀█   █▀▀██▄  █     █     █   ▀▄▄▄▄▀█    ▀▄▄   ▀▄▄   ▀▄▄▄▄▀   █   
 ▀▀    █   █    ▀▀

  ACTIVATOR! This sets your shell environment variables.

Activating environment (setting environment variables):

  Setting environment variables for CIPD package manager...done
  Setting environment variables for Project actions........skipped
  Setting environment variables for Python environment.....done
  Setting environment variables for pw packages............skipped
  Setting environment variables for Host tools.............done

Checking the environment:

20231010 06:06:43 INF Environment passes all checks!

Environment looks good, you are ready to go!

Done. Made 7451 targets from 350 files in 220ms
ninja: Entering directory `./out/python_lib'
[224/230] ld -shared obj/src/pybindings/pycontroller/pychip/PyChip.so
FAILED: obj/src/pybindings/pycontroller/pychip/PyChip.so obj/src/pybindings/pycontroller/pychip/PyChip.map 
g++ -O0 -fPIC -Werror -Wl,--fatal-warnings -Wl,-z,defs -fdiagnostics-color -Wl,--gc-sections -Wl,-Map,obj/src/pybindings/pycontroller/pychip/PyChip.map -Wl,--cref @obj/src/pybindings/pycontroller/pychip/PyChip.so.rsp -o obj/src/pybindings/pycontroller/pychip/PyChip.so -shared
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::DefaultTracePointTraits::GetActiveInstances(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::DefaultTracePointTraits::TracePointData)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10967: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::CategoryTracePointTraits::GetActiveInstances(perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::CategoryTracePointTraits::TracePointData)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:17909: undefined reference to `perfetto::perfetto_track_event::internal::kCategoryRegistry'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::IsDynamicCategoryEnabled(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext*, perfetto::DynamicCategory const&)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:18067: undefined reference to `perfetto::perfetto_track_event::internal::kCategoryRegistry'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::EventContext perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::WriteTrackEvent<char const*, decltype(nullptr), perfetto::Track, perfetto::TraceTimestamp, void, void>(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext&, char const* const&, decltype(nullptr) const&, perfetto::protos::pbzero::perfetto_pbzero_enum_TrackEvent::Type, perfetto::Track const&, perfetto::TraceTimestamp const&)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:17930: undefined reference to `perfetto::perfetto_track_event::internal::kCategoryRegistry'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::EventContext perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::WriteTrackEvent<unsigned long, decltype(nullptr), perfetto::Track, perfetto::TraceTimestamp, void, void>(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext&, unsigned long const&, decltype(nullptr) const&, perfetto::protos::pbzero::perfetto_pbzero_enum_TrackEvent::Type, perfetto::Track const&, perfetto::TraceTimestamp const&)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:17930: undefined reference to `perfetto::perfetto_track_event::internal::kCategoryRegistry'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::EventContext perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::WriteTrackEvent<char const*, perfetto::StaticString, perfetto::Track, perfetto::TraceTimestamp, void, void>(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext&, char const* const&, perfetto::StaticString const&, perfetto::protos::pbzero::perfetto_pbzero_enum_TrackEvent::Type, perfetto::Track const&, perfetto::TraceTimestamp const&)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:17930: undefined reference to `perfetto::perfetto_track_event::internal::kCategoryRegistry'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o):/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:17930: more undefined references to `perfetto::perfetto_track_event::internal::kCategoryRegistry' follow
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext::GetIncrementalState()':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10816: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext::GetDataSourceLocked() const':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10798: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o): in function `void perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceWithInstances<perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::DefaultTracePointTraits, perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::TraceForCategoryImpl<char const*, decltype(nullptr), perfetto::Track, perfetto::TraceTimestamp, void, void>(unsigned int, char const* const&, decltype(nullptr) const&, perfetto::protos::pbzero::perfetto_pbzero_enum_TrackEvent::Type, perfetto::Track const&, perfetto::TraceTimestamp const&)::{lambda(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext)#1}>(unsigned int, perfetto::internal::TrackEventDataSource<perfetto::perfetto_track_event::TrackEvent, &perfetto::perfetto_track_event::internal::kCategoryRegistry>::TraceForCategoryImpl<char const*, decltype(nullptr), perfetto::Track, perfetto::TraceTimestamp, void, void>(unsigned int, char const* const&, decltype(nullptr) const&, perfetto::protos::pbzero::perfetto_pbzero_enum_TrackEvent::Type, perfetto::Track const&, perfetto::TraceTimestamp const&)::{lambda(perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::TraceContext)#1}, perfetto::DataSource<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::DefaultTracePointTraits::TracePointData)':
/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10894: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: /home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10900: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: /home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10902: undefined reference to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()'
/usr/bin/ld: lib/libCHIP.a(libTransportLayer.SessionManager.cpp.o):/home/ubuntu/dev/csa/connectedhomeip/out/python_lib/../../third_party/perfetto/repo/sdk/perfetto.h:10907: more undefined references to `perfetto::DataSourceHelper<perfetto::perfetto_track_event::TrackEvent, perfetto::internal::TrackEventDataSourceTraits>::type()' follow
collect2: error: ld returned 1 exit status
[225/230] ld -shared obj/src/controller/python/chip/_ChipDeviceCtrl.so
ninja: build stopped: subcommand failed.

```

Succeeds with additional parameters:
``` shell
scripts/run_in_build_env.sh '. /scripts/build_python.sh -i out/venv -c no -p true --enable_tracing_support false'
```

