### PR TITLE
Add RVC operational state enums to the list of enums not used as a type

### DIFF
--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -22,6 +22,8 @@ EnumsNotUsedAsTypeInXML:
     - "RvcRunMode::StatusCode"
     - "RvcCleanMode::ModeTag"
     - "RvcCleanMode::StatusCode"
+    - "RvcOperationalState::OperationalStateEnum"
+    - "RvcOperationalState::ErrorStateEnum"
 
 CommandHandlerInterfaceOnlyClusters:
     # List of clusters that are implemented entirely with

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -18770,21 +18770,21 @@ class RvcOperationalState(Cluster):
             kWaterTankMissing = 0x45
             kWaterTankLidOpen = 0x46
             kMopCleaningPadMissing = 0x47
-            # All received enum values that are not listed above will be mapped
-            # to kUnknownEnumValue. This is a helper enum value that should only
-            # be used by code to process how it handles receiving and unknown
-            # enum value. This specific should never be transmitted.
-            kUnknownEnumValue = 0,
+            # kUnknownEnumValue intentionally not defined. This enum never goes
+            # through DataModel::Decode, likely because it is a part of a derived
+            # cluster. As a result having kUnknownEnumValue in this enum is error
+            # prone, and was removed. See
+            # src/app/common/templates/config-data.yaml.
 
         class OperationalStateEnum(MatterIntEnum):
             kSeekingCharger = 0x40
             kCharging = 0x41
             kDocked = 0x42
-            # All received enum values that are not listed above will be mapped
-            # to kUnknownEnumValue. This is a helper enum value that should only
-            # be used by code to process how it handles receiving and unknown
-            # enum value. This specific should never be transmitted.
-            kUnknownEnumValue = 0,
+            # kUnknownEnumValue intentionally not defined. This enum never goes
+            # through DataModel::Decode, likely because it is a part of a derived
+            # cluster. As a result having kUnknownEnumValue in this enum is error
+            # prone, and was removed. See
+            # src/app/common/templates/config-data.yaml.
 
     class Structs:
         @dataclass

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -1361,38 +1361,6 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalState::Opera
     }
 }
 
-static auto __attribute__((unused)) EnsureKnownEnumValue(RvcOperationalState::ErrorStateEnum val)
-{
-    using EnumType = RvcOperationalState::ErrorStateEnum;
-    switch (val)
-    {
-    case EnumType::kFailedToFindChargingDock:
-    case EnumType::kStuck:
-    case EnumType::kDustBinMissing:
-    case EnumType::kDustBinFull:
-    case EnumType::kWaterTankEmpty:
-    case EnumType::kWaterTankMissing:
-    case EnumType::kWaterTankLidOpen:
-    case EnumType::kMopCleaningPadMissing:
-        return val;
-    default:
-        return static_cast<EnumType>(0);
-    }
-}
-static auto __attribute__((unused)) EnsureKnownEnumValue(RvcOperationalState::OperationalStateEnum val)
-{
-    using EnumType = RvcOperationalState::OperationalStateEnum;
-    switch (val)
-    {
-    case EnumType::kSeekingCharger:
-    case EnumType::kCharging:
-    case EnumType::kDocked:
-        return val;
-    default:
-        return static_cast<EnumType>(0);
-    }
-}
-
 static auto __attribute__((unused)) EnsureKnownEnumValue(HepaFilterMonitoring::ChangeIndicationEnum val)
 {
     using EnumType = HepaFilterMonitoring::ChangeIndicationEnum;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1852,11 +1852,11 @@ enum class ErrorStateEnum : uint8_t
     kWaterTankMissing         = 0x45,
     kWaterTankLidOpen         = 0x46,
     kMopCleaningPadMissing    = 0x47,
-    // All received enum values that are not listed above will be mapped
-    // to kUnknownEnumValue. This is a helper enum value that should only
-    // be used by code to process how it handles receiving and unknown
-    // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    // kUnknownEnumValue intentionally not defined. This enum never goes
+    // through DataModel::Decode, likely because it is a part of a derived
+    // cluster. As a result having kUnknownEnumValue in this enum is error
+    // prone, and was removed. See
+    // src/app/common/templates/config-data.yaml.
 };
 
 // Enum for OperationalStateEnum
@@ -1865,11 +1865,11 @@ enum class OperationalStateEnum : uint8_t
     kSeekingCharger = 0x40,
     kCharging       = 0x41,
     kDocked         = 0x42,
-    // All received enum values that are not listed above will be mapped
-    // to kUnknownEnumValue. This is a helper enum value that should only
-    // be used by code to process how it handles receiving and unknown
-    // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    // kUnknownEnumValue intentionally not defined. This enum never goes
+    // through DataModel::Decode, likely because it is a part of a derived
+    // cluster. As a result having kUnknownEnumValue in this enum is error
+    // prone, and was removed. See
+    // src/app/common/templates/config-data.yaml.
 };
 } // namespace RvcOperationalState
 


### PR DESCRIPTION
Inline with the changes in #29739, this PR adds the Operational State's enums to the list of enums that are not used as types.

- Adds the RVC operational state's `OperationalStateEnum` and `ErrorStateEnum` enums to the `EnumsNotUsedAsTypeInXML` list.
- Regenerates zap files.
