### PR TITLE
Ensure that MTRDevice invokes provide a timed invoke timeout when needed.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommandTimedCheck.h
+++ b/src/darwin/Framework/CHIP/MTRCommandTimedCheck.h
@@ -1,0 +1,26 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+BOOL MTRCommandNeedsTimedInvoke(NSNumber * aClusterID, NSNumber * aCommandID);
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -57,3 +57,6 @@
     _Pragma("clang diagnostic pop")
 typedef struct {} variable_hidden_by_mtr_hide;
 // clang-format on
+
+// Default timed interaction timeout, in ms, if another one is not provided.
+#define MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS 10000

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -126,32 +126,56 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 /**
  * Invoke a command with a designated command path
  *
- * @param commandFields   command fields object. The object must be a data-value NSDictionary object
- *                      as described in the MTRDeviceResponseHandler.
- *                      The attribute must be a Structure, i.e.,
- *                      the NSDictionary MTRTypeKey key must have the value MTRStructureValueType.
+ * @param commandFields command fields object. If not nil, the object must be a data-value
+ *                      NSDictionary object as described in the MTRDeviceResponseHandler
+ *                      documentation. The value must be a Structure, i.e., the NSDictionary
+ *                      MTRTypeKey key must have the value MTRStructureValueType.
  *
- * @param expectedValues  array of dictionaries containing the expected values in the same format as
- *                       attribute read completion handler. Requires MTRAttributePathKey values.
- *                       See MTRDeviceResponseHandler definition for dictionary details.
+ *                      If commandFields is nil, it will be treated as a Structure with no fields.
+ *
+ * @param expectedValues The expected values of attributes that will be affected by the command, if
+ *                       any.  If these are provided, the relevant attributes will have the provided
+ *                       values when read until one of the following happens:
+ *
+ *                       1. Something (another invoke or a write) sets different expected values.
+ *                       2. expectedValueInterval elapses without the device reporting the
+ *                          attributes changing their values to the expected values.
+ *                       3. The command invoke fails.
+ *                       4. The device reports some other values for these attributes.
+ *
+ *                       The dictionaries in this array are expected to be response-value
+ *                       dictionaries as documented in the documentation of
+ *                       MTRDeviceResponseHandler, and each one must have an MTRAttributePathKey.
+ *
  *                       The expectedValues and expectedValueInterval arguments need to be both
  *                       nil or both non-nil, or both will be both ignored.
  *
- * TODO: document better the expectedValues is how this command is expected to change attributes when read, and that the next
- * readAttribute will get these values
- *
- * @param expectedValueInterval  maximum interval in milliseconds during which reads of the attribute will return the value being
- * written. If the value is less than 1, both this value and expectedValues will be ignored.
-            If this value is greater than UINT32_MAX, it will be clamped to UINT32_MAX.
- *
- * @param timeout   timeout in milliseconds for timed invoke, or nil. This value must be within [1, UINT16_MAX], and will be clamped
- * to this range.
+ * @param expectedValueInterval  maximum interval in milliseconds during which reads of the
+ *                               attributes that had expected values provided will return the
+ *                               expected values. If the value is less than 1, both this value and
+ *                               expectedValues will be ignored. If this value is greater than
+ *                               UINT32_MAX, it will be clamped to UINT32_MAX.
  *
  * @param completion  response handler will receive either values or error.  A
  *                    path-specific error status from the command invocation
  *                    will result in an error being passed to the completion, so
  *                    values will only be passed in when the command succeeds.
+ *
+ *                    If values are passed, the array length will always be 1 and the single
+ *                    response-value in it will have an MTRCommandPathKey.  If the command
+ *                    response is just a success status, there will be no MTRDataKey.  If the
+ *                    command response has data fields, there will be an MTRDataKey, whose value
+ *                    will be of type MTRStructureValueType and describe the response payload.
  */
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
+                      commandFields:(NSDictionary<NSString *, id> * _Nullable)commandFields
+                     expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues
+              expectedValueInterval:(NSNumber * _Nullable)expectedValueInterval
+                              queue:(dispatch_queue_t)queue
+                         completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
+
 - (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
                           clusterID:(NSNumber *)clusterID
                           commandID:(NSNumber *)commandID

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -12,6 +12,7 @@
 #import "MTRStructsObjc.h"
 #import "NSStringSpanConversion.h"
 #import "NSDataSpanConversion.h"
+#import "MTRDefines_Internal.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/im-client-callbacks.h>
@@ -97,7 +98,7 @@ MTR{{cluster}}Cluster{{command}}Params
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     {{#if mustUseTimedInvoke}}
     if (timedInvokeTimeoutMs == nil) {
-      timedInvokeTimeoutMs = @(10000);
+      timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
     {{/if}}
 
@@ -175,9 +176,9 @@ MTR{{cluster}}Cluster{{command}}Params
             timedWriteTimeout.SetValue(params.timedWriteTimeout.unsignedShortValue);
           }
         }
-        {{#if mustUseTimedInvoke}}
+        {{#if mustUseTimedWrite}}
         if (!timedWriteTimeout.HasValue()) {
-          timedWriteTimeout.SetValue(10000);
+          timedWriteTimeout.SetValue(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
         }
         {{/if}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -10,6 +10,7 @@
 #import "MTRStructsObjc.h"
 #import "MTRCommandPayloadsObjc.h"
 #import "MTRLogging_Internal.h"
+#import "MTRDefines_Internal.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -79,7 +80,7 @@ MTR{{cluster}}Cluster{{command}}Params
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     {{#if mustUseTimedInvoke}}
     if (timedInvokeTimeoutMs == nil) {
-      timedInvokeTimeoutMs = @(10000);
+      timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
     {{/if}}
 
@@ -133,7 +134,7 @@ MTR{{cluster}}Cluster{{command}}Params
     NSNumber *timedWriteTimeout = params.timedWriteTimeout;
     {{#if mustUseTimedWrite}}
     if (!timedWriteTimeout) {
-        timedWriteTimeout = @(10000);
+        timedWriteTimeout = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
     {{/if}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandTimedCheck-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandTimedCheck-src.zapt
@@ -1,0 +1,51 @@
+{{> header excludeZapComment=true}}
+
+#import "MTRCommandTimedCheck.h"
+
+#include <app-common/zap-generated/ids/Commands.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+
+using namespace chip;
+using namespace chip::app;
+
+{{#zcl_clusters}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+static BOOL CommandNeedsTimedInvokeIn{{asUpperCamelCase name preserveAcronyms=true}}Cluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::{{asUpperCamelCase name}};
+    switch (aAttributeId) {
+        {{#zcl_commands}}
+        {{#if (and (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
+                   mustUseTimedInvoke)}}
+        case Commands::{{asUpperCamelCase name}}::Id: {
+            return YES;
+        }
+        {{/if}}
+        {{/zcl_commands}}
+        default: {
+            return NO;
+        }
+    }
+}
+{{/if}}
+{{/zcl_clusters}}
+
+BOOL MTRCommandNeedsTimedInvoke(NSNumber * _Nonnull aClusterID, NSNumber * _Nonnull aCommandID)
+{
+    ClusterId clusterID = static_cast<ClusterId>(aClusterID.unsignedLongLongValue);
+    CommandId commandID = static_cast<CommandId>(aCommandID.unsignedLongLongValue);
+
+    switch (clusterID)
+    {
+        {{#zcl_clusters}}
+        {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+        case Clusters::{{asUpperCamelCase name}}::Id: {
+            return CommandNeedsTimedInvokeIn{{asUpperCamelCase name preserveAcronyms=true}}Cluster(commandID);
+        }
+        {{/if}}
+        {{/zcl_clusters}}
+        default: {
+            return NO;
+        }
+    }
+}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -123,6 +123,11 @@
             "path": "MTRAttributeSpecifiedCheck-src.zapt",
             "name": "Function to check if attribute is specified",
             "output": "src/darwin/Framework/CHIP/zap-generated/MTRAttributeSpecifiedCheck.mm"
+        },
+        {
+            "path": "MTRCommandTimedCheck-src.zapt",
+            "name": "Function to check if command needs timed invoke",
+            "output": "src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm"
         }
     ]
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -22,6 +22,7 @@
 #import "MTRCluster_Internal.h"
 #import "MTRClusters_Internal.h"
 #import "MTRCommandPayloadsObjc.h"
+#import "MTRDefines_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "MTRStructsObjc.h"
@@ -5856,7 +5857,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AdministratorCommissioning::Commands::OpenCommissioningWindow::Type;
@@ -5886,7 +5887,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type;
@@ -5920,7 +5921,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AdministratorCommissioning::Commands::RevokeCommissioning::Type;
@@ -8903,7 +8904,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::LockDoor::Type;
@@ -8933,7 +8934,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::UnlockDoor::Type;
@@ -8963,7 +8964,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::UnlockWithTimeout::Type;
@@ -9236,7 +9237,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::SetUser::Type;
@@ -9293,7 +9294,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::ClearUser::Type;
@@ -9323,7 +9324,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::SetCredential::Type;
@@ -9380,7 +9381,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::ClearCredential::Type;
@@ -9410,7 +9411,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = DoorLock::Commands::UnboltDoor::Type;
@@ -16713,7 +16714,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AccountLogin::Commands::GetSetupPIN::Type;
@@ -16743,7 +16744,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AccountLogin::Commands::Login::Type;
@@ -16777,7 +16778,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = AccountLogin::Commands::Logout::Type;
@@ -18245,7 +18246,7 @@ using chip::System::Clock::Timeout;
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
     if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(10000);
+        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     using RequestType = UnitTesting::Commands::TimedInvokeRequest::Type;
@@ -19060,7 +19061,7 @@ using chip::System::Clock::Timeout;
 {
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
     if (!timedWriteTimeout) {
-        timedWriteTimeout = @(10000);
+        timedWriteTimeout = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
     }
 
     [self.device writeAttributeWithEndpointID:@(self.endpoint) clusterID:@(MTRClusterIDTypeUnitTestingID) attributeID:@(MTRAttributeIDTypeClusterUnitTestingAttributeTimedWriteBooleanID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm
@@ -1,0 +1,1210 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRCommandTimedCheck.h"
+
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app-common/zap-generated/ids/Commands.h>
+
+using namespace chip;
+using namespace chip::app;
+
+static BOOL CommandNeedsTimedInvokeInIdentifyCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Identify;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInGroupsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Groups;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInScenesCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Scenes;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOnOffCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OnOff;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOnOffSwitchConfigurationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OnOffSwitchConfiguration;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInLevelControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::LevelControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBinaryInputBasicCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BinaryInputBasic;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPulseWidthModulationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::PulseWidthModulation;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInDescriptorCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Descriptor;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBindingCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Binding;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInAccessControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::AccessControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInActionsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Actions;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBasicInformationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BasicInformation;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOTASoftwareUpdateProviderCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OtaSoftwareUpdateProvider;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOTASoftwareUpdateRequestorCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OtaSoftwareUpdateRequestor;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInLocalizationConfigurationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::LocalizationConfiguration;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTimeFormatLocalizationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TimeFormatLocalization;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInUnitLocalizationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::UnitLocalization;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPowerSourceConfigurationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::PowerSourceConfiguration;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPowerSourceCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::PowerSource;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInGeneralCommissioningCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::GeneralCommissioning;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInNetworkCommissioningCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::NetworkCommissioning;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInDiagnosticLogsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::DiagnosticLogs;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInGeneralDiagnosticsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::GeneralDiagnostics;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInSoftwareDiagnosticsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::SoftwareDiagnostics;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInThreadNetworkDiagnosticsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ThreadNetworkDiagnostics;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInWiFiNetworkDiagnosticsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::WiFiNetworkDiagnostics;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInEthernetNetworkDiagnosticsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::EthernetNetworkDiagnostics;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTimeSynchronizationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TimeSynchronization;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBridgedDeviceBasicInformationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BridgedDeviceBasicInformation;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInSwitchCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Switch;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInAdministratorCommissioningCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::AdministratorCommissioning;
+    switch (aAttributeId) {
+    case Commands::OpenCommissioningWindow::Id: {
+        return YES;
+    }
+    case Commands::OpenBasicCommissioningWindow::Id: {
+        return YES;
+    }
+    case Commands::RevokeCommissioning::Id: {
+        return YES;
+    }
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOperationalCredentialsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OperationalCredentials;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInGroupKeyManagementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::GroupKeyManagement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInFixedLabelCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::FixedLabel;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInUserLabelCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::UserLabel;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBooleanStateCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BooleanState;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInICDManagementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::IcdManagement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInModeSelectCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ModeSelect;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInLaundryWasherModeCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::LaundryWasherMode;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRefrigeratorAndTemperatureControlledCabinetModeCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RefrigeratorAndTemperatureControlledCabinetMode;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInLaundryWasherControlsCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::LaundryWasherControls;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRVCRunModeCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RvcRunMode;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRVCCleanModeCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RvcCleanMode;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTemperatureControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TemperatureControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRefrigeratorAlarmCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RefrigeratorAlarm;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInDishwasherModeCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::DishwasherMode;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInAirQualityCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::AirQuality;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInSmokeCOAlarmCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::SmokeCoAlarm;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInDishwasherAlarmCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::DishwasherAlarm;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOperationalStateCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OperationalState;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRVCOperationalStateCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RvcOperationalState;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInHEPAFilterMonitoringCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::HepaFilterMonitoring;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInActivatedCarbonFilterMonitoringCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ActivatedCarbonFilterMonitoring;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInDoorLockCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::DoorLock;
+    switch (aAttributeId) {
+    case Commands::LockDoor::Id: {
+        return YES;
+    }
+    case Commands::UnlockDoor::Id: {
+        return YES;
+    }
+    case Commands::UnlockWithTimeout::Id: {
+        return YES;
+    }
+    case Commands::SetUser::Id: {
+        return YES;
+    }
+    case Commands::ClearUser::Id: {
+        return YES;
+    }
+    case Commands::SetCredential::Id: {
+        return YES;
+    }
+    case Commands::ClearCredential::Id: {
+        return YES;
+    }
+    case Commands::UnboltDoor::Id: {
+        return YES;
+    }
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInWindowCoveringCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::WindowCovering;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBarrierControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BarrierControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPumpConfigurationAndControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::PumpConfigurationAndControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInThermostatCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Thermostat;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInFanControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::FanControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInThermostatUserInterfaceConfigurationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ThermostatUserInterfaceConfiguration;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInColorControlCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ColorControl;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInBallastConfigurationCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::BallastConfiguration;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInIlluminanceMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::IlluminanceMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTemperatureMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TemperatureMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPressureMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::PressureMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInFlowMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::FlowMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRelativeHumidityMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RelativeHumidityMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOccupancySensingCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OccupancySensing;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInCarbonMonoxideConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::CarbonMonoxideConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInCarbonDioxideConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::CarbonDioxideConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInNitrogenDioxideConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::NitrogenDioxideConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInOzoneConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::OzoneConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPM25ConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Pm25ConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInFormaldehydeConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::FormaldehydeConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPM1ConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Pm1ConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInPM10ConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Pm10ConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTotalVolatileOrganicCompoundsConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TotalVolatileOrganicCompoundsConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInRadonConcentrationMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::RadonConcentrationMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInWakeOnLANCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::WakeOnLan;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInChannelCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::Channel;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInTargetNavigatorCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::TargetNavigator;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInMediaPlaybackCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::MediaPlayback;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInMediaInputCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::MediaInput;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInLowPowerCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::LowPower;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInKeypadInputCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::KeypadInput;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInContentLauncherCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ContentLauncher;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInAudioOutputCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::AudioOutput;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInApplicationLauncherCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ApplicationLauncher;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInApplicationBasicCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ApplicationBasic;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInAccountLoginCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::AccountLogin;
+    switch (aAttributeId) {
+    case Commands::GetSetupPIN::Id: {
+        return YES;
+    }
+    case Commands::Login::Id: {
+        return YES;
+    }
+    case Commands::Logout::Id: {
+        return YES;
+    }
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInElectricalMeasurementCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::ElectricalMeasurement;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInUnitTestingCluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::UnitTesting;
+    switch (aAttributeId) {
+    case Commands::TimedInvokeRequest::Id: {
+        return YES;
+    }
+    default: {
+        return NO;
+    }
+    }
+}
+static BOOL CommandNeedsTimedInvokeInSampleMEICluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::SampleMei;
+    switch (aAttributeId) {
+    default: {
+        return NO;
+    }
+    }
+}
+
+BOOL MTRCommandNeedsTimedInvoke(NSNumber * _Nonnull aClusterID, NSNumber * _Nonnull aCommandID)
+{
+    ClusterId clusterID = static_cast<ClusterId>(aClusterID.unsignedLongLongValue);
+    CommandId commandID = static_cast<CommandId>(aCommandID.unsignedLongLongValue);
+
+    switch (clusterID) {
+    case Clusters::Identify::Id: {
+        return CommandNeedsTimedInvokeInIdentifyCluster(commandID);
+    }
+    case Clusters::Groups::Id: {
+        return CommandNeedsTimedInvokeInGroupsCluster(commandID);
+    }
+    case Clusters::Scenes::Id: {
+        return CommandNeedsTimedInvokeInScenesCluster(commandID);
+    }
+    case Clusters::OnOff::Id: {
+        return CommandNeedsTimedInvokeInOnOffCluster(commandID);
+    }
+    case Clusters::OnOffSwitchConfiguration::Id: {
+        return CommandNeedsTimedInvokeInOnOffSwitchConfigurationCluster(commandID);
+    }
+    case Clusters::LevelControl::Id: {
+        return CommandNeedsTimedInvokeInLevelControlCluster(commandID);
+    }
+    case Clusters::BinaryInputBasic::Id: {
+        return CommandNeedsTimedInvokeInBinaryInputBasicCluster(commandID);
+    }
+    case Clusters::PulseWidthModulation::Id: {
+        return CommandNeedsTimedInvokeInPulseWidthModulationCluster(commandID);
+    }
+    case Clusters::Descriptor::Id: {
+        return CommandNeedsTimedInvokeInDescriptorCluster(commandID);
+    }
+    case Clusters::Binding::Id: {
+        return CommandNeedsTimedInvokeInBindingCluster(commandID);
+    }
+    case Clusters::AccessControl::Id: {
+        return CommandNeedsTimedInvokeInAccessControlCluster(commandID);
+    }
+    case Clusters::Actions::Id: {
+        return CommandNeedsTimedInvokeInActionsCluster(commandID);
+    }
+    case Clusters::BasicInformation::Id: {
+        return CommandNeedsTimedInvokeInBasicInformationCluster(commandID);
+    }
+    case Clusters::OtaSoftwareUpdateProvider::Id: {
+        return CommandNeedsTimedInvokeInOTASoftwareUpdateProviderCluster(commandID);
+    }
+    case Clusters::OtaSoftwareUpdateRequestor::Id: {
+        return CommandNeedsTimedInvokeInOTASoftwareUpdateRequestorCluster(commandID);
+    }
+    case Clusters::LocalizationConfiguration::Id: {
+        return CommandNeedsTimedInvokeInLocalizationConfigurationCluster(commandID);
+    }
+    case Clusters::TimeFormatLocalization::Id: {
+        return CommandNeedsTimedInvokeInTimeFormatLocalizationCluster(commandID);
+    }
+    case Clusters::UnitLocalization::Id: {
+        return CommandNeedsTimedInvokeInUnitLocalizationCluster(commandID);
+    }
+    case Clusters::PowerSourceConfiguration::Id: {
+        return CommandNeedsTimedInvokeInPowerSourceConfigurationCluster(commandID);
+    }
+    case Clusters::PowerSource::Id: {
+        return CommandNeedsTimedInvokeInPowerSourceCluster(commandID);
+    }
+    case Clusters::GeneralCommissioning::Id: {
+        return CommandNeedsTimedInvokeInGeneralCommissioningCluster(commandID);
+    }
+    case Clusters::NetworkCommissioning::Id: {
+        return CommandNeedsTimedInvokeInNetworkCommissioningCluster(commandID);
+    }
+    case Clusters::DiagnosticLogs::Id: {
+        return CommandNeedsTimedInvokeInDiagnosticLogsCluster(commandID);
+    }
+    case Clusters::GeneralDiagnostics::Id: {
+        return CommandNeedsTimedInvokeInGeneralDiagnosticsCluster(commandID);
+    }
+    case Clusters::SoftwareDiagnostics::Id: {
+        return CommandNeedsTimedInvokeInSoftwareDiagnosticsCluster(commandID);
+    }
+    case Clusters::ThreadNetworkDiagnostics::Id: {
+        return CommandNeedsTimedInvokeInThreadNetworkDiagnosticsCluster(commandID);
+    }
+    case Clusters::WiFiNetworkDiagnostics::Id: {
+        return CommandNeedsTimedInvokeInWiFiNetworkDiagnosticsCluster(commandID);
+    }
+    case Clusters::EthernetNetworkDiagnostics::Id: {
+        return CommandNeedsTimedInvokeInEthernetNetworkDiagnosticsCluster(commandID);
+    }
+    case Clusters::TimeSynchronization::Id: {
+        return CommandNeedsTimedInvokeInTimeSynchronizationCluster(commandID);
+    }
+    case Clusters::BridgedDeviceBasicInformation::Id: {
+        return CommandNeedsTimedInvokeInBridgedDeviceBasicInformationCluster(commandID);
+    }
+    case Clusters::Switch::Id: {
+        return CommandNeedsTimedInvokeInSwitchCluster(commandID);
+    }
+    case Clusters::AdministratorCommissioning::Id: {
+        return CommandNeedsTimedInvokeInAdministratorCommissioningCluster(commandID);
+    }
+    case Clusters::OperationalCredentials::Id: {
+        return CommandNeedsTimedInvokeInOperationalCredentialsCluster(commandID);
+    }
+    case Clusters::GroupKeyManagement::Id: {
+        return CommandNeedsTimedInvokeInGroupKeyManagementCluster(commandID);
+    }
+    case Clusters::FixedLabel::Id: {
+        return CommandNeedsTimedInvokeInFixedLabelCluster(commandID);
+    }
+    case Clusters::UserLabel::Id: {
+        return CommandNeedsTimedInvokeInUserLabelCluster(commandID);
+    }
+    case Clusters::BooleanState::Id: {
+        return CommandNeedsTimedInvokeInBooleanStateCluster(commandID);
+    }
+    case Clusters::IcdManagement::Id: {
+        return CommandNeedsTimedInvokeInICDManagementCluster(commandID);
+    }
+    case Clusters::ModeSelect::Id: {
+        return CommandNeedsTimedInvokeInModeSelectCluster(commandID);
+    }
+    case Clusters::LaundryWasherMode::Id: {
+        return CommandNeedsTimedInvokeInLaundryWasherModeCluster(commandID);
+    }
+    case Clusters::RefrigeratorAndTemperatureControlledCabinetMode::Id: {
+        return CommandNeedsTimedInvokeInRefrigeratorAndTemperatureControlledCabinetModeCluster(commandID);
+    }
+    case Clusters::LaundryWasherControls::Id: {
+        return CommandNeedsTimedInvokeInLaundryWasherControlsCluster(commandID);
+    }
+    case Clusters::RvcRunMode::Id: {
+        return CommandNeedsTimedInvokeInRVCRunModeCluster(commandID);
+    }
+    case Clusters::RvcCleanMode::Id: {
+        return CommandNeedsTimedInvokeInRVCCleanModeCluster(commandID);
+    }
+    case Clusters::TemperatureControl::Id: {
+        return CommandNeedsTimedInvokeInTemperatureControlCluster(commandID);
+    }
+    case Clusters::RefrigeratorAlarm::Id: {
+        return CommandNeedsTimedInvokeInRefrigeratorAlarmCluster(commandID);
+    }
+    case Clusters::DishwasherMode::Id: {
+        return CommandNeedsTimedInvokeInDishwasherModeCluster(commandID);
+    }
+    case Clusters::AirQuality::Id: {
+        return CommandNeedsTimedInvokeInAirQualityCluster(commandID);
+    }
+    case Clusters::SmokeCoAlarm::Id: {
+        return CommandNeedsTimedInvokeInSmokeCOAlarmCluster(commandID);
+    }
+    case Clusters::DishwasherAlarm::Id: {
+        return CommandNeedsTimedInvokeInDishwasherAlarmCluster(commandID);
+    }
+    case Clusters::OperationalState::Id: {
+        return CommandNeedsTimedInvokeInOperationalStateCluster(commandID);
+    }
+    case Clusters::RvcOperationalState::Id: {
+        return CommandNeedsTimedInvokeInRVCOperationalStateCluster(commandID);
+    }
+    case Clusters::HepaFilterMonitoring::Id: {
+        return CommandNeedsTimedInvokeInHEPAFilterMonitoringCluster(commandID);
+    }
+    case Clusters::ActivatedCarbonFilterMonitoring::Id: {
+        return CommandNeedsTimedInvokeInActivatedCarbonFilterMonitoringCluster(commandID);
+    }
+    case Clusters::DoorLock::Id: {
+        return CommandNeedsTimedInvokeInDoorLockCluster(commandID);
+    }
+    case Clusters::WindowCovering::Id: {
+        return CommandNeedsTimedInvokeInWindowCoveringCluster(commandID);
+    }
+    case Clusters::BarrierControl::Id: {
+        return CommandNeedsTimedInvokeInBarrierControlCluster(commandID);
+    }
+    case Clusters::PumpConfigurationAndControl::Id: {
+        return CommandNeedsTimedInvokeInPumpConfigurationAndControlCluster(commandID);
+    }
+    case Clusters::Thermostat::Id: {
+        return CommandNeedsTimedInvokeInThermostatCluster(commandID);
+    }
+    case Clusters::FanControl::Id: {
+        return CommandNeedsTimedInvokeInFanControlCluster(commandID);
+    }
+    case Clusters::ThermostatUserInterfaceConfiguration::Id: {
+        return CommandNeedsTimedInvokeInThermostatUserInterfaceConfigurationCluster(commandID);
+    }
+    case Clusters::ColorControl::Id: {
+        return CommandNeedsTimedInvokeInColorControlCluster(commandID);
+    }
+    case Clusters::BallastConfiguration::Id: {
+        return CommandNeedsTimedInvokeInBallastConfigurationCluster(commandID);
+    }
+    case Clusters::IlluminanceMeasurement::Id: {
+        return CommandNeedsTimedInvokeInIlluminanceMeasurementCluster(commandID);
+    }
+    case Clusters::TemperatureMeasurement::Id: {
+        return CommandNeedsTimedInvokeInTemperatureMeasurementCluster(commandID);
+    }
+    case Clusters::PressureMeasurement::Id: {
+        return CommandNeedsTimedInvokeInPressureMeasurementCluster(commandID);
+    }
+    case Clusters::FlowMeasurement::Id: {
+        return CommandNeedsTimedInvokeInFlowMeasurementCluster(commandID);
+    }
+    case Clusters::RelativeHumidityMeasurement::Id: {
+        return CommandNeedsTimedInvokeInRelativeHumidityMeasurementCluster(commandID);
+    }
+    case Clusters::OccupancySensing::Id: {
+        return CommandNeedsTimedInvokeInOccupancySensingCluster(commandID);
+    }
+    case Clusters::CarbonMonoxideConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInCarbonMonoxideConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::CarbonDioxideConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInCarbonDioxideConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::NitrogenDioxideConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInNitrogenDioxideConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::OzoneConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInOzoneConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::Pm25ConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInPM25ConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::FormaldehydeConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInFormaldehydeConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::Pm1ConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInPM1ConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::Pm10ConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInPM10ConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::TotalVolatileOrganicCompoundsConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInTotalVolatileOrganicCompoundsConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::RadonConcentrationMeasurement::Id: {
+        return CommandNeedsTimedInvokeInRadonConcentrationMeasurementCluster(commandID);
+    }
+    case Clusters::WakeOnLan::Id: {
+        return CommandNeedsTimedInvokeInWakeOnLANCluster(commandID);
+    }
+    case Clusters::Channel::Id: {
+        return CommandNeedsTimedInvokeInChannelCluster(commandID);
+    }
+    case Clusters::TargetNavigator::Id: {
+        return CommandNeedsTimedInvokeInTargetNavigatorCluster(commandID);
+    }
+    case Clusters::MediaPlayback::Id: {
+        return CommandNeedsTimedInvokeInMediaPlaybackCluster(commandID);
+    }
+    case Clusters::MediaInput::Id: {
+        return CommandNeedsTimedInvokeInMediaInputCluster(commandID);
+    }
+    case Clusters::LowPower::Id: {
+        return CommandNeedsTimedInvokeInLowPowerCluster(commandID);
+    }
+    case Clusters::KeypadInput::Id: {
+        return CommandNeedsTimedInvokeInKeypadInputCluster(commandID);
+    }
+    case Clusters::ContentLauncher::Id: {
+        return CommandNeedsTimedInvokeInContentLauncherCluster(commandID);
+    }
+    case Clusters::AudioOutput::Id: {
+        return CommandNeedsTimedInvokeInAudioOutputCluster(commandID);
+    }
+    case Clusters::ApplicationLauncher::Id: {
+        return CommandNeedsTimedInvokeInApplicationLauncherCluster(commandID);
+    }
+    case Clusters::ApplicationBasic::Id: {
+        return CommandNeedsTimedInvokeInApplicationBasicCluster(commandID);
+    }
+    case Clusters::AccountLogin::Id: {
+        return CommandNeedsTimedInvokeInAccountLoginCluster(commandID);
+    }
+    case Clusters::ElectricalMeasurement::Id: {
+        return CommandNeedsTimedInvokeInElectricalMeasurementCluster(commandID);
+    }
+    case Clusters::UnitTesting::Id: {
+        return CommandNeedsTimedInvokeInUnitTestingCluster(commandID);
+    }
+    case Clusters::SampleMei::Id: {
+        return CommandNeedsTimedInvokeInSampleMEICluster(commandID);
+    }
+    default: {
+        return NO;
+    }
+    }
+}

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -1750,13 +1750,18 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                      }];
 
     XCTestExpectation * offExpectation = [self expectationWithDescription:@"Off command executed"];
-    [onOffCluster offWithParams:nil
-                 expectedValues:nil
-          expectedValueInterval:nil
-                     completion:^(NSError * _Nullable error) {
-                         XCTAssertNil(error);
-                         [offExpectation fulfill];
-                     }];
+    // Send this one via MTRDevice, to test that codepath.
+    [device invokeCommandWithEndpointID:@(1)
+                              clusterID:@(MTRClusterIDTypeOnOffID)
+                              commandID:@(MTRCommandIDTypeClusterOnOffCommandOffID)
+                          commandFields:nil
+                         expectedValues:nil
+                  expectedValueInterval:nil
+                                  queue:queue
+                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                 XCTAssertNil(error);
+                                 [offExpectation fulfill];
+                             }];
 
     XCTestExpectation * onFailedExpectation = [self expectationWithDescription:@"On command failed"];
     [badOnOffCluster onWithParams:nil
@@ -2240,12 +2245,15 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                  {
                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                      NSArray * resultArray = values;
+                                     XCTAssertEqual(resultArray.count, 1);
                                      for (NSDictionary * result in resultArray) {
                                          MTRCommandPath * path = result[@"commandPath"];
                                          XCTAssertEqualObjects(path.endpoint, @1);
                                          XCTAssertEqualObjects(path.cluster, @6);
                                          XCTAssertEqualObjects(path.command, @1);
                                          XCTAssertNil(result[@"error"]);
+                                         // This command just has a status response.
+                                         XCTAssertNil(result[@"value"]);
                                      }
                                      XCTAssertEqual([resultArray count], 1);
                                  }

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -164,6 +164,9 @@
 		5173A47929C0E82300F67F48 /* MTRFabricInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5173A47829C0E82300F67F48 /* MTRFabricInfoTests.m */; };
 		51742B4A29CB5FC1009974FE /* MTRTestResetCommissioneeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */; };
 		51742B4E29CB6B88009974FE /* MTRPairingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51742B4D29CB6B88009974FE /* MTRPairingTests.m */; };
+		5178E67E2AE098210069DF72 /* MTRCommandTimedCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5178E67D2AE098210069DF72 /* MTRCommandTimedCheck.mm */; };
+		5178E6812AE098520069DF72 /* MTRCommandTimedCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 5178E67F2AE098510069DF72 /* MTRCommandTimedCheck.h */; };
+		5178E6822AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5178E6802AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h */; };
 		517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 517BF3EE282B62B800A8B7DB /* MTRCertificates.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		517BF3F1282B62B800A8B7DB /* MTRCertificates.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */; };
 		517BF3F3282B62CB00A8B7DB /* MTRCertificateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */; };
@@ -519,6 +522,12 @@
 		51742B4829CB5F45009974FE /* MTRTestResetCommissioneeHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTestResetCommissioneeHelper.h; sourceTree = "<group>"; };
 		51742B4929CB5FC0009974FE /* MTRTestResetCommissioneeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestResetCommissioneeHelper.m; sourceTree = "<group>"; };
 		51742B4D29CB6B88009974FE /* MTRPairingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRPairingTests.m; sourceTree = "<group>"; };
+		5178E6592AE097A20069DF72 /* MTRCommandPayloads_Internal.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = MTRCommandPayloads_Internal.zapt; sourceTree = "<group>"; };
+		5178E65A2AE097A20069DF72 /* MTRCommandTimedCheck-src.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MTRCommandTimedCheck-src.zapt"; sourceTree = "<group>"; };
+		5178E65B2AE097B30069DF72 /* availability.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = availability.yaml; sourceTree = "<group>"; };
+		5178E67D2AE098210069DF72 /* MTRCommandTimedCheck.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommandTimedCheck.mm; sourceTree = "<group>"; };
+		5178E67F2AE098510069DF72 /* MTRCommandTimedCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommandTimedCheck.h; sourceTree = "<group>"; };
+		5178E6802AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommissionableBrowserResult_Internal.h; sourceTree = "<group>"; };
 		517BF3EE282B62B800A8B7DB /* MTRCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCertificates.h; sourceTree = "<group>"; };
 		517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCertificates.mm; sourceTree = "<group>"; };
 		517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRCertificateTests.m; sourceTree = "<group>"; };
@@ -981,6 +990,7 @@
 				7560FD1B27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm */,
 				51B22C1D2740CB0A008D5055 /* MTRStructsObjc.h */,
 				51B22C252740CB32008D5055 /* MTRStructsObjc.mm */,
+				5178E67D2AE098210069DF72 /* MTRCommandTimedCheck.mm */,
 			);
 			path = "zap-generated";
 			sourceTree = "<group>";
@@ -1019,6 +1029,9 @@
 				3D84371D294984AF0070D20A /* MTREventTLVValueDecoder-src.zapt */,
 				3D84371F294984AF0070D20A /* MTRStructsObjc.zapt */,
 				3D843722294984AF0070D20A /* MTRStructsObjc-src.zapt */,
+				5178E6592AE097A20069DF72 /* MTRCommandPayloads_Internal.zapt */,
+				5178E65A2AE097A20069DF72 /* MTRCommandTimedCheck-src.zapt */,
+				5178E65B2AE097B30069DF72 /* availability.yaml */,
 				3D843729294984AF0070D20A /* partials */,
 			);
 			path = templates;
@@ -1121,7 +1134,9 @@
 				5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */,
 				5ACDDD7C27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm */,
 				5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */,
+				5178E67F2AE098510069DF72 /* MTRCommandTimedCheck.h */,
 				51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */,
+				5178E6802AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h */,
 				99D466E02798936D0089A18F /* MTRCommissioningParameters.h */,
 				99AECC7F2798A57E00B6355B /* MTRCommissioningParameters.mm */,
 				3DFCB32B29678C9500332B35 /* MTRConversion.h */,
@@ -1383,6 +1398,7 @@
 				517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */,
 				51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */,
 				5136661628067D550025EDAE /* MTRDeviceControllerFactory.h in Headers */,
+				5178E6812AE098520069DF72 /* MTRCommandTimedCheck.h in Headers */,
 				7596A84B287636C1004DAE0E /* MTRDevice_Internal.h in Headers */,
 				5A6FEC9927B5C88900F25F42 /* MTRDeviceOverXPC.h in Headers */,
 				51B22C222740CB1D008D5055 /* MTRCommandPayloadsObjc.h in Headers */,
@@ -1412,6 +1428,7 @@
 				AF1CB86E2874B03B00865A96 /* MTROTAProviderDelegate.h in Headers */,
 				754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */,
 				3CF134AF289D90FF0017A19E /* MTROperationalCertificateIssuer.h in Headers */,
+				5178E6822AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h in Headers */,
 				3CF134AB289D8DF70017A19E /* MTRDeviceAttestationInfo.h in Headers */,
 				B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */,
 				3CF134A7289D8ADA0017A19E /* MTRCSRInfo.h in Headers */,
@@ -1738,6 +1755,7 @@
 				3CF134AD289D8E570017A19E /* MTRDeviceAttestationInfo.mm in Sources */,
 				2C1B027A2641DB4E00780EF1 /* MTROperationalCredentialsDelegate.mm in Sources */,
 				7560FD1C27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm in Sources */,
+				5178E67E2AE098210069DF72 /* MTRCommandTimedCheck.mm in Sources */,
 				7596A84928762783004DAE0E /* MTRAsyncCallbackWorkQueue.mm in Sources */,
 				B2E0D7B9245B0B5C003C5B48 /* MTRSetupPayload.mm in Sources */,
 				B2E0D7B6245B0B5C003C5B48 /* MTRManualSetupPayloadParser.mm in Sources */,


### PR DESCRIPTION
If we know the command being invoked needs a timed invoke, and the caller did not provide a timed invoke timeout, go ahead and use a default one.

This is a relanding of https://github.com/project-chip/connectedhomeip/pull/29855 but with a slightly nicer method signature.