### PR TITLE
[Android] virtual-device-app: Add usecase of the Doorlock/PowerSource cluster

### DIFF
--- a/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/GetLockStateFlowUseCase.kt
+++ b/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/GetLockStateFlowUseCase.kt
@@ -1,0 +1,12 @@
+package com.matter.virtual.device.app.core.domain.usecase.matter.cluster.doorlock
+
+import com.matter.virtual.device.app.core.data.repository.cluster.DoorLockManagerRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+
+class GetLockStateFlowUseCase
+@Inject
+constructor(private val doorLockManagerRepository: DoorLockManagerRepository) {
+
+  operator fun invoke(): StateFlow<Boolean> = doorLockManagerRepository.getLockStateFlow()
+}

--- a/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/SendLockAlarmEventUseCase.kt
+++ b/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/SendLockAlarmEventUseCase.kt
@@ -1,0 +1,19 @@
+package com.matter.virtual.device.app.core.domain.usecase.matter.cluster.doorlock
+
+import com.matter.virtual.device.app.core.common.di.IoDispatcher
+import com.matter.virtual.device.app.core.data.repository.cluster.DoorLockManagerRepository
+import com.matter.virtual.device.app.core.domain.NonParamCoroutineUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SendLockAlarmEventUseCase
+@Inject
+constructor(
+  private val doorLockManagerRepository: DoorLockManagerRepository,
+  @IoDispatcher dispatcher: CoroutineDispatcher
+) : NonParamCoroutineUseCase<Unit>(dispatcher) {
+
+  override suspend fun execute() {
+    return doorLockManagerRepository.sendLockAlarmEvent()
+  }
+}

--- a/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/SetLockStateUseCase.kt
+++ b/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/doorlock/SetLockStateUseCase.kt
@@ -1,0 +1,19 @@
+package com.matter.virtual.device.app.core.domain.usecase.matter.cluster.doorlock
+
+import com.matter.virtual.device.app.core.common.di.IoDispatcher
+import com.matter.virtual.device.app.core.data.repository.cluster.DoorLockManagerRepository
+import com.matter.virtual.device.app.core.domain.CoroutineUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SetLockStateUseCase
+@Inject
+constructor(
+  private val doorLockManagerRepository: DoorLockManagerRepository,
+  @IoDispatcher dispatcher: CoroutineDispatcher
+) : CoroutineUseCase<Boolean, Unit>(dispatcher) {
+
+  override suspend fun execute(param: Boolean) {
+    doorLockManagerRepository.setLockState(param)
+  }
+}

--- a/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/powersource/GetBatPercentRemainingUseCase.kt
+++ b/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/powersource/GetBatPercentRemainingUseCase.kt
@@ -1,0 +1,13 @@
+package com.matter.virtual.device.app.core.domain.usecase.matter.cluster.powersource
+
+import com.matter.virtual.device.app.core.data.repository.cluster.PowerSourceManagerRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+
+class GetBatPercentRemainingUseCase
+@Inject
+constructor(
+  private val powerSourceManagerRepository: PowerSourceManagerRepository,
+) {
+  operator fun invoke(): StateFlow<Int> = powerSourceManagerRepository.getBatPercent()
+}

--- a/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/powersource/SetBatPercentRemainingUseCase.kt
+++ b/examples/virtual-device-app/android/App/core/domain/src/main/java/com/matter/virtual/device/app/core/domain/usecase/matter/cluster/powersource/SetBatPercentRemainingUseCase.kt
@@ -1,0 +1,19 @@
+package com.matter.virtual.device.app.core.domain.usecase.matter.cluster.powersource
+
+import com.matter.virtual.device.app.core.common.di.IoDispatcher
+import com.matter.virtual.device.app.core.data.repository.cluster.PowerSourceManagerRepository
+import com.matter.virtual.device.app.core.domain.CoroutineUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+
+class SetBatPercentRemainingUseCase
+@Inject
+constructor(
+  private val powerSourceManagerRepository: PowerSourceManagerRepository,
+  @IoDispatcher dispatcher: CoroutineDispatcher
+) : CoroutineUseCase<Int, Unit>(dispatcher) {
+
+  override suspend fun execute(param: Int) {
+    powerSourceManagerRepository.setBatPercentRemaining(param)
+  }
+}


### PR DESCRIPTION
#### Problem
* Need basic usecase of the doorlock/powersource cluster 


#### Change overview
* Add cluster usecase files


#### Testing
* 1st build with "./scripts/build/build_examples.py --target android-arm64-virtual-device-app build" command
* Excute Android studio and make project virtual-device-app on /examples
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission virtual-device-app and It is possible to test full automation




