### PR TITLE
[SMOKECO-TC] Fix smokeco tests as per test plan document

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -17,7 +17,6 @@ name:
     Server
 
 PICS:
-    - SMOKECO.S
     - SMOKECO.S.F00
 
 config:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -145,7 +145,7 @@ tests:
                 value: "y"
 
     - label: "Step 10: TH reads TestInProgress attribute from DUT"
-      PICS: SMOKECO.S.A0005
+      PICS: SMOKECO.S.A0005 && SMOKECO.M.ManuallyControlledTest
       command: "readAttribute"
       attribute: "TestInProgress"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_2.yaml
@@ -18,6 +18,7 @@ name:
 
 PICS:
     - SMOKECO.S
+    - SMOKECO.S.F00
 
 config:
     nodeId: 0x12344321

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -17,6 +17,7 @@ name:
 
 PICS:
     - SMOKECO.S
+    - SMOKECO.S.F01
 
 config:
     nodeId: 0x12344321

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -16,7 +16,6 @@ name:
     4.2.3. [TC-SMOKECO-2.3] Primary Functionality - CO Alarm with DUT as Server
 
 PICS:
-    - SMOKECO.S
     - SMOKECO.S.F01
 
 config:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_3.yaml
@@ -144,7 +144,7 @@ tests:
                 value: "y"
 
     - label: "Step 10: TH reads TestInProgress attribute from DUT"
-      PICS: SMOKECO.S.A0005
+      PICS: SMOKECO.S.A0005 && SMOKECO.M.ManuallyControlledTest
       command: "readAttribute"
       attribute: "TestInProgress"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SMOKECO_2_4.yaml
@@ -511,7 +511,7 @@ tests:
     - label:
           "Step 38: TH waits for a report of TestInProgress attribute from DUT
           with a timeout of 180 seconds"
-      PICS: SMOKECO.S.A0005
+      PICS: SMOKECO.S.A0005 && SMOKECO.M.ManuallyControlledTest
       command: "waitForReport"
       attribute: "TestInProgress"
       timeout: 180
@@ -521,7 +521,7 @@ tests:
               type: boolean
 
     - label: "Step 39: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
+      PICS: SMOKECO.S.A0000 && SMOKECO.M.ManuallyControlledTest
       command: "readAttribute"
       attribute: "ExpressedState"
       response:
@@ -532,7 +532,7 @@ tests:
     - label:
           "Step 40: TH waits for a report of TestInProgress attribute from DUT
           with a timeout of 180 seconds"
-      PICS: SMOKECO.S.A0005
+      PICS: SMOKECO.S.A0005 && SMOKECO.M.ManuallyControlledTest
       command: "waitForReport"
       attribute: "TestInProgress"
       timeout: 180
@@ -542,7 +542,7 @@ tests:
               type: boolean
 
     - label: "Step 41: TH reads SelfTestComplete event from DUT"
-      PICS: SMOKECO.S.E05
+      PICS: SMOKECO.S.E05 && SMOKECO.M.ManuallyControlledTest
       command: "readEvent"
       event: "SelfTestComplete"
       eventNumber: "LastReceivedEventNumber + 1"
@@ -550,7 +550,7 @@ tests:
           value: {}
 
     - label: "Step 42: TH reads ExpressedState attribute from DUT"
-      PICS: SMOKECO.S.A0000
+      PICS: SMOKECO.S.A0000 && SMOKECO.M.ManuallyControlledTest
       command: "readAttribute"
       attribute: "ExpressedState"
       response:
@@ -559,7 +559,7 @@ tests:
               type: enum8
 
     - label: "Step 43: TH reads AllClear event from DUT"
-      PICS: SMOKECO.S.E0a
+      PICS: SMOKECO.S.E0a && SMOKECO.M.ManuallyControlledTest
       command: "readEvent"
       event: "AllClear"
       eventNumber: "LastReceivedEventNumber + 1"


### PR DESCRIPTION
- Add SMOKECO.M.ManuallyControlledTest PICS
Adapting to the latest changes in the Test Plan: [smco.adoc](https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/cluster/smco.adoc)

- Change top-level PICS
According to https://github.com/CHIP-Specifications/chip-test-plans/issues/3459, change PICS to avoid situations like smoke alarms requiring a CO test item.
