### PR TITLE
Fix parsing heuristics for sizing bitmaps and enums

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -65,19 +65,23 @@ class BitmapHandler(BaseHandler):
         # try to find the best size that fits
         # TODO: this is a pure heuristic. XML containing this would be better.
         #       https://github.com/csa-data-model/projects/issues/345
-        acceptable = {8, 16, 32}
+        acceptable = {8, 16, 32, 64}
         for entry in self._bitmap.entries:
             if entry.code > 0xFF and 8 in acceptable:
                 acceptable.remove(8)
             if entry.code > 0xFFFF and 16 in acceptable:
                 acceptable.remove(16)
+            if entry.code > 0xFFFFFFFF and 32 in acceptable:
+                acceptable.remove(32)
 
         if 8 in acceptable:
             self._bitmap.base_type = "bitmap8"
         elif 16 in acceptable:
             self._bitmap.base_type = "bitmap16"
-        else:
+        elif 32 in acceptable:
             self._bitmap.base_type = "bitmap32"
+        else:
+            self._bitmap.base_type = "bitmap64"
 
         self._cluster.bitmaps.append(self._bitmap)
 
@@ -223,19 +227,15 @@ class EnumHandler(BaseHandler):
         # try to find the best enum size that fits out of enum8, enum32 and enum32
         # TODO: this is a pure heuristic. XML containing this would be better.
         #       https://github.com/csa-data-model/projects/issues/345
-        acceptable = {8, 16, 32}
+        acceptable = {8, 16}
         for entry in self._enum.entries:
             if entry.code > 0xFF and 8 in acceptable:
                 acceptable.remove(8)
-            if entry.code > 0xFFFF and 16 in acceptable:
-                acceptable.remove(16)
 
         if 8 in acceptable:
             self._enum.base_type = "enum8"
-        elif 16 in acceptable:
-            self._enum.base_type = "enum16"
         else:
-            self._enum.base_type = "enum32"
+            self._enum.base_type = "enum16"
 
         self._cluster.enums.append(self._enum)
 

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -64,6 +64,7 @@ class BitmapHandler(BaseHandler):
 
         # try to find the best size that fits
         # TODO: this is a pure heuristic. XML containing this would be better.
+        #       https://github.com/csa-data-model/projects/issues/345
         acceptable = {8, 16, 32}
         for entry in self._bitmap.entries:
             if entry.code > 0xFF and 8 in acceptable:
@@ -221,6 +222,7 @@ class EnumHandler(BaseHandler):
 
         # try to find the best enum size that fits out of enum8, enum32 and enum32
         # TODO: this is a pure heuristic. XML containing this would be better.
+        #       https://github.com/csa-data-model/projects/issues/345
         acceptable = {8, 16, 32}
         for entry in self._enum.entries:
             if entry.code > 0xFF and 8 in acceptable:

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -66,9 +66,9 @@ class BitmapHandler(BaseHandler):
         # TODO: this is a pure heuristic. XML containing this would be better.
         acceptable = {8, 16, 32}
         for entry in self._bitmap.entries:
-            if entry.code > 0xFF:
+            if entry.code > 0xFF and 8 in acceptable:
                 acceptable.remove(8)
-            if entry.code > 0xFFFF:
+            if entry.code > 0xFFFF and 16 in acceptable:
                 acceptable.remove(16)
 
         if 8 in acceptable:
@@ -223,9 +223,9 @@ class EnumHandler(BaseHandler):
         # TODO: this is a pure heuristic. XML containing this would be better.
         acceptable = {8, 16, 32}
         for entry in self._enum.entries:
-            if entry.code > 0xFF:
+            if entry.code > 0xFF and 8 in acceptable:
                 acceptable.remove(8)
-            if entry.code > 0xFFFF:
+            if entry.code > 0xFFFF and 16 in acceptable:
                 acceptable.remove(16)
 
         if 8 in acceptable:

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -78,6 +78,11 @@ class TestXmlParser(unittest.TestCase):
         xml_idl = XmlToIdl('''
             <cluster id="123" name="Test" revision="1">
               <dataTypes>
+                <bitmap name="OneLarge">
+                  <bitfield name="Ten" bit="10">
+                    <mandatoryConform/>
+                  </bitfield>
+                </bitmap>
                 <bitmap name="LargeBitmap">
                   <bitfield name="One" bit="0">
                     <mandatoryConform/>
@@ -95,6 +100,10 @@ class TestXmlParser(unittest.TestCase):
 
         expected_idl = IdlTextToIdl('''
             client cluster Test = 123 {
+               bitmap OneLarge: bitmap16 {
+                  kTen = 0x400;
+               }
+
                bitmap LargeBitmap: bitmap32 {
                   kOne = 0x1;
                   kTen = 0x400;

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -94,6 +94,11 @@ class TestXmlParser(unittest.TestCase):
                     <mandatoryConform/>
                   </bitfield>
                 </bitmap>
+                <bitmap name="HugeBitmap">
+                  <bitfield name="Forty" bit="40">
+                    <mandatoryConform/>
+                  </bitfield>
+                </bitmap>
               </dataTypes>
             </cluster>
         ''')
@@ -108,6 +113,10 @@ class TestXmlParser(unittest.TestCase):
                   kOne = 0x1;
                   kTen = 0x400;
                   kTwenty = 0x100000;
+               }
+
+               bitmap HugeBitmap: bitmap64 {
+                  kForty = 0x10000000000;
                }
 
                readonly attribute attrib_id attributeList[] = 65531;

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -72,6 +72,46 @@ class TestXmlParser(unittest.TestCase):
 
         self.assertEqual(xml_idl, expected_idl)
 
+    def testEnumRange(self):
+        # Check heuristic for enum ranges
+
+        xml_idl = XmlToIdl('''
+            <cluster id="123" name="Test" revision="1">
+              <dataTypes>
+                <bitmap name="LargeBitmap">
+                  <bitfield name="One" bit="0">
+                    <mandatoryConform/>
+                  </bitfield>
+                  <bitfield name="Ten" bit="10">
+                    <mandatoryConform/>
+                  </bitfield>
+                  <bitfield name="Twenty" bit="20">
+                    <mandatoryConform/>
+                  </bitfield>
+                </bitmap>
+              </dataTypes>
+            </cluster>
+        ''')
+
+        expected_idl = IdlTextToIdl('''
+            client cluster Test = 123 {
+               bitmap LargeBitmap: bitmap32 {
+                  kOne = 0x1;
+                  kTen = 0x400;
+                  kTwenty = 0x100000;
+               }
+
+               readonly attribute attrib_id attributeList[] = 65531;
+               readonly attribute event_id eventList[] = 65530;
+               readonly attribute command_id acceptedCommandList[] = 65529;
+               readonly attribute command_id generatedCommandList[] = 65528;
+               readonly attribute bitmap32 featureMap = 65532;
+               readonly attribute int16u clusterRevision = 65533;
+           }
+        ''')
+
+        self.assertEqual(xml_idl, expected_idl)
+
     def testAttributes(self):
         # Validate an attribute with a type list
         # This is a very stripped down version from the original AudioOutput.xml

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -78,6 +78,17 @@ class TestXmlParser(unittest.TestCase):
         xml_idl = XmlToIdl('''
             <cluster id="123" name="Test" revision="1">
               <dataTypes>
+                <bitmap name="Basic">
+                  <bitfield name="One" bit="0">
+                    <mandatoryConform/>
+                  </bitfield>
+                  <bitfield name="Two" bit="1">
+                    <mandatoryConform/>
+                  </bitfield>
+                  <bitfield name="Three" bit="2">
+                    <mandatoryConform/>
+                  </bitfield>
+                </bitmap>
                 <bitmap name="OneLarge">
                   <bitfield name="Ten" bit="10">
                     <mandatoryConform/>
@@ -105,6 +116,12 @@ class TestXmlParser(unittest.TestCase):
 
         expected_idl = IdlTextToIdl('''
             client cluster Test = 123 {
+               bitmap Basic: bitmap8 {
+                  kOne = 0x01;
+                  kTwo = 0x02;
+                  kThree = 0x04;
+               }
+
                bitmap OneLarge: bitmap16 {
                   kTen = 0x400;
                }


### PR DESCRIPTION
Apparently removing a key that does not exist from a set throws.
Alter code to only remove from the set if key exists and add unit test for this.

Changes:
  - apparently enum32 is not a thing. Only support enum8 and enum16
  - add support for bitmap64 in heuristics and add unit tests for it
  - add "in set" tests before removing from acceptable ranges.