### PR TITLE
Commissioning time sync: copy parameters to autocommissioner

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -85,7 +85,8 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
          IsUnsafeSpan(params.GetIcac(), mParams.GetIcac()) || IsUnsafeSpan(params.GetIpk(), mParams.GetIpk()) ||
          IsUnsafeSpan(params.GetAttestationElements(), mParams.GetAttestationElements()) ||
          IsUnsafeSpan(params.GetAttestationSignature(), mParams.GetAttestationSignature()) ||
-         IsUnsafeSpan(params.GetPAI(), mParams.GetPAI()) || IsUnsafeSpan(params.GetDAC(), mParams.GetDAC()));
+         IsUnsafeSpan(params.GetPAI(), mParams.GetPAI()) || IsUnsafeSpan(params.GetDAC(), mParams.GetDAC()) ||
+         IsUnsafeSpan(params.GetTimeZone(), mParams.GetTimeZone()) || IsUnsafeSpan(params.GetDSTOffsets(), mParams.GetDSTOffsets()));
 
     mParams = params;
 
@@ -173,6 +174,31 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
         Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce));
     }
     mParams.SetCSRNonce(ByteSpan(mCSRNonce, sizeof(mCSRNonce)));
+
+    if (params.GetDSTOffsets().HasValue()) {
+        ChipLogProgress(Controller, "Setting DST offsets from parameters");
+        size_t size = params.GetDSTOffsets().Value().size();
+        size = size > kMaxSupportedDstStructs ? kMaxSupportedDstStructs : size;
+        for (size_t i = 0; i < size; ++i) {
+            mDstOffsetsBuf[i] = params.GetDSTOffsets().Value()[i];
+        }
+        auto list = app::DataModel::List<app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type>(mDstOffsetsBuf, size);
+        mParams.SetDSTOffsets(list);
+    }
+    if (params.GetTimeZone().HasValue()) {
+        ChipLogProgress(Controller, "Setting Time Zone from parameters");
+        size_t size = params.GetTimeZone().Value().size();
+        size = size > kMaxSupportedTimeZones ? kMaxSupportedTimeZones : size;
+        for (size_t i = 0; i < size; ++i) {
+            mTimeZoneBuf[i] = params.GetTimeZone().Value()[i];
+            if (mTimeZoneBuf[i].name.HasValue()) {
+                auto span = MutableCharSpan(mTimeZoneNames[i], kMaxTimeZoneNameLen);
+                CopyCharSpanToMutableCharSpan(mTimeZoneBuf[i].name.Value(), span);
+                mTimeZoneBuf[i].name.SetValue(span);
+
+            }
+        }
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -179,8 +179,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
     if (params.GetDSTOffsets().HasValue())
     {
         ChipLogProgress(Controller, "Setting DST offsets from parameters");
-        size_t size = params.GetDSTOffsets().Value().size();
-        size        = size > kMaxSupportedDstStructs ? kMaxSupportedDstStructs : size;
+        size_t size = std::min(params.GetDSTOffsets().Value().size(), kMaxSupportedDstStructs);
         for (size_t i = 0; i < size; ++i)
         {
             mDstOffsetsBuf[i] = params.GetDSTOffsets().Value()[i];
@@ -191,8 +190,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
     if (params.GetTimeZone().HasValue())
     {
         ChipLogProgress(Controller, "Setting Time Zone from parameters");
-        size_t size = params.GetTimeZone().Value().size();
-        size        = size > kMaxSupportedTimeZones ? kMaxSupportedTimeZones : size;
+        size_t size = std::min(params.GetTimeZone().Value().size(), kMaxSupportedTimeZones);
         for (size_t i = 0; i < size; ++i)
         {
             mTimeZoneBuf[i] = params.GetTimeZone().Value()[i];

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -86,7 +86,8 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
          IsUnsafeSpan(params.GetAttestationElements(), mParams.GetAttestationElements()) ||
          IsUnsafeSpan(params.GetAttestationSignature(), mParams.GetAttestationSignature()) ||
          IsUnsafeSpan(params.GetPAI(), mParams.GetPAI()) || IsUnsafeSpan(params.GetDAC(), mParams.GetDAC()) ||
-         IsUnsafeSpan(params.GetTimeZone(), mParams.GetTimeZone()) || IsUnsafeSpan(params.GetDSTOffsets(), mParams.GetDSTOffsets()));
+         IsUnsafeSpan(params.GetTimeZone(), mParams.GetTimeZone()) ||
+         IsUnsafeSpan(params.GetDSTOffsets(), mParams.GetDSTOffsets()));
 
     mParams = params;
 
@@ -175,27 +176,31 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
     }
     mParams.SetCSRNonce(ByteSpan(mCSRNonce, sizeof(mCSRNonce)));
 
-    if (params.GetDSTOffsets().HasValue()) {
+    if (params.GetDSTOffsets().HasValue())
+    {
         ChipLogProgress(Controller, "Setting DST offsets from parameters");
         size_t size = params.GetDSTOffsets().Value().size();
-        size = size > kMaxSupportedDstStructs ? kMaxSupportedDstStructs : size;
-        for (size_t i = 0; i < size; ++i) {
+        size        = size > kMaxSupportedDstStructs ? kMaxSupportedDstStructs : size;
+        for (size_t i = 0; i < size; ++i)
+        {
             mDstOffsetsBuf[i] = params.GetDSTOffsets().Value()[i];
         }
         auto list = app::DataModel::List<app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type>(mDstOffsetsBuf, size);
         mParams.SetDSTOffsets(list);
     }
-    if (params.GetTimeZone().HasValue()) {
+    if (params.GetTimeZone().HasValue())
+    {
         ChipLogProgress(Controller, "Setting Time Zone from parameters");
         size_t size = params.GetTimeZone().Value().size();
-        size = size > kMaxSupportedTimeZones ? kMaxSupportedTimeZones : size;
-        for (size_t i = 0; i < size; ++i) {
+        size        = size > kMaxSupportedTimeZones ? kMaxSupportedTimeZones : size;
+        for (size_t i = 0; i < size; ++i)
+        {
             mTimeZoneBuf[i] = params.GetTimeZone().Value()[i];
-            if (mTimeZoneBuf[i].name.HasValue()) {
+            if (mTimeZoneBuf[i].name.HasValue())
+            {
                 auto span = MutableCharSpan(mTimeZoneNames[i], kMaxTimeZoneNameLen);
                 CopyCharSpanToMutableCharSpan(mTimeZoneBuf[i].name.Value(), span);
                 mTimeZoneBuf[i].name.SetValue(span);
-
             }
         }
     }

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -102,6 +102,17 @@ private:
     uint8_t mThreadOperationalDataset[CommissioningParameters::kMaxThreadDatasetLen];
     char mCountryCode[CommissioningParameters::kMaxCountryCodeLen];
 
+    // Time zone is statically allocated because it is max 2 and not trivially destructible
+    static constexpr size_t kMaxSupportedTimeZones = 2;
+    app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type mTimeZoneBuf[kMaxSupportedTimeZones];
+    static constexpr size_t kMaxTimeZoneNameLen = 64;
+    char mTimeZoneNames[kMaxTimeZoneNameLen][kMaxSupportedTimeZones];
+
+    // DSTOffsetStructs are similarly not trivially destructible. They don't have a defined size, but we're
+    // going to do static allocation of the buffers anyway until we replace chip::Optional with std::optional.
+    static constexpr size_t kMaxSupportedDstStructs = 10;
+    app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type mDstOffsetsBuf[kMaxSupportedDstStructs];
+
     bool mNeedsNetworkSetup = false;
     ReadCommissioningInfo mDeviceCommissioningInfo;
     bool mNeedsDST = false;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -511,6 +511,8 @@ public:
         mAttestationSignature.ClearValue();
         mPAI.ClearValue();
         mDAC.ClearValue();
+        mTimeZone.ClearValue();
+        mDSTOffsets.ClearValue();
     }
 
 private:


### PR DESCRIPTION
The auto commissioner is meant to take ownership of the supplied buffers from the caller. PR adds static buffers for time zone and DST. Unfortunately, neither is trivially destructible until we move from chip::Optional to std::optional. For now, they are static, we can move to dynamic allocation if required once we have support and can use proper memory management tools.

