### PR TITLE
Handle `otherwiseConform` tags when parsing CSA datamodel XML

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -93,7 +93,7 @@ class BitmapHandler(BaseHandler):
             return BaseHandler(self.context)
 
 
-class MandatoryConfirmFieldHandler(BaseHandler):
+class MandatoryConformFieldHandler(BaseHandler):
     def __init__(self, context: Context, field: Field):
         super().__init__(context, handled=HandledDepth.SINGLE_TAG)
         self._field = field
@@ -120,7 +120,7 @@ class FieldHandler(BaseHandler):
             ApplyConstraint(attrs, self._field)
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
         elif name == "mandatoryConform":
-            return MandatoryConfirmFieldHandler(self.context, self._field)
+            return MandatoryConformFieldHandler(self.context, self._field)
         elif name == "optionalConform":
             self._field.qualities |= FieldQuality.OPTIONAL
             return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
@@ -323,8 +323,11 @@ class AttributeHandler(BaseHandler):
         elif name == "optionalConform":
             self._attribute.definition.qualities |= FieldQuality.OPTIONAL
             return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
+        elif name == "otherwiseConform":
+            self._attribute.definition.qualities |= FieldQuality.OPTIONAL
+            return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
         elif name == "mandatoryConform":
-            return MandatoryConfirmFieldHandler(self.context, self._attribute.definition)
+            return MandatoryConformFieldHandler(self.context, self._attribute.definition)
         elif name == "deprecateConform":
             self._deprecated = True
             return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -91,6 +91,17 @@ class TestXmlParser(unittest.TestCase):
                   <access read="true" readPrivilege="view"/>
                   <mandatoryConform/>
                 </attribute>
+                <attribute id="0x0001" name="TestConform" type="enum8">
+                  <access read="true" readPrivilege="view"/>
+                  <otherwiseConform>
+                    <mandatoryConform>
+                      <feature name="PRSCONST"/>
+                    </mandatoryConform>
+                    <optionalConform>
+                      <feature name="AUTO"/>
+                    </optionalConform>
+                  </otherwiseConform>
+                </attribute>
               </attributes>
             </cluster>
         ''')
@@ -102,6 +113,7 @@ class TestXmlParser(unittest.TestCase):
                }
 
                readonly attribute OutputInfoStruct outputList[] = 0;
+               readonly attribute optional enum8 testConform = 1;
 
                readonly attribute attrib_id attributeList[] = 65531;
                readonly attribute event_id eventList[] = 65530;


### PR DESCRIPTION
These conformance tags showed up in Pump Configuration and Control XML.

An otherwiseConform seems to mean that there is a case when the items are not mandatory, so I handle them as optional.