### PR TITLE
[ICD] Update root device type to include icdm cluster

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -84,6 +84,11 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="ICD Management" clients="false" server="false" clientLocked="true" serverLocked="false">
+                <requireAttribute>IDLE_MODE_DURATION</requireAttribute>
+                <requireAttribute>ACTIVE_MODE_DURATION</requireAttribute>
+                <requireAttribute>ACTIVE_MODE_THRESHOLD</requireAttribute>
+            </include>
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -84,7 +84,7 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="ICD Management" clients="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -84,11 +84,7 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="ICD Management" clients="false" server="false" clientLocked="true" serverLocked="false">
-                <requireAttribute>IDLE_MODE_DURATION</requireAttribute>
-                <requireAttribute>ACTIVE_MODE_DURATION</requireAttribute>
-                <requireAttribute>ACTIVE_MODE_THRESHOLD</requireAttribute>
-            </include>
+            <include cluster="ICD Management" clients="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>


### PR DESCRIPTION
#### Description
Spec added the ICDM cluster to root node device type. 
Adding it in the SDK.

fixes #26798 