### PR TITLE
[Android] Change default val of udpListenPort to 0

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/ControllerParams.java
+++ b/src/controller/java/src/chip/devicecontroller/ControllerParams.java
@@ -23,8 +23,6 @@ public final class ControllerParams {
   @Nullable private final byte[] ipk;
   private final long adminSubject;
 
-  private static final int LEGACY_GLOBAL_CHIP_PORT = 5540;
-
   /** @param udpListenPort the UDP listening port, or 0 to pick any available port. */
   private ControllerParams(Builder builder) {
     this.fabricId = builder.fabricId;
@@ -132,7 +130,7 @@ public final class ControllerParams {
   /** Builder for {@link ControllerParams}. */
   public static class Builder {
     private long fabricId = 1;
-    private int udpListenPort = LEGACY_GLOBAL_CHIP_PORT + 1;
+    private int udpListenPort = 0;
     private int controllerVendorId = 0xFFFF;
     private int failsafeTimerSeconds = 30;
     private int caseFailsafeTimerSeconds = 0;


### PR DESCRIPTION
This PR changes the default value of the UDP listen port used in Android platform's ControllerParams from 5541 to 0. Since the default value of UDP listen port was 5541, if multiple matter applications using default settings are run on one matter device, UDP listen port conflict occurs. If we set the UDP listen port to 0, port collisions can be avoided because the port is bound randomly. Although matter applications can avoid conflicts by setting a UDP listen port, it is better to set this to its default value of 0 so that matter applications that use the default settings can avoid conflicts.
