### PR TITLE
[Bouffalolab] Use Openthread stack in Bouffalo Lab SDK by default

### DIFF
--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -127,6 +127,8 @@ develop `XT-ZB6-DevKit` and `BL706DK` bl706 board, and `BL704LDK` BL704L board .
     application.
 -   `-thread`, to specify that connectivity Thread is enabled for Matter
     application.
+-   `-mot`, to specify to use openthread stack under `third_party/openthread/repo`
+    - Without `-mot` specified, Matter Thread will use openthread stack under Bouffalo Lab SDK
 -   `-fp`, to specify to enable frame pointer feature to print call stack when
     hit an exception for debug purpose.
 

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -127,8 +127,10 @@ develop `XT-ZB6-DevKit` and `BL706DK` bl706 board, and `BL704LDK` BL704L board .
     application.
 -   `-thread`, to specify that connectivity Thread is enabled for Matter
     application.
--   `-mot`, to specify to use openthread stack under `third_party/openthread/repo`
-    - Without `-mot` specified, Matter Thread will use openthread stack under `Bouffalo Lab` SDK
+-   `-mot`, to specify to use openthread stack under
+    `third_party/openthread/repo`
+    -   Without `-mot` specified, Matter Thread will use openthread stack under
+        `Bouffalo Lab` SDK
 -   `-fp`, to specify to enable frame pointer feature to print call stack when
     hit an exception for debug purpose.
 

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -128,7 +128,7 @@ develop `XT-ZB6-DevKit` and `BL706DK` bl706 board, and `BL704LDK` BL704L board .
 -   `-thread`, to specify that connectivity Thread is enabled for Matter
     application.
 -   `-mot`, to specify to use openthread stack under `third_party/openthread/repo`
-    - Without `-mot` specified, Matter Thread will use openthread stack under Bouffalo Lab SDK
+    - Without `-mot` specified, Matter Thread will use openthread stack under `Bouffalo Lab` SDK
 -   `-fp`, to specify to enable frame pointer feature to print call stack when
     hit an exception for debug purpose.
 

--- a/examples/lighting-app/bouffalolab/bl702/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702/BUILD.gn
@@ -216,14 +216,14 @@ bouffalolab_executable("lighting_app") {
     if (chip_openthread_ftd) {
       defines += [ "CHIP_DEVICE_CONFIG_THREAD_FTD=1" ]
       deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+        "${openthread_root}:libopenthread-cli-ftd",
+        "${openthread_root}:libopenthread-ftd",
       ]
     } else {
       defines += [ "CHIP_DEVICE_CONFIG_THREAD_FTD=0" ]
       deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-mtd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-mtd",
+        "${openthread_root}:libopenthread-cli-mtd",
+        "${openthread_root}:libopenthread-mtd",
       ]
     }
   }

--- a/examples/lighting-app/bouffalolab/bl702l/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702l/BUILD.gn
@@ -170,14 +170,14 @@ bouffalolab_executable("lighting_app") {
     if (chip_openthread_ftd) {
       defines += [ "CHIP_DEVICE_CONFIG_THREAD_FTD=1" ]
       deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+        "${openthread_root}:libopenthread-cli-ftd",
+        "${openthread_root}:libopenthread-ftd",
       ]
     } else {
       defines += [ "CHIP_DEVICE_CONFIG_THREAD_FTD=0" ]
       deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-mtd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-mtd",
+        "${openthread_root}:libopenthread-cli-mtd",
+        "${openthread_root}:libopenthread-mtd",
       ]
     }
   }

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -655,6 +655,7 @@ def BuildBouffalolabTarget():
     target.AppendModifier('thread', enable_thread=True)
     target.AppendModifier('fp', enable_frame_ptr=True)
     target.AppendModifier('memmonitor', enable_heap_monitoring=True)
+    target.AppendModifier('mot', use_matter_openthread=True)
 
     return target
 

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -158,8 +158,6 @@ class BouffalolabBuilder(GnBuilder):
         self.argsOpt.append(f'chip_enable_ethernet={str(enable_ethernet).lower()}')
         self.argsOpt.append(f'chip_enable_wifi={str(enable_wifi).lower()}')
         self.argsOpt.append(f'chip_enable_openthread={str(enable_thread).lower()}')
-        if not use_matter_openthread:
-            self.argsOpt.append('openthread_root="//third_party/connectedhomeip/third_party/bouffalolab/repo/components/network/thread/openthread"')
 
         # for enable_ethernet, do not need ble for commissioning
         self.argsOpt.append(f'chip_config_network_layer_ble={str(enable_wifi or enable_thread).lower()}')
@@ -169,6 +167,8 @@ class BouffalolabBuilder(GnBuilder):
 
         if enable_thread:
             self.argsOpt.append(f'openthread_project_core_config_file="{bouffalo_chip}-openthread-core-bl-config.h"')
