### PR TITLE
TC-DA-1.4/8 generation script: use standard order

### DIFF
--- a/credentials/development/gen_commissioner_dut_test_plan_table.py
+++ b/credentials/development/gen_commissioner_dut_test_plan_table.py
@@ -79,7 +79,7 @@ def main():
 
     success_cases = []
     failure_cases = []
-    for p in os.listdir(cert_path):
+    for p in sorted(os.listdir(cert_path)):
         if p in skip_cases:
             continue
         path = str(os.path.join(cert_path, p, 'test_case_vector.json'))


### PR DESCRIPTION
listdir doesn't use any particular ordering apparently, so this comes out in a different order every time, which is very annoying.

Change to use sorted. I'm going to update the test plans to use the new ordering so it doesn't keep changing and so we can match it with the runner script.

