### PR TITLE
Add tracing dependencies to pycontroller

### DIFF
--- a/src/pybindings/pycontroller/BUILD.gn
+++ b/src/pybindings/pycontroller/BUILD.gn
@@ -69,6 +69,14 @@ shared_library("CHIPController") {
     "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport",
+    "${chip_root}/src/tracing/json",
+    "${chip_root}/src/tracing/perfetto",
+    "${chip_root}/src/tracing/perfetto:file_output",
+    "${chip_root}/third_party/jsoncpp",
+  ]
+  deps = [
+    "${chip_root}/src/tracing/perfetto:event_storage",
+    "${chip_root}/src/tracing/perfetto:simple_initialization",
   ]
   configs += [ ":controller_wno_deprecate" ]
   if (current_os == "mac") {

--- a/src/pybindings/pycontroller/BUILD.gn
+++ b/src/pybindings/pycontroller/BUILD.gn
@@ -68,10 +68,10 @@ shared_library("CHIPController") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
-    "${chip_root}/src/transport",
     "${chip_root}/src/tracing/json",
     "${chip_root}/src/tracing/perfetto",
     "${chip_root}/src/tracing/perfetto:file_output",
+    "${chip_root}/src/transport",
     "${chip_root}/third_party/jsoncpp",
   ]
   deps = [


### PR DESCRIPTION
PyController did not add tracing dependencies to its build logic.

This is a "add dependencies" change, as opposed to #29672 (which tries to add a tracing disable option).