### PR TITLE
[Silabs][WiFi] Added fix for commissioning failing with power cycle on board 917 NCP

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -179,7 +179,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
         {
             xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
-        } 
+        }
         is_wifi_disconnection_event = true;
         return SL_STATUS_FAIL;
     }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -179,12 +179,8 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
         {
             xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
-        }
-
-        if (wfx_rsi.dev_state & WFX_RSI_ST_STA_PROVISIONED)
-        {
-            is_wifi_disconnection_event = true;
-        }
+        } 
+        is_wifi_disconnection_event = true;
         return SL_STATUS_FAIL;
     }
     /*
@@ -260,7 +256,6 @@ int32_t wfx_wifi_rsi_init(void)
 static sl_status_t wfx_rsi_init(void)
 {
     sl_status_t status;
-    sl_wifi_version_string_t version = { 0 };
 
 #ifndef RSI_M4_INTERFACE
     status = wfx_wifi_rsi_init();
@@ -270,20 +265,15 @@ static sl_status_t wfx_rsi_init(void)
         return status;
     }
 #endif
-
     status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, (sl_mac_address_t *) &wfx_rsi.sta_mac.octet[0]);
     if (status != SL_STATUS_OK)
     {
         SILABS_LOG("sl_wifi_get_mac_address failed: %x", status);
         return status;
     }
-
     wfx_rsi.events = xEventGroupCreateStatic(&rsiDriverEventGroup);
     wfx_rsi.dev_state |= WFX_RSI_ST_DEV_READY;
     osSemaphoreRelease(sl_rs_ble_init_sem);
-    status = sl_wifi_get_firmware_version(&version);
-    SILABS_LOG("Firmware version %s", version.version);
-    VERIFY_STATUS_AND_RETURN(status);
     return status;
 }
 

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -409,19 +409,18 @@ static void wfx_rsi_save_ap_info() // translation
     }
     wfx_rsi.dev_state |= WFX_RSI_ST_SCANSTARTED;
     sl_status_t status                                   = SL_STATUS_OK;
-    #if (!(EXP_BOARD)) {
-        // TODO: this changes will be reverted back after the SDK team fix the scan API
+    #ifndef EXP_BOARD        // TODO: this changes will be reverted back after the SDK team fix the scan API
         sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
         wifi_scan_configuration                              = default_wifi_scan_configuration;
-    }
+    #endif
     sl_wifi_ssid_t ssid_arg;
     ssid_arg.length = strlen(wfx_rsi.sec.ssid);
     memcpy(ssid_arg.value, (int8_t *) &wfx_rsi.sec.ssid[0], ssid_arg.length);
     sl_wifi_set_scan_callback(scan_callback_handler, NULL);
-    #if (!(EXP_BOARD)) {
+    #ifndef EXP_BOARD
         // TODO: this changes will be reverted back after the SDK team fix the scan API
         status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
-    }
+    #endif
     if (SL_STATUS_IN_PROGRESS == status)
     {
         const uint32_t start = osKernelGetTickCount();

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -401,13 +401,15 @@ static void wfx_rsi_save_ap_info() // translation
     }
     wfx_rsi.dev_state |= WFX_RSI_ST_SCANSTARTED;
     sl_status_t status                                   = SL_STATUS_OK;
-    sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
-    wifi_scan_configuration                              = default_wifi_scan_configuration;
+    // TODO: this changes will be reverted back after the SDK team fix the scan API
+//    sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
+//    wifi_scan_configuration                              = default_wifi_scan_configuration;
     sl_wifi_ssid_t ssid_arg;
     ssid_arg.length = strlen(wfx_rsi.sec.ssid);
     memcpy(ssid_arg.value, (int8_t *) &wfx_rsi.sec.ssid[0], ssid_arg.length);
     sl_wifi_set_scan_callback(scan_callback_handler, NULL);
-    status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
+    // TODO: this changes will be reverted back after the SDK team fix the scan API
+    //status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
     if (SL_STATUS_IN_PROGRESS == status)
     {
         const uint32_t start = osKernelGetTickCount();

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -398,19 +398,19 @@ static void wfx_rsi_save_ap_info() // translation
         return;
     }
     wfx_rsi.dev_state |= WFX_RSI_ST_SCANSTARTED;
-    sl_status_t status                                   = SL_STATUS_OK;
-    #ifndef EXP_BOARD        // TODO: this changes will be reverted back after the SDK team fix the scan API
-        sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
-        wifi_scan_configuration                              = default_wifi_scan_configuration;
-    #endif
+    sl_status_t status = SL_STATUS_OK;
+#ifndef EXP_BOARD // TODO: this changes will be reverted back after the SDK team fix the scan API
+    sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
+    wifi_scan_configuration                              = default_wifi_scan_configuration;
+#endif
     sl_wifi_ssid_t ssid_arg;
     ssid_arg.length = strlen(wfx_rsi.sec.ssid);
     memcpy(ssid_arg.value, (int8_t *) &wfx_rsi.sec.ssid[0], ssid_arg.length);
     sl_wifi_set_scan_callback(scan_callback_handler, NULL);
-    #ifndef EXP_BOARD
-        // TODO: this changes will be reverted back after the SDK team fix the scan API
-        status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
-    #endif
+#ifndef EXP_BOARD
+    // TODO: this changes will be reverted back after the SDK team fix the scan API
+    status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
+#endif
     if (SL_STATUS_IN_PROGRESS == status)
     {
         const uint32_t start = osKernelGetTickCount();


### PR DESCRIPTION
Description of Problem/Feature:
On the power cycle, DUT 917 NCP is not rejoining the network on ecosystem and chip-tool 

Description of Fix/Solution:
Scan API from new SDK 3.0.1 causing the issue on 917 NCP.

Testing Done:
917 NCP + ecosystem and chiptools 