### PR TITLE
Decrease dependency on `WeakEnum`: GeneralDiagnostics::RadioFaultEnum, InterfaceTypeEnum

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -235,13 +235,13 @@ void AllClustersAppCommandHandler::OnGeneralFaultEventHandler(uint32_t eventId)
         GeneralFaults<kMaxRadioFaults> current;
 
         // On Linux Simulation, set following radio faults statically.
-        ReturnOnFailure(previous.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnOnFailure(previous.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+        ReturnOnFailure(previous.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnOnFailure(previous.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
 
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
         Clusters::GeneralDiagnosticsServer::Instance().OnRadioFaultsDetect(previous, current);
     }
     else if (eventId == Clusters::GeneralDiagnostics::Events::NetworkFaultChange::Id)

--- a/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
@@ -199,13 +199,13 @@ void LightingAppCommandHandler::OnGeneralFaultEventHandler(uint32_t eventId)
         GeneralFaults<kMaxRadioFaults> current;
 
         // On Linux Simulation, set following radio faults statically.
-        ReturnOnFailure(previous.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnOnFailure(previous.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+        ReturnOnFailure(previous.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnOnFailure(previous.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
 
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
-        ReturnOnFailure(current.add(EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+        ReturnOnFailure(current.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
         Clusters::GeneralDiagnosticsServer::Instance().OnRadioFaultsDetect(previous, current);
     }
     else if (eventId == Clusters::GeneralDiagnostics::Events::NetworkFaultChange::Id)

--- a/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
+++ b/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
@@ -53,13 +53,14 @@ CHIP_ERROR GenericFaultTestEventTriggerDelegate::HandleEventTrigger(uint64_t eve
         GeneralFaults<kMaxRadioFaults> radioFaultsPrevious;
         GeneralFaults<kMaxRadioFaults> radioFaultsCurrent;
 
-        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
-        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+        using app::Clusters::GeneralDiagnostics::RadioFaultEnum;
+        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(RadioFaultEnum::kWiFiFault)));
+        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(RadioFaultEnum::kThreadFault)));
 
-        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(RadioFaultEnum::kWiFiFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(RadioFaultEnum::kCellularFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(RadioFaultEnum::kThreadFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(RadioFaultEnum::kNFCFault)));
 
         app::Clusters::GeneralDiagnosticsServer::Instance().OnRadioFaultsDetect(radioFaultsPrevious, radioFaultsCurrent);
 

--- a/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
+++ b/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
@@ -53,13 +53,13 @@ CHIP_ERROR GenericFaultTestEventTriggerDelegate::HandleEventTrigger(uint64_t eve
         GeneralFaults<kMaxRadioFaults> radioFaultsPrevious;
         GeneralFaults<kMaxRadioFaults> radioFaultsCurrent;
 
-        ReturnErrorOnFailure(radioFaultsPrevious.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnErrorOnFailure(radioFaultsPrevious.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+        ReturnErrorOnFailure(radioFaultsPrevious.add(RadioFaultEnum::kWiFiFault));
+        ReturnErrorOnFailure(radioFaultsPrevious.add(RadioFaultEnum::kThreadFault));
 
-        ReturnErrorOnFailure(radioFaultsCurrent.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kWiFiFault));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kCellularFault));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kThreadFault));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kNFCFault));
 
         app::Clusters::GeneralDiagnosticsServer::Instance().OnRadioFaultsDetect(radioFaultsPrevious, radioFaultsCurrent);
 

--- a/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
+++ b/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerDelegate.cpp
@@ -53,13 +53,13 @@ CHIP_ERROR GenericFaultTestEventTriggerDelegate::HandleEventTrigger(uint64_t eve
         GeneralFaults<kMaxRadioFaults> radioFaultsPrevious;
         GeneralFaults<kMaxRadioFaults> radioFaultsCurrent;
 
-        ReturnErrorOnFailure(radioFaultsPrevious.add(RadioFaultEnum::kWiFiFault));
-        ReturnErrorOnFailure(radioFaultsPrevious.add(RadioFaultEnum::kThreadFault));
+        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnErrorOnFailure(radioFaultsPrevious.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
 
-        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kWiFiFault));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kCellularFault));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kThreadFault));
-        ReturnErrorOnFailure(radioFaultsCurrent.add(RadioFaultEnum::kNFCFault));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+        ReturnErrorOnFailure(radioFaultsCurrent.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
 
         app::Clusters::GeneralDiagnosticsServer::Instance().OnRadioFaultsDetect(radioFaultsPrevious, radioFaultsCurrent);
 

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -6,7 +6,6 @@ WeakEnums:
     - ColorControlOptions
     - ColorMode
     - EnhancedColorMode
-    - InterfaceTypeEnum
     - MoveMode
     - PHYRateEnum
     - StepMode

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -9,7 +9,6 @@ WeakEnums:
     - InterfaceTypeEnum
     - MoveMode
     - PHYRateEnum
-    - RadioFaultEnum
     - StepMode
 
 CommandHandlerInterfaceOnlyClusters:

--- a/src/platform/ASR/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ASR/DiagnosticDataProviderImpl.cpp
@@ -165,9 +165,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         if ((ifa->flags) & NETIF_FLAG_ETHERNET)
-            ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
         else
-            ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4.SetNull();
         ifp->offPremiseServicesReachableIPv6.SetNull();
 

--- a/src/platform/ASR/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ASR/DiagnosticDataProviderImpl.cpp
@@ -165,9 +165,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         if ((ifa->flags) & NETIF_FLAG_ETHERNET)
-            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
+            ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
         else
-            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+            ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4.SetNull();
         ifp->offPremiseServicesReachableIPv6.SetNull();
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -199,9 +199,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         if ((ifa->flags) & NETIF_FLAG_ETHERNET)
-            ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
         else
-            ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4.SetNull();
         ifp->offPremiseServicesReachableIPv6.SetNull();
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -199,9 +199,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         if ((ifa->flags) & NETIF_FLAG_ETHERNET)
-            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
+            ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
         else
-            ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+            ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4.SetNull();
         ifp->offPremiseServicesReachableIPv6.SetNull();
 

--- a/src/platform/Beken/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Beken/DiagnosticDataProviderImpl.cpp
@@ -134,7 +134,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 
     Platform::CopyString(ifp->Name, netif->hostname);
     ifp->name = CharSpan::fromCharString(ifp->Name);
-    ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
     ifp->offPremiseServicesReachableIPv4.SetNonNull(false);
     ifp->offPremiseServicesReachableIPv6.SetNonNull(false);
     memcpy(ifp->MacAddress, netif->hwaddr, sizeof(netif->hwaddr));

--- a/src/platform/Beken/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Beken/DiagnosticDataProviderImpl.cpp
@@ -134,7 +134,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 
     Platform::CopyString(ifp->Name, netif->hostname);
     ifp->name = CharSpan::fromCharString(ifp->Name);
-    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+    ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
     ifp->offPremiseServicesReachableIPv4.SetNonNull(false);
     ifp->offPremiseServicesReachableIPv6.SetNonNull(false);
     memcpy(ifp->MacAddress, netif->hwaddr, sizeof(netif->hwaddr));

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -53,12 +53,12 @@ namespace {
 InterfaceTypeEnum GetInterfaceType(const char * if_desc)
 {
     if (strncmp(if_desc, "ap", strnlen(if_desc, 2)) == 0 || strncmp(if_desc, "sta", strnlen(if_desc, 3)) == 0)
-        return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+        return InterfaceTypeEnum::kWiFi;
     if (strncmp(if_desc, "openthread", strnlen(if_desc, 10)) == 0)
-        return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+        return InterfaceTypeEnum::kThread;
     if (strncmp(if_desc, "eth", strnlen(if_desc, 3)) == 0)
-        return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
-    return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+        return InterfaceTypeEnum::kEthernet;
+    return InterfaceTypeEnum::kUnspecified;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/src/platform/Infineon/CYW30739/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Infineon/CYW30739/DiagnosticDataProviderImpl.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
     ifp->hardwareAddress = ByteSpan(ifp->MacAddress);
-    ifp->type            = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type            = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kThread;
 
     static_assert(sizeof(ifp->MacAddress) >= ConfigurationManager::kPrimaryMACAddressLength, "Invalid MacAddress buffer size");
     ConfigurationMgr().GetPrimary802154MACAddress(ifp->MacAddress);

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
@@ -161,7 +161,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         /* Update Network Interface list */
         ifp->name                            = CharSpan::fromCharString(net_interface->name);
         ifp->isOperational                   = net_interface->flags & NETIF_FLAG_LINK_UP;
-        ifp->type                            = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+        ifp->type                            = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4 = mipv4_offpremise;
         ifp->offPremiseServicesReachableIPv6 = mipv6_offpremise;
         ifp->hardwareAddress                 = ByteSpan(net_interface->hwaddr, net_interface->hwaddr_len);

--- a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp
@@ -161,7 +161,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         /* Update Network Interface list */
         ifp->name                            = CharSpan::fromCharString(net_interface->name);
         ifp->isOperational                   = net_interface->flags & NETIF_FLAG_LINK_UP;
-        ifp->type                            = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+        ifp->type                            = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
         ifp->offPremiseServicesReachableIPv4 = mipv4_offpremise;
         ifp->offPremiseServicesReachableIPv6 = mipv6_offpremise;
         ifp->hardwareAddress                 = ByteSpan(net_interface->hwaddr, net_interface->hwaddr_len);

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1220,8 +1220,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, value.data(), kMaxHardwareAddrSize) !=
                     CHIP_NO_ERROR)

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -245,13 +245,13 @@ double ConnectivityUtils::ConvertFrequenceToFloat(const iw_freq * in)
 
 InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 {
-    InterfaceTypeEnum ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+    InterfaceTypeEnum ret = InterfaceTypeEnum::kUnspecified;
     int sock              = -1;
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to open socket");
-        return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+        return InterfaceTypeEnum::kUnspecified;
     }
 
     // Test wireless extensions for CONNECTION_WIFI
@@ -260,7 +260,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
 
     if (ioctl(sock, SIOCGIWNAME, &pwrq) != -1)
     {
-        ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+        ret = InterfaceTypeEnum::kWiFi;
     }
     else if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
     {
@@ -271,7 +271,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
         Platform::CopyString(ifr.ifr_name, ifname);
 
         if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
-            ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+            ret = InterfaceTypeEnum::kEthernet;
     }
 
     close(sock);
@@ -420,7 +420,7 @@ CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 Platform::CopyString(ifname, bufSize, ifa->ifa_name);
                 err = CHIP_NO_ERROR;
@@ -614,7 +614,7 @@ CHIP_ERROR ConnectivityUtils::GetEthInterfaceName(char * ifname, size_t bufSize)
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 Platform::CopyString(ifname, bufSize, ifa->ifa_name);
                 err = CHIP_NO_ERROR;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -91,8 +91,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -156,8 +155,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -615,8 +613,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -781,8 +778,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -411,10 +411,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kWiFiFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kCellularFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kNFCFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -413,10 +413,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kWiFiFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kCellularFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kNFCFault));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -413,10 +413,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kWiFiFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kCellularFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kNFCFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -74,7 +74,7 @@ uint8_t ConnectivityUtils::MapFrequencyToChannel(const uint16_t frequency)
 
 InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 {
-    InterfaceTypeEnum ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+    InterfaceTypeEnum ret = InterfaceTypeEnum::kUnspecified;
     int sock              = -1;
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
@@ -89,7 +89,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
 
     if (ioctl(sock, SIOCGIWNAME, &pwrq) != -1)
     {
-        ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+        ret = InterfaceTypeEnum::kWiFi;
     }
     else if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
     {
@@ -100,7 +100,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
         Platform::CopyString(ifr.ifr_name, ifname);
 
         if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
-            ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+            ret = InterfaceTypeEnum::kEthernet;
     }
 
     close(sock);
@@ -239,7 +239,7 @@ CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+        if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
         {
             Platform::CopyString(ifname, bufSize, ifa->ifa_name);
             err = CHIP_NO_ERROR;
@@ -405,7 +405,7 @@ CHIP_ERROR ConnectivityUtils::GetEthInterfaceName(char * ifname, size_t bufSize)
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+        if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
         {
             Platform::CopyString(ifname, bufSize, ifa->ifa_name);
             err = CHIP_NO_ERROR;

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
@@ -70,8 +70,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-            InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
         {
             ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
             break;
@@ -131,7 +130,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
         {
             ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
             break;
@@ -459,8 +458,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-            InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
         {
             ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
             break;
@@ -628,7 +626,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
     struct ifaddrs * ifa = nullptr;
     for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
-        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+        if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
         {
             ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
             break;

--- a/src/platform/Tizen/NetworkCommissioningEthernetDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningEthernetDriver.cpp
@@ -43,7 +43,7 @@ TizenEthernetDriver::EthernetNetworkIterator::EthernetNetworkIterator(TizenEther
     for (const auto * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
     {
         if (DeviceLayer::Internal::ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-            app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet)
         {
             mInterfaces.push_back(ifa->ifa_name);
             if (mInterfaces.size() == mDriver->GetMaxNetworks())

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -258,19 +258,19 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             switch (interfaceType)
             {
             case Inet::InterfaceType::Unknown:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
                 break;
             case Inet::InterfaceType::WiFi:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             case Inet::InterfaceType::Ethernet:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
                 break;
             case Inet::InterfaceType::Thread:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kThread;
                 break;
             case Inet::InterfaceType::Cellular:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kCellular;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kCellular;
                 break;
             }
         }

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -258,19 +258,19 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             switch (interfaceType)
             {
             case Inet::InterfaceType::Unknown:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
                 break;
             case Inet::InterfaceType::WiFi:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             case Inet::InterfaceType::Ethernet:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
                 break;
             case Inet::InterfaceType::Thread:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
                 break;
             case Inet::InterfaceType::Cellular:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_CELLULAR;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kCellular;
                 break;
             }
         }

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -191,7 +191,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -191,8 +191,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
     ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);
@@ -231,9 +231,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->name          = CharSpan::fromCharString(ifp->Name);
     ifp->isOperational = true;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    ifp->type          = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+    ifp->type          = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
 #else
-    ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
 #endif
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -192,7 +192,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -191,7 +191,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
+    ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kThread;
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
     ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);
@@ -231,9 +231,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->name          = CharSpan::fromCharString(ifp->Name);
     ifp->isOperational = true;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    ifp->type          = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+    ifp->type          = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
 #else
-    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
+    ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
 #endif
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
+    ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kThread;
 
     otExtAddress extAddr;
     ThreadStackMgrImpl().GetExtAddress(extAddr);

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
 
     otExtAddress extAddr;
     ThreadStackMgrImpl().GetExtAddress(extAddr);

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -219,8 +219,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13xx_26xx/DiagnosticDataProviderImpl.cpp
@@ -220,7 +220,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
@@ -183,7 +183,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
@@ -210,7 +210,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->fabricConnected           = true;
     ifp->offPremiseServicesReachableIPv4.SetNonNull(false);
     ifp->offPremiseServicesReachableIPv6.SetNonNull(false);
-    ifp->type = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = InterfaceTypeEnum::kThread;
 #else
     /* TODO */
 #endif

--- a/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mt793x/DiagnosticDataProviderImpl.cpp
@@ -182,8 +182,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = InterfaceTypeEnum::kThread;
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
     ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);

--- a/src/platform/nxp/k32w/k32w1/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/k32w/k32w1/DiagnosticDataProviderImpl.cpp
@@ -209,7 +209,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = InterfaceTypeEnum::kThread;
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
     ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);

--- a/src/platform/nxp/mw320/ConnectivityUtils.cpp
+++ b/src/platform/nxp/mw320/ConnectivityUtils.cpp
@@ -243,7 +243,7 @@ double ConnectivityUtils::ConvertFrequenceToFloat(const iw_freq * in)
 InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 {
     // MW320 only has the wifi interface
-    InterfaceTypeEnum ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+    InterfaceTypeEnum ret = InterfaceTypeEnum::kWiFi;
     return ret;
 }
 

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
@@ -163,7 +163,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
     ifp->name                                          = CharSpan::fromCharString(ifp->Name);
     ifp->isOperational                                 = true;
-    ifp->type                                          = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+    ifp->type                                          = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
     if (ConnectivityUtils::GetInterfaceIPv4Addrs("", size, ifp) == CHIP_NO_ERROR)

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
@@ -163,7 +163,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
     ifp->name                                          = CharSpan::fromCharString(ifp->Name);
     ifp->isOperational                                 = true;
-    ifp->type                                          = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+    ifp->type                                          = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
     if (ConnectivityUtils::GetInterfaceIPv4Addrs("", size, ifp) == CHIP_NO_ERROR)

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -161,7 +161,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
     ChipLogProgress(DeviceLayer, "GetActiveRadioFaults");
 #if CHIP_CONFIG_TEST
     ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -160,7 +160,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
     ChipLogProgress(DeviceLayer, "GetActiveRadioFaults");
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -160,8 +160,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
     ChipLogProgress(DeviceLayer, "GetActiveRadioFaults");
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -160,7 +160,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
     ChipLogProgress(DeviceLayer, "GetActiveRadioFaults");
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -270,22 +270,22 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             switch (interfaceType)
             {
             case Inet::InterfaceType::Unknown:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
                 break;
             case Inet::InterfaceType::WiFi:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             case Inet::InterfaceType::Ethernet:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
                 break;
             case Inet::InterfaceType::Thread:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
                 break;
             case Inet::InterfaceType::Cellular:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_CELLULAR;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kCellular;
                 break;
             default:
-                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             }
         }

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -252,7 +252,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
-    ifp->type = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD;
+    ifp->type = InterfaceTypeEnum::kThread;
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
     ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -224,8 +224,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -225,7 +225,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kBLEFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -270,22 +270,22 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             switch (interfaceType)
             {
             case Inet::InterfaceType::Unknown:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kUnspecified;
                 break;
             case Inet::InterfaceType::WiFi:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             case Inet::InterfaceType::Ethernet:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kEthernet;
                 break;
             case Inet::InterfaceType::Thread:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kThread;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kThread;
                 break;
             case Inet::InterfaceType::Cellular:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kCellular;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kCellular;
                 break;
             default:
-                ifp->type = GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
+                ifp->type = app::Clusters::GeneralDiagnostics::InterfaceTypeEnum::kWiFi;
                 break;
             }
         }

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -224,7 +224,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -224,7 +224,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMa
 CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
 {
 #if CHIP_CONFIG_TEST
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
     ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT));
 #endif
 

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -1133,8 +1133,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, value.data(), kMaxHardwareAddrSize) !=
                     CHIP_NO_ERROR)

--- a/src/platform/webos/ConnectivityUtils.cpp
+++ b/src/platform/webos/ConnectivityUtils.cpp
@@ -245,13 +245,13 @@ double ConnectivityUtils::ConvertFrequenceToFloat(const iw_freq * in)
 
 InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
 {
-    InterfaceTypeEnum ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+    InterfaceTypeEnum ret = InterfaceTypeEnum::kUnspecified;
     int sock              = -1;
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to open socket");
-        return InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED;
+        return InterfaceTypeEnum::kUnspecified;
     }
 
     // Test wireless extensions for CONNECTION_WIFI
@@ -260,7 +260,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
 
     if (ioctl(sock, SIOCGIWNAME, &pwrq) != -1)
     {
-        ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI;
+        ret = InterfaceTypeEnum::kWiFi;
     }
     else if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
     {
@@ -271,7 +271,7 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
         Platform::CopyString(ifr.ifr_name, ifname);
 
         if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
-            ret = InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET;
+            ret = InterfaceTypeEnum::kEthernet;
     }
 
     close(sock);
@@ -328,7 +328,7 @@ CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 Platform::CopyString(ifname, bufSize, ifa->ifa_name);
                 err = CHIP_NO_ERROR;
@@ -522,7 +522,7 @@ CHIP_ERROR ConnectivityUtils::GetEthInterfaceName(char * ifname, size_t bufSize)
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 Platform::CopyString(ifname, bufSize, ifa->ifa_name);
                 err = CHIP_NO_ERROR;

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -397,10 +397,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
-    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kWiFiFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kCellularFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(RadioFaultEnum::kNFCFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -88,8 +88,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -153,8 +152,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -584,8 +582,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;
@@ -750,8 +747,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
         // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) ==
-                InterfaceTypeEnum::EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI)
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kWiFi)
             {
                 ChipLogProgress(DeviceLayer, "Found the primary WiFi interface:%s", StringOrNullMarker(ifa->ifa_name));
                 break;

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -399,10 +399,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kWiFiFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kCellularFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
-    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kNFCFault));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kWiFiFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kCellularFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kThreadFault)));
+    ReturnErrorOnFailure(radioFaults.add(to_underlying(GeneralDiagnostics::RadioFaultEnum::kNFCFault)));
 #endif
 
     return CHIP_NO_ERROR;

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -399,10 +399,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRa
 {
 #if CHIP_CONFIG_TEST
     // On Linux Simulation, set following radio faults statically.
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT));
-    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kWiFiFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kCellularFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kThreadFault));
+    ReturnErrorOnFailure(radioFaults.add(RadioFaultEnum::kNFCFault));
 #endif
 
     return CHIP_NO_ERROR;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -884,9 +884,6 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Rad
     using EnumType = GeneralDiagnostics::RadioFaultEnum;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kUnspecified:
     case EnumType::kWiFiFault:
     case EnumType::kCellularFault:
@@ -894,15 +891,6 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Rad
     case EnumType::kNFCFault:
     case EnumType::kBLEFault:
     case EnumType::kEthernetFault:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_RADIO_FAULT_ENUM_UNSPECIFIED:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT:
-    case EMBER_ZCL_RADIO_FAULT_ENUM_ETHERNET_FAULT:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(7);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -845,21 +845,11 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Int
     using EnumType = GeneralDiagnostics::InterfaceTypeEnum;
     switch (val)
     {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     case EnumType::kUnspecified:
     case EnumType::kWiFi:
     case EnumType::kEthernet:
     case EnumType::kCellular:
     case EnumType::kThread:
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    case EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED:
-    case EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI:
-    case EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET:
-    case EMBER_ZCL_INTERFACE_TYPE_ENUM_CELLULAR:
-    case EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD:
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         return val;
     default:
         return static_cast<EnumType>(5);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1047,9 +1047,6 @@ enum class NetworkFaultEnum : uint8_t
     kUnknownEnumValue = 4,
 };
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for RadioFaultEnum
 enum class RadioFaultEnum : uint8_t
 {
@@ -1066,10 +1063,6 @@ enum class RadioFaultEnum : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 7,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using RadioFaultEnum                                                           = EmberAfRadioFaultEnum;
-static RadioFaultEnum __attribute__((unused)) kRadioFaultEnumkUnknownEnumValue = static_cast<RadioFaultEnum>(7);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 } // namespace GeneralDiagnostics
 
 namespace SoftwareDiagnostics {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1011,9 +1011,6 @@ enum class HardwareFaultEnum : uint8_t
     kUnknownEnumValue = 11,
 };
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for InterfaceTypeEnum
 enum class InterfaceTypeEnum : uint8_t
 {
@@ -1028,10 +1025,6 @@ enum class InterfaceTypeEnum : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 5,
 };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using InterfaceTypeEnum                                                              = EmberAfInterfaceTypeEnum;
-static InterfaceTypeEnum __attribute__((unused)) kInterfaceTypeEnumkUnknownEnumValue = static_cast<InterfaceTypeEnum>(5);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
 // Enum for NetworkFaultEnum
 enum class NetworkFaultEnum : uint8_t

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -63,16 +63,6 @@ enum EmberAfEnhancedColorMode : uint8_t
     EMBER_ZCL_ENHANCED_COLOR_MODE_ENHANCED_CURRENT_HUE_AND_CURRENT_SATURATION = 3,
 };
 
-// Enum for InterfaceTypeEnum
-enum EmberAfInterfaceTypeEnum : uint8_t
-{
-    EMBER_ZCL_INTERFACE_TYPE_ENUM_UNSPECIFIED = 0,
-    EMBER_ZCL_INTERFACE_TYPE_ENUM_WI_FI       = 1,
-    EMBER_ZCL_INTERFACE_TYPE_ENUM_ETHERNET    = 2,
-    EMBER_ZCL_INTERFACE_TYPE_ENUM_CELLULAR    = 3,
-    EMBER_ZCL_INTERFACE_TYPE_ENUM_THREAD      = 4,
-};
-
 // Enum for MoveMode
 enum EmberAfMoveMode : uint8_t
 {

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -95,18 +95,6 @@ enum EmberAfPHYRateEnum : uint8_t
     EMBER_ZCL_PHY_RATE_ENUM_RATE400_G = 9,
 };
 
-// Enum for RadioFaultEnum
-enum EmberAfRadioFaultEnum : uint8_t
-{
-    EMBER_ZCL_RADIO_FAULT_ENUM_UNSPECIFIED    = 0,
-    EMBER_ZCL_RADIO_FAULT_ENUM_WI_FI_FAULT    = 1,
-    EMBER_ZCL_RADIO_FAULT_ENUM_CELLULAR_FAULT = 2,
-    EMBER_ZCL_RADIO_FAULT_ENUM_THREAD_FAULT   = 3,
-    EMBER_ZCL_RADIO_FAULT_ENUM_NFC_FAULT      = 4,
-    EMBER_ZCL_RADIO_FAULT_ENUM_BLE_FAULT      = 5,
-    EMBER_ZCL_RADIO_FAULT_ENUM_ETHERNET_FAULT = 6,
-};
-
 // Enum for StepMode
 enum EmberAfStepMode : uint8_t
 {


### PR DESCRIPTION
Removed RadioFaultEnum from WeakEnum list.

Updated code to make it compile. Tested linux all-clusters, light and qpg light (for platform code). Assuming all the rest are ok since updated via scripts. CI should catch any other errors.

