### PR TITLE
Use image version 20 for android CI

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:1
+            image: ghcr.io/project-chip/chip-build-android:20
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:1
+            image: ghcr.io/project-chip/chip-build-android:20
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 


### PR DESCRIPTION
This image is 800MB smaller, hoping to decrease out of storage space errors in CI.