### PR TITLE
Make the vscode devcontainer load again

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,7 +62,6 @@ RUN mkdir -p /opt/sdk/sdks/ \
     $ANDROID_HOME `# allow licenses to be accepted` \
     $AMEBA_PATH `# AmebaD requires access to change build_info.h` \
     $IMX_SDK_ROOT \
-    $OPENOCD_PATH \
     && :
 
 # Fix Tizen SDK paths for new user

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,14 +55,14 @@ RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/resty
 RUN mkdir -p /opt/sdk/sdks/ \
     && chown -R $USERNAME:$USERNAME \
     /opt/sdk/sdks/ `# NXP uses a patch_sdk script to change SDK files` \
-    /opt/espressif/esp-idf `# $USERNAME needs to own the esp-idf and tools for the examples to build` \
-    /opt/espressif/tools \
     /opt/NordicSemiconductor/nrfconnect/ `# $USERNAME needs to own west configuration to build nRF Connect examples` \
-    /opt/ubuntu-21.04-aarch64-sysroot/usr/ `# allow read/write access to header and libraries` \
-    /opt/android/sdk `# allow licenses to be accepted` \
-    /opt/ameba/ambd_sdk_with_chip_non_NDA/ `# AmebaD requires access to change build_info.h` \
-    /opt/fsl-imx-xwayland/5.15-kirkstone/ \
-    /opt/openocd \
+    $IDF_PATH `# $USERNAME needs to own the esp-idf and tools for the examples to build` \
+    $IDF_TOOLS_PATH \
+    $SYSROOT_AARCH64 `# allow read/write access to header and libraries` \
+    $ANDROID_HOME `# allow licenses to be accepted` \
+    $AMEBA_PATH `# AmebaD requires access to change build_info.h` \
+    $IMX_SDK_ROOT \
+    $OPENOCD_PATH \
     && :
 
 # Fix Tizen SDK paths for new user

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],
-    "initializeCommand": ".devcontainer/build.sh --tag matter-dev-environment:local --version 21",
+    "initializeCommand": ".devcontainer/build.sh --tag matter-dev-environment:local --version 22",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],
-    "initializeCommand": ".devcontainer/build.sh --tag matter-dev-environment:local --version 20",
+    "initializeCommand": ".devcontainer/build.sh --tag matter-dev-environment:local --version 21",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "customizations": {


### PR DESCRIPTION
Changes:
  - Update to image 22 (past 21 so we get java. 22 is the latest)
  - Several paths were wrong. I switched to using env variables since those should be more stable than hard-coded ones. At least the cross compile paths and wayland ones were wrong
  - openocd is not part of our images anymore. Removed that attempt to set its permissions
 
Tested:
  - opened the folder in a container locally and it passed
 
 
 note:
   - I had to `rm ~/.docker/config.json` for some odd reason because it would auth fail otherwise even for a public repo. Others may want to be aware of this.