### PR TITLE
esp32: make the shell command line buffer size configurable

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -96,6 +96,22 @@ menu "CHIP Core"
             help
                 Link the application against CHIP interactive shell.
 
+        config CHIP_SHELL_CMD_LINE_BUF_MAX_LENGTH
+            int "Maximum command line buffer length of the chip shell"
+            depends on ENABLE_CHIP_SHELL
+            default 256
+            help
+                Maximum command line buffer length of the chip shell. The command strings might be received
+                incompletely in the command handlers if they are longer than this buffer length.
+
+        config CHIP_SHELL_CMD_LINE_ARG_MAX_COUNT
+            int "Maximum command line arguments count of the chip shell"
+            depends on ENABLE_CHIP_SHELL
+            default 32
+            help
+                Maximum command line arguments count of the chip shell. The command arguments might be ignored
+                if they are more than this count.
+
         config ENABLE_CHIP_CONTROLLER_BUILD
             bool "Enable chip-controller build"
             default n

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -95,8 +95,8 @@ int streamer_esp32_init(streamer_t * streamer)
     esp_vfs_dev_uart_register();
 #endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     esp_console_config_t console_config = {
-        .max_cmdline_length = 256,
-        .max_cmdline_args   = 32,
+        .max_cmdline_length = CONFIG_CHIP_SHELL_CMD_LINE_BUF_MAX_LENGTH,
+        .max_cmdline_args   = CONFIG_CHIP_SHELL_CMD_LINE_ARG_MAX_COUNT,
     };
     ESP_ERROR_CHECK(esp_console_init(&console_config));
     linenoiseSetMultiLine(1);


### PR DESCRIPTION
The command strings might be received incompletely in the command handlers if they are longer than the max command line buffer size. Make this buffer size and command line arguments count configurable.