### PR TITLE
Fix ID field in TheradMetricsStruct to have a name that matches the spec.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
   <struct name="ThreadMetricsStruct">
     <cluster code="0x0034"/>
-    <item name="Id" type="INT64U"/>
+    <item name="ID" type="INT64U"/>
     <item name="Name" type="CHAR_STRING" length="8" optional="true"/>
     <item name="StackFreeCurrent" type="INT32U" optional="true"/>
     <item name="StackFreeMinimum" type="INT32U" optional="true"/>


### PR DESCRIPTION
No codegen changes (codegen does some case-canonicalization already, and is not affected by this bit), so easy fix.
