### PR TITLE
Fix support for readAttributePaths: for multiple paths in MTRDeviceOverXPC.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -139,22 +139,49 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
                      queue:(dispatch_queue_t)queue
                 completion:(MTRDeviceResponseHandler)completion
 {
-    if (attributePaths == nil || attributePaths.count != 1 || eventPaths != nil) {
-        MTR_LOG_ERROR("MTRBaseDevice doesn't support reading more than a single attribute path at a time over XPC");
+    if (attributePaths == nil || eventPaths != nil) {
+        MTR_LOG_ERROR("MTRBaseDevice doesn't support reading event paths over XPC");
         dispatch_async(queue, ^{
             completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil]);
         });
         return;
     }
 
-    auto * path = attributePaths[0];
+    // TODO: Have a better XPC setup for the multiple-paths case, instead of
+    // just converting it into a bunch of separate reads.
+    auto expectedResponses = attributePaths.count;
+    __block decltype(expectedResponses) responses = 0;
+    NSMutableArray<NSDictionary<NSString *, id> *> * seenValues = [[NSMutableArray alloc] init];
+    __block BOOL dispatched = NO;
 
-    [self readAttributesWithEndpointID:path.endpoint
-                             clusterID:path.cluster
-                           attributeID:path.attribute
-                                params:params
-                                 queue:queue
-                            completion:completion];
+    for (MTRAttributeRequestPath * path in attributePaths) {
+        __auto_type singleAttributeResponseHandler = ^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+            if (dispatched) {
+                // We hit an error earlier or something.
+                return;
+            }
+
+            if (error != nil) {
+                dispatched = YES;
+                completion(nil, error);
+                return;
+            }
+
+            [seenValues addObjectsFromArray:values];
+            ++responses;
+            if (responses == expectedResponses) {
+                dispatched = YES;
+                completion([seenValues copy], nil);
+            };
+        };
+
+        [self readAttributesWithEndpointID:path.endpoint
+                                 clusterID:path.cluster
+                               attributeID:path.attribute
+                                    params:params
+                                     queue:queue
+                                completion:singleAttributeResponseHandler];
+    }
 }
 
 - (void)writeAttributeWithEndpointID:(NSNumber *)endpointID


### PR DESCRIPTION
Because MTRDevice will batch reads, we need to handle multiple paths here.
