### PR TITLE
Install openjdk8 in chip-build-java

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-20 : [Chip-build] Decrease some image sizes
+21 : [chip-build-java] Ensure java is actually available in the docker image

--- a/integrations/docker/images/stage-2/chip-build-java/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-java/Dockerfile
@@ -2,6 +2,14 @@ ARG VERSION=1
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
+# Ensure some java is installed
+RUN set -x \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
+    openjdk-8-jdk \
+    && rm -rf /var/lib/apt/lists/ \
+    && : # last line
+
 # Download and install kotlin compiler
 RUN set -x \
     && cd /usr/lib \

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -72,22 +72,22 @@ RUN set -x \
     && chmod -R a+w /opt/android/sdk/licenses \
     && : # last line
 
-# Required for the Tizen SDK
+# Required for the Tizen SDK:
+#   - zip
+# Required for the Open IoT SDK platform
+#   - expect
+#   - telnet
+#   - srecord
+# For java builds:
+#   - openjdk-8-jdk
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     zip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && : # last line
-
-# Required for the Open IoT SDK platform
-RUN set -x \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
     expect \
     telnet \
     srecord \
+    openjdk-8-jdk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line


### PR DESCRIPTION
Docker image 20 removed java from the main image (since most platforms do not require java and it is large) ... however chip-build-java should have java ...

Changes:
  - add jdk into chip-build-java (android already had this)
  - add jdk into chip-build-vscode (supposed to support all possible builds).