### PR TITLE
Ensure maybe_placeholders is set in lark parsing

### DIFF
--- a/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_parser.py
@@ -543,6 +543,7 @@ class ParserWithLines:
         # For this reason, every attempt should be made to make the grammar context free
         self.parser = Lark.open(
             'matter_grammar.lark', rel_to=__file__, start='idl', parser='lalr', propagate_positions=True,
+            maybe_placeholders=True,
             # separate callbacks to ignore from regular parsing (no tokens)
             # while still getting notified about them
             lexer_callbacks={


### PR DESCRIPTION
Our parsers rely that `[...]` actually sets None on things and this seems to vary by lark versions.

make maybe_placeholders explicit in parsing.