### PR TITLE
[Silabs]restructuring low level output api

### DIFF
--- a/src/platform/silabs/efr32/wifi/ethernetif.cpp
+++ b/src/platform/silabs/efr32/wifi/ethernetif.cpp
@@ -359,7 +359,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
 #endif
     struct pbuf * q;
     uint16_t framelength = 0;
-    uint16_t datalength = 0;
+    uint16_t datalength  = 0;
 #ifdef WIFI_DEBUG_ENABLED
     SILABS_LOG("LWIP : low_level_output");
 #endif
@@ -391,7 +391,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
                                               SL_WIFI_ALLOCATE_COMMAND_BUFFER_WAIT_TIME_MS);
     VERIFY_STATUS_AND_RETURN(status);
     if (packet == NULL)
-#else // RS9116
+#else  // RS9116
     packet = wfx_rsi_alloc_pkt();
     if (!packet)
 #endif // SIWX_917
@@ -434,7 +434,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     packet->command = RSI_SEND_RAW_DATA;
     if (sl_si91x_driver_send_data_packet(SI91X_WLAN_CMD_QUEUE, buffer, 1000))
 #else
-     /* forward the generated packet to RSI to
+    /* forward the generated packet to RSI to
      * send the data over wifi network
      */
     if (wfx_rsi_send_data(packet, datalength))

--- a/src/platform/silabs/efr32/wifi/ethernetif.cpp
+++ b/src/platform/silabs/efr32/wifi/ethernetif.cpp
@@ -358,13 +358,23 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     void * packet;
 #endif
     struct pbuf * q;
-    uint16_t framelength;
+    uint16_t framelength = 0;
+    uint16_t datalength = 0;
 #ifdef WIFI_DEBUG_ENABLED
     SILABS_LOG("LWIP : low_level_output");
 #endif
     if (xSemaphoreTake(ethout_sem, portMAX_DELAY) != pdTRUE)
     {
         return ERR_IF;
+    }
+    /* Calculate total packet size */
+    for (q = p, framelength = 0; q != NULL; q = q->next)
+    {
+        framelength += q->len;
+    }
+    if (framelength < LWIP_FRAME_ALIGNMENT)
+    {
+        framelength = LWIP_FRAME_ALIGNMENT;
     }
 #ifdef WIFI_DEBUG_ENABLED
     SILABS_LOG("EN-RSI: Output");
@@ -377,11 +387,11 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     }
     /* Confirm if packet is allocated */
 #if (SIWX_917 | EXP_BOARD)
-    status = sl_si91x_allocate_command_buffer(&buffer, (void **) &packet, sizeof(sl_si91x_packet_t) + p->len,
+    status = sl_si91x_allocate_command_buffer(&buffer, (void **) &packet, sizeof(sl_si91x_packet_t) + framelength,
                                               SL_WIFI_ALLOCATE_COMMAND_BUFFER_WAIT_TIME_MS);
     VERIFY_STATUS_AND_RETURN(status);
     if (packet == NULL)
-#else  // RS9116
+#else // RS9116
     packet = wfx_rsi_alloc_pkt();
     if (!packet)
 #endif // SIWX_917
@@ -402,29 +412,32 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
                b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13]);
 #endif
     /* Generate the packet */
-    for (q = p, framelength = 0; q != NULL; q = q->next)
+    for (q = p, datalength = 0; q != NULL; q = q->next)
     {
-        wfx_rsi_pkt_add_data(packet, (uint8_t *) (q->payload), (uint16_t) q->len, framelength);
-        framelength += q->len;
+        wfx_rsi_pkt_add_data(packet, (uint8_t *) (q->payload), (uint16_t) q->len, datalength);
+        datalength += q->len;
     }
-    if (framelength < LWIP_FRAME_ALIGNMENT)
+    if (datalength < LWIP_FRAME_ALIGNMENT)
     {
         /* Add junk data to the end for frame alignment if framelength is less than 60 */
-        wfx_rsi_pkt_add_data(packet, (uint8_t *) (p->payload), LWIP_FRAME_ALIGNMENT - framelength, framelength);
+        wfx_rsi_pkt_add_data(packet, (uint8_t *) (p->payload), LWIP_FRAME_ALIGNMENT - datalength, datalength);
     }
 #ifdef WIFI_DEBUG_ENABLED
     SILABS_LOG("EN-RSI: Sending %d", framelength);
 #endif
 
-#if (SIWX_917 | EXP_BOARD)
-    packet->length  = p->len & 0xFFF;
-    packet->command = RSI_SEND_RAW_DATA;
-    if (sl_si91x_driver_send_data_packet(SI91X_WLAN_CMD_QUEUE, buffer, 1000))
-#else
     /* forward the generated packet to RSI to
      * send the data over wifi network
      */
-    if (wfx_rsi_send_data(packet, framelength))
+#if (SIWX_917 | EXP_BOARD)
+    packet->length  = framelength & 0xFFF;
+    packet->command = RSI_SEND_RAW_DATA;
+    if (sl_si91x_driver_send_data_packet(SI91X_WLAN_CMD_QUEUE, buffer, 1000))
+#else
+     /* forward the generated packet to RSI to
+     * send the data over wifi network
+     */
+    if (wfx_rsi_send_data(packet, datalength))
 #endif
     {
         SILABS_LOG("*ERR*EN-RSI:Send fail");


### PR DESCRIPTION
Added:
- Restructuring low level output function
-  added to  calculate total packet size in low level output funtion

Tested:

- 917 NCP and MG24+RS9116 sanity done locally