### PR TITLE
Fix android build: add cast for formatting

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -333,7 +333,8 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
     ChipLogProgress(AppServer,
                     "CastingStore::WriteAll TLV(CastingStoreData).LengthWritten: %d bytes, CastingPlayers size: %lu "
                     "and version: %d",
-                    tlvWriter.GetLengthWritten(), castingPlayers.size(), kCurrentCastingStoreDataVersion);
+                    tlvWriter.GetLengthWritten(), static_cast<unsigned long>(castingPlayers.size()),
+                    kCurrentCastingStoreDataVersion);
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(kCastingStoreDataKey, castingStoreData,
                                                                        tlvWriter.GetLengthWritten());
 }


### PR DESCRIPTION
Without it we get:

```
INFO    ../../examples/tv-casting-app/android/third_party/connectedhomeip/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp:336:51: error: format specifies type 'unsigned long' but the argument has type 'std::vector<matter::casting::core::CastingPlayer>::size_type' (aka 'unsigned int') [-Werror,-Wformat]
INFO                        tlvWriter.GetLengthWritten(), castingPlayers.size(), kCurrentCastingStoreDataVersion);
INFO                                                      ^~~~~~~~~~~~~~~~~~~~~
INFO    ../../examples/tv-casting-app/android/third_party/connectedhomeip/src/lib/support/logging/TextOnlyLogging.h:108:78: note: expanded from macro 'ChipLogProgress'
INFO    #define ChipLogProgress(MOD, MSG, ...) ChipInternalLog(MOD, PROGRESS, MSG, ##__VA_ARGS__)
...
```