### PR TITLE
Use continue-on-error for workflow action steps trying to save space by removing dir

### DIFF
--- a/.github/actions/checkout-submodules-and-bootstrap/action.yaml
+++ b/.github/actions/checkout-submodules-and-bootstrap/action.yaml
@@ -33,8 +33,9 @@ runs:
       # there is roughly 1.4GB that remains in this cache that is useless from
       # this point onwards.
       shell: bash
+      continue-on-error: true
       run: |
-        du -sh $HOME/.cipd-cache-dir/ || true
+        du -sh $HOME/.cipd-cache-dir/
         rm -rf $HOME/.cipd-cache-dir/ || echo "Removing cipd cache dir failed"
     - name: Dump disk info after checkout submodule & Bootstrap
       shell: bash

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -63,6 +63,7 @@ jobs:
               # This should not generally be needed, however android CI runs out of space
               # We do not need pigweed cross compile here because we use android NDK
               # compilers. Removing this package saves a significant amount of space.
+              continue-on-error: true
               run: |
                 du -sh .environment/cipd/packages/arm
                 rm -rf .environment/cipd/packages/arm

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -52,6 +52,7 @@ jobs:
               # This should not generally be needed, however android CI runs out of space
               # We do not need pigweed cross compile here because we use android NDK
               # compilers. Removing this package save significant amount of space.
+              continue-on-error: true
               run: |
                 du -sh .environment/cipd/packages/arm
                 rm -rf .environment/cipd/packages/arm


### PR DESCRIPTION
### Problem:

Android jobs can fail if they fail to remove a directory that doesn't exist. We haven't seen this in practice, but preemptively fixing this. Making it a little cleaner in another step where we used `|| true` to prevent step from failure

Test:
* CI passes