### PR TITLE
Adding Air Purifier example to `cc32xx` build scripts and CI

### DIFF
--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -57,7 +57,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py  \
-                      --target cc32xx-lock build \
+                      --target cc32xx-lock --target cc32xx-air-purifier build \
                       --copy-artifacts-to out/artifacts \
                   "
             - name: Get lock app size stats
@@ -65,6 +65,13 @@ jobs:
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     cc32xx CC3235SF_LAUNCHXL lock \
                     out/artifacts/cc32xx-lock/chip-CC3235SF_LAUNCHXL-lock-example.out \
+                    /tmp/bloat_reports/
+
+            - name: Get air purifier app size stats
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    cc32xx CC3235SF_LAUNCHXL air-purifier \
+                    out/artifacts/cc32xx-air-purifier/chip-CC3235SF_LAUNCHXL-air-purifier-example.out \
                     /tmp/bloat_reports/
 
             - name: Uploading Size Reports

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -535,6 +535,7 @@ def Buildcc32xxTarget():
     # apps
     target.AppendFixedTargets([
         TargetPart('lock', app=cc32xxApp.LOCK),
+        TargetPart('air-purifier', app=cc32xxApp.AIR_PURIFIER),
 
     ])
 

--- a/scripts/build/builders/cc32xx.py
+++ b/scripts/build/builders/cc32xx.py
@@ -20,16 +20,21 @@ from .gn import GnBuilder
 
 class cc32xxApp(Enum):
     LOCK = auto()
+    AIR_PURIFIER = auto()
 
     def ExampleName(self):
         if self == cc32xxApp.LOCK:
             return 'lock-app'
+        elif self == cc32xxApp.AIR_PURIFIER:
+            return 'air-purifier-app'
         else:
             raise Exception('Unknown app type: %r' % self)
 
     def AppNamePrefix(self):
         if self == cc32xxApp.LOCK:
             return 'chip-CC3235SF_LAUNCHXL-lock-example'
+        elif self == cc32xxApp.AIR_PURIFIER:
+            return 'chip-CC3235SF_LAUNCHXL-air-purifier-example'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -59,6 +64,8 @@ class cc32xxBuilder(GnBuilder):
     def build_outputs(self):
         items = {}
         if (self.app == cc32xxApp.LOCK):
+            extensions = [".out", ".bin", ".out.map"]
+        elif (self.app == cc32xxApp.AIR_PURIFIER):
             extensions = [".out", ".bin", ".out.map"]
 
         else:

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -2,7 +2,7 @@ ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 asr-{asr582x,asr595x,asr550x}-{all-clusters,all-clusters-minimal,lighting,light-switch,lock,bridge,temperature-measurement,thermostat,ota-requestor,dishwasher,refrigerator}[-ota][-shell][-no_logging][-factory][-rotating_id][-rio]
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller,kotlin-matter-controller,virtual-device-app}[-no-debug]
 bouffalolab-{bl602-iot-matter-v1,bl602-night-light,xt-zb6-devkit,bl706-night-light,bl706dk,bl704ldk}-light[-shell][-115200][-rpc][-cdc][-resetcnt][-rotating_device_id][-mfd][-mfdtest][-ethernet][-wifi][-thread][-fp][-memmonitor][-mot]
-cc32xx-lock
+cc32xx-{lock,air-purifier}
 ti-cc13x2x7_26x2x7-{lighting,lock,pump,pump-controller}[-mtd]
 ti-cc13x4_26x4-{all-clusters,lighting,lock,pump,pump-controller}[-mtd][-ftd]
 cyw30739-cyw930739m2evb_01-{light,lock,ota-requestor,switch}


### PR DESCRIPTION
Add's ability to build Air Purifier app for cc32xx` via `build_examples.py` and also adds it to the `cc32xx` CI action.

Fixes #29939 