+            if not use_matter_openthread:
+                self.argsOpt.append('openthread_root="//third_party/connectedhomeip/third_party/bouffalolab/repo/components/network/thread/openthread"')
 
         if enable_cdc:
             if bouffalo_chip != "bl702":

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -91,7 +91,8 @@ class BouffalolabBuilder(GnBuilder):
                  enable_wifi: bool = False,
                  enable_thread: bool = False,
                  enable_frame_ptr: bool = False,
-                 enable_heap_monitoring: bool = False
+                 enable_heap_monitoring: bool = False,
+                 use_matter_openthread: bool = False
                  ):
 
         if 'BL602' == module_type:
@@ -157,6 +158,8 @@ class BouffalolabBuilder(GnBuilder):
         self.argsOpt.append(f'chip_enable_ethernet={str(enable_ethernet).lower()}')
         self.argsOpt.append(f'chip_enable_wifi={str(enable_wifi).lower()}')
         self.argsOpt.append(f'chip_enable_openthread={str(enable_thread).lower()}')
+        if not use_matter_openthread:
+            self.argsOpt.append('openthread_root="//third_party/connectedhomeip/third_party/bouffalolab/repo/components/network/thread/openthread"')
 
         # for enable_ethernet, do not need ble for commissioning
         self.argsOpt.append(f'chip_config_network_layer_ble={str(enable_wifi or enable_thread).lower()}')

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -168,7 +168,8 @@ class BouffalolabBuilder(GnBuilder):
         if enable_thread:
             self.argsOpt.append(f'openthread_project_core_config_file="{bouffalo_chip}-openthread-core-bl-config.h"')
             if not use_matter_openthread:
-                self.argsOpt.append('openthread_root="//third_party/connectedhomeip/third_party/bouffalolab/repo/components/network/thread/openthread"')
+                self.argsOpt.append(
+                    'openthread_root="//third_party/connectedhomeip/third_party/bouffalolab/repo/components/network/thread/openthread"')
 
         if enable_cdc:
             if bouffalo_chip != "bl702":

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,7 +1,7 @@
 ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 asr-{asr582x,asr595x,asr550x}-{all-clusters,all-clusters-minimal,lighting,light-switch,lock,bridge,temperature-measurement,thermostat,ota-requestor,dishwasher,refrigerator}[-ota][-shell][-no_logging][-factory][-rotating_id][-rio]
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller,kotlin-matter-controller,virtual-device-app}[-no-debug]
-bouffalolab-{bl602-iot-matter-v1,bl602-night-light,xt-zb6-devkit,bl706-night-light,bl706dk,bl704ldk}-light[-shell][-115200][-rpc][-cdc][-resetcnt][-rotating_device_id][-mfd][-mfdtest][-ethernet][-wifi][-thread][-fp][-memmonitor]
+bouffalolab-{bl602-iot-matter-v1,bl602-night-light,xt-zb6-devkit,bl706-night-light,bl706dk,bl704ldk}-light[-shell][-115200][-rpc][-cdc][-resetcnt][-rotating_device_id][-mfd][-mfdtest][-ethernet][-wifi][-thread][-fp][-memmonitor][-mot]
 cc32xx-lock
 ti-cc13x2x7_26x2x7-{lighting,lock,pump,pump-controller}[-mtd]
 ti-cc13x4_26x4-{all-clusters,lighting,lock,pump,pump-controller}[-mtd][-ftd]

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -715,9 +715,8 @@ template("bl_iot_sdk") {
     defines = [ "OT_FREERTOS_ENABLE=1" ]
 
     include_dirs = [
-      "${chip_root}/platform/bl702",
-      "${chip_root}/third_party/openthread/repo/src/core",
-      "${chip_root}/third_party/openthread/repo/examples/platforms",
+      "${openthread_root}/src/core",
+      "${openthread_root}/examples/platforms",
       "${bl_iot_sdk_root}/components/network/thread/openthread_port/include",
       "${bl_iot_sdk_root}/components/network/thread/openthread_utils/include",
     ]

--- a/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
@@ -648,9 +648,8 @@ template("bl_iot_sdk") {
 
   config("${sdk_target_name}_config_openthread_port") {
     include_dirs = [
-      "${chip_root}/platform/bl702l",
-      "${chip_root}/third_party/openthread/repo/src/core",
-      "${chip_root}/third_party/openthread/repo/examples/platforms",
+      "${openthread_root}/src/core",
+      "${openthread_root}/examples/platforms",
       "${bl_iot_sdk_root}/components/network/thread/openthread_port/include",
       "${bl_iot_sdk_root}/components/network/thread/openthread_utils/include",
     ]


### PR DESCRIPTION
- Use Openthread stack in Bouffalo Lab SDK by default
    - Matter project uses almost latest revision from  openthread official
    - Our porting code to openthread stack may not support with latest revision
- Add build option `-mot` to switch openthread stack to `third_party/openthread/repo` 