### PR TITLE
[Android] Shutdown factory with device controller

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -368,6 +368,12 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     return wrapper.release();
 }
 
+void AndroidDeviceControllerWrapper::Shutdown()
+{
+    mController->Shutdown();
+    DeviceControllerFactory::GetInstance().Shutdown();
+}
+
 CHIP_ERROR AndroidDeviceControllerWrapper::ApplyNetworkCredentials(chip::Controller::CommissioningParameters & params,
                                                                    jobject networkCredentials)
 {

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -173,6 +173,8 @@ public:
                 uint16_t failsafeTimerSeconds, bool attemptNetworkScanWiFi, bool attemptNetworkScanThread,
                 bool skipCommissioningComplete, CHIP_ERROR * errInfoOnFailure);
 
+    void Shutdown();
+
 #ifdef JAVA_MATTER_CONTROLLER_TEST
     chip::Controller::ExampleOperationalCredentialsIssuer * GetAndroidOperationalCredentialsIssuer()
 #else

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1960,7 +1960,7 @@ JNI_METHOD(void, shutdownCommissioning)
     StopIOThread();
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    wrapper->Controller()->Shutdown();
+    wrapper->Shutdown();
 }
 
 JNI_METHOD(jbyteArray, getAttestationChallenge)


### PR DESCRIPTION
This change adds shutdown to AndroidDeviceControllerWrapper, which wraps CHIPDeviceController on the Android platform, so that DeviceControllerFactory and CHIPDeviceController can be shutdown. AndroidDeviceControllerWrapper initializes DeviceControllerFactory and CHIPDeviceController, but since it supports only CHIPDeviceController shutdown, DeviceControllerFactory shutdown is required. If you reuse AndroidDeviceControllerWrapper with the call below without shutting down DeviceControllerFactory, sometimes the DeviceControllerSystemState of DeviceControllerFactory becomes incorrect, causing AndroidDeviceControllerWrapper to operate incorrectly, and the problem cannot be solved unless the process is restarted.

- AndroidDeviceControllerWrapper::AllocateNew()
- AndroidDeviceControllerWrapper::Controller()->Shutdown()