### PR TITLE
Hook up some MTRDevice bits to XPC.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1576,7 +1576,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 - (MTRBaseDevice *)newBaseDevice
 {
-    return [[MTRBaseDevice alloc] initWithNodeID:self.nodeID controller:self.deviceController];
+    return [MTRBaseDevice deviceWithNodeID:self.nodeID controller:self.deviceController];
 }
 
 @end


### PR DESCRIPTION
Specific changes:

* Make MTRDevice get its MTRBaseDevice in a way that is XPC-friendly.
* Implement readAttributePaths (which is what ends up getting called by MTRDevice's readAttributeWithEndpointID) over XPC, as long as there is just a single attribute path.
* Implement _invokeCommandWithEndpointID (which is what ends up getting called by MTRDevice's _invokeKnownCommandWithEndpointID) over XPC, as long as serverSideProcessingTimeout is nil.
* Writes already called an MTRBaseDevice function that was implemented over XPC.
* Tests for the new setup; these were checked to fail without the other changes.

This also makes MTRClusters work over XPC.
