### PR TITLE
Support list in dm xml

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
@@ -14,18 +14,20 @@
 
 import logging
 import re
-from typing import Optional
 from dataclasses import dataclass
+from typing import Optional
 
 from matter_idl.generators.types import GetDataTypeSizeInBits, IsSignedDataType
 from matter_idl.matter_idl_types import AccessPrivilege, Attribute, Command, ConstantEntry, DataType, Event, EventPriority, Field
 
 LOGGER = logging.getLogger('data-model-xml-data-parsing')
 
+
 @dataclass
 class ParsedType:
     name: str
     is_list: bool = False
+
 
 def ParseInt(value: str, data_type: Optional[DataType] = None) -> int:
     """
@@ -102,7 +104,6 @@ def ParseType(t: str) -> ParsedType:
         t = t[:-5]
 
     return ParsedType(name=NormalizeDataType(t), is_list=is_list)
-
 
 
 def NormalizeName(name: str) -> str:

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
@@ -181,7 +181,7 @@ def AttributesToAttribute(attrs) -> Attribute:
         LOGGER.error(f"Attribute {attrs['name']} has no type")
         attr_type = "sint32"
 
-    t = ParseType(attrs["type"])
+    t = ParseType(attr_type)
 
     return Attribute(
         definition=Field(

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
@@ -68,7 +68,7 @@ _TYPE_REMAP = {
     "uint32": "int32u",
     "uint48": "int48u",
     "uint52": "int52u",
-    "uint64": "int54u",
+    "uint64": "int64u",
     # signed
     "sint8": "int8s",
     "sint16": "int16s",
@@ -76,7 +76,7 @@ _TYPE_REMAP = {
     "sint32": "int32s",
     "sint48": "int48s",
     "sint52": "int52s",
-    "sint64": "int54s",
+    "sint64": "int64s",
     # other
     "bool": "boolean",
     "string": "char_string",

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -114,7 +114,6 @@ class TestXmlParser(unittest.TestCase):
 
         self.assertEqual(xml_idl, expected_idl)
 
-
     def testComplexInput(self):
         # This parses a known copy of Switch.xml which happens to be fully
         # spec-conformant (so assuming it as a good input)

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -72,6 +72,49 @@ class TestXmlParser(unittest.TestCase):
 
         self.assertEqual(xml_idl, expected_idl)
 
+    def testAttributes(self):
+        # Validate an attribute with a type list
+        # This is a very stripped down version from the original AudioOutput.xml
+
+        xml_idl = XmlToIdl('''
+            <cluster id="123" name="Test" revision="1">
+              <dataTypes>
+                <struct name="OutputInfoStruct">
+                  <field id="0" name="Index" type="uint8">
+                    <access read="true" write="true"/>
+                    <mandatoryConform/>
+                  </field>
+                </struct>
+              </dataTypes>
+              <attributes>
+                <attribute id="0x0000" name="OutputList" type="list[OutputInfoStruct Type]">
+                  <access read="true" readPrivilege="view"/>
+                  <mandatoryConform/>
+                </attribute>
+              </attributes>
+            </cluster>
+        ''')
+
+        expected_idl = IdlTextToIdl('''
+            client cluster Test = 123 {
+               struct OutputInfoStruct {
+                  int8u index = 0;
+               }
+
+               readonly attribute OutputInfoStruct outputList[] = 0;
+
+               readonly attribute attrib_id attributeList[] = 65531;
+               readonly attribute event_id eventList[] = 65530;
+               readonly attribute command_id acceptedCommandList[] = 65529;
+               readonly attribute command_id generatedCommandList[] = 65528;
+               readonly attribute bitmap32 featureMap = 65532;
+               readonly attribute int16u clusterRevision = 65533;
+           }
+        ''')
+
+        self.assertEqual(xml_idl, expected_idl)
+
+
     def testComplexInput(self):
         # This parses a known copy of Switch.xml which happens to be fully
         # spec-conformant (so assuming it as a good input)


### PR DESCRIPTION
Previously the types of lists when parsed were `readonly attribute list[Foo type] bar = 1`. Now they become `readonly atrribute Foo bar[] = 1`

Changes:
  - add support for list data type parsing and unit test
  - fix a typo in type conversions for 64-bit integers