### PR TITLE
Remove unnecessary include in linux

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -59,6 +59,7 @@ jobs:
                         --target linux-arm64-chip-cert-clang \
                         --target linux-arm64-all-clusters-clang \
                         --target linux-arm64-chip-tool-ipv6only-clang \
+                        --target linux-arm64-chip-tool-nodeps-ipv6only \
                         --target linux-arm64-lock-clang \
                         --target linux-arm64-minmdns-clang \
                         --target linux-arm64-light-rpc-ipv6only-clang \

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -21,7 +21,6 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/DiagnosticDataProvider.h>
-#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/ConnectivityUtils.h>
 #include <platform/Linux/DiagnosticDataProviderImpl.h>
 #include <platform/Linux/NetworkCommissioningDriver.h>


### PR DESCRIPTION
This fixes the compilation of `linux-arm64-chip-tool-nodeps-ipv6only`.

The nodeps variant does not build ble and wifi and glib is only needed when WPA is enabled. The correct include is already done on line 61 of this file, so no need for a global include.