### PR TITLE
Fix conformance issue on all-clusters on/off

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -7627,7 +7627,7 @@ endpoint 2 {
     callback attribute acceptedCommandList;
     callback attribute eventList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 0x0000;
+    ram      attribute featureMap default = 0x0001;
     ram      attribute clusterRevision default = 5;
   }
 

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -31707,7 +31707,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0000",
+              "defaultValue": "0x0001",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
The on off cluster on EP2 exposes several attributes and commands that all require LT feature, but the feature was not marked.

