### PR TITLE
[Infineon]Update button init sequence before wifi commissioning

### DIFF
--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -253,22 +253,6 @@ void AppTask::lockMgr_Init()
         appError(err);
     }
 
-    // Initialise WSTK buttons PB0 and PB1 (including debounce).
-    ButtonHandler::Init();
-
-    // Create FreeRTOS sw timer for Function Selection.
-    sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel
-                                  1,                // == default timer period (mS)
-                                  false,            // no timer reload (==one-shot)
-                                  (void *) this,    // init timer id = app task obj context
-                                  TimerEventHandler // timer callback handler
-    );
-    if (sFunctionTimer == NULL)
-    {
-        P6_LOG("funct timer create failed");
-        appError(APP_ERROR_CREATE_TIMER_FAILED);
-    }
-
     LockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
     // Initialize LEDs
@@ -301,6 +285,22 @@ void AppTask::Init()
         appError(CHIP_ERROR_WELL_UNINITIALIZED);
     }
 #endif
+    // Initialise WSTK buttons PB0 and PB1 (including debounce).
+    ButtonHandler::Init();
+
+    // Create FreeRTOS sw timer for Function Selection.
+    sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel
+                                  1,                // == default timer period (mS)
+                                  false,            // no timer reload (==one-shot)
+                                  (void *) this,    // init timer id = app task obj context
+                                  TimerEventHandler // timer callback handler
+    );
+    if (sFunctionTimer == NULL)
+    {
+        P6_LOG("funct timer create failed");
+        appError(APP_ERROR_CREATE_TIMER_FAILED);
+    }
+
     // Register the callback to init the MDNS server when connectivity is available
     PlatformMgr().AddEventHandler(
         [](const ChipDeviceEvent * event, intptr_t arg) {


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/29611

- Support button init before wifi commissioning sequence in-order to do factory reset during error scenarios.
- call starttimer using schedulelamba as it was causing chipDie during wifi connect retry sequences (if wifi password is wrong)