### PR TITLE
Stop using the pigweed clang for darwin-framework-tool.

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
-    
+
 jobs:
     test_suites_chip_tool_darwin:
         name: Test Suites - Darwin
@@ -38,6 +38,14 @@ jobs:
                 build_variant: [no-ble-asan-clang]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
+
+            # We can't use the pigweed clang to build the Darwin framework once we start using
+            # Swift, because it does not handle CLANG_ENABLE_MODULES correctly.
+            #
+            # But the Xcode clang does not handle LSan correctly.  Since we can't easily apply
+            # LSAN_OPTIONS to just everything except darwin-framework-tool, instead disable asan for
+            # it.
+            BUILD_VARIANT_FRAMEWORK_TOOL: no-ble
             LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
@@ -83,7 +91,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target darwin-x64-darwin-framework-tool-${BUILD_VARIANT} \
+                        --target darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
                         --target darwin-x64-lock-${BUILD_VARIANT} \
                         --target darwin-x64-ota-provider-${BUILD_VARIANT} \
@@ -97,7 +105,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \
+                     --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
                      --target-skip-glob '{TestAccessControlConstraints}' \
                      run \
                      --iterations 1 \
@@ -114,7 +122,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_darwin_framework_ota_test.py \
                      run \
-                     --darwin-framework-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \
+                     --darwin-framework-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
                      --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
                      --ota-data-file /tmp/rawImage \
                      --ota-image-file /tmp/otaImage \
@@ -139,8 +147,8 @@ jobs:
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}
               with:
-                  name: framework-build-log-darwin-${{ matrix.build_variant }}
-                  path: out/darwin-x64-darwin-framework-tool-${{ matrix.build_variant }}/darwin_framework_build.log
+                  name: framework-build-log-darwin-${{BUILD_VARIANT_FRAMEWORK_TOOL}}
+                  path: out/darwin-x64-darwin-framework-tool-${{BUILD_VARIANT_FRAMEWORK_TOOL}}/darwin_framework_build.log
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}


### PR DESCRIPTION
It does not play nicely with CLANG_ENABLE_MODULES, and we will need that for using Swift in Matter.framework.
