### PR TITLE
Fix lint warning releated to potential leak

### DIFF
--- a/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
@@ -42,7 +42,7 @@ public class NsdManagerServiceBrowser implements ServiceBrowser {
     this.mainThreadHandler = new Handler(Looper.getMainLooper());
 
     this.multicastLock =
-        ((WifiManager) context.getSystemService(Context.WIFI_SERVICE))
+        ((WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE))
             .createMulticastLock("chipBrowseMulticastLock");
     this.multicastLock.setReferenceCounted(true);
     callbackMap = new HashMap<>();


### PR DESCRIPTION
```
NsdManagerServiceBrowser.java:51: Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing context to context.getApplicationContext() [WifiManagerPotentialLeak]
```

Apply the recommendation from this check.
