### PR TITLE
[Silabs] Modified cluster-revsion default value

### DIFF
--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -2044,7 +2044,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
+    ram      attribute clusterRevision default = 2;
   }
 }
 

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -5017,7 +5017,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
Defaultvalue is 1 in thermostat.zap file for cluster-revision attribute in THERMOSTAT_USER_INTERFACE_CONFIGURATION_CLUSTER,  In the Test Case(TSUIC_1.1) test plan expected cluster revision value should be 2.  So , by modifying the defaultValue in THERMOSTAT_USER_INTERFACE_CONFIGURATION_CLUSTER for server side it is giving 2 as cluster-revision value.