### PR TITLE
find entry first, then createObject to avoid too many unreference entry alloced

### DIFF
--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -213,16 +213,18 @@ private:
     CHIP_ERROR AllocEntry(UnauthenticatedSession::SessionRole sessionRole, NodeId ephemeralInitiatorNodeID,
                           const ReliableMessageProtocolConfig & config, UnauthenticatedSession *& entry)
     {
-        entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config);
-        if (entry != nullptr)
-            return CHIP_NO_ERROR;
 
         entry = FindLeastRecentUsedEntry();
         if (entry == nullptr)
         {
-            return CHIP_ERROR_NO_MEMORY;
+            entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config);
+            if (entry != nullptr)
+                return CHIP_NO_ERROR;
+            else
+                return CHIP_ERROR_NO_MEMORY;
         }
 
+        ChipLogProgress(ExchangeManager, "Allocated new session. Current session count: %zu", mEntries.Allocated());
         mEntries.ResetObject(entry, sessionRole, ephemeralInitiatorNodeID, config);
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
try to fix bug:#29929
There are max of 4 unsecure sessions default( defined by CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE), if the CASE sigma1 was received more than 4 times. The mEntries in UnauthenticatedSessionTable will never release object, as in AllocEntry of UnauthenticatedSessionTable , it will CreateObject first, but it is less memory consumption to call FindLeastRecentUsedEntry first.

