### PR TITLE
Used a more correct error code in the RVC example app

### DIFF
--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -39,7 +39,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         // We could be in the charging state with an RvcRun mode != idle.
         if (currentMode != RvcRunMode::ModeIdle && newMode != RvcRunMode::ModeIdle)
         {
-            response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
+            response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
                 chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
             return;
@@ -56,7 +56,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
     case to_underlying(OperationalState::OperationalStateEnum::kRunning): {
         if (newMode != RvcRunMode::ModeIdle)
         {
-            response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
+            response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
                 chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
             return;
@@ -71,8 +71,8 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
     }
 
     // If we fall through at any point, it's because the change is not supported in the current state.
-    response.status = to_underlying(ModeBase::StatusCode::kGenericFailure);
-    response.statusText.SetValue(chip::CharSpan::fromCharString("This change is not allowed at this time. "));
+    response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
+    response.statusText.SetValue(chip::CharSpan::fromCharString("This change is not allowed at this time."));
 }
 
 void RvcDevice::HandleRvcCleanChangeToMode(uint8_t newMode, ModeBase::Commands::ChangeToModeResponse::Type & response)

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -41,7 +41,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
-                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
+                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle."));
             return;
         }
 
@@ -58,7 +58,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
-                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
+                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle."));
             return;
         }
 


### PR DESCRIPTION
Replaced the use of the status code `kGenericFaliure` with the more correct `kInvalidInMode` in the RVC example app.
