### PR TITLE
Clear endpoint bitmask before reporting the PartList attribute

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -943,6 +943,7 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
         else
         {
             shutdownEndpoint(&(emAfEndpoints[index]));
+            emAfEndpoints[index].bitmask.Clear(EmberAfEndpointOptions::isEnabled);
         }
 
         EndpointId parentEndpointId = emberAfParentEndpointFromIndex(index);
@@ -961,11 +962,6 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
 
         MatterReportingAttributeChangeCallback(/* endpoint = */ 0, app::Clusters::Descriptor::Id,
                                                app::Clusters::Descriptor::Attributes::PartsList::Id);
-    }
-
-    if (!enable)
-    {
-        emAfEndpoints[index].bitmask.Clear(EmberAfEndpointOptions::isEnabled);
     }
 
     return true;


### PR DESCRIPTION
When we set a low value to the minimum subscription interval for subscription for the PartList attribute of the Description cluster, and then remove a dynamic endpoint the related bitmask may change after reporting it to a controller.
The controller receives the old number of endpoints and does not update it within the following subscriptions until the next change of the PartList attribute occurs.

To resolve the issue the endpoint bitmask should be cleared before reporting the PartList attribute of the Descriptor cluster to avoid race conditions.

