### PR TITLE
Wait 1.25 instead of 1.05 seconds on test to make CI less flaky

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
@@ -589,14 +589,14 @@ tests:
               - name: "SceneID"
                 value: 0x01
 
-    - label: "Wait 1s"
+    - label: "Wait 1+ s"
       PICS: PICS_SDK_CI_ONLY
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 1050
+                value: 1250
 
     - label:
           "TH confirm the DUT reached AC1 (on level control cluster) after 1s"


### PR DESCRIPTION
The test TC_S_2_3 is flaky because it waits for a 1s transition to finish in 1.05s and that is not the case on darwin (odd ... large system): https://github.com/project-chip/connectedhomeip/actions/runs/6610929940/job/17953872378?pr=29902


Bump this quite a bit to 1.25s.