### PR TITLE
Add a device type metadata table in Darwin codegen.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -6873,7 +6873,7 @@ endpoint 2 {
   }
 }
 endpoint 65534 {
-  device type ma_secondary_network_commissioning = 61442, version 1;
+  device type ma_secondary_network_commissioning = 4293984258, version 1;
 
 
   server cluster Descriptor {
@@ -6881,6 +6881,10 @@ endpoint 65534 {
     callback attribute serverList;
     callback attribute clientList;
     callback attribute partsList;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     ram      attribute featureMap default = 0;
     callback attribute clusterRevision default = 2;
   }
@@ -6894,6 +6898,10 @@ endpoint 65534 {
     callback attribute lastNetworkingStatus;
     callback attribute lastNetworkID;
     callback attribute lastConnectErrorValue;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     callback attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
 

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -19,17 +19,17 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
+      "path": "../../../src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "version": "chip-v1"
+    },
+    {
+      "pathRelativity": "relativeToZap",
       "path": "../../../src/app/zap-templates/zcl/zcl-with-test-extensions.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data with some extensions"
-    },
-    {
-      "pathRelativity": "relativeToZap",
-      "path": "../../../src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -21384,14 +21384,14 @@
       "id": 4,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 61442,
+        "code": 4293984258,
         "profileId": 259,
         "label": "MA-secondary-network-commissioning",
         "name": "MA-secondary-network-commissioning"
       },
       "deviceTypes": [
         {
-          "code": 61442,
+          "code": 4293984258,
           "profileId": 259,
           "label": "MA-secondary-network-commissioning",
           "name": "MA-secondary-network-commissioning"
@@ -21401,10 +21401,10 @@
         1
       ],
       "deviceIdentifiers": [
-        61442
+        4293984258
       ],
       "deviceTypeName": "MA-secondary-network-commissioning",
-      "deviceTypeCode": 61442,
+      "deviceTypeCode": 4293984258,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -21466,6 +21466,70 @@
             {
               "name": "PartsList",
               "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
               "mfgCode": null,
               "side": "server",
               "type": "array",
@@ -21724,6 +21788,70 @@
               "reportableChange": 0
             },
             {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -21789,5 +21917,6 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -5022,7 +5022,7 @@ endpoint 2 {
   }
 }
 endpoint 65534 {
-  device type ma_secondary_network_commissioning = 61442, version 1;
+  device type ma_secondary_network_commissioning = 4293984258, version 1;
 
 
   server cluster Descriptor {
@@ -5030,6 +5030,10 @@ endpoint 65534 {
     callback attribute serverList;
     callback attribute clientList;
     callback attribute partsList;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     ram      attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
   }
@@ -5043,6 +5047,10 @@ endpoint 65534 {
     callback attribute lastNetworkingStatus;
     callback attribute lastNetworkID;
     callback attribute lastConnectErrorValue;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     callback attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
 

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
@@ -11783,14 +11783,14 @@
       "id": 4,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 61442,
+        "code": 4293984258,
         "profileId": 259,
         "label": "MA-secondary-network-commissioning",
         "name": "MA-secondary-network-commissioning"
       },
       "deviceTypes": [
         {
-          "code": 61442,
+          "code": 4293984258,
           "profileId": 259,
           "label": "MA-secondary-network-commissioning",
           "name": "MA-secondary-network-commissioning"
@@ -11800,10 +11800,10 @@
         1
       ],
       "deviceIdentifiers": [
-        61442
+        4293984258
       ],
       "deviceTypeName": "MA-secondary-network-commissioning",
-      "deviceTypeCode": 61442,
+      "deviceTypeCode": 4293984258,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -11876,6 +11876,70 @@
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
               "reportableChange": 0
             },
             {
@@ -12123,6 +12187,70 @@
               "reportableChange": 0
             },
             {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -12188,5 +12316,6 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/chef/devices/template.zap
+++ b/examples/chef/devices/template.zap
@@ -1876,14 +1876,14 @@
       "id": 2,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 0,
+        "code": 4293984259,
         "profileId": 259,
         "label": "MA-all-clusters-app",
         "name": "MA-all-clusters-app"
       },
       "deviceTypes": [
         {
-          "code": 0,
+          "code": 4293984259,
           "profileId": 259,
           "label": "MA-all-clusters-app",
           "name": "MA-all-clusters-app"
@@ -1893,10 +1893,10 @@
         1
       ],
       "deviceIdentifiers": [
-        0
+        4293984259
       ],
       "deviceTypeName": "MA-all-clusters-app",
-      "deviceTypeCode": 0,
+      "deviceTypeCode": 4293984259,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -1984,6 +1984,22 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -2164,6 +2180,22 @@
             {
               "name": "AcceptedCommandList",
               "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
               "mfgCode": null,
               "side": "server",
               "type": "array",
@@ -2487,6 +2519,22 @@
               "reportableChange": 0
             },
             {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "AttributeList",
               "code": 65531,
               "mfgCode": null,
@@ -2641,6 +2689,22 @@
               "reportableChange": 0
             },
             {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "AttributeList",
               "code": 65531,
               "mfgCode": null,
@@ -2708,5 +2772,6 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -429,7 +429,7 @@ server cluster OperationalCredentials = 62 {
 }
 
 endpoint 0 {
-  device type ma_all_clusters_app = 0, version 1;
+  device type ma_all_clusters_app = 4293984259, version 1;
 
 
   server cluster AccessControl {

--- a/examples/log-source-app/log-source-common/log-source-app.zap
+++ b/examples/log-source-app/log-source-common/log-source-app.zap
@@ -37,14 +37,14 @@
       "id": 1,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 0,
+        "code": 4293984259,
         "profileId": 259,
         "label": "MA-all-clusters-app",
         "name": "MA-all-clusters-app"
       },
       "deviceTypes": [
         {
-          "code": 0,
+          "code": 4293984259,
           "profileId": 259,
           "label": "MA-all-clusters-app",
           "name": "MA-all-clusters-app"
@@ -54,10 +54,10 @@
         1
       ],
       "deviceIdentifiers": [
-        0
+        4293984259
       ],
       "deviceTypeName": "MA-all-clusters-app",
-      "deviceTypeCode": 0,
+      "deviceTypeCode": 4293984259,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -733,9 +733,10 @@
     {
       "endpointTypeName": "Anonymous Endpoint Type",
       "endpointTypeIndex": 0,
-      "profileId": 598,
+      "profileId": 259,
       "endpointId": 0,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -1419,7 +1419,7 @@ endpoint 1 {
   }
 }
 endpoint 65534 {
-  device type ma_secondary_network_commissioning = 61442, version 1;
+  device type ma_secondary_network_commissioning = 4293984258, version 1;
 
 
   server cluster Descriptor {
@@ -1427,6 +1427,10 @@ endpoint 65534 {
     callback attribute serverList;
     callback attribute clientList;
     callback attribute partsList;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     ram      attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
   }
@@ -1440,6 +1444,10 @@ endpoint 65534 {
     callback attribute lastNetworkingStatus;
     callback attribute lastNetworkID;
     callback attribute lastConnectErrorValue;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
     callback attribute featureMap default = 0;
     callback attribute clusterRevision default = 1;
 

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
@@ -2898,14 +2898,14 @@
       "id": 3,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 61442,
+        "code": 4293984258,
         "profileId": 259,
         "label": "MA-secondary-network-commissioning",
         "name": "MA-secondary-network-commissioning"
       },
       "deviceTypes": [
         {
-          "code": 61442,
+          "code": 4293984258,
           "profileId": 259,
           "label": "MA-secondary-network-commissioning",
           "name": "MA-secondary-network-commissioning"
@@ -2915,10 +2915,10 @@
         1
       ],
       "deviceIdentifiers": [
-        61442
+        4293984258
       ],
       "deviceTypeName": "MA-secondary-network-commissioning",
-      "deviceTypeCode": 61442,
+      "deviceTypeCode": 4293984258,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -2990,6 +2990,70 @@
               "defaultValue": "",
               "reportable": 1,
               "minInterval": 0,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
             },
@@ -3238,6 +3302,70 @@
               "reportableChange": 0
             },
             {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -3296,5 +3424,6 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.10.14-nightly.1"]
+            "tags": ["version:2@v2023.10.24-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2023.10.14-nightly.1"]
+            "tags": ["version:2@v2023.10.24-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.10.14-nightly
+v2023.10.24-nightly

--- a/scripts/tools/zap/tests/inputs/all-clusters-app.zap
+++ b/scripts/tools/zap/tests/inputs/all-clusters-app.zap
@@ -19,17 +19,17 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
+      "path": "../../../../../src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "version": "chip-v1"
+    },
+    {
+      "pathRelativity": "relativeToZap",
       "path": "../../../../../src/app/zap-templates/zcl/zcl-with-test-extensions.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data with some extensions"
-    },
-    {
-      "pathRelativity": "relativeToZap",
-      "path": "../../../../../src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -16264,14 +16264,14 @@
       "id": 4,
       "name": "Anonymous Endpoint Type",
       "deviceTypeRef": {
-        "code": 61442,
+        "code": 4293984258,
         "profileId": 259,
         "label": "MA-secondary-network-commissioning",
         "name": "MA-secondary-network-commissioning"
       },
       "deviceTypes": [
         {
-          "code": 61442,
+          "code": 4293984258,
           "profileId": 259,
           "label": "MA-secondary-network-commissioning",
           "name": "MA-secondary-network-commissioning"
@@ -16281,10 +16281,10 @@
         1
       ],
       "deviceIdentifiers": [
-        61442
+        4293984258
       ],
       "deviceTypeName": "MA-secondary-network-commissioning",
-      "deviceTypeCode": 61442,
+      "deviceTypeCode": 4293984258,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -16357,6 +16357,70 @@
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
               "reportableChange": 0
             },
             {
@@ -16604,6 +16668,70 @@
               "reportableChange": 0
             },
             {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "FeatureMap",
               "code": 65532,
               "mfgCode": null,
@@ -16669,5 +16797,6 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ]
+  ],
+  "log": []
 }

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -3058,9 +3058,9 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                                         \
     {                                                                                                                              \
-        { 0x0011, 1 }, { 0x0016, 1 }, { 0x0100, 1 }, { 0x0011, 1 }, { 0x0100, 1 }, { 0x0011, 1 },                                  \
+        { 0x00000011, 1 }, { 0x00000016, 1 }, { 0x00000100, 1 }, { 0x00000011, 1 }, { 0x00000100, 1 }, { 0x00000011, 1 },          \
         {                                                                                                                          \
-            0xF002, 1                                                                                                              \
+            0xFFF10002, 1                                                                                                          \
         }                                                                                                                          \
     }
 

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
@@ -1186,9 +1186,9 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                                         \
     {                                                                                                                              \
-        { 0x0016, 1 },                                                                                                             \
+        { 0x00000016, 1 },                                                                                                         \
         {                                                                                                                          \
-            0x0101, 1                                                                                                              \
+            0x00000101, 1                                                                                                          \
         }                                                                                                                          \
     }
 

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.10.14'
+MIN_ZAP_VERSION = '2023.10.24'
 
 
 class ZapTool:

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -21,7 +21,7 @@ limitations under the License.
         <domain>CHIP</domain>
         <typeName>Matter Orphan Clusters</typeName>
         <profileId editable="false">0x0103</profileId>
-        <deviceId editable="false">0xF001</deviceId>
+        <deviceId editable="false">0xFFF10001</deviceId>
         <clusters lockOthers="true">
             <include cluster="Proxy Configuration" client="false" server="true" clientLocked="true" serverLocked="true"/>
             <include cluster="Proxy Discovery" client="false" server="true" clientLocked="true" serverLocked="true"/>
@@ -1475,7 +1475,7 @@ limitations under the License.
     </deviceType>
     <deviceType>
         <name>MA-heatcool</name>
-        <domain>XCHIP</domain>
+        <domain>CHIP</domain>
         <typeName>Matter Heating/Cooling Unit</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0300</deviceId>
@@ -1539,7 +1539,7 @@ limitations under the License.
     </deviceType>
     <deviceType>
         <name>MA-thermostat</name>
-        <domain>HA</domain>
+        <domain>CHIP</domain>
         <typeName>Matter Thermostat</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0301</deviceId>
@@ -2036,7 +2036,7 @@ limitations under the License.
         <domain>CHIP</domain>
         <typeName>Matter All-clusters-app Server Example</typeName>
         <profileId editable="false">0x0103</profileId>
-        <deviceId editable="false">0x0000</deviceId>
+        <deviceId editable="false">0xFFF10003</deviceId>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>IDENTIFY_TIME</requireAttribute>
@@ -2197,7 +2197,7 @@ limitations under the License.
         <domain>CHIP</domain>
         <typeName>Matter Secondary Network Commissioning Device Type</typeName>
         <profileId editable="false">0x0103</profileId>
-        <deviceId editable="false">0xF002</deviceId>
+        <deviceId editable="false">0xFFF10002</deviceId>
         <clusters lockOthers="true">
             <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">

--- a/src/darwin/Framework/CHIP/MTRDeviceTypeMetadata.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceTypeMetadata.h
@@ -1,0 +1,24 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#include <lib/core/DataModelTypes.h>
+
+BOOL MTRIsKnownUtilityDeviceType(chip::DeviceTypeId aDeviceTypeId);

--- a/src/darwin/Framework/CHIP/templates/MTRDeviceTypeMetadata-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRDeviceTypeMetadata-src.zapt
@@ -1,0 +1,47 @@
+{{> header excludeZapComment=true}}
+
+#import "MTRDeviceTypeMetadata.h"
+
+using namespace chip;
+
+namespace {
+enum class DeviceTypeClass {
+  Utility,
+  Simple,
+  Node, // Might not be a real class, but we have it for Root Node for now.
+  // If new classes get added, plase audit MTRIsKnownUtilityDeviceType below.
+};
+
+struct DeviceTypeData {
+  DeviceTypeId id;
+  DeviceTypeClass deviceClass;
+  const char * name;
+};
+
+constexpr DeviceTypeData knownDeviceTypes[] = {
+  {{#zcl_device_types}}
+  {{#if class}}
+  {{! For now work around the "Dynamic Utility" thing on Aggregator by just
+      taking the last word. }}
+  { {{asHex code 8}}, DeviceTypeClass::{{asLastWord class}}, "{{caption}}" },
+  {{/if}}
+  {{/zcl_device_types}}
+};
+
+{{#zcl_device_types}}
+{{#unless class}}
+static_assert(ExtractVendorFromMEI({{asHex code 8}}) != 0, "Must have class defined for \"{{caption}}\" if it's a standard device type");
+{{/unless}}
+{{/zcl_device_types}}
+
+} // anonymous namespace
+
+BOOL MTRIsKnownUtilityDeviceType(DeviceTypeId aDeviceTypeId)
+{
+    for (auto & deviceType : knownDeviceTypes) {
+        if (deviceType.id == aDeviceTypeId) {
+            return deviceType.deviceClass != DeviceTypeClass::Simple;
+        }
+    }
+    return NO;
+}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -133,6 +133,11 @@
             "path": "MTRCommandTimedCheck-src.zapt",
             "name": "Function to check if command needs timed invoke",
             "output": "src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm"
+        },
+        {
+            "path": "MTRDeviceTypeMetadata-src.zapt",
+            "name": "Functions to ask for information about device types",
+            "output": "src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm"
         }
     ]
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRDeviceTypeMetadata.h"
+
+using namespace chip;
+
+namespace {
+enum class DeviceTypeClass {
+    Utility,
+    Simple,
+    Node, // Might not be a real class, but we have it for Root Node for now.
+    // If new classes get added, plase audit MTRIsKnownUtilityDeviceType below.
+};
+
+struct DeviceTypeData {
+    DeviceTypeId id;
+    DeviceTypeClass deviceClass;
+    const char * name;
+};
+
+constexpr DeviceTypeData knownDeviceTypes[] = {
+    { 0x0000000A, DeviceTypeClass::Simple, "Matter Door Lock" },
+    { 0x0000000B, DeviceTypeClass::Simple, "Matter Door Lock Controller" },
+    { 0x0000000E, DeviceTypeClass::Utility, "Matter Aggregator" },
+    { 0x0000000F, DeviceTypeClass::Simple, "Matter Generic Switch" },
+    { 0x00000011, DeviceTypeClass::Utility, "Matter Power Source" },
+    { 0x00000012, DeviceTypeClass::Utility, "Matter OTA Requestor" },
+    { 0x00000013, DeviceTypeClass::Utility, "Matter Bridged Device" },
+    { 0x00000014, DeviceTypeClass::Utility, "Matter OTA Provider" },
+    { 0x00000015, DeviceTypeClass::Simple, "Matter Contact Sensor" },
+    { 0x00000016, DeviceTypeClass::Node, "Matter Root Node" },
+    { 0x00000022, DeviceTypeClass::Simple, "Matter Speaker" },
+    { 0x00000023, DeviceTypeClass::Simple, "Matter Casting Video Player" },
+    { 0x00000024, DeviceTypeClass::Simple, "Matter Content App" },
+    { 0x00000027, DeviceTypeClass::Simple, "Matter Mode Select" },
+    { 0x00000028, DeviceTypeClass::Simple, "Matter Basic Video Player" },
+    { 0x00000029, DeviceTypeClass::Simple, "Matter Casting Video Client" },
+    { 0x0000002A, DeviceTypeClass::Simple, "Matter Video Remote Control" },
+    { 0x0000002B, DeviceTypeClass::Simple, "Matter Fan" },
+    { 0x0000002C, DeviceTypeClass::Simple, "Matter Air Quality Sensor" },
+    { 0x0000002D, DeviceTypeClass::Simple, "Matter Air Purifier" },
+    { 0x00000070, DeviceTypeClass::Simple, "Matter Refrigerator" },
+    { 0x00000071, DeviceTypeClass::Simple, "Matter Temperature Controlled Cabinet" },
+    { 0x00000072, DeviceTypeClass::Simple, "Matter Room Air Conditioner" },
+    { 0x00000073, DeviceTypeClass::Simple, "Matter Laundry Washer" },
+    { 0x00000074, DeviceTypeClass::Simple, "Matter Robotic Vacuum Cleaner" },
+    { 0x00000075, DeviceTypeClass::Simple, "Matter Dishwasher" },
+    { 0x00000076, DeviceTypeClass::Simple, "Matter Smoke CO Alarm" },
+    { 0x00000100, DeviceTypeClass::Simple, "Matter On/Off Light" },
+    { 0x00000101, DeviceTypeClass::Simple, "Matter Dimmable Light" },
+    { 0x00000103, DeviceTypeClass::Simple, "Matter On/Off Light Switch" },
+    { 0x00000104, DeviceTypeClass::Simple, "Matter Dimmer Switch" },
+    { 0x00000105, DeviceTypeClass::Simple, "Matter Color Dimmer Switch" },
+    { 0x00000106, DeviceTypeClass::Simple, "Matter Light Sensor" },
+    { 0x00000107, DeviceTypeClass::Simple, "Matter Occupancy Sensor" },
+    { 0x0000010A, DeviceTypeClass::Simple, "Matter On/Off Plug-in Unit" },
+    { 0x0000010B, DeviceTypeClass::Simple, "Matter Dimmable Plug-in Unit" },
+    { 0x0000010C, DeviceTypeClass::Simple, "Matter Color Temperature Light" },
+    { 0x0000010D, DeviceTypeClass::Simple, "Matter Extended Color Light" },
+    { 0x00000202, DeviceTypeClass::Simple, "Matter Window Covering" },
+    { 0x00000203, DeviceTypeClass::Simple, "Matter Window Covering Controller" },
+    { 0x00000300, DeviceTypeClass::Simple, "Matter Heating/Cooling Unit" },
+    { 0x00000301, DeviceTypeClass::Simple, "Matter Thermostat" },
+    { 0x00000302, DeviceTypeClass::Simple, "Matter Temperature Sensor" },
+    { 0x00000303, DeviceTypeClass::Simple, "Matter Pump" },
+    { 0x00000304, DeviceTypeClass::Simple, "Matter Pump Controller" },
+    { 0x00000305, DeviceTypeClass::Simple, "Matter Pressure Sensor" },
+    { 0x00000306, DeviceTypeClass::Simple, "Matter Flow Sensor" },
+    { 0x00000307, DeviceTypeClass::Simple, "Matter Humidity Sensor" },
+    { 0x00000840, DeviceTypeClass::Simple, "Matter Control Bridge" },
+    { 0x00000850, DeviceTypeClass::Simple, "Matter On/Off Sensor" },
+};
+
+static_assert(ExtractVendorFromMEI(0xFFF10001) != 0, "Must have class defined for \"Matter Orphan Clusters\" if it's a standard device type");
+static_assert(ExtractVendorFromMEI(0xFFF10002) != 0, "Must have class defined for \"Matter Secondary Network Commissioning Device Type\" if it's a standard device type");
+static_assert(ExtractVendorFromMEI(0xFFF10003) != 0, "Must have class defined for \"Matter All-clusters-app Server Example\" if it's a standard device type");
+
+} // anonymous namespace
+
+BOOL MTRIsKnownUtilityDeviceType(DeviceTypeId aDeviceTypeId)
+{
+    for (auto & deviceType : knownDeviceTypes) {
+        if (deviceType.id == aDeviceTypeId) {
+            return deviceType.deviceClass != DeviceTypeClass::Simple;
+        }
+    }
+    return NO;
+}

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		51E95DFB2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */; };
 		51E95DFC2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */; };
 		51EF279F2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51F522682AE70734000C4050 /* MTRDeviceTypeMetadata.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51F522672AE70734000C4050 /* MTRDeviceTypeMetadata.mm */; };
+		51F5226A2AE70761000C4050 /* MTRDeviceTypeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 51F522692AE70761000C4050 /* MTRDeviceTypeMetadata.h */; };
 		51FE72352ACDB40000437032 /* MTRCommandPayloads_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FE72342ACDB40000437032 /* MTRCommandPayloads_Internal.h */; };
 		51FE723F2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */; };
 		5A60370827EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */; };
@@ -558,6 +560,9 @@
 		51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRSessionResumptionStorageBridge.h; sourceTree = "<group>"; };
 		51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRSessionResumptionStorageBridge.mm; sourceTree = "<group>"; };
 		51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBackwardsCompatShims.h; sourceTree = "<group>"; };
+		51F522662AE7071E000C4050 /* MTRDeviceTypeMetadata-src.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MTRDeviceTypeMetadata-src.zapt"; sourceTree = "<group>"; };
+		51F522672AE70734000C4050 /* MTRDeviceTypeMetadata.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceTypeMetadata.mm; sourceTree = "<group>"; };
+		51F522692AE70761000C4050 /* MTRDeviceTypeMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceTypeMetadata.h; sourceTree = "<group>"; };
 		51FE72342ACDB40000437032 /* MTRCommandPayloads_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommandPayloads_Internal.h; sourceTree = "<group>"; };
 		51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCommandPayloadExtensions_Internal.h; sourceTree = "<group>"; };
 		5A60370727EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MTRClusterStateCacheContainer+XPC.h"; sourceTree = "<group>"; };
@@ -996,6 +1001,7 @@
 				51B22C252740CB32008D5055 /* MTRStructsObjc.mm */,
 				5178E67D2AE098210069DF72 /* MTRCommandTimedCheck.mm */,
 				51B6C5C52AD85B3D003F4D3A /* MTRClusters.swift */,
+				51F522672AE70734000C4050 /* MTRDeviceTypeMetadata.mm */,
 			);
 			path = "zap-generated";
 			sourceTree = "<group>";
@@ -1038,6 +1044,7 @@
 				3D843722294984AF0070D20A /* MTRStructsObjc-src.zapt */,
 				5178E6592AE097A20069DF72 /* MTRCommandPayloads_Internal.zapt */,
 				5178E65A2AE097A20069DF72 /* MTRCommandTimedCheck-src.zapt */,
+				51F522662AE7071E000C4050 /* MTRDeviceTypeMetadata-src.zapt */,
 				5178E65B2AE097B30069DF72 /* availability.yaml */,
 				3D843729294984AF0070D20A /* partials */,
 			);
@@ -1187,6 +1194,7 @@
 				5A6FEC9527B5983000F25F42 /* MTRDeviceControllerXPCConnection.mm */,
 				5A6FEC8B27B5609C00F25F42 /* MTRDeviceOverXPC.h */,
 				5A6FEC9727B5C6AF00F25F42 /* MTRDeviceOverXPC.mm */,
+				51F522692AE70761000C4050 /* MTRDeviceTypeMetadata.h */,
 				5129BCFC26A9EE3300122DDF /* MTRError.h */,
 				B2E0D7AB245B0B5C003C5B48 /* MTRError_Internal.h */,
 				B2E0D7AA245B0B5C003C5B48 /* MTRError.mm */,
@@ -1483,6 +1491,7 @@
 				5A7947E527C0129F00434CF2 /* MTRDeviceController+XPC.h in Headers */,
 				51E95DFB2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* MTRError_Internal.h in Headers */,
+				51F5226A2AE70761000C4050 /* MTRDeviceTypeMetadata.h in Headers */,
 				5146544B2A72F9F500904E61 /* MTRDemuxingStorage.h in Headers */,
 				1EDCE545289049A100E41EC9 /* MTROTAHeader.h in Headers */,
 			);
@@ -1728,6 +1737,7 @@
 				998F287126D56940001846C6 /* MTRP256KeypairBridge.mm in Sources */,
 				5136661428067D550025EDAE /* MTRDeviceControllerFactory.mm in Sources */,
 				51B22C2A2740CB47008D5055 /* MTRCommandPayloadsObjc.mm in Sources */,
+				51F522682AE70734000C4050 /* MTRDeviceTypeMetadata.mm in Sources */,
 				75B765C32A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm in Sources */,
 				AF5F90FF2878D351005503FA /* MTROTAProviderDelegateBridge.mm in Sources */,
 				51E95DFC2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm in Sources */,


### PR DESCRIPTION
The changes in device type XML were to clearly mark our test device types as
having a test vendor id.  The .zap files were updated with those new device type
IDs, but this also has some noise in the .zap file, apparently.

The first changeset here is manual; the second one is just codegen.

This will fail CI until https://github.com/project-chip/zap/pull/1180 merges and ZAP is updated.

Lays the groundwork for fixing https://github.com/project-chip/connectedhomeip/issues/29270