### PR TITLE
[Linux] Fix GAutoPtr deleter for GSource

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -60,6 +60,16 @@ struct GErrorDeleter
     void operator()(GError * object) { g_error_free(object); }
 };
 
+struct GIOChannelDeleter
+{
+    void operator()(GIOChannel * object) { g_io_channel_unref(object); }
+};
+
+struct GSourceDeleter
+{
+    void operator()(GSource * object) { g_source_unref(object); }
+};
+
 struct GVariantDeleter
 {
     void operator()(GVariant * object) { g_variant_unref(object); }
@@ -111,9 +121,15 @@ struct GAutoPtrDeleter<GError>
 };
 
 template <>
+struct GAutoPtrDeleter<GIOChannel>
+{
+    using deleter = GIOChannelDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GSource>
 {
-    using deleter = GObjectDeleter;
+    using deleter = GSourceDeleter;
 };
 
 template <>

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -380,6 +380,11 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
 
     ChipLogDetail(DeviceLayer, "BluezCharacteristicAcquireWrite is called, conn: %p", conn);
 
+    VerifyOrReturnValue(
+        g_variant_lookup(aOptions, "mtu", "q", &conn->mMtu), FALSE,
+        ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "MTU negotiation failed"));
+
     if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) < 0)
     {
 #if CHIP_ERROR_LOGGING
@@ -389,11 +394,6 @@ static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
         return FALSE;
     }
-
-    VerifyOrReturnValue(
-        g_variant_lookup(aOptions, "mtu", "q", &conn->mMtu), FALSE,
-        ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "MTU negotiation failed"));
 
     channel = g_io_channel_unix_new(fds[0]);
     g_io_channel_set_encoding(channel, nullptr, nullptr);


### PR DESCRIPTION
This PR is a cherry-pick of bug fixes from #29798 

### Changes

- use `g_source_unref` to release `GSource` instead of incorrect `g_object_unref`
- fix socketpair FDs leak in case of `g_variant_lookup` failure

### Testing

CI will test potential build failures