### PR TITLE
tv-casting-app/android: resetting discovery state vars onStartDiscoveryFailed

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/NsdDiscoveryListener.java
@@ -109,6 +109,7 @@ public class NsdDiscoveryListener implements NsdManager.DiscoveryListener {
   @Override
   public void onStartDiscoveryFailed(String serviceType, int errorCode) {
     Log.e(TAG, "Discovery failed to start: Error code:" + errorCode);
+    TvCastingApp.getInstance().resetDiscoveryState();
     failureCallback.handle(
         new MatterError(
             3, "NsdDiscoveryListener Discovery failed to start: Nsd Error code:" + errorCode));

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -178,6 +178,17 @@ public class TvCastingApp {
     }
   }
 
+  void resetDiscoveryState() {
+    synchronized (discoveryLock) {
+      Log.d(TAG, "TvCastingApp resetting discovery state");
+      this.discoveryStarted = false;
+      this.nsdDiscoveryListener = null;
+      if (multicastLock != null && multicastLock.isHeld()) {
+        multicastLock.release();
+      }
+    }
+  }
+
   public native boolean openBasicCommissioningWindow(
       int duration,
       CommissioningCallbacks commissioningCallbacks,


### PR DESCRIPTION
Fixes #29835

### Problem

Occasionally, the NsdManager fails to start discovery and would callback on onStartDiscoveryFailed(). The android TvCastingApp does not reset its discovery related state variables in such a case, and then enters an inconsistent state that blocks re-trying discovery.

See attached github issue above for logs.

### Solution overview

1.  Expose a package private function `resetDiscoveryState()` in the singleton `TvCastingApp` and reset the discovery state variables used by the `TvCastingApp` object there.
2.  Call this function from `NsdDiscoveryListener.onStartDiscoveryFailed()`

### Testing

Tested by running discovery on the Android tv-casting-app and ensuring it runs successfully.