### PR TITLE
Remove unused include from PlatformManagerImpl.cpp

### DIFF
--- a/src/platform/android/PlatformManagerImpl.cpp
+++ b/src/platform/android/PlatformManagerImpl.cpp
@@ -29,7 +29,6 @@
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/PlatformManager.h>
 #include <platform/android/DeviceInstanceInfoProviderImpl.h>
-#include <platform/android/DiagnosticDataProviderImpl.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
 
 #include <thread>


### PR DESCRIPTION
This include statement for DiagnosticDataProviderImpl is unused.

