### PR TITLE
[Android]Remove unnecessary globalRef for android IM JNI

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -73,8 +73,10 @@ CHIP_ERROR ReportCallback::CreateChipEventPath(JNIEnv * env, const app::Concrete
 GetConnectedDeviceCallback::GetConnectedDeviceCallback(jobject wrapperCallback, jobject javaCallback) :
     mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnDeviceConnectionFailureFn, this)
 {
-    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mWrapperCallbackRef in %s",  __func__));
-    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mJavaCallbackRef in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mWrapperCallbackRef in %s", __func__));
+    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mJavaCallbackRef in %s", __func__));
 }
 
 GetConnectedDeviceCallback::~GetConnectedDeviceCallback() {}
@@ -84,14 +86,14 @@ void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, Messaging::
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
-    auto * self          = static_cast<GetConnectedDeviceCallback *>(context);
+    auto * self = static_cast<GetConnectedDeviceCallback *>(context);
     VerifyOrReturn(self->mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+                   ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = self->mJavaCallbackRef.ObjectRef();
     JniLocalReferenceManager manager(env);
     // Release wrapper's global ref so application can clean up the actual callback underneath.
     VerifyOrReturn(self->mWrapperCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s",  __func__));
+                   ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     JniGlobalReference globalRef(std::move(self->mWrapperCallbackRef));
 
     jclass getConnectedDeviceCallbackCls = nullptr;
@@ -116,9 +118,9 @@ void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context, con
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
-    auto * self          = static_cast<GetConnectedDeviceCallback *>(context);
+    auto * self = static_cast<GetConnectedDeviceCallback *>(context);
     VerifyOrReturn(self->mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+                   ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = self->mJavaCallbackRef.ObjectRef();
     JniLocalReferenceManager manager(env);
 
@@ -153,15 +155,19 @@ ReportCallback::ReportCallback(jobject wrapperCallback, jobject subscriptionEsta
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     if (subscriptionEstablishedCallback != nullptr)
     {
-        VerifyOrReturn(mSubscriptionEstablishedCallbackRef.Init(subscriptionEstablishedCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mSubscriptionEstablishedCallbackRef in %s",  __func__));
+        VerifyOrReturn(mSubscriptionEstablishedCallbackRef.Init(subscriptionEstablishedCallback) == CHIP_NO_ERROR,
+                       ChipLogError(Controller, "Could not init mSubscriptionEstablishedCallbackRef in %s", __func__));
     }
 
-    VerifyOrReturn(mReportCallbackRef.Init(reportCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mReportCallbackRef in %s",  __func__));
-    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mWrapperCallbackRef in %s",  __func__));
+    VerifyOrReturn(mReportCallbackRef.Init(reportCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mReportCallbackRef in %s", __func__));
+    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mWrapperCallbackRef in %s", __func__));
 
     if (resubscriptionAttemptCallback != nullptr)
     {
-        VerifyOrReturn(mResubscriptionAttemptCallbackRef.Init(resubscriptionAttemptCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mResubscriptionAttemptCallbackRef in %s",  __func__));
+        VerifyOrReturn(mResubscriptionAttemptCallbackRef.Init(resubscriptionAttemptCallback) == CHIP_NO_ERROR,
+                       ChipLogError(Controller, "Could not init mResubscriptionAttemptCallbackRef in %s", __func__));
     }
 }
 
@@ -185,7 +191,8 @@ void ReportCallback::OnReportBegin()
     VerifyOrReturn(nodeStateCtor != nullptr, ChipLogError(Controller, "Could not find NodeState constructor"));
     jobject nodeState = env->NewObject(nodeStateCls, nodeStateCtor);
     VerifyOrReturn(nodeState != nullptr, ChipLogError(Controller, "Could not create local object for nodeState"));
-    VerifyOrReturn(mNodeStateObj.Init(nodeState) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mNodeStateObj in %s",  __func__));
+    VerifyOrReturn(mNodeStateObj.Init(nodeState) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mNodeStateObj in %s", __func__));
 }
 
 void ReportCallback::OnDeallocatePaths(app::ReadPrepareParams && aReadPrepareParams)
@@ -210,7 +217,8 @@ void ReportCallback::OnReportEnd()
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
-    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mReportCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mReportCallbackRef is not valid in %s", __func__));
     jobject reportCallback = mReportCallbackRef.ObjectRef();
     JniGlobalReference globalRef(std::move(mNodeStateObj));
     jmethodID onReportMethod;
@@ -336,8 +344,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     err = JniReferences::GetInstance().FindMethod(env, nodeState, "addAttribute",
                                                   "(IJJLchip/devicecontroller/model/AttributeState;)V", &addAttributeMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find addAttribute method"));
-    env->CallVoidMethod(nodeState, addAttributeMethod, static_cast<jint>(aPath.mEndpointId),
-                        static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId), attributeStateObj);
+    env->CallVoidMethod(nodeState, addAttributeMethod, static_cast<jint>(aPath.mEndpointId), static_cast<jlong>(aPath.mClusterId),
+                        static_cast<jlong>(aPath.mAttributeId), attributeStateObj);
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 
     UpdateClusterDataVersion();
@@ -544,12 +552,14 @@ void ReportCallback::OnDone(app::ReadClient *)
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
-    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     JniGlobalReference globalRef(std::move(mWrapperCallbackRef));
     jmethodID onDoneMethod;
-    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mReportCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mReportCallbackRef is not valid in %s", __func__));
     jobject reportCallback = mReportCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, reportCallback, "onDone", "()V", &onDoneMethod);
+    err                    = JniReferences::GetInstance().FindMethod(env, reportCallback, "onDone", "()V", &onDoneMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find onDone method"));
 
     if (mReadClient != nullptr)
@@ -569,7 +579,8 @@ void ReportCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
     DeviceLayer::StackUnlock unlock;
-    VerifyOrReturn(mSubscriptionEstablishedCallbackRef.HasValidObjectRef(), ChipLogError(Controller," mSubscriptionEstablishedCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mSubscriptionEstablishedCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, " mSubscriptionEstablishedCallbackRef is not valid in %s", __func__));
     JniReferences::GetInstance().CallSubscriptionEstablished(mSubscriptionEstablishedCallbackRef.ObjectRef(), aSubscriptionId);
 }
 
@@ -610,7 +621,8 @@ void ReportCallback::ReportError(jobject attributePath, jobject eventPath, const
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
-    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mReportCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mReportCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mReportCallbackRef is not valid in %s", __func__));
     jobject reportCallback = mReportCallbackRef.ObjectRef();
     jthrowable exception;
     err = AndroidControllerExceptions::GetInstance().CreateAndroidControllerException(env, message, errorCode, exception);
@@ -631,8 +643,10 @@ void ReportCallback::ReportError(jobject attributePath, jobject eventPath, const
 
 WriteAttributesCallback::WriteAttributesCallback(jobject wrapperCallback, jobject javaCallback) : mChunkedWriteCallback(this)
 {
-    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mWrapperCallbackRef for WriteAttributesCallback"));
-    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mJavaCallbackRef in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mWrapperCallbackRef for WriteAttributesCallback"));
+    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mJavaCallbackRef in %s", __func__));
 }
 
 WriteAttributesCallback::~WriteAttributesCallback()
@@ -662,11 +676,10 @@ void WriteAttributesCallback::OnResponse(const app::WriteClient * apWriteClient,
     }
 
     jmethodID onResponseMethod;
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onResponse",
-                                                  "(Lchip/devicecontroller/model/ChipAttributePath;)V", &onResponseMethod);
+    err                  = JniReferences::GetInstance().FindMethod(env, javaCallback, "onResponse",
+                                                                   "(Lchip/devicecontroller/model/ChipAttributePath;)V", &onResponseMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
 
     DeviceLayer::StackUnlock unlock;
@@ -685,13 +698,13 @@ void WriteAttributesCallback::OnDone(app::WriteClient *)
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
-    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     JniGlobalReference globalRef(std::move(mWrapperCallbackRef));
     jmethodID onDoneMethod;
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onDone", "()V", &onDoneMethod);
+    err                  = JniReferences::GetInstance().FindMethod(env, javaCallback, "onDone", "()V", &onDoneMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find onDone method"));
 
     DeviceLayer::StackUnlock unlock;
@@ -723,12 +736,10 @@ void WriteAttributesCallback::ReportError(jobject attributePath, const char * me
                                 "Unable to create AndroidControllerException on WriteAttributesCallback::ReportError: %s",
                                 ErrorStr(err)));
     jmethodID onErrorMethod;
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onError",
-                                                  "(Lchip/devicecontroller/model/ChipAttributePath;Ljava/lang/Exception;)V",
-                                                  &onErrorMethod);
+    err                  = JniReferences::GetInstance().FindMethod(
+        env, javaCallback, "onError", "(Lchip/devicecontroller/model/ChipAttributePath;Ljava/lang/Exception;)V", &onErrorMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
 
     DeviceLayer::StackUnlock unlock;
@@ -738,8 +749,10 @@ void WriteAttributesCallback::ReportError(jobject attributePath, const char * me
 
 InvokeCallback::InvokeCallback(jobject wrapperCallback, jobject javaCallback)
 {
-    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mWrapperCallbackRef for InvokeCallback"));
-    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR, ChipLogError(Controller, "Could not init mJavaCallbackRef in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.Init(wrapperCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mWrapperCallbackRef for InvokeCallback"));
+    VerifyOrReturn(mJavaCallbackRef.Init(javaCallback) == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not init mJavaCallbackRef in %s", __func__));
 }
 
 InvokeCallback::~InvokeCallback()
@@ -761,18 +774,16 @@ void InvokeCallback::OnResponse(app::CommandSender * apCommandSender, const app:
     JniLocalReferenceManager manager(env);
     err = CreateInvokeElement(env, aPath, apData, invokeElementObj);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to create Java InvokeElement: %s", ErrorStr(err)));
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onResponse",
-                                                  "(Lchip/devicecontroller/model/InvokeElement;J)V", &onResponseMethod);
+    err                  = JniReferences::GetInstance().FindMethod(env, javaCallback, "onResponse",
+                                                                   "(Lchip/devicecontroller/model/InvokeElement;J)V", &onResponseMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onResponse method: %s", ErrorStr(err)));
 
     DeviceLayer::StackUnlock unlock;
     if (aStatusIB.mClusterStatus.HasValue())
     {
-        env->CallVoidMethod(javaCallback, onResponseMethod, invokeElementObj,
-                            static_cast<jlong>(aStatusIB.mClusterStatus.Value()));
+        env->CallVoidMethod(javaCallback, onResponseMethod, invokeElementObj, static_cast<jlong>(aStatusIB.mClusterStatus.Value()));
     }
     else
     {
@@ -793,13 +804,13 @@ void InvokeCallback::OnDone(app::CommandSender * apCommandSender)
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceManager manager(env);
-    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(),
+                   ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     JniGlobalReference globalRef(std::move(mWrapperCallbackRef));
     jmethodID onDoneMethod;
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
-    err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onDone", "()V", &onDoneMethod);
+    err                  = JniReferences::GetInstance().FindMethod(env, javaCallback, "onDone", "()V", &onDoneMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find onDone method"));
 
     DeviceLayer::StackUnlock unlock;
@@ -831,8 +842,7 @@ void InvokeCallback::ReportError(const char * message, ChipError::StorageType er
         ChipLogError(Controller, "Unable to create AndroidControllerException: %s on InvokeCallback::ReportError", ErrorStr(err)));
 
     jmethodID onErrorMethod;
-    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(),
-        ChipLogError(Controller, "mJavaCallbackRef is not valid in %s",  __func__));
+    VerifyOrReturn(mJavaCallbackRef.HasValidObjectRef(), ChipLogError(Controller, "mJavaCallbackRef is not valid in %s", __func__));
     jobject javaCallback = mJavaCallbackRef.ObjectRef();
     err = JniReferences::GetInstance().FindMethod(env, javaCallback, "onError", "(Ljava/lang/Exception;)V", &onErrorMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -44,13 +44,13 @@ static const int EXTRA_SPACE_FOR_ATTRIBUTE_TAG = 19;
 CHIP_ERROR CreateChipAttributePath(JNIEnv * env, const app::ConcreteDataAttributePath & aPath, jobject & outObj)
 {
     jclass attributePathCls = nullptr;
-    ReturnErrorOnFailure(JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/model/ChipAttributePath",
-                                                                            attributePathCls));
+    ReturnErrorOnFailure(
+        JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/model/ChipAttributePath", attributePathCls));
     jmethodID attributePathCtor =
         env->GetStaticMethodID(attributePathCls, "newInstance", "(IJJ)Lchip/devicecontroller/model/ChipAttributePath;");
     VerifyOrReturnError(attributePathCtor != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
     outObj = env->CallStaticObjectMethod(attributePathCls, attributePathCtor, static_cast<jint>(aPath.mEndpointId),
-                                        static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId));
+                                         static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId));
     VerifyOrReturnError(outObj != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
     return CHIP_NO_ERROR;
 }
@@ -66,7 +66,7 @@ CHIP_ERROR ReportCallback::CreateChipEventPath(JNIEnv * env, const app::Concrete
     VerifyOrReturnError(eventPathCtor != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     outObj = env->CallStaticObjectMethod(eventPathCls, eventPathCtor, static_cast<jint>(aPath.mEndpointId),
-                                        static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mEventId));
+                                         static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mEventId));
     VerifyOrReturnError(outObj != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
     return CHIP_NO_ERROR;
 }
@@ -309,9 +309,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     JniLocalReferenceManager manager(env);
 
     jobject attributePathObj = nullptr;
-    err = CreateChipAttributePath(env, aPath, attributePathObj);
-    VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Unable to create Java ChipAttributePath: %s", ErrorStr(err)));
+    err                      = CreateChipAttributePath(env, aPath, attributePathObj);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to create Java ChipAttributePath: %s", ErrorStr(err)));
 
     if (aPath.IsListItemOperation())
     {
@@ -435,9 +434,8 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     jobject eventPathObj = nullptr;
-    err = CreateChipEventPath(env, aEventHeader.mPath, eventPathObj);
-    VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Unable to create Java ChipEventPath: %s", ErrorStr(err)));
+    err                  = CreateChipEventPath(env, aEventHeader.mPath, eventPathObj);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to create Java ChipEventPath: %s", ErrorStr(err)));
 
     if (apData == nullptr)
     {
@@ -719,9 +717,8 @@ void WriteAttributesCallback::OnResponse(const app::WriteClient * apWriteClient,
     JniLocalReferenceManager manager(env);
 
     jobject attributePathObj = nullptr;
-    err = CreateChipAttributePath(env, aPath, attributePathObj);
-    VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Unable to create Java ChipAttributePath: %s", ErrorStr(err)));
+    err                      = CreateChipAttributePath(env, aPath, attributePathObj);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to create Java ChipAttributePath: %s", ErrorStr(err)));
 
     if (aStatus.mStatus != Protocols::InteractionModel::Status::Success)
     {

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -23,9 +23,9 @@
 #include <controller/CHIPDeviceController.h>
 #include <jni.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/JniTypeWrappers.h>
 #include <list>
 #include <utility>
-#include <lib/support/JniTypeWrappers.h>
 
 namespace chip {
 namespace Controller {

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -25,6 +25,7 @@
 #include <lib/core/CHIPError.h>
 #include <list>
 #include <utility>
+#include <lib/support/JniTypeWrappers.h>
 
 namespace chip {
 namespace Controller {
@@ -42,8 +43,8 @@ struct GetConnectedDeviceCallback
 
     Callback::Callback<OnDeviceConnected> mOnSuccess;
     Callback::Callback<OnDeviceConnectionFailure> mOnFailure;
-    jobject mWrapperCallbackRef = nullptr;
-    jobject mJavaCallbackRef    = nullptr;
+    JniGlobalReference mWrapperCallbackRef;
+    JniGlobalReference mJavaCallbackRef;
 };
 
 struct ReportCallback : public app::ClusterStateCache::Callback
@@ -83,12 +84,12 @@ struct ReportCallback : public app::ClusterStateCache::Callback
     app::ReadClient * mReadClient = nullptr;
 
     app::ClusterStateCache mClusterCacheAdapter;
-    jobject mWrapperCallbackRef                 = nullptr;
-    jobject mSubscriptionEstablishedCallbackRef = nullptr;
-    jobject mResubscriptionAttemptCallbackRef   = nullptr;
-    jobject mReportCallbackRef                  = nullptr;
+    JniGlobalReference mWrapperCallbackRef;
+    JniGlobalReference mSubscriptionEstablishedCallbackRef;
+    JniGlobalReference mResubscriptionAttemptCallbackRef;
+    JniGlobalReference mReportCallbackRef;
     // NodeState Java object that will be returned to the application.
-    jobject mNodeStateObj = nullptr;
+    JniGlobalReference mNodeStateObj;
 };
 
 struct WriteAttributesCallback : public app::WriteClient::Callback
@@ -110,8 +111,8 @@ struct WriteAttributesCallback : public app::WriteClient::Callback
 
     app::WriteClient * mWriteClient = nullptr;
     app::ChunkedWriteCallback mChunkedWriteCallback;
-    jobject mWrapperCallbackRef = nullptr;
-    jobject mJavaCallbackRef    = nullptr;
+    JniGlobalReference mWrapperCallbackRef;
+    JniGlobalReference mJavaCallbackRef;
 };
 
 struct InvokeCallback : public app::CommandSender::Callback
@@ -132,8 +133,8 @@ struct InvokeCallback : public app::CommandSender::Callback
     void ReportError(const char * message, ChipError::StorageType errorCode);
 
     app::CommandSender * mCommandSender = nullptr;
-    jobject mWrapperCallbackRef         = nullptr;
-    jobject mJavaCallbackRef            = nullptr;
+    JniGlobalReference mWrapperCallbackRef;
+    JniGlobalReference mJavaCallbackRef;
 };
 
 } // namespace Controller

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -29,7 +29,7 @@
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR CreateChipAttributePath(const app::ConcreteDataAttributePath & aPath, jobject & outObj);
+CHIP_ERROR CreateChipAttributePath(JNIEnv * env, const app::ConcreteDataAttributePath & aPath, jobject & outObj);
 
 // Callback for success and failure cases of GetConnectedDevice().
 struct GetConnectedDeviceCallback
@@ -76,7 +76,7 @@ struct ReportCallback : public app::ClusterStateCache::Callback
     void ReportError(jobject attributePath, jobject eventPath, Protocols::InteractionModel::Status status);
     void ReportError(jobject attributePath, jobject eventPath, const char * message, ChipError::StorageType errorCode);
 
-    CHIP_ERROR CreateChipEventPath(const app::ConcreteEventPath & aPath, jobject & outObj);
+    CHIP_ERROR CreateChipEventPath(JNIEnv * env, const app::ConcreteEventPath & aPath, jobject & outObj);
 
     void UpdateClusterDataVersion();
 

--- a/src/controller/java/AndroidControllerExceptions.cpp
+++ b/src/controller/java/AndroidControllerExceptions.cpp
@@ -28,18 +28,14 @@ CHIP_ERROR AndroidControllerExceptions::CreateAndroidControllerException(JNIEnv 
                                                                          jthrowable & outEx)
 {
     jclass controllerExceptionCls;
-    CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipDeviceControllerException",
-                                                              controllerExceptionCls);
+    CHIP_ERROR err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipDeviceControllerException",
+                                                                   controllerExceptionCls);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-    JniObject controllerExceptionJniCls(env, static_cast<jobject>(controllerExceptionCls));
-
     jmethodID exceptionConstructor = env->GetMethodID(controllerExceptionCls, "<init>", "(JLjava/lang/String;)V");
-    jobject localRef =
-        env->NewObject(controllerExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode), env->NewStringUTF(message));
-    VerifyOrReturnError(localRef != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
-    outEx = (jthrowable) (env->NewGlobalRef(localRef));
-    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+    outEx                          = static_cast<jthrowable>(
+        env->NewObject(controllerExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode), env->NewStringUTF(message)));
+    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -77,8 +77,18 @@ JNIEnv * JniReferences::GetEnvForCurrentThread()
 
 CHIP_ERROR JniReferences::GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     jclass cls     = nullptr;
+    CHIP_ERROR err = GetLocalClassRef(env, clsType, cls);
+    ReturnErrorOnFailure(err);
+    outCls = (jclass) env->NewGlobalRef((jobject) cls);
+    VerifyOrReturnError(outCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+
+    return err;
+}
+
+CHIP_ERROR JniReferences::GetLocalClassRef(JNIEnv * env, const char * clsType, jclass & outCls)
+{
+    jclass cls = nullptr;
 
     // Try `j$/util/Optional` when enabling Java8.
     if (strcmp(clsType, "java/util/Optional") == 0)
@@ -100,10 +110,8 @@ CHIP_ERROR JniReferences::GetClassRef(JNIEnv * env, const char * clsType, jclass
         VerifyOrReturnError(cls != nullptr && env->ExceptionCheck() != JNI_TRUE, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     }
 
-    outCls = (jclass) env->NewGlobalRef((jobject) cls);
-    VerifyOrReturnError(outCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-
-    return err;
+    outCls = cls;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR JniReferences::N2J_ByteArray(JNIEnv * env, const uint8_t * inArray, jsize inArrayLen, jbyteArray & outArray)

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -58,7 +58,7 @@ public:
 
     /**
      * @brief
-     *   Creates a jclass reference to the given class type.
+     *   Creates a global jclass reference to the given class type.
      *
      *   This must be called after SetJavaVm().
      *
@@ -67,6 +67,19 @@ public:
      * @param[out] outCls A Java reference to the class matching clsType.
      */
     CHIP_ERROR GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls);
+
+    /**
+     * @brief
+     *   Creates a local jclass reference to the given class type.
+     *
+     *   This must be called after SetJavaVm().
+     *
+     * @param[in] env The JNIEnv for finding a Java class and creating a new Java reference.
+     * @param[in] clsType The fully-qualified Java class name to find, e.g. java/lang/IllegalStateException.
+     * @param[out] outCls A Java reference to the class matching clsType.
+     */
+    CHIP_ERROR GetLocalClassRef(JNIEnv * env, const char * clsType, jclass & outCls);
+
     CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
                           jmethodID * methodId);
     void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -238,8 +238,8 @@ public:
     jobject ObjectRef() { return mObjectRef; }
 
     bool HasValidObjectRef()
-    { 
-        return mObjectRef != nullptr; 
+    {
+        return mObjectRef != nullptr;
     }
 
 private:

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -19,8 +19,8 @@
 
 #include <cstdint>
 #include <jni.h>
-#include <lib/support/JniReferences.h>
 #include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
 #include <lib/support/Span.h>
 #include <string>
 
@@ -221,8 +221,9 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    JniGlobalReference(JniGlobalReference && aOther) {
-        mObjectRef = aOther.mObjectRef;
+    JniGlobalReference(JniGlobalReference && aOther)
+    {
+        mObjectRef        = aOther.mObjectRef;
         aOther.mObjectRef = nullptr;
     }
 
@@ -237,10 +238,7 @@ public:
 
     jobject ObjectRef() { return mObjectRef; }
 
-    bool HasValidObjectRef()
-    {
-        return mObjectRef != nullptr;
-    }
+    bool HasValidObjectRef() { return mObjectRef != nullptr; }
 
 private:
     jobject mObjectRef = nullptr;

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <jni.h>
 #include <lib/support/JniReferences.h>
+#include <lib/support/CHIPJNIError.h>
 #include <lib/support/Span.h>
 #include <string>
 
@@ -203,22 +204,45 @@ private:
     bool mlocalFramePushed = false;
 };
 
-class JniObject
+class JniGlobalReference
 {
 public:
-    JniObject(JNIEnv * aEnv, jobject aObjectRef) : mEnv(aEnv), mObjectRef(aObjectRef) {}
-    ~JniObject()
+    JniGlobalReference() {}
+
+    CHIP_ERROR Init(jobject aObjectRef)
     {
-        if (mEnv != nullptr && mObjectRef != nullptr)
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+        VerifyOrReturnError(aObjectRef != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+        VerifyOrReturnError(mObjectRef == nullptr, CHIP_ERROR_INCORRECT_STATE);
+        mObjectRef = env->NewGlobalRef(aObjectRef);
+        VerifyOrReturnError(!env->ExceptionCheck(), CHIP_JNI_ERROR_EXCEPTION_THROWN);
+        VerifyOrReturnError(mObjectRef != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+        return CHIP_NO_ERROR;
+    }
+
+    JniGlobalReference(JniGlobalReference && aOther) {
+        mObjectRef = aOther.mObjectRef;
+        aOther.mObjectRef = nullptr;
+    }
+
+    ~JniGlobalReference()
+    {
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        if (env != nullptr && mObjectRef != nullptr)
         {
-            mEnv->DeleteGlobalRef(mObjectRef);
+            env->DeleteGlobalRef(mObjectRef);
         }
     }
 
-    jobject objectRef() { return mObjectRef; }
+    jobject ObjectRef() { return mObjectRef; }
+
+    bool HasValidObjectRef()
+    { 
+        return mObjectRef != nullptr; 
+    }
 
 private:
-    JNIEnv * mEnv      = nullptr;
     jobject mObjectRef = nullptr;
 };
 


### PR DESCRIPTION
localReferences created by sdk's local callback functions are still valid after returned, and managed by default jni frame/cookie, so there is no need to create globalRef to extend lifetime for the references when it is returned from local functions. Further We have used push/pop local frame in previous pr 29236, where localReferenced created in local callback function are managed by local jni frame.
Add JniGlobalReference class to handle the global reference creation/move/destory.

Address the rest of comments from 29236.
