### PR TITLE
chip::to_underlying is missing [air-quality-sensor-manager]

### DIFF
--- a/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
@@ -136,7 +136,7 @@ void AirQualitySensorManager::Init()
 
 void AirQualitySensorManager::OnAirQualityChangeHandler(AirQualityEnum newValue)
 {
-    mAirQualityInstance.UpdateAirQuality(static_cast<AirQualityEnum>(newValue));
+    mAirQualityInstance.UpdateAirQuality(newValue);
     ChipLogDetail(NotSpecified, "Updated AirQuality value: %huu", chip::to_underlying(newValue));
 }
 

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
@@ -137,7 +137,7 @@ void AirQualitySensorManager::Init()
 void AirQualitySensorManager::OnAirQualityChangeHandler(AirQualityEnum newValue)
 {
     mAirQualityInstance.UpdateAirQuality(static_cast<AirQualityEnum>(newValue));
-    ChipLogDetail(NotSpecified, "Updated AirQuality value: %huu", newValue);
+    ChipLogDetail(NotSpecified, "Updated AirQuality value: %huu", chip::to_underlying(newValue));
 }
 
 void AirQualitySensorManager::OnCarbonDioxideMeasurementChangeHandler(float newValue)


### PR DESCRIPTION
Fixes #29735
chip::to_underlying is missing
