### PR TITLE
Move kotlin lib tlv/jsontlv to package matter [Part II]

### DIFF
--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -75,10 +75,10 @@ jobs:
                  $JAVA_PATH/bin/java \
                    -cp 'third_party/java_deps/artifacts/*:out/linux-x64-tests/lib/src/controller/java/*' \
                    org.junit.runner.JUnitCore       \
-                   chip.tlv.TlvWriterTest           \
-                   chip.tlv.TlvReadWriteTest        \
-                   chip.tlv.TlvReaderTest           \
-                   chip.jsontlv.JsonToTlvToJsonTest \
+                   matter.tlv.TlvWriterTest           \
+                   matter.tlv.TlvReadWriteTest        \
+                   matter.tlv.TlvReaderTest           \
+                   matter.jsontlv.JsonToTlvToJsonTest \
                    matter.onboardingpayload.ManualCodeTest \
                    matter.onboardingpayload.QRCodeTest
             - name: Build Java Matter Controller and all clusters app

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
@@ -17,9 +17,6 @@ import chip.devicecontroller.model.AttributeWriteRequest
 import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
@@ -28,6 +25,9 @@ import com.google.chip.chiptool.util.toAny
 import java.util.Optional
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicClientFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/GroupSettingFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/GroupSettingFragment.kt
@@ -25,10 +25,6 @@ import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.InvokeElement
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
@@ -37,6 +33,10 @@ import com.google.chip.chiptool.util.DeviceIdUtil
 import java.lang.Exception
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GroupSettingFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -16,15 +16,15 @@ import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.InvokeElement
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.databinding.MultiAdminClientFragmentBinding
 import com.google.chip.chiptool.util.toAny
 import kotlinx.coroutines.*
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class MultiAdminClientFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -22,10 +22,6 @@ import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.InvokeElement
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
@@ -36,6 +32,10 @@ import java.util.Calendar
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OnOffClientFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
@@ -15,10 +15,6 @@ import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.InvokeElement
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
@@ -26,6 +22,10 @@ import com.google.chip.chiptool.databinding.OpCredClientFragmentBinding
 import com.google.chip.chiptool.util.toAny
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OpCredClientFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -17,8 +17,6 @@ import chip.devicecontroller.ReportCallback
 import chip.devicecontroller.model.ChipAttributePath
 import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.NodeState
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.databinding.SensorClientFragmentBinding
@@ -32,6 +30,8 @@ import java.util.Calendar
 import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
 
 class SensorClientFragment : Fragment() {
   private val deviceController: ChipDeviceController

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -27,10 +27,6 @@ import chip.devicecontroller.model.ChipEventPath
 import chip.devicecontroller.model.ChipPathId
 import chip.devicecontroller.model.InvokeElement
 import chip.devicecontroller.model.NodeState
-import chip.jsontlv.putJsonString
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.databinding.WildcardFragmentBinding
@@ -41,6 +37,10 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import matter.jsontlv.putJsonString
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class WildcardFragment : Fragment() {
   private var _binding: WildcardFragmentBinding? = null
@@ -646,7 +646,7 @@ class WildcardFragment : Fragment() {
   }
 
   interface TlvWriterInterface {
-    fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag = AnonymousTag)
+    fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag = AnonymousTag)
   }
 
   companion object {
@@ -660,49 +660,49 @@ class WildcardFragment : Fragment() {
       mapOf(
         "json" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.putJsonString(tag, value)
             }
           },
         "UnsignedInt" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value.toULong())
             }
           },
         "Int" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value.toLong())
             }
           },
         "Boolean" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value.toBoolean())
             }
           },
         "Float" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value.toFloat())
             }
           },
         "Double" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value.toDouble())
             }
           },
         "String" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(tag, value)
             }
           },
         "ByteArray(Hex)" to
           object : TlvWriterInterface {
-            override fun generate(writer: TlvWriter, value: String, tag: chip.tlv.Tag) {
+            override fun generate(writer: TlvWriter, value: String, tag: matter.tlv.Tag) {
               writer.put(
                 tag,
                 value.chunked(2).map { it.toInt(16) and 0xFF }.map { it.toByte() }.toByteArray()

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/TlvUtil.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/TlvUtil.kt
@@ -1,11 +1,11 @@
 package com.google.chip.chiptool.util
 
-import chip.tlv.AnonymousTag
-import chip.tlv.ArrayValue
-import chip.tlv.NullValue
-import chip.tlv.StructureValue
-import chip.tlv.Tag
-import chip.tlv.TlvReader
+import matter.tlv.AnonymousTag
+import matter.tlv.ArrayValue
+import matter.tlv.NullValue
+import matter.tlv.StructureValue
+import matter.tlv.Tag
+import matter.tlv.TlvReader
 
 /**
  * Encodes TLV into kotlin Object. If the TLV reader is positioned TLV Structure, Object will return

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
@@ -21,13 +21,13 @@ import chip.devicecontroller.ChipDeviceController
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback
 import chip.devicecontroller.InvokeCallback
 import chip.devicecontroller.model.InvokeElement
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.TlvWriter
 import com.matter.controller.commands.common.CredentialsIssuer
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.UShort
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.TlvWriter
 
 class PairOnNetworkLongImInvokeCommand(
   controller: ChipDeviceController,

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
@@ -22,11 +22,11 @@ import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCal
 import chip.devicecontroller.WriteAttributesCallback
 import chip.devicecontroller.model.AttributeWriteRequest
 import chip.devicecontroller.model.ChipAttributePath
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvWriter
 import com.matter.controller.commands.common.CredentialsIssuer
 import java.util.logging.Level
 import java.util.logging.Logger
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvWriter
 
 class PairOnNetworkLongImWriteCommand(
   controller: ChipDeviceController,

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
@@ -17,9 +17,6 @@
  */
 package com.matter.controller.commands.pairing
 
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.TlvWriter
 import com.matter.controller.commands.common.CredentialsIssuer
 import java.time.Duration
 import java.util.logging.Level
@@ -29,6 +26,9 @@ import matter.controller.InvokeRequest
 import matter.controller.InvokeResponse
 import matter.controller.MatterController
 import matter.controller.model.CommandPath
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.TlvWriter
 
 class PairOnNetworkLongImInvokeCommand(
   controller: MatterController,

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
@@ -17,8 +17,6 @@
  */
 package com.matter.controller.commands.pairing
 
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvWriter
 import com.matter.controller.commands.common.CredentialsIssuer
 import java.time.Duration
 import java.util.logging.Level
@@ -29,6 +27,8 @@ import matter.controller.WriteRequest
 import matter.controller.WriteRequests
 import matter.controller.WriteResponse
 import matter.controller.model.AttributePath
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvWriter
 
 class PairOnNetworkLongImWriteCommand(
   controller: MatterController,

--- a/kotlin-detect-config.yaml
+++ b/kotlin-detect-config.yaml
@@ -23,7 +23,7 @@ style:
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt"
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt"
             - "**/examples/java-matter-controller/java/src/com/matter/controller/Main.kt"
-            - "**/src/controller/java/src/chip/jsontlv/JsonToTlv.kt"
+            - "**/src/controller/java/src/matter/jsontlv/JsonToTlv.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/Base38.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadParser.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/OnboardingPayload.kt"
@@ -31,21 +31,21 @@ style:
             - "**/src/controller/java/src/matter/onboardingpayload/QRCodeOnboardingPayloadGenerator.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/QRCodeOnboardingPayloadParser.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/VendorId.kt"
-            - "**/src/controller/java/src/chip/tlv/tags.kt"
-            - "**/src/controller/java/src/chip/tlv/TlvWriter.kt"
-            - "**/src/controller/java/src/chip/tlv/types.kt"
-            - "**/src/controller/java/src/chip/tlv/utils.kt"
-            - "**/src/controller/java/src/chip/tlv/values.kt"
+            - "**/src/controller/java/src/matter/tlv/tags.kt"
+            - "**/src/controller/java/src/matter/tlv/TlvWriter.kt"
+            - "**/src/controller/java/src/matter/tlv/types.kt"
+            - "**/src/controller/java/src/matter/tlv/utils.kt"
+            - "**/src/controller/java/src/matter/tlv/values.kt"
             - "**/src/controller/java/src/chip/WildcardImport
               examples/android/CHIPTest/app/src/androidTest/java/com/tcl/chip/chiptest/ExampleInstrumentedTest.kt"
             - "**/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterEventStructTest.kt"
             - "**/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterStructTest.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/ManualCodeTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/QRCodeTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvReaderTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvReadWriteTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvWriterTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvWriterTest.kt"
     WildcardImport:
         excludes:
             - "**/examples/android/CHIPTest/app/src/androidTest/java/com/tcl/chip/chiptest/ExampleInstrumentedTest.kt"
@@ -61,9 +61,9 @@ style:
             - "**/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt"
             - "**/examples/java-matter-controller/java/src/com/matter/controller/Main.kt"
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/jsontlv/JsonToTlv.kt"
-            - "**/src/controller/java/src/chip/jsontlv/TlvToJson.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/src/matter/jsontlv/JsonToTlv.kt"
+            - "**/src/controller/java/src/matter/jsontlv/TlvToJson.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
     NewLineAtEndOfFile:
         excludes:
             - "**/examples/android/CHIPTest/app/src/androidTest/java/com/tcl/chip/chiptest/ExampleInstrumentedTest.kt"
@@ -127,7 +127,7 @@ style:
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt"
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImSubscribeCommand.kt"
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/jsontlv/TlvToJson.kt"
+            - "**/src/controller/java/src/matter/jsontlv/TlvToJson.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadGenerator.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadParser.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/OnboardingPayload.kt"
@@ -169,9 +169,9 @@ style:
         excludes:
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.kt"
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/tlv/TlvReader.kt"
-            - "**/src/controller/java/src/chip/jsontlv/JsonToTlv.kt"
-            - "**/src/controller/java/src/chip/jsontlv/TlvToJson.kt"
+            - "**/src/controller/java/src/matter/tlv/TlvReader.kt"
+            - "**/src/controller/java/src/matter/jsontlv/JsonToTlv.kt"
+            - "**/src/controller/java/src/matter/jsontlv/TlvToJson.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadParser.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadGenerator.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/Base38.kt"
@@ -186,12 +186,12 @@ style:
     UseCheckOrError:
         excludes:
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/tlv/tags.kt"
-            - "**/src/controller/java/src/chip/tlv/types.kt"
+            - "**/src/controller/java/src/matter/tlv/tags.kt"
+            - "**/src/controller/java/src/matter/tlv/types.kt"
     UseRequire:
         excludes:
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/jsontlv/JsonToTlv.kt"
+            - "**/src/controller/java/src/matter/jsontlv/JsonToTlv.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/Verhoeff10.kt"
     UtilityClassWithPublicConstructor:
         excludes:
@@ -235,10 +235,10 @@ naming:
         excludes:
             - "**/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt"
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/tests/chip/tlv/TlvReadWriteTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvWriterTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvReaderTest.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvWriterTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/ManualCodeTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/QRCodeTest.kt"
             - "**/examples/android/CHIPTest/app/src/test/java/com/tcl/chip/chiptest/ExampleUnitTest.kt"
@@ -255,7 +255,7 @@ performance:
     SpreadOperator:
         excludes:
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/tests/chip/tlv/TlvReaderTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
 
 potential-bugs:
     EqualsWithHashCodeExist:
@@ -285,16 +285,16 @@ complexity:
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/common/CommandManager.kt"
             - "**/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt"
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/jsontlv/JsonToTlv.kt"
+            - "**/src/controller/java/src/matter/jsontlv/JsonToTlv.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/OnboardingPayload.kt"
-            - "**/src/controller/java/src/chip/tlv/TlvReader.kt"
-            - "**/src/controller/java/src/chip/tlv/TlvWriter.kt"
+            - "**/src/controller/java/src/matter/tlv/TlvReader.kt"
+            - "**/src/controller/java/src/matter/tlv/TlvWriter.kt"
             - "**/src/controller/java/src/matter/controller/MatterControllerImpl.kt"
             - "**/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/ManualCodeTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/QRCodeTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvReadWriteTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
     NestedBlockDepth:
         excludes:
             - "**/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt"
@@ -313,21 +313,21 @@ complexity:
             - "**/src/controller/java/src/matter/onboardingpayload/Base38.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadGenerator.kt"
             - "**/src/controller/java/src/matter/onboardingpayload/ManualOnboardingPayloadParser.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/ManualCodeTest.kt"
             - "**/src/controller/java/tests/matter/onboardingpayload/QRCodeTest.kt"
-            - "**/src/controller/java/tests/chip/tlv/TlvReaderTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
     LargeClass:
         excludes:
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/tests/chip/tlv/TlvReadWriteTest.kt"
-            - "**/src/controller/java/tests/chip/jsontlv/JsonToTlvToJsonTest.kt"
+            - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
+            - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"
     CyclomaticComplexMethod:
         excludes:
             - "**/src/controller/java/generated/java/**/*"
-            - "**/src/controller/java/src/chip/tlv/TlvReader.kt"
-            - "**/src/controller/java/src/chip/tlv/types.kt"
-            - "**/src/controller/java/src/chip/jsontlv/TlvToJson.kt"
+            - "**/src/controller/java/src/matter/tlv/TlvReader.kt"
+            - "**/src/controller/java/src/matter/tlv/types.kt"
+            - "**/src/controller/java/src/matter/jsontlv/TlvToJson.kt"
     ComplexCondition:
         excludes:
             - "**/src/controller/java/generated/java/**/*"

--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipEventStructs.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipEventStructs.jinja
@@ -92,12 +92,12 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvParsingException
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvParsingException
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 import java.util.Optional
 

--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipStructs.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipStructs.jinja
@@ -92,12 +92,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvParsingException
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvParsingException
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 import java.util.Optional
 

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/SecondClusterFabricDescriptorStruct.kt
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/SecondClusterFabricDescriptorStruct.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvParsingException
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvParsingException
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 import java.util.Optional
 

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -177,13 +177,13 @@ kotlin_library("tlv") {
   output_name = "libCHIPTlv.jar"
 
   sources = [
-    "src/chip/tlv/Element.kt",
-    "src/chip/tlv/TlvReader.kt",
-    "src/chip/tlv/TlvWriter.kt",
-    "src/chip/tlv/tags.kt",
-    "src/chip/tlv/types.kt",
-    "src/chip/tlv/utils.kt",
-    "src/chip/tlv/values.kt",
+    "src/matter/tlv/Element.kt",
+    "src/matter/tlv/TlvReader.kt",
+    "src/matter/tlv/TlvWriter.kt",
+    "src/matter/tlv/tags.kt",
+    "src/matter/tlv/types.kt",
+    "src/matter/tlv/utils.kt",
+    "src/matter/tlv/values.kt",
   ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
@@ -198,7 +198,7 @@ kotlin_library("tlv_reader_test") {
     "${chip_root}/third_party/java_deps:truth",
   ]
 
-  sources = [ "tests/chip/tlv/TlvReaderTest.kt" ]
+  sources = [ "tests/matter/tlv/TlvReaderTest.kt" ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
 }
@@ -212,7 +212,7 @@ kotlin_library("tlv_writer_test") {
     "${chip_root}/third_party/java_deps:truth",
   ]
 
-  sources = [ "tests/chip/tlv/TlvWriterTest.kt" ]
+  sources = [ "tests/matter/tlv/TlvWriterTest.kt" ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
 }
@@ -227,7 +227,7 @@ kotlin_library("tlv_read_write_test") {
     "${chip_root}/third_party/java_deps:truth",
   ]
 
-  sources = [ "tests/chip/tlv/TlvReadWriteTest.kt" ]
+  sources = [ "tests/matter/tlv/TlvReadWriteTest.kt" ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
 }
@@ -242,9 +242,9 @@ kotlin_library("jsontlv") {
   ]
 
   sources = [
-    "src/chip/jsontlv/JsonToTlv.kt",
-    "src/chip/jsontlv/TlvToJson.kt",
-    "src/chip/jsontlv/types.kt",
+    "src/matter/jsontlv/JsonToTlv.kt",
+    "src/matter/jsontlv/TlvToJson.kt",
+    "src/matter/jsontlv/types.kt",
   ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
@@ -261,7 +261,7 @@ kotlin_library("json_to_tlv_to_json_test") {
     "${chip_root}/third_party/java_deps:truth",
   ]
 
-  sources = [ "tests/chip/jsontlv/JsonToTlvToJsonTest.kt" ]
+  sources = [ "tests/matter/jsontlv/JsonToTlvToJsonTest.kt" ]
 
   kotlinc_flags = [ "-Xlint:deprecation" ]
 }

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/AccessControlClusterAccessControlEntryChangedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/AccessControlClusterAccessControlEntryChangedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AccessControlClusterAccessControlEntryChangedEvent(
   val adminNodeID: ULong?,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/AccessControlClusterAccessControlExtensionChangedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/AccessControlClusterAccessControlExtensionChangedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AccessControlClusterAccessControlExtensionChangedEvent(
   val adminNodeID: ULong?,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ActionsClusterActionFailedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ActionsClusterActionFailedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ActionsClusterActionFailedEvent(
   val actionID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ActionsClusterStateChangedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ActionsClusterStateChangedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ActionsClusterStateChangedEvent(val actionID: UInt, val invokeID: ULong, val newState: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterLeaveEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterLeaveEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicInformationClusterLeaveEvent(val fabricIndex: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterReachableChangedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterReachableChangedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicInformationClusterReachableChangedEvent(val reachableNewValue: Boolean) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterStartUpEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BasicInformationClusterStartUpEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicInformationClusterStartUpEvent(val softwareVersion: ULong) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BooleanStateClusterStateChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BooleanStateClusterStateChangeEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BooleanStateClusterStateChangeEvent(val stateValue: Boolean) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BridgedDeviceBasicInformationClusterReachableChangedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BridgedDeviceBasicInformationClusterReachableChangedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BridgedDeviceBasicInformationClusterReachableChangedEvent(val reachableNewValue: Boolean) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BridgedDeviceBasicInformationClusterStartUpEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/BridgedDeviceBasicInformationClusterStartUpEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BridgedDeviceBasicInformationClusterStartUpEvent(val softwareVersion: ULong) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DishwasherAlarmClusterNotifyEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DishwasherAlarmClusterNotifyEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DishwasherAlarmClusterNotifyEvent(
   val active: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterDoorLockAlarmEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterDoorLockAlarmEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterDoorLockAlarmEvent(val alarmCode: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterDoorStateChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterDoorStateChangeEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterDoorStateChangeEvent(val doorState: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockOperationErrorEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockOperationErrorEvent.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterLockOperationErrorEvent(
   val lockOperationType: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockOperationEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockOperationEvent.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterLockOperationEvent(
   val lockOperationType: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockUserChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/DoorLockClusterLockUserChangeEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterLockUserChangeEvent(
   val lockDataType: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterBootReasonEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterBootReasonEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralDiagnosticsClusterBootReasonEvent(val bootReason: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterHardwareFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterHardwareFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralDiagnosticsClusterHardwareFaultChangeEvent(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterNetworkFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterNetworkFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralDiagnosticsClusterNetworkFaultChangeEvent(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterRadioFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/GeneralDiagnosticsClusterRadioFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralDiagnosticsClusterRadioFaultChangeEvent(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OperationalStateClusterOperationCompletionEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OperationalStateClusterOperationCompletionEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalStateClusterOperationCompletionEvent(
   val completionErrorCode: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OperationalStateClusterOperationalErrorEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OperationalStateClusterOperationalErrorEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalStateClusterOperationalErrorEvent(
   val errorState: chip.devicecontroller.cluster.structs.OperationalStateClusterErrorStateStruct

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterDownloadErrorEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterDownloadErrorEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OtaSoftwareUpdateRequestorClusterDownloadErrorEvent(
   val softwareVersion: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterStateTransitionEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterStateTransitionEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OtaSoftwareUpdateRequestorClusterStateTransitionEvent(
   val previousState: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterVersionAppliedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/OtaSoftwareUpdateRequestorClusterVersionAppliedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OtaSoftwareUpdateRequestorClusterVersionAppliedEvent(
   val softwareVersion: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterBatChargeFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterBatChargeFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterBatChargeFaultChangeEvent(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterBatFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterBatFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterBatFaultChangeEvent(val current: List<UInt>, val previous: List<UInt>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterWiredFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/PowerSourceClusterWiredFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterWiredFaultChangeEvent(val current: List<UInt>, val previous: List<UInt>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RefrigeratorAlarmClusterNotifyEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RefrigeratorAlarmClusterNotifyEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RefrigeratorAlarmClusterNotifyEvent(
   val active: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RvcOperationalStateClusterOperationCompletionEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RvcOperationalStateClusterOperationCompletionEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcOperationalStateClusterOperationCompletionEvent(
   val completionErrorCode: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RvcOperationalStateClusterOperationalErrorEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/RvcOperationalStateClusterOperationalErrorEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcOperationalStateClusterOperationalErrorEvent(
   val errorState: chip.devicecontroller.cluster.structs.RvcOperationalStateClusterErrorStateStruct

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterCOAlarmEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterCOAlarmEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SmokeCoAlarmClusterCOAlarmEvent(val alarmSeverityLevel: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterInterconnectCOAlarmEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterInterconnectCOAlarmEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SmokeCoAlarmClusterInterconnectCOAlarmEvent(val alarmSeverityLevel: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterInterconnectSmokeAlarmEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterInterconnectSmokeAlarmEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SmokeCoAlarmClusterInterconnectSmokeAlarmEvent(val alarmSeverityLevel: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterLowBatteryEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterLowBatteryEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SmokeCoAlarmClusterLowBatteryEvent(val alarmSeverityLevel: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterSmokeAlarmEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SmokeCoAlarmClusterSmokeAlarmEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SmokeCoAlarmClusterSmokeAlarmEvent(val alarmSeverityLevel: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SoftwareDiagnosticsClusterSoftwareFaultEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SoftwareDiagnosticsClusterSoftwareFaultEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SoftwareDiagnosticsClusterSoftwareFaultEvent(
   val id: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterInitialPressEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterInitialPressEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterInitialPressEvent(val newPosition: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterLongPressEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterLongPressEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterLongPressEvent(val newPosition: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterLongReleaseEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterLongReleaseEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterLongReleaseEvent(val previousPosition: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterMultiPressCompleteEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterMultiPressCompleteEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterMultiPressCompleteEvent(
   val previousPosition: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterMultiPressOngoingEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterMultiPressOngoingEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterMultiPressOngoingEvent(
   val newPosition: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterShortReleaseEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterShortReleaseEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterShortReleaseEvent(val previousPosition: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterSwitchLatchedEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/SwitchClusterSwitchLatchedEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SwitchClusterSwitchLatchedEvent(val newPosition: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ThreadNetworkDiagnosticsClusterConnectionStatusEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ThreadNetworkDiagnosticsClusterConnectionStatusEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterConnectionStatusEvent(val connectionStatus: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/TimeSynchronizationClusterDSTStatusEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/TimeSynchronizationClusterDSTStatusEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterDSTStatusEvent(val DSTOffsetActive: Boolean) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/TimeSynchronizationClusterTimeZoneStatusEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/TimeSynchronizationClusterTimeZoneStatusEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterTimeZoneStatusEvent(val offset: Long, val name: Optional<String>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/UnitTestingClusterTestEventEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/UnitTestingClusterTestEventEvent.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterTestEventEvent(
   val arg1: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/UnitTestingClusterTestFabricScopedEventEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/UnitTestingClusterTestFabricScopedEventEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterTestFabricScopedEventEvent(val fabricIndex: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterAssociationFailureEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterAssociationFailureEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class WiFiNetworkDiagnosticsClusterAssociationFailureEvent(
   val associationFailure: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterConnectionStatusEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterConnectionStatusEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class WiFiNetworkDiagnosticsClusterConnectionStatusEvent(val connectionStatus: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterDisconnectionEvent.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/eventstructs/WiFiNetworkDiagnosticsClusterDisconnectionEvent.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.eventstructs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class WiFiNetworkDiagnosticsClusterDisconnectionEvent(val reasonCode: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlEntryStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlEntryStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AccessControlClusterAccessControlEntryStruct(
   val privilege: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlExtensionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlExtensionStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AccessControlClusterAccessControlExtensionStruct(val data: ByteArray, val fabricIndex: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlTargetStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AccessControlClusterAccessControlTargetStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AccessControlClusterAccessControlTargetStruct(
   val cluster: ULong?,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActionsClusterActionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActionsClusterActionStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ActionsClusterActionStruct(
   val actionID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActionsClusterEndpointListStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActionsClusterEndpointListStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ActionsClusterEndpointListStruct(
   val endpointListID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActivatedCarbonFilterMonitoringClusterReplacementProductStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ActivatedCarbonFilterMonitoringClusterReplacementProductStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ActivatedCarbonFilterMonitoringClusterReplacementProductStruct(
   val productIdentifierType: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationBasicClusterApplicationStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationBasicClusterApplicationStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ApplicationBasicClusterApplicationStruct(
   val catalogVendorID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationLauncherClusterApplicationEPStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationLauncherClusterApplicationEPStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ApplicationLauncherClusterApplicationEPStruct(
   val application: ApplicationLauncherClusterApplicationStruct,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationLauncherClusterApplicationStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ApplicationLauncherClusterApplicationStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ApplicationLauncherClusterApplicationStruct(
   val catalogVendorID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AudioOutputClusterOutputInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/AudioOutputClusterOutputInfoStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class AudioOutputClusterOutputInfoStruct(val index: UInt, val outputType: UInt, val name: String) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BasicInformationClusterCapabilityMinimaStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BasicInformationClusterCapabilityMinimaStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicInformationClusterCapabilityMinimaStruct(
   val caseSessionsPerFabric: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BasicInformationClusterProductAppearanceStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BasicInformationClusterProductAppearanceStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BasicInformationClusterProductAppearanceStruct(val finish: UInt, val primaryColor: UInt?) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BindingClusterTargetStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BindingClusterTargetStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BindingClusterTargetStruct(
   val node: Optional<ULong>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BridgedDeviceBasicInformationClusterProductAppearanceStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/BridgedDeviceBasicInformationClusterProductAppearanceStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class BridgedDeviceBasicInformationClusterProductAppearanceStruct(
   val finish: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ChannelClusterChannelInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ChannelClusterChannelInfoStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ChannelClusterChannelInfoStruct(
   val majorNumber: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ChannelClusterLineupInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ChannelClusterLineupInfoStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ChannelClusterLineupInfoStruct(
   val operatorName: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterAdditionalInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterAdditionalInfoStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterAdditionalInfoStruct(val name: String, val value: String) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterBrandingInformationStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterBrandingInformationStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterBrandingInformationStruct(
   val providerName: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterContentSearchStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterContentSearchStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterContentSearchStruct(
   val parameterList: List<ContentLauncherClusterParameterStruct>

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterDimensionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterDimensionStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterDimensionStruct(
   val width: Double,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterParameterStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterParameterStruct.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterParameterStruct(
   val type: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterStyleInformationStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ContentLauncherClusterStyleInformationStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ContentLauncherClusterStyleInformationStruct(
   val imageURL: Optional<String>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DescriptorClusterDeviceTypeStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DescriptorClusterDeviceTypeStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DescriptorClusterDeviceTypeStruct(val deviceType: ULong, val revision: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DescriptorClusterSemanticTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DescriptorClusterSemanticTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DescriptorClusterSemanticTagStruct(
   val mfgCode: UInt?,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DishwasherModeClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DishwasherModeClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DishwasherModeClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DishwasherModeClusterModeTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DishwasherModeClusterModeTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DishwasherModeClusterModeTagStruct(val mfgCode: Optional<UInt>, val value: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DoorLockClusterCredentialStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/DoorLockClusterCredentialStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class DoorLockClusterCredentialStruct(val credentialType: UInt, val credentialIndex: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/FixedLabelClusterLabelStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/FixedLabelClusterLabelStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class FixedLabelClusterLabelStruct(val label: String, val value: String) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GeneralCommissioningClusterBasicCommissioningInfo.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GeneralCommissioningClusterBasicCommissioningInfo.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralCommissioningClusterBasicCommissioningInfo(
   val failSafeExpiryLengthSeconds: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GeneralDiagnosticsClusterNetworkInterface.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GeneralDiagnosticsClusterNetworkInterface.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GeneralDiagnosticsClusterNetworkInterface(
   val name: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupInfoMapStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupInfoMapStruct.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GroupKeyManagementClusterGroupInfoMapStruct(
   val groupId: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupKeyMapStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupKeyMapStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GroupKeyManagementClusterGroupKeyMapStruct(
   val groupId: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupKeySetStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/GroupKeyManagementClusterGroupKeySetStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class GroupKeyManagementClusterGroupKeySetStruct(
   val groupKeySetID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/HepaFilterMonitoringClusterReplacementProductStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/HepaFilterMonitoringClusterReplacementProductStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class HepaFilterMonitoringClusterReplacementProductStruct(
   val productIdentifierType: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/IcdManagementClusterMonitoringRegistrationStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/IcdManagementClusterMonitoringRegistrationStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class IcdManagementClusterMonitoringRegistrationStruct(
   val checkInNodeID: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/LaundryWasherModeClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/LaundryWasherModeClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class LaundryWasherModeClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/LaundryWasherModeClusterModeTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/LaundryWasherModeClusterModeTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class LaundryWasherModeClusterModeTagStruct(val mfgCode: Optional<UInt>, val value: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/MediaInputClusterInputInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/MediaInputClusterInputInfoStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class MediaInputClusterInputInfoStruct(
   val index: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/MediaPlaybackClusterPlaybackPositionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/MediaPlaybackClusterPlaybackPositionStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class MediaPlaybackClusterPlaybackPositionStruct(val updatedAt: ULong, val position: ULong?) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ModeSelectClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ModeSelectClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ModeSelectClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ModeSelectClusterSemanticTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ModeSelectClusterSemanticTagStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ModeSelectClusterSemanticTagStruct(val mfgCode: UInt, val value: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterNetworkInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterNetworkInfoStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class NetworkCommissioningClusterNetworkInfoStruct(
   val networkID: ByteArray,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterThreadInterfaceScanResultStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterThreadInterfaceScanResultStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class NetworkCommissioningClusterThreadInterfaceScanResultStruct(
   val panId: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterWiFiInterfaceScanResultStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/NetworkCommissioningClusterWiFiInterfaceScanResultStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class NetworkCommissioningClusterWiFiInterfaceScanResultStruct(
   val security: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalCredentialsClusterFabricDescriptorStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalCredentialsClusterFabricDescriptorStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalCredentialsClusterFabricDescriptorStruct(
   val rootPublicKey: ByteArray,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalCredentialsClusterNOCStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalCredentialsClusterNOCStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalCredentialsClusterNOCStruct(
   val noc: ByteArray,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalStateClusterErrorStateStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalStateClusterErrorStateStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalStateClusterErrorStateStruct(
   val errorStateID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalStateClusterOperationalStateStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OperationalStateClusterOperationalStateStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OperationalStateClusterOperationalStateStruct(
   val operationalStateID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OtaSoftwareUpdateRequestorClusterProviderLocation.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/OtaSoftwareUpdateRequestorClusterProviderLocation.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class OtaSoftwareUpdateRequestorClusterProviderLocation(
   val providerNodeID: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterBatChargeFaultChangeType.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterBatChargeFaultChangeType.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterBatChargeFaultChangeType(
   val current: List<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterBatFaultChangeType.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterBatFaultChangeType.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterBatFaultChangeType(val current: List<UInt>, val previous: List<UInt>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterWiredFaultChangeType.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/PowerSourceClusterWiredFaultChangeType.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class PowerSourceClusterWiredFaultChangeType(val current: List<UInt>, val previous: List<UInt>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct(
   val mfgCode: Optional<UInt>,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcCleanModeClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcCleanModeClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcCleanModeClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcCleanModeClusterModeTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcCleanModeClusterModeTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcCleanModeClusterModeTagStruct(val mfgCode: Optional<UInt>, val value: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcOperationalStateClusterErrorStateStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcOperationalStateClusterErrorStateStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcOperationalStateClusterErrorStateStruct(
   val errorStateID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcOperationalStateClusterOperationalStateStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcOperationalStateClusterOperationalStateStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcOperationalStateClusterOperationalStateStruct(
   val operationalStateID: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcRunModeClusterModeOptionStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcRunModeClusterModeOptionStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcRunModeClusterModeOptionStruct(
   val label: String,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcRunModeClusterModeTagStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/RvcRunModeClusterModeTagStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class RvcRunModeClusterModeTagStruct(val mfgCode: Optional<UInt>, val value: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ScenesClusterAttributeValuePair.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ScenesClusterAttributeValuePair.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ScenesClusterAttributeValuePair(val attributeID: ULong, val attributeValue: ULong) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ScenesClusterExtensionFieldSet.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ScenesClusterExtensionFieldSet.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ScenesClusterExtensionFieldSet(
   val clusterID: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/SoftwareDiagnosticsClusterThreadMetricsStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/SoftwareDiagnosticsClusterThreadMetricsStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class SoftwareDiagnosticsClusterThreadMetricsStruct(
   val id: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TargetNavigatorClusterTargetInfoStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TargetNavigatorClusterTargetInfoStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TargetNavigatorClusterTargetInfoStruct(val identifier: UInt, val name: String) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThermostatClusterThermostatScheduleTransition.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThermostatClusterThermostatScheduleTransition.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThermostatClusterThermostatScheduleTransition(
   val transitionTime: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterNeighborTableStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterNeighborTableStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterNeighborTableStruct(
   val extAddress: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterOperationalDatasetComponents.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterOperationalDatasetComponents.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterOperationalDatasetComponents(
   val activeTimestampPresent: Boolean,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterRouteTableStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterRouteTableStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterRouteTableStruct(
   val extAddress: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterSecurityPolicy.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/ThreadNetworkDiagnosticsClusterSecurityPolicy.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class ThreadNetworkDiagnosticsClusterSecurityPolicy(val rotationTime: UInt, val flags: UInt) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterDSTOffsetStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterDSTOffsetStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterDSTOffsetStruct(
   val offset: Long,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct(
   val nodeID: ULong,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterTimeZoneStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterTimeZoneStruct.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterTimeZoneStruct(
   val offset: Long,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterTrustedTimeSourceStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/TimeSynchronizationClusterTrustedTimeSourceStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class TimeSynchronizationClusterTrustedTimeSourceStruct(
   val fabricIndex: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterDoubleNestedStructList.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterDoubleNestedStructList.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterDoubleNestedStructList(val a: List<UnitTestingClusterNestedStructList>) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNestedStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNestedStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterNestedStruct(
   val a: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNestedStructList.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNestedStructList.kt
@@ -17,11 +17,11 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterNestedStructList(
   val a: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNullablesAndOptionalsStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterNullablesAndOptionalsStruct.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterNullablesAndOptionalsStruct(
   val nullableInt: UInt?,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterSimpleStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterSimpleStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterSimpleStruct(
   val a: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterTestFabricScoped.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterTestFabricScoped.kt
@@ -17,12 +17,12 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterTestFabricScoped(
   val fabricSensitiveInt8u: UInt,

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterTestListStructOctet.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UnitTestingClusterTestListStructOctet.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UnitTestingClusterTestListStructOctet(val member1: ULong, val member2: ByteArray) {
   override fun toString(): String = buildString {

--- a/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UserLabelClusterLabelStruct.kt
+++ b/src/controller/java/generated/java/chip/devicecontroller/cluster/structs/UserLabelClusterLabelStruct.kt
@@ -17,10 +17,10 @@
 package chip.devicecontroller.cluster.structs
 
 import chip.devicecontroller.cluster.*
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 
 class UserLabelClusterLabelStruct(val label: String, val value: String) {
   override fun toString(): String = buildString {

--- a/src/controller/java/src/chip/devicecontroller/cluster/TlvReaderExtension.kt
+++ b/src/controller/java/src/chip/devicecontroller/cluster/TlvReaderExtension.kt
@@ -17,9 +17,9 @@
 
 package chip.devicecontroller.cluster
 
-import chip.tlv.NullValue
-import chip.tlv.Tag
-import chip.tlv.TlvReader
+import matter.tlv.NullValue
+import matter.tlv.Tag
+import matter.tlv.TlvReader
 
 fun TlvReader.getBoolean(tag: Tag): Boolean {
   return getBool(tag)

--- a/src/controller/java/src/matter/jsontlv/JsonToTlv.kt
+++ b/src/controller/java/src/matter/jsontlv/JsonToTlv.kt
@@ -16,14 +16,14 @@
  *    limitations under the License.
  */
 
-package chip.jsontlv
+package matter.jsontlv
 
-import chip.tlv.*
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import java.util.Base64
+import matter.tlv.*
 
 /**
  * Implements Matter JSON to TLV converter.

--- a/src/controller/java/src/matter/jsontlv/TlvToJson.kt
+++ b/src/controller/java/src/matter/jsontlv/TlvToJson.kt
@@ -16,13 +16,13 @@
  *    limitations under the License.
  */
 
-package chip.jsontlv
+package matter.jsontlv
 
-import chip.tlv.*
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import java.util.Base64
+import matter.tlv.*
 
 /**
  * Implements Matter TLV to JSON converter.

--- a/src/controller/java/src/matter/jsontlv/types.kt
+++ b/src/controller/java/src/matter/jsontlv/types.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.jsontlv
+package matter.jsontlv
 
 internal const val JSON_VALUE_TYPE_INT = "INT"
 internal const val JSON_VALUE_TYPE_UINT = "UINT"

--- a/src/controller/java/src/matter/onboardingpayload/QRCodeOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/matter/onboardingpayload/QRCodeOnboardingPayloadGenerator.kt
@@ -17,10 +17,10 @@
 
 package matter.onboardingpayload
 
-import chip.tlv.AnonymousTag
-import chip.tlv.ContextSpecificTag
-import chip.tlv.Tag
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.ContextSpecificTag
+import matter.tlv.Tag
+import matter.tlv.TlvWriter
 
 class QRCodeOnboardingPayloadGenerator(private val onboardingPayload: OnboardingPayload) {
   private var allowInvalidPayload = false

--- a/src/controller/java/src/matter/tlv/Element.kt
+++ b/src/controller/java/src/matter/tlv/Element.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 /**
  * Represents a single TLV element.

--- a/src/controller/java/src/matter/tlv/TlvReader.kt
+++ b/src/controller/java/src/matter/tlv/TlvReader.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import java.lang.Double.longBitsToDouble
 import java.lang.Float.intBitsToFloat

--- a/src/controller/java/src/matter/tlv/TlvWriter.kt
+++ b/src/controller/java/src/matter/tlv/TlvWriter.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import java.io.ByteArrayOutputStream
 

--- a/src/controller/java/src/matter/tlv/tags.kt
+++ b/src/controller/java/src/matter/tlv/tags.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import kotlin.experimental.and
 import kotlin.experimental.or

--- a/src/controller/java/src/matter/tlv/types.kt
+++ b/src/controller/java/src/matter/tlv/types.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import kotlin.experimental.and
 import kotlin.experimental.or

--- a/src/controller/java/src/matter/tlv/utils.kt
+++ b/src/controller/java/src/matter/tlv/utils.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 /** Converts bytes in a Little Endian format into Long integer. */
 internal fun ByteArray.fromLittleEndianToLong(isSigned: Boolean = false): Long =

--- a/src/controller/java/src/matter/tlv/values.kt
+++ b/src/controller/java/src/matter/tlv/values.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import java.lang.Double.doubleToLongBits
 import java.lang.Float.floatToIntBits

--- a/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterEventStructTest.kt
+++ b/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterEventStructTest.kt
@@ -19,9 +19,9 @@ package chip.devicecontroller.cluster
 import chip.devicecontroller.cluster.eventstructs.UnitTestingClusterTestEventEvent
 import chip.devicecontroller.cluster.eventstructs.UnitTestingClusterTestFabricScopedEventEvent
 import chip.devicecontroller.cluster.structs.UnitTestingClusterSimpleStruct
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 import org.junit.Test
 
 class ChipClusterEventStructTest {

--- a/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterStructTest.kt
+++ b/src/controller/java/tests/chip/devicecontroller/cluster/ChipClusterStructTest.kt
@@ -22,10 +22,10 @@ import chip.devicecontroller.cluster.structs.UnitTestingClusterNullablesAndOptio
 import chip.devicecontroller.cluster.structs.UnitTestingClusterSimpleStruct
 import chip.devicecontroller.cluster.structs.UnitTestingClusterTestFabricScoped
 import chip.devicecontroller.cluster.structs.UnitTestingClusterTestListStructOctet
-import chip.tlv.AnonymousTag
-import chip.tlv.TlvReader
-import chip.tlv.TlvWriter
 import java.util.Optional
+import matter.tlv.AnonymousTag
+import matter.tlv.TlvReader
+import matter.tlv.TlvWriter
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt
+++ b/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt
@@ -16,12 +16,12 @@
  *    limitations under the License.
  */
 
-package chip.jsontlv
+package matter.jsontlv
 
-import chip.tlv.*
 import com.google.common.truth.Truth.assertThat
 import com.google.gson.JsonParser
 import kotlin.test.assertFailsWith
+import matter.tlv.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt
+++ b/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith

--- a/src/controller/java/tests/matter/tlv/TlvReaderTest.kt
+++ b/src/controller/java/tests/matter/tlv/TlvReaderTest.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import com.google.common.truth.Truth.assertThat
 import java.math.BigInteger

--- a/src/controller/java/tests/matter/tlv/TlvWriterTest.kt
+++ b/src/controller/java/tests/matter/tlv/TlvWriterTest.kt
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-package chip.tlv
+package matter.tlv
 
 import com.google.common.truth.Truth.assertThat
 import java.math.BigInteger


### PR DESCRIPTION
Follow-up of https://github.com/project-chip/connectedhomeip/pull/29623

The plan is to consolidate all kotlin libraries into package matter to integrate seamlessly with existing Kotlin libraries to create a complete suite of Kotlin APIs.

This is a mechanical package name adjustment with no changes to the underlying logic.

