### PR TITLE
[Linux] Convert possible Bluez object to GAutoPtr<>

### DIFF
--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -71,6 +71,7 @@
 #include <system/SystemPacketBuffer.h>
 
 #include "BluezConnection.h"
+#include "Types.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -691,18 +692,14 @@ static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject 
 {
     // TODO: right now we do not handle addition/removal of adapters
     // Primary focus here is to handle addition of a device
-    BluezDevice1 * device = bluez_object_get_device1(BLUEZ_OBJECT(aObject));
-    if (device == nullptr)
-    {
-        return;
-    }
+    GAutoPtr<BluezDevice1> device(bluez_object_get_device1(BLUEZ_OBJECT(aObject)));
 
-    if (BluezIsDeviceOnAdapter(device, endpoint->mpAdapter) == TRUE)
-    {
-        BluezHandleNewDevice(device, endpoint);
-    }
+    VerifyOrReturn(device.get() != nullptr);
 
-    g_object_unref(device);
+    if (BluezIsDeviceOnAdapter(device.get(), endpoint->mpAdapter) == TRUE)
+    {
+        BluezHandleNewDevice(device.get(), endpoint);
+    }
 }
 
 static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, gpointer apClosure)

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -223,24 +223,20 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
 
 void ChipDeviceScanner::SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self)
 {
-    BluezDevice1 * device = bluez_object_get_device1(BLUEZ_OBJECT(object));
-    VerifyOrReturn(device != nullptr);
+    GAutoPtr<BluezDevice1> device(bluez_object_get_device1(BLUEZ_OBJECT(object)));
+    VerifyOrReturn(device.get() != nullptr);
 
-    self->ReportDevice(*device);
-
-    g_object_unref(device);
+    self->ReportDevice(*device.get());
 }
 
 void ChipDeviceScanner::SignalInterfaceChanged(GDBusObjectManagerClient * manager, GDBusObjectProxy * object,
                                                GDBusProxy * aInterface, GVariant * aChangedProperties,
                                                const gchar * const * aInvalidatedProps, ChipDeviceScanner * self)
 {
-    BluezDevice1 * device = bluez_object_get_device1(BLUEZ_OBJECT(object));
-    VerifyOrReturn(device != nullptr);
+    GAutoPtr<BluezDevice1> device(bluez_object_get_device1(BLUEZ_OBJECT(object)));
+    VerifyOrReturn(device.get() != nullptr);
 
-    self->ReportDevice(*device);
-
-    g_object_unref(device);
+    self->ReportDevice(*device.get());
 }
 
 void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
@@ -295,11 +291,10 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     ChipLogProgress(Ble, "BLE removing known devices.");
     for (BluezObject & object : BluezObjectList(self->mManager))
     {
-        BluezDevice1 * device = bluez_object_get_device1(&object);
-        if (device != nullptr)
+        GAutoPtr<BluezDevice1> device(bluez_object_get_device1(&object));
+        if (device.get() != nullptr)
         {
-            self->RemoveDevice(*device);
-            g_object_unref(device);
+            self->RemoveDevice(*device.get());
         }
     }
 

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -46,10 +46,20 @@
 #pragma once
 
 #include <platform/CHIPDeviceConfig.h>
+#include <platform/GLibTypeDeleter.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
+
 namespace chip {
+
+template <>
+struct GAutoPtrDeleter<BluezDevice1>
+{
+    using deleter = GObjectDeleter;
+};
+
 namespace DeviceLayer {
 namespace Internal {
 


### PR DESCRIPTION
### Problem

Linux still has explicit Bluez memory management. This is follow-up PRs (https://github.com/project-chip/connectedhomeip/pull/28304) which will replace gdbus explicit memory management with GAutoPtr<>.

### Changes

- Changed explicit memory management of bluez objects to GAutoPtr<> were possible for the Linux platform.

### Testing

CI will test for potential build breaks.

Valgrind test result for linux-x64-light target:

```==561870== LEAK SUMMARY:
==561870==    definitely lost: 0 bytes in 0 blocks
==561870==    indirectly lost: 0 bytes in 0 blocks
==561870==      possibly lost: 640 bytes in 2 blocks
==561870==    still reachable: 202,743 bytes in 2,898 blocks
==561870==         suppressed: 0 bytes in 0 blocks```