### PR TITLE
Fix python type checks

### DIFF
--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -28,7 +28,7 @@ except ImportError:
     from matter_idl.data_model_xml import ParseSource, ParseXmls
 
 from matter_idl.matter_idl_types import Idl
-from matter_idl_parser import CreateParser
+from matter_idl.matter_idl_parser import CreateParser
 
 
 def XmlToIdl(what: Union[str, List[str]]) -> Idl:

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -27,8 +27,8 @@ except ImportError:
         os.path.join(os.path.dirname(__file__), '..')))
     from matter_idl.data_model_xml import ParseSource, ParseXmls
 
-from matter_idl.matter_idl_types import Idl
 from matter_idl.matter_idl_parser import CreateParser
+from matter_idl.matter_idl_types import Idl
 
 
 def XmlToIdl(what: Union[str, List[str]]) -> Idl:


### PR DESCRIPTION
mypy found that _command in a parser is optional and could be none.

Fixes:
   - fix logic to handle that `_command` may be optional in handlers
   - fix import path to specify `matter_idl` prefix 