### PR TITLE
[Linux] Wrap BlueZ endpoint functions in a class

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -571,8 +571,7 @@ void BLEManagerImpl::DriveBLEState()
     // Initializes the Bluez BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kBluezBLELayerInitialized))
     {
-        mEndpoint = Platform::MakeUnique<BluezEndpoint>(mAdapterId, mIsCentral);
-        VerifyOrExit(mEndpoint, ChipLogError(DeviceLayer, "FAIL: memory allocation in %s", __func__));
+        VerifyOrExit((mEndpoint = Platform::MakeUnique<BluezEndpoint>(mAdapterId, mIsCentral)), err = CHIP_ERROR_NO_MEMORY);
         SuccessOrExit(err = mEndpoint->Init(nullptr, mDeviceName));
         mFlags.Set(Flags::kBluezBLELayerInitialized);
     }
@@ -653,7 +652,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
         return;
     }
 
-    if (!mEndpoint)
+    if (!mFlags.Has(Flags::kBluezBLELayerInitialized))
     {
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);
         ChipLogError(Ble, "BLE Layer is not yet initialized");

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -595,15 +595,13 @@ void BLEManagerImpl::DriveBLEState()
             // Configure advertising data if it hasn't been done yet.
             if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
-                err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs);
-                SuccessOrExit(err);
+                SuccessOrExit(err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
                 mFlags.Set(Flags::kAdvertisingConfigured);
             }
 
             // Start advertising. This is an asynchronous step. BLE manager will be notified of
             // advertising start completion via a call to NotifyBLEPeripheralAdvStartComplete.
-            err = mBLEAdvertisement.Start();
-            SuccessOrExit(err);
+            SuccessOrExit(err = mBLEAdvertisement.Start());
             mFlags.Set(Flags::kControlOpInProgress);
             ExitNow();
         }
@@ -614,8 +612,7 @@ void BLEManagerImpl::DriveBLEState()
     {
         if (mFlags.Has(Flags::kAdvertising))
         {
-            err = mBLEAdvertisement.Stop();
-            SuccessOrExit(err);
+            SuccessOrExit(err = mBLEAdvertisement.Stop());
             mFlags.Set(Flags::kControlOpInProgress);
 
             ExitNow();

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -595,7 +595,7 @@ void BLEManagerImpl::DriveBLEState()
             // Configure advertising data if it hasn't been done yet.
             if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
-                err = mBLEAdvertisement.Init(&mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs);
+                err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs);
                 SuccessOrExit(err);
                 mFlags.Set(Flags::kAdvertisingConfigured);
             }

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -660,7 +660,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
         return;
     }
 
-    if (mEndpoint->mpAdapter == nullptr)
+    if (mEndpoint->GetAdapter() == nullptr)
     {
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);
         ChipLogError(Ble, "No adapter available for new connection establishment");
@@ -669,7 +669,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     mBLEScanConfig.mBleScanState = scanType;
 
-    CHIP_ERROR err = mDeviceScanner.Init(mEndpoint->mpAdapter, this);
+    CHIP_ERROR err = mDeviceScanner.Init(mEndpoint->GetAdapter(), this);
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -580,7 +580,7 @@ void BLEManagerImpl::DriveBLEState()
     // Register the CHIPoBLE application with the Bluez BLE layer if needed.
     if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
-        SuccessOrExit(err = mEndpoint->BluezGattAppRegister());
+        SuccessOrExit(err = mEndpoint->RegisterGattApplication());
         mFlags.Set(Flags::kControlOpInProgress);
         ExitNow();
     }

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -187,7 +187,7 @@ private:
     uint32_t mAdapterId = 0;
     char mDeviceName[kMaxDeviceNameLength + 1];
     bool mIsCentral = false;
-    Platform::UniquePtr<BluezEndpoint> mEndpoint;
+    BluezEndpoint mEndpoint;
 
     BluezAdvertisement mBLEAdvertisement;
     ChipAdvType mBLEAdvType    = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -27,6 +27,7 @@
 #include <string>
 
 #include <ble/BleLayer.h>
+#include <lib/support/CHIPMem.h>
 #include <platform/internal/BLEManager.h>
 
 #include "bluez/BluezAdvertisement.h"
@@ -185,8 +186,8 @@ private:
 
     uint32_t mAdapterId = 0;
     char mDeviceName[kMaxDeviceNameLength + 1];
-    bool mIsCentral            = false;
-    BluezEndpoint * mpEndpoint = nullptr;
+    bool mIsCentral = false;
+    Platform::UniquePtr<BluezEndpoint> mEndpoint;
 
     BluezAdvertisement mBLEAdvertisement;
     ChipAdvType mBLEAdvType    = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -27,7 +27,6 @@
 #include <string>
 
 #include <ble/BleLayer.h>
-#include <lib/support/CHIPMem.h>
 #include <platform/internal/BLEManager.h>
 
 #include "bluez/BluezAdvertisement.h"

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -142,7 +142,7 @@ CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType
     VerifyOrExit(mpAdv == nullptr, err = CHIP_ERROR_INCORRECT_STATE;
                  ChipLogError(DeviceLayer, "FAIL: BLE advertisement already initialized in %s", __func__));
 
-    mpRoot        = reinterpret_cast<GDBusObjectManagerServer *>(g_object_ref(aEndpoint.mpRoot));
+    mpRoot        = reinterpret_cast<GDBusObjectManagerServer *>(g_object_ref(aEndpoint.GetGattApplicationObjectManager()));
     mpAdapter     = reinterpret_cast<BluezAdapter1 *>(g_object_ref(aEndpoint.GetAdapter()));
     mpAdapterName = g_strdup(aEndpoint.GetAdapterName());
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -133,20 +133,18 @@ CHIP_ERROR BluezAdvertisement::InitImpl()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BluezAdvertisement::Init(BluezEndpoint * apEndpoint, ChipAdvType aAdvType, const char * aAdvUUID,
+CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID,
                                     uint32_t aAdvDurationMs)
 {
     GAutoPtr<char> rootPath;
     CHIP_ERROR err;
 
-    VerifyOrExit(apEndpoint != nullptr, err = CHIP_ERROR_INCORRECT_STATE;
-                 ChipLogError(DeviceLayer, "FAIL: NULL endpoint in %s", __func__));
     VerifyOrExit(mpAdv == nullptr, err = CHIP_ERROR_INCORRECT_STATE;
                  ChipLogError(DeviceLayer, "FAIL: BLE advertisement already initialized in %s", __func__));
 
-    mpRoot        = reinterpret_cast<GDBusObjectManagerServer *>(g_object_ref(apEndpoint->mpRoot));
-    mpAdapter     = reinterpret_cast<BluezAdapter1 *>(g_object_ref(apEndpoint->mpAdapter));
-    mpAdapterName = g_strdup(apEndpoint->mpAdapterName);
+    mpRoot        = reinterpret_cast<GDBusObjectManagerServer *>(g_object_ref(aEndpoint.mpRoot));
+    mpAdapter     = reinterpret_cast<BluezAdapter1 *>(g_object_ref(aEndpoint.GetAdapter()));
+    mpAdapterName = g_strdup(aEndpoint.GetAdapterName());
 
     g_object_get(G_OBJECT(mpRoot), "object-path", &MakeUniquePointerReceiver(rootPath).Get(), nullptr);
     mpAdvPath      = g_strdup_printf("%s/advertising", rootPath.get());

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -41,7 +41,7 @@ public:
     BluezAdvertisement() = default;
     ~BluezAdvertisement() { Shutdown(); }
 
-    CHIP_ERROR Init(BluezEndpoint * apEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
+    CHIP_ERROR Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
     void Shutdown();
 
     /// Start BLE advertising.

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -33,7 +33,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-struct BluezEndpoint;
+class BluezEndpoint;
 
 class BluezAdvertisement
 {

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -59,10 +59,10 @@ gboolean BluezIsCharOnService(BluezGattCharacteristic1 * aChar, BluezGattService
 
 } // namespace
 
-BluezConnection::BluezConnection(BluezEndpoint * apEndpoint, BluezDevice1 * apDevice) :
-    mpEndpoint(apEndpoint), mpDevice(BLUEZ_DEVICE1(g_object_ref(apDevice)))
+BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice) :
+    mpDevice(BLUEZ_DEVICE1(g_object_ref(apDevice)))
 {
-    Init();
+    Init(aEndpoint);
 }
 
 BluezConnection::~BluezConnection()
@@ -93,21 +93,21 @@ BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnectio
     mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
-CHIP_ERROR BluezConnection::Init()
+CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 {
     // populate the service and the characteristics
     GList * objects = nullptr;
     GList * l;
 
-    if (!mpEndpoint->mIsCentral)
+    if (!aEndpoint.mIsCentral)
     {
-        mpService = BLUEZ_GATT_SERVICE1(g_object_ref(mpEndpoint->mpService));
-        mpC1      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(mpEndpoint->mpC1));
-        mpC2      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(mpEndpoint->mpC2));
+        mpService = BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService));
+        mpC1      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1));
+        mpC2      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2));
     }
     else
     {
-        objects = g_dbus_object_manager_get_objects(mpEndpoint->mpObjMgr);
+        objects = g_dbus_object_manager_get_objects(aEndpoint.mpObjMgr);
 
         for (l = objects; l != nullptr; l = l->next)
         {

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -37,7 +37,7 @@ class BluezEndpoint;
 class BluezConnection
 {
 public:
-    BluezConnection(BluezEndpoint * apEndpoint, BluezDevice1 * apDevice);
+    BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice);
     ~BluezConnection();
 
     const char * GetPeerAddress() const;
@@ -95,7 +95,7 @@ private:
         GAutoPtr<GVariant> mData;
     };
 
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(const BluezEndpoint & aEndpoint);
 
     static CHIP_ERROR BluezDisconnect(BluezConnection * apConn);
 
@@ -115,7 +115,6 @@ private:
     static void UnsubscribeCharacteristicDone(GObject * aObject, GAsyncResult * aResult, gpointer apConn);
     static CHIP_ERROR UnsubscribeCharacteristicImpl(BluezConnection * apConn);
 
-    BluezEndpoint * mpEndpoint;
     BluezDevice1 * mpDevice;
 
     bool mNotifyAcquired = false;

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -32,7 +32,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-struct BluezEndpoint;
+class BluezEndpoint;
 
 class BluezConnection
 {

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -535,7 +535,7 @@ void BluezEndpoint::SetupGattService()
     static const char * const c3_flags[] = { "read", nullptr };
 #endif
 
-    mpService = CreateGattService("0xFFF6");
+    mpService = CreateGattService(CHIP_BLE_UUID_SERVICE_SHORT_STRING);
 
     // C1 characteristic
     mpC1 = CreateGattCharacteristic(mpService, "c1", CHIP_PLAT_BLE_UUID_C1_STRING);

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -654,7 +654,6 @@ BluezEndpoint::BluezEndpoint()
 
 BluezEndpoint::~BluezEndpoint()
 {
-    Shutdown();
     g_hash_table_destroy(mpConnMap);
 }
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -282,7 +282,7 @@ static void BluezPeripheralRegisterAppDone(GObject * aObject, GAsyncResult * aRe
     ChipLogDetail(DeviceLayer, "BluezPeripheralRegisterAppDone done");
 }
 
-static CHIP_ERROR BluezPeripheralRegisterApp(BluezEndpoint * endpoint)
+CHIP_ERROR BluezEndpoint::BluezGattAppRegisterImpl(BluezEndpoint * endpoint)
 {
     GDBusObject * adapter;
     BluezGattManager1 * gattMgr;
@@ -638,9 +638,9 @@ BluezEndpoint::~BluezEndpoint()
 
 CHIP_ERROR BluezEndpoint::BluezGattAppRegister()
 {
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(BluezPeripheralRegisterApp, this);
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(BluezGattAppRegisterImpl, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
-                        ChipLogError(Ble, "Failed to schedule BluezPeripheralRegisterApp() on CHIPoBluez thread"));
+                        ChipLogError(Ble, "Failed to schedule BluezGattAppRegister() on CHIPoBluez thread"));
     return err;
 }
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -685,12 +685,16 @@ CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char 
         +[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization"));
 
-    ChipLogDetail(DeviceLayer, "PlatformBlueZInit init success");
+    ChipLogDetail(DeviceLayer, "BlueZ integration init success");
+    mIsInitialized = true;
+
     return CHIP_NO_ERROR;
 }
 
 void BluezEndpoint::Shutdown()
 {
+    VerifyOrReturn(mIsInitialized);
+
     // Run endpoint cleanup on the CHIPoBluez thread. This is necessary because the
     // cleanup function releases the D-Bus manager client object, which handles D-Bus
     // signals. Otherwise, we will face race condition when the D-Bus signal is in
@@ -725,6 +729,8 @@ void BluezEndpoint::Shutdown()
     g_free(mpRootPath);
     g_free(mpServicePath);
     g_free(mpPeerDevicePath);
+
+    mIsInitialized = false;
 }
 
 // ConnectDevice callbacks

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -162,7 +162,7 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
     uint16_t mtu;
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
-    isAdditionalAdvertising = (aChar == self->mpC3);
+    isAdditionalAdvertising = (aChar == mpC3);
 #endif
 
     if (bluez_gatt_characteristic1_get_notifying(aChar))

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -647,7 +647,7 @@ CHIP_ERROR BluezEndpoint::StartupEndpointBindings()
     return CHIP_NO_ERROR;
 }
 
-BluezEndpoint::BluezEndpoint(uint32_t aAdapterId, bool aIsCentral) : mAdapterId(aAdapterId), mIsCentral(aIsCentral)
+BluezEndpoint::BluezEndpoint()
 {
     mpConnMap = g_hash_table_new(g_str_hash, g_str_equal);
 }
@@ -655,16 +655,7 @@ BluezEndpoint::BluezEndpoint(uint32_t aAdapterId, bool aIsCentral) : mAdapterId(
 BluezEndpoint::~BluezEndpoint()
 {
     Shutdown();
-    g_free(mpOwningName);
-    g_free(mpAdapterName);
-    g_free(mpAdapterAddr);
-    g_free(mpRootPath);
-    g_free(mpServicePath);
-    if (mpConnMap != nullptr)
-        g_hash_table_destroy(mpConnMap);
-    g_free(mpPeerDevicePath);
-    if (mpConnectCancellable != nullptr)
-        g_object_unref(mpConnectCancellable);
+    g_hash_table_destroy(mpConnMap);
 }
 
 CHIP_ERROR BluezEndpoint::RegisterGattApplication()
@@ -676,14 +667,17 @@ CHIP_ERROR BluezEndpoint::RegisterGattApplication()
     return err;
 }
 
-CHIP_ERROR BluezEndpoint::Init(const char * apBleAddr, const char * apBleName)
+CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName)
 {
     CHIP_ERROR err;
+
+    mAdapterId = aAdapterId;
+    mIsCentral = aIsCentral;
 
     if (apBleAddr != nullptr)
         mpAdapterAddr = g_strdup(apBleAddr);
 
-    if (!mIsCentral)
+    if (!aIsCentral)
     {
         mpAdapterName = g_strdup(apBleName);
     }
@@ -724,9 +718,18 @@ void BluezEndpoint::Shutdown()
                 g_object_unref(self->mpC2);
             if (self->mpC3 != nullptr)
                 g_object_unref(self->mpC3);
+            if (self->mpConnectCancellable != nullptr)
+                g_object_unref(self->mpConnectCancellable);
             return CHIP_NO_ERROR;
         },
         this);
+
+    g_free(mpOwningName);
+    g_free(mpAdapterName);
+    g_free(mpAdapterAddr);
+    g_free(mpRootPath);
+    g_free(mpServicePath);
+    g_free(mpPeerDevicePath);
 }
 
 // ConnectDevice callbacks

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -329,7 +329,7 @@ void BluezEndpoint::UpdateConnectionTable(BluezDevice1 * apDevice)
     if (connection == nullptr && bluez_device1_get_connected(apDevice) &&
         (!mIsCentral || bluez_device1_get_services_resolved(apDevice)))
     {
-        connection       = chip::Platform::New<BluezConnection>(this, apDevice);
+        connection       = chip::Platform::New<BluezConnection>(*this, apDevice);
         mpPeerDevicePath = g_strdup(objectPath);
         g_hash_table_insert(mpConnMap, mpPeerDevicePath, connection);
 
@@ -369,7 +369,7 @@ void BluezEndpoint::HandleNewDevice(BluezDevice1 * device)
                  ChipLogError(DeviceLayer, "FAIL: connection already tracked: conn: %p new device: %s", conn,
                               g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
 
-    conn             = chip::Platform::New<BluezConnection>(this, device);
+    conn             = chip::Platform::New<BluezConnection>(*this, device);
     mpPeerDevicePath = g_strdup(g_dbus_proxy_get_object_path(G_DBUS_PROXY(device)));
     g_hash_table_insert(mpConnMap, mpPeerDevicePath, conn);
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -112,7 +112,7 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1
     conn = self->GetBluezConnectionViaDevice();
     VerifyOrReturnValue(
         conn != nullptr, FALSE,
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection"));
 
     ChipLogDetail(DeviceLayer, "BluezCharacteristicAcquireWrite is called, conn: %p", conn);
 
@@ -174,7 +174,7 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
     conn = self->GetBluezConnectionViaDevice();
     VerifyOrReturnValue(
         conn != nullptr, FALSE,
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection"));
 
     VerifyOrReturnValue(
         g_variant_lookup(aOptions, "mtu", "q", &mtu), FALSE, ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -60,17 +60,31 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-struct BluezEndpoint
+class BluezEndpoint
 {
-    char * mpOwningName; // Bus owning name
+public:
+    BluezEndpoint(uint32_t aAdapterId, bool aIsCentral);
+    ~BluezEndpoint();
+
+    CHIP_ERROR Init(const char * apBleAddr, const char * apBleName);
+    void Shutdown();
+
+    CHIP_ERROR BluezGattAppRegister();
+
+    CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
+    void CancelConnect();
+
+public:
+    // Bus owning name
+    char * mpOwningName = nullptr;
 
     // Adapter properties
-    char * mpAdapterName;
-    char * mpAdapterAddr;
+    char * mpAdapterName = nullptr;
+    char * mpAdapterAddr = nullptr;
 
     // Paths for objects published by this service
-    char * mpRootPath;
-    char * mpServicePath;
+    char * mpRootPath    = nullptr;
+    char * mpServicePath = nullptr;
 
     // Objects (interfaces) subscribed to by this service
     GDBusObjectManager * mpObjMgr = nullptr;
@@ -78,28 +92,20 @@ struct BluezEndpoint
     BluezDevice1 * mpDevice       = nullptr;
 
     // Objects (interfaces) published by this service
-    GDBusObjectManagerServer * mpRoot;
-    BluezGattService1 * mpService;
-    BluezGattCharacteristic1 * mpC1;
-    BluezGattCharacteristic1 * mpC2;
+    GDBusObjectManagerServer * mpRoot = nullptr;
+    BluezGattService1 * mpService     = nullptr;
+    BluezGattCharacteristic1 * mpC1   = nullptr;
+    BluezGattCharacteristic1 * mpC2   = nullptr;
     // additional data characteristics
-    BluezGattCharacteristic1 * mpC3;
+    BluezGattCharacteristic1 * mpC3 = nullptr;
 
     // map device path to the connection
-    GHashTable * mpConnMap;
-    uint32_t mAdapterId;
-    bool mIsCentral;
-    char * mpPeerDevicePath;
+    GHashTable * mpConnMap              = nullptr;
+    uint32_t mAdapterId                 = 0;
+    bool mIsCentral                     = false;
+    char * mpPeerDevicePath             = nullptr;
     GCancellable * mpConnectCancellable = nullptr;
 };
-
-CHIP_ERROR InitBluezBleLayer(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName,
-                             BluezEndpoint *& apEndpoint);
-CHIP_ERROR ShutdownBluezBleLayer(BluezEndpoint * apEndpoint);
-CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint);
-
-CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice, BluezEndpoint * apEndpoint);
-void CancelConnect(BluezEndpoint * apEndpoint);
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -85,10 +85,13 @@ private:
         uint16_t mNumRetries = 0;
     };
 
-    BluezGattService1 * BluezServiceCreate();
+    void SetupAdapter();
+    void SetupGattService();
+
+    BluezGattService1 * CreateGattService(const char * aUUID);
+    BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID);
+
     void BluezOnBusAcquired(GDBusConnection * aConn, const char * aName);
-    void BluezPeripheralObjectsSetup();
-    void BluezObjectsSetup();
 
     static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -70,6 +70,8 @@ public:
     CHIP_ERROR Init(const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
+    BluezAdapter1 * GetAdapter() const { return mpAdapter; }
+
     CHIP_ERROR RegisterGattApplication();
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
@@ -122,7 +124,6 @@ private:
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
 
-public:
     // Bus owning name
     char * mpOwningName = nullptr;
 
@@ -153,6 +154,9 @@ public:
     bool mIsCentral                     = false;
     char * mpPeerDevicePath             = nullptr;
     GCancellable * mpConnectCancellable = nullptr;
+
+    // Allow BluezConnection to access our private members
+    friend class BluezConnection;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -85,15 +85,17 @@ private:
         uint16_t mNumRetries = 0;
     };
 
+    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
+    void BluezOnBusAcquired(GDBusConnection * aConn, const char * aName);
+
     void SetupAdapter();
     void SetupGattService();
 
     BluezGattService1 * CreateGattService(const char * aUUID);
     BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID);
+    BluezLEAdvertisement1 * CreateLEAdvertisement();
 
-    void BluezOnBusAcquired(GDBusConnection * aConn, const char * aName);
-
-    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
+    static CHIP_ERROR BluezGattAppRegisterImpl(BluezEndpoint * endpoint);
 
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -46,6 +46,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <unordered_map>
 
 #include <gio/gio.h>
 #include <glib.h>
@@ -64,8 +66,8 @@ namespace Internal {
 class BluezEndpoint
 {
 public:
-    BluezEndpoint();
-    ~BluezEndpoint();
+    BluezEndpoint()  = default;
+    ~BluezEndpoint() = default;
 
     CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
     void Shutdown();
@@ -101,6 +103,7 @@ private:
 
     void HandleNewDevice(BluezDevice1 * aDevice);
     void UpdateConnectionTable(BluezDevice1 * aDevice);
+    BluezConnection * GetBluezConnection(const char * aPath);
     BluezConnection * GetBluezConnectionViaDevice();
 
     gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
@@ -120,10 +123,13 @@ private:
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
 
+    bool mIsCentral = false;
+
     // Bus owning name
     char * mpOwningName = nullptr;
 
     // Adapter properties
+    uint32_t mAdapterId  = 0;
     char * mpAdapterName = nullptr;
     char * mpAdapterAddr = nullptr;
 
@@ -144,12 +150,9 @@ private:
     // additional data characteristics
     BluezGattCharacteristic1 * mpC3 = nullptr;
 
-    // map device path to the connection
-    GHashTable * mpConnMap              = nullptr;
-    uint32_t mAdapterId                 = 0;
-    bool mIsCentral                     = false;
-    char * mpPeerDevicePath             = nullptr;
+    std::unordered_map<std::string, BluezConnection *> mConnMap;
     GCancellable * mpConnectCancellable = nullptr;
+    char * mpPeerDevicePath             = nullptr;
 
     // Allow BluezAdvertisement and BluezConnection to access our private members
     // TODO: Fix this tight coupling

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -52,6 +52,7 @@
 
 #include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
 
 #include "BluezConnection.h"
 #include "Types.h"
@@ -85,7 +86,7 @@ private:
         uint16_t mNumRetries = 0;
     };
 
-    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
+    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * self);
 
     void SetupAdapter();
     void SetupGattServer(GDBusConnection * aConn);
@@ -96,21 +97,32 @@ private:
 
     void HandleNewDevice(BluezDevice1 * aDevice);
     void UpdateConnectionTable(BluezDevice1 * aDevice);
+    BluezConnection * GetBluezConnectionViaDevice();
 
-    static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * endpoint);
-    static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * endpoint);
+    static gboolean BluezAdvertisingRelease(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation,
+                                            BluezEndpoint * self);
+
+    static gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
+                                                 GVariant * aOptions, BluezEndpoint * self);
+    static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
+                                                    GVariant * aOptions, BluezEndpoint * self);
+    static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
+                                                     GVariant * aOptions, BluezEndpoint * self);
+    static gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
+                                               BluezEndpoint * self);
+
+    static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * self);
+    static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * self);
     static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
                                                       GDBusProxy * aInterface, GVariant * aChangedProperties,
-                                                      const char * const * aInvalidatedProps, BluezEndpoint * endpoint);
+                                                      const char * const * aInvalidatedProps, BluezEndpoint * self);
 
-    static CHIP_ERROR RegisterGattApplicationImpl(BluezEndpoint * endpoint);
+    static CHIP_ERROR RegisterGattApplicationImpl(BluezEndpoint * self);
 
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
 
 public:
-    BluezConnection * GetBluezConnectionViaDevice();
-
     // Bus owning name
     char * mpOwningName = nullptr;
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -124,7 +124,8 @@ private:
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
 
-    bool mIsCentral = false;
+    bool mIsCentral     = false;
+    bool mIsInitialized = false;
 
     // Bus owning name
     char * mpOwningName = nullptr;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -86,7 +86,7 @@ private:
         uint16_t mNumRetries = 0;
     };
 
-    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * self);
+    CHIP_ERROR StartupEndpointBindings();
 
     void SetupAdapter();
     void SetupGattServer(GDBusConnection * aConn);
@@ -117,7 +117,7 @@ private:
                                                       GDBusProxy * aInterface, GVariant * aChangedProperties,
                                                       const char * const * aInvalidatedProps, BluezEndpoint * self);
 
-    static CHIP_ERROR RegisterGattApplicationImpl(BluezEndpoint * self);
+    CHIP_ERROR RegisterGattApplicationImpl();
 
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -113,6 +113,7 @@ private:
                                                GDBusProxy * aInterface, GVariant * aChangedProperties,
                                                const char * const * aInvalidatedProps);
 
+    void RegisterGattApplicationDone(GObject * aObject, GAsyncResult * aResult);
     CHIP_ERROR RegisterGattApplicationImpl();
 
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -65,10 +65,10 @@ namespace Internal {
 class BluezEndpoint
 {
 public:
-    BluezEndpoint(uint32_t aAdapterId, bool aIsCentral);
+    BluezEndpoint();
     ~BluezEndpoint();
 
-    CHIP_ERROR Init(const char * apBleAddr, const char * apBleName);
+    CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
     BluezAdapter1 * GetAdapter() const { return mpAdapter; }

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -74,7 +74,30 @@ public:
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();
 
+private:
+    struct ConnectParams
+    {
+        ConnectParams(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice) : mEndpoint(aEndpoint), mpDevice(apDevice) {}
+        ~ConnectParams() = default;
+
+        const BluezEndpoint & mEndpoint;
+        BluezDevice1 * mpDevice;
+        uint16_t mNumRetries = 0;
+    };
+
+    BluezGattService1 * BluezServiceCreate();
+    void BluezOnBusAcquired(GDBusConnection * aConn, const char * aName);
+    void BluezPeripheralObjectsSetup();
+    void BluezObjectsSetup();
+
+    static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
+
+    static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
+    static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
+
 public:
+    BluezConnection * GetBluezConnectionViaDevice();
+
     // Bus owning name
     char * mpOwningName = nullptr;
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -54,6 +54,7 @@
 #include <lib/core/CHIPError.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
+#include "BluezAdvertisement.h"
 #include "BluezConnection.h"
 #include "Types.h"
 
@@ -101,8 +102,8 @@ private:
     void UpdateConnectionTable(BluezDevice1 * aDevice);
     BluezConnection * GetBluezConnectionViaDevice();
 
-    static gboolean BluezAdvertisingRelease(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation,
-                                            BluezEndpoint * self);
+    static gboolean BluezAdvertisementRelease(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation,
+                                              BluezEndpoint * self);
 
     static gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
                                                  GVariant * aOptions, BluezEndpoint * self);
@@ -155,7 +156,9 @@ private:
     char * mpPeerDevicePath             = nullptr;
     GCancellable * mpConnectCancellable = nullptr;
 
-    // Allow BluezConnection to access our private members
+    // Allow BluezAdvertisement and BluezConnection to access our private members
+    // TODO: Fix this tight coupling
+    friend class BluezAdvertisement;
     friend class BluezConnection;
 };
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -69,7 +69,7 @@ public:
     CHIP_ERROR Init(const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
-    CHIP_ERROR BluezGattAppRegister();
+    CHIP_ERROR RegisterGattApplication();
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();
@@ -86,16 +86,16 @@ private:
     };
 
     static CHIP_ERROR StartupEndpointBindings(BluezEndpoint * endpoint);
-    void BluezOnBusAcquired(GDBusConnection * aConn, const char * aName);
 
     void SetupAdapter();
+    void SetupGattServer(GDBusConnection * aConn);
     void SetupGattService();
 
     BluezGattService1 * CreateGattService(const char * aUUID);
     BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID);
     BluezLEAdvertisement1 * CreateLEAdvertisement();
 
-    static CHIP_ERROR BluezGattAppRegisterImpl(BluezEndpoint * endpoint);
+    static CHIP_ERROR RegisterGattApplicationImpl(BluezEndpoint * endpoint);
 
     static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
     static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -54,7 +54,6 @@
 #include <lib/core/CHIPError.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
-#include "BluezAdvertisement.h"
 #include "BluezConnection.h"
 #include "Types.h"
 
@@ -72,6 +71,7 @@ public:
     void Shutdown();
 
     BluezAdapter1 * GetAdapter() const { return mpAdapter; }
+    const char * GetAdapterName() const { return mpAdapterName; }
 
     CHIP_ERROR RegisterGattApplication();
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -96,7 +96,8 @@ private:
     void SetupGattService();
 
     BluezGattService1 * CreateGattService(const char * aUUID);
-    BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID);
+    BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID,
+                                                        const char * const * aFlags);
 
     void HandleNewDevice(BluezDevice1 * aDevice);
     void UpdateConnectionTable(BluezDevice1 * aDevice);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -76,6 +76,7 @@ public:
     const char * GetAdapterName() const { return mpAdapterName; }
 
     CHIP_ERROR RegisterGattApplication();
+    GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot; }
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();
@@ -154,9 +155,7 @@ private:
     GCancellable * mpConnectCancellable = nullptr;
     char * mpPeerDevicePath             = nullptr;
 
-    // Allow BluezAdvertisement and BluezConnection to access our private members
-    // TODO: Fix this tight coupling
-    friend class BluezAdvertisement;
+    // Allow BluezConnection to access our private members
     friend class BluezConnection;
 };
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -93,7 +93,15 @@ private:
 
     BluezGattService1 * CreateGattService(const char * aUUID);
     BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID);
-    BluezLEAdvertisement1 * CreateLEAdvertisement();
+
+    void HandleNewDevice(BluezDevice1 * aDevice);
+    void UpdateConnectionTable(BluezDevice1 * aDevice);
+
+    static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * endpoint);
+    static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * endpoint);
+    static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
+                                                      GDBusProxy * aInterface, GVariant * aChangedProperties,
+                                                      const char * const * aInvalidatedProps, BluezEndpoint * endpoint);
 
     static CHIP_ERROR RegisterGattApplicationImpl(BluezEndpoint * endpoint);
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -102,23 +102,16 @@ private:
     void UpdateConnectionTable(BluezDevice1 * aDevice);
     BluezConnection * GetBluezConnectionViaDevice();
 
-    static gboolean BluezAdvertisementRelease(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation,
-                                              BluezEndpoint * self);
+    gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
+    gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
+    gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
+    gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv);
 
-    static gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                 GVariant * aOptions, BluezEndpoint * self);
-    static gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                    GVariant * aOptions, BluezEndpoint * self);
-    static gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                     GVariant * aOptions, BluezEndpoint * self);
-    static gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                               BluezEndpoint * self);
-
-    static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * self);
-    static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * self);
-    static void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
-                                                      GDBusProxy * aInterface, GVariant * aChangedProperties,
-                                                      const char * const * aInvalidatedProps, BluezEndpoint * self);
+    void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject);
+    void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject);
+    void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
+                                               GDBusProxy * aInterface, GVariant * aChangedProperties,
+                                               const char * const * aInvalidatedProps);
 
     CHIP_ERROR RegisterGattApplicationImpl();
 


### PR DESCRIPTION
### Problem

BluezEndpoint struct can be converted to a class in order to narrow "public" interface.
Followup for https://github.com/project-chip/connectedhomeip/pull/29722

### Changes

- convert `BluezEndpoint` struct to class
- make GATT service setup function names more descriptive
- reduce number of signals on the D-Bus bus during initialization (by attaching connection to object manager after setting it up)
- fix crash when trying to read characteristic value without prior write from the client side
- get rid of passing `BluezEndpoint *` as much as possible

### Testing

Locally tested BLE commissioning with ble-wifi type.
CI will test potential build brakes.