### PR TITLE
[Kotlin] Uses Kotlin's coroutines to handle the asynchronous operation and returns the result directly 

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
@@ -61,77 +61,84 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 {% set typeLookup = idl | createLookupContext(cluster) %}
 class {{cluster.name}}Cluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = {{cluster.code}}u
-  }
-{% for command in cluster.commands | sort(attribute='code') -%}
-{%- set callbackName = command | javaCommandCallbackName() -%}
-{%- if not command.is_timed_invoke %}
-  suspend fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
-{%- if command.input_param -%}
-{%- for field in (cluster.structs | named(command.input_param)).fields -%}
-  , {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
-{%- endfor -%}
-{%- endif -%}
-  ) {
-    // Implementation needs to be added here
-  }
-{%- endif %}
 
-  suspend fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
-{%- if command.input_param -%}
-{%- for field in (cluster.structs | named(command.input_param)).fields -%}
-  , {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
-{%- endfor -%}
-{%- endif -%}
-  , timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-{% endfor %}
 {%- set already_handled_command = [] -%}
 {%- for command in cluster.commands | sort(attribute='code') -%}
 {%- if command | isCommandNotDefaultCallback() -%}
 {%- set callbackName = command | javaCommandCallbackName() -%}
 {%- if callbackName not in already_handled_command %}
-  interface {{callbackName}}Callback {
-    fun onSuccess(
-{%- for field in (cluster.structs | named(command.output_param)).fields -%}
-    {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}{% if not loop.last %}, {% endif %}
-{%- endfor -%}
-    )
-    fun onError(error: Exception)
-  }
+  class {{callbackName}}(
+{%- for field in (cluster.structs | named(command.output_param)).fields %}
+    val {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
+{%- if not loop.last %}, {% endif %}
+{%- endfor %}
+  )
 {% if already_handled_command.append(callbackName) -%}
 {%- endif -%}
 {%- endif -%}
 {%- endif -%}
 {%- endfor %}
+
 {%- set already_handled_attribute = [] -%}
 {% for attribute in cluster.attributes | rejectattr('definition', 'is_field_global_name', typeLookup) %}
 {%- set encodable = attribute.definition | asEncodable(typeLookup) -%}
 {%- set interfaceName = attribute | javaAttributeCallbackName(typeLookup) -%}
 {%- if interfaceName not in already_handled_attribute %}
-  interface {{interfaceName}} {
-    fun onSuccess(value: {{encode_value(cluster, encodable, 0)}})
-    fun onError(ex: Exception)
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
+  class {{interfaceName}}(
+    val value: {{encode_value(cluster, encodable, 0)}}
+  )
 {% if already_handled_attribute.append(interfaceName) -%}
 {#- This block does nothing, it only exists to append to already_handled_attribute. -#}
 {%- endif -%}
 {%- endif -%}
 {% endfor -%}
+
+{%- for command in cluster.commands | sort(attribute='code') -%}
+{%- set callbackName = command | javaCommandCallbackName() -%}
+{%- if not command.is_timed_invoke %}
+  suspend fun {{command.name | lowfirst_except_acronym}}(
+{%- if command.input_param -%}
+{%- for field in (cluster.structs | named(command.input_param)).fields -%}
+  {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
+{%- if not loop.last -%}, {% endif %}
+{%- endfor -%}
+{%- endif -%}
+  )
+{%- if command | hasResponse -%}
+    : {{callbackName}} {
+{%- else %} {
+{%- endif %}  
+    // Implementation needs to be added here
+  }
+{%- endif %}
+
+  suspend fun {{command.name | lowfirst_except_acronym}}(
+{%- if command.input_param -%}
+{%- for field in (cluster.structs | named(command.input_param)).fields -%}
+  {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
+{%- if not loop.last -%}, {% endif %}  
+{%- endfor -%}
+  , timedInvokeTimeoutMs: Int)
+{%- else -%}
+  timedInvokeTimeoutMs: Int)
+{%- endif -%}
+{%- if command | hasResponse -%}
+    : {{callbackName}} {
+{%- else %} {
+{%- endif %}  
+    // Implementation needs to be added here
+  }
+{% endfor -%}
+
 {% for attribute in cluster.attributes | sort(attribute='code') %}
-  fun read{{ attribute.definition.name | upfirst }}Attribute(
-    callback: {{ attribute | javaAttributeCallbackName(typeLookup) }}
-  ) {
+{%- set interfaceName = attribute | javaAttributeCallbackName(typeLookup) %}
+  suspend fun read{{ attribute.definition.name | upfirst }}Attribute(): {{interfaceName}} {
     // Implementation needs to be added here
   }
 {% if attribute | isFabricScopedList(typeLookup) %}
-  fun read{{ attribute.definition.name | upfirst }}AttributeWithFabricFilter(
-    callback: {{ attribute | javaAttributeCallbackName(typeLookup) }},
+  suspend fun read{{ attribute.definition.name | upfirst }}AttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): {{interfaceName}} {
     // Implementation needs to be added here
   }
 
@@ -140,15 +147,13 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
 {%- set encodable = attribute.definition | asEncodable(typeLookup) -%}
 {%- set encodable2 = attribute.definition | asEncodable(typeLookup) -%}
 {%- if not attribute.requires_timed_write %}
-  fun write{{ attribute.definition.name | upfirst }}Attribute(
-    callback: DefaultClusterCallback,
+  suspend fun write{{ attribute.definition.name | upfirst }}Attribute(
     value: {{ encode_value_without_optional_nullable(cluster, encodable, 0) }}
   ) {
     // Implementation needs to be added here
   }
 {% endif %}
-  fun write{{ attribute.definition.name | upfirst }}Attribute(
-    callback: DefaultClusterCallback,
+  suspend fun write{{ attribute.definition.name | upfirst }}Attribute(
     value: {{ encode_value_without_optional_nullable(cluster, encodable2, 0) }},
     timedWriteTimeoutMs: Int
   ) {
@@ -156,13 +161,15 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
   }
 {% endif %}
 {%- if attribute.is_subscribable %}
-  fun subscribe{{ attribute.definition.name | upfirst }}Attribute(
-    callback: {{ attribute | javaAttributeCallbackName(typeLookup) }},
+  suspend fun subscribe{{ attribute.definition.name | upfirst }}Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): {{interfaceName}} {
     // Implementation needs to be added here
   }
 {% endif -%}
-{%- endfor -%}
+{%- endfor %}
+  companion object {
+    const val CLUSTER_ID: UInt = {{cluster.code}}u
+  }
 }

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
@@ -11,7 +11,7 @@
     {%- set struct = encodable.get_underlying_struct() -%}
     ChipStructs.{{source.name}}Cluster{{struct.name}}
   {%- else -%}
-    {{encodable.boxed_java_type}}
+    {{encodable.kotlin_type}}
   {%- endif -%}
 {%- endmacro -%}
 
@@ -24,7 +24,7 @@
     {%- set struct = encodable.get_underlying_struct() -%}
     ChipStructs.{{source.name}}Cluster{{struct.name}}
   {%- else -%}
-    {{encodable.boxed_java_type}}
+    {{encodable.kotlin_type}}
   {%- endif -%}
 {%- endmacro -%}
 
@@ -35,7 +35,7 @@
     {%- set struct = encodable.get_underlying_struct() -%}
     ChipStructs.{{source.name}}Cluster{{struct.name}}
   {%- else -%}
-    {{encodable.boxed_java_type}}
+    {{encodable.kotlin_type}}
   {%- endif -%}
 {%- endmacro -%}
 
@@ -67,7 +67,7 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
 {% for command in cluster.commands | sort(attribute='code') -%}
 {%- set callbackName = command | javaCommandCallbackName() -%}
 {%- if not command.is_timed_invoke %}
-  fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
+  suspend fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
 {%- if command.input_param -%}
 {%- for field in (cluster.structs | named(command.input_param)).fields -%}
   , {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
@@ -78,7 +78,7 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
   }
 {%- endif %}
 
-  fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
+  suspend fun {{command.name | lowfirst_except_acronym}}(callback: {{callbackName}}Callback
 {%- if command.input_param -%}
 {%- for field in (cluster.structs | named(command.input_param)).fields -%}
   , {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
@@ -405,43 +405,6 @@ class EncodableValue:
         return e
 
     @property
-    def boxed_java_type(self):
-        t = ParseDataType(self.data_type, self.context)
-
-        if isinstance(t, FundamentalType):
-            if t == FundamentalType.BOOL:
-                return "Boolean"
-            elif t == FundamentalType.FLOAT:
-                return "Float"
-            elif t == FundamentalType.DOUBLE:
-                return "Double"
-            else:
-                raise Exception("Unknown fundamental type")
-        elif isinstance(t, BasicInteger):
-            # the >= 3 will include int24_t to be considered "long"
-            if t.byte_count >= 3:
-                return "Long"
-            else:
-                return "Integer"
-        elif isinstance(t, BasicString):
-            if t.is_binary:
-                return "ByteArray"
-            else:
-                return "String"
-        elif isinstance(t, IdlEnumType):
-            if t.base_type.byte_count >= 3:
-                return "Long"
-            else:
-                return "Integer"
-        elif isinstance(t, IdlBitmapType):
-            if t.base_type.byte_count >= 3:
-                return "Long"
-            else:
-                return "Integer"
-        else:
-            return "Object"
-
-    @property
     def kotlin_type(self):
         t = ParseDataType(self.data_type, self.context)
 
@@ -455,17 +418,22 @@ class EncodableValue:
             else:
                 raise Exception("Unknown fundamental type")
         elif isinstance(t, BasicInteger):
-            # the >= 3 will include int24_t to be considered "long"
             if t.is_signed:
-                if t.byte_count >= 3:
-                    return "Long"
-                else:
+                if t.byte_count <= 1:
+                    return "Byte"
+                if t.byte_count <= 2:
+                    return "Short"
+                if t.byte_count <= 4:
                     return "Int"
-            else:
-                if t.byte_count >= 3:
-                    return "ULong"
-                else:
+                return "Long"
+            else:  # unsigned
+                if t.byte_count <= 1:
+                    return "UByte"
+                if t.byte_count <= 2:
+                    return "UShort"
+                if t.byte_count <= 4:
                     return "UInt"
+                return "ULong"
         elif isinstance(t, BasicString):
             if t.is_binary:
                 return "ByteArray"

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
@@ -212,9 +212,9 @@ def JavaAttributeCallbackName(attr: Attribute, context: TypeLookupContext) -> st
     global_name = FieldToGlobalName(attr.definition, context)
 
     if global_name:
-        return '{}AttributeCallback'.format(GlobalNameToJavaName(global_name))
+        return '{}'.format(GlobalNameToJavaName(global_name))
 
-    return '{}AttributeCallback'.format(capitalcase(attr.definition.name))
+    return '{}Attribute'.format(capitalcase(attr.definition.name))
 
 
 def IsFieldGlobalName(field: Field, context: TypeLookupContext) -> bool:
@@ -583,6 +583,11 @@ def IsFabricScopedList(attr: Attribute, lookup: TypeLookupContext) -> bool:
     return struct and struct.qualities == StructQuality.FABRIC_SCOPED
 
 
+def CommandHasResponse(command: Command) -> bool:
+    """Returns true if a command has a specific response."""
+    return command.output_param != "DefaultSuccess"
+
+
 def IsResponseStruct(s: Struct) -> bool:
     return s.tag == StructTag.RESPONSE
 
@@ -617,6 +622,7 @@ class __KotlinCodeGenerator(CodeGenerator):
         self.jinja_env.filters['createLookupContext'] = CreateLookupContext
         self.jinja_env.filters['canGenerateSubscribe'] = CanGenerateSubscribe
         self.jinja_env.filters['isFabricScopedList'] = IsFabricScopedList
+        self.jinja_env.filters['hasResponse'] = CommandHasResponse
 
         self.jinja_env.tests['is_response_struct'] = IsResponseStruct
         self.jinja_env.tests['is_using_global_callback'] = _IsUsingGlobalCallback

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccessControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccessControlCluster.kt
@@ -20,224 +20,165 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class AccessControlCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 31u
-  }
+  class AclAttribute(
+    val value: ArrayList<ChipStructs.AccessControlClusterAccessControlEntryStruct>
+  )
 
-  interface AclAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.AccessControlClusterAccessControlEntryStruct>)
+  class ExtensionAttribute(
+    val value: ArrayList<ChipStructs.AccessControlClusterAccessControlExtensionStruct>?
+  )
 
-    fun onError(ex: Exception)
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
 
-  interface ExtensionAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.AccessControlClusterAccessControlExtensionStruct>?)
+  class EventListAttribute(val value: ArrayList<UInt>)
 
-    fun onError(ex: Exception)
+  class AttributeListAttribute(val value: ArrayList<UInt>)
 
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readAclAttribute(callback: AclAttributeCallback) {
+  suspend fun readAclAttribute(): AclAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAclAttributeWithFabricFilter(callback: AclAttributeCallback, isFabricFiltered: Boolean) {
+  suspend fun readAclAttributeWithFabricFilter(isFabricFiltered: Boolean): AclAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeAclAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeAclAttribute(
     value: ArrayList<ChipStructs.AccessControlClusterAccessControlEntryStruct>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeAclAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeAclAttribute(
     value: ArrayList<ChipStructs.AccessControlClusterAccessControlEntryStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeAclAttribute(callback: AclAttributeCallback, minInterval: Int, maxInterval: Int) {
+  suspend fun subscribeAclAttribute(minInterval: Int, maxInterval: Int): AclAttribute {
     // Implementation needs to be added here
   }
 
-  fun readExtensionAttribute(callback: ExtensionAttributeCallback) {
+  suspend fun readExtensionAttribute(): ExtensionAttribute {
     // Implementation needs to be added here
   }
 
-  fun readExtensionAttributeWithFabricFilter(
-    callback: ExtensionAttributeCallback,
+  suspend fun readExtensionAttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): ExtensionAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeExtensionAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeExtensionAttribute(
     value: ArrayList<ChipStructs.AccessControlClusterAccessControlExtensionStruct>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeExtensionAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeExtensionAttribute(
     value: ArrayList<ChipStructs.AccessControlClusterAccessControlExtensionStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeExtensionAttribute(
-    callback: ExtensionAttributeCallback,
+  suspend fun subscribeExtensionAttribute(minInterval: Int, maxInterval: Int): ExtensionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSubjectsPerAccessControlEntryAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSubjectsPerAccessControlEntryAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readSubjectsPerAccessControlEntryAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readTargetsPerAccessControlEntryAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeSubjectsPerAccessControlEntryAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeTargetsPerAccessControlEntryAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readTargetsPerAccessControlEntryAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAccessControlEntriesPerFabricAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeTargetsPerAccessControlEntryAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAccessControlEntriesPerFabricAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAccessControlEntriesPerFabricAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAccessControlEntriesPerFabricAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 31u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccountLoginCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccountLoginCluster.kt
@@ -20,138 +20,89 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class AccountLoginCluster(private val endpointId: UShort) {
+  class GetSetupPINResponse(val setupPIN: String)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun getSetupPIN(
+    tempAccountIdentifier: String,
+    timedInvokeTimeoutMs: Int
+  ): GetSetupPINResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun login(tempAccountIdentifier: String, setupPIN: String, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun logout(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1294u
-  }
-
-  fun getSetupPIN(
-    callback: GetSetupPINResponseCallback,
-    tempAccountIdentifier: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun login(
-    callback: DefaultClusterCallback,
-    tempAccountIdentifier: String,
-    setupPIN: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun logout(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface GetSetupPINResponseCallback {
-    fun onSuccess(setupPIN: String)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActionsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActionsCluster.kt
@@ -20,349 +20,231 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ActionsCluster(private val endpointId: UShort) {
+  class ActionListAttribute(val value: ArrayList<ChipStructs.ActionsClusterActionStruct>)
+
+  class EndpointListsAttribute(val value: ArrayList<ChipStructs.ActionsClusterEndpointListStruct>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun instantAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun instantAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun instantActionWithTransition(
+    actionID: UShort,
+    invokeID: UInt?,
+    transitionTime: UShort
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun instantActionWithTransition(
+    actionID: UShort,
+    invokeID: UInt?,
+    transitionTime: UShort,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startActionWithDuration(actionID: UShort, invokeID: UInt?, duration: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startActionWithDuration(
+    actionID: UShort,
+    invokeID: UInt?,
+    duration: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pauseAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pauseAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pauseActionWithDuration(actionID: UShort, invokeID: UInt?, duration: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pauseActionWithDuration(
+    actionID: UShort,
+    invokeID: UInt?,
+    duration: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resumeAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resumeAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enableAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enableAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enableActionWithDuration(actionID: UShort, invokeID: UInt?, duration: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enableActionWithDuration(
+    actionID: UShort,
+    invokeID: UInt?,
+    duration: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun disableAction(actionID: UShort, invokeID: UInt?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun disableAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun disableActionWithDuration(actionID: UShort, invokeID: UInt?, duration: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun disableActionWithDuration(
+    actionID: UShort,
+    invokeID: UInt?,
+    duration: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActionListAttribute(): ActionListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActionListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActionListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEndpointListsAttribute(): EndpointListsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEndpointListsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): EndpointListsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSetupURLAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSetupURLAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 37u
-  }
-
-  fun instantAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun instantAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun instantActionWithTransition(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    transitionTime: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun instantActionWithTransition(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    transitionTime: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun startAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun startAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun startActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun startActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stopAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun stopAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun pauseAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun pauseAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun pauseActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun pauseActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun resumeAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun resumeAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enableAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun enableAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enableActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enableActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun disableAction(callback: DefaultClusterCallback, actionID: Integer, invokeID: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun disableAction(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun disableActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun disableActionWithDuration(
-    callback: DefaultClusterCallback,
-    actionID: Integer,
-    invokeID: Long?,
-    duration: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ActionListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ActionsClusterActionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EndpointListsAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ActionsClusterEndpointListStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readActionListAttribute(callback: ActionListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActionListAttribute(
-    callback: ActionListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEndpointListsAttribute(callback: EndpointListsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEndpointListsAttribute(
-    callback: EndpointListsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSetupURLAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSetupURLAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActivatedCarbonFilterMonitoringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActivatedCarbonFilterMonitoringCluster.kt
@@ -20,221 +20,149 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ActivatedCarbonFilterMonitoringCluster(private val endpointId: UShort) {
+  class LastChangedTimeAttribute(val value: UInt?)
+
+  class ReplacementProductListAttribute(
+    val value:
+      ArrayList<ChipStructs.ActivatedCarbonFilterMonitoringClusterReplacementProductStruct>?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetCondition() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetCondition(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readConditionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeConditionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDegradationDirectionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDegradationDirectionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChangeIndicationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChangeIndicationAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInPlaceIndicatorAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInPlaceIndicatorAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastChangedTimeAttribute(): LastChangedTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLastChangedTimeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastChangedTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastChangedTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readReplacementProductListAttribute(): ReplacementProductListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeReplacementProductListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ReplacementProductListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 114u
-  }
-
-  fun resetCondition(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetCondition(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface LastChangedTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ReplacementProductListAttributeCallback {
-    fun onSuccess(
-      value: ArrayList<ChipStructs.ActivatedCarbonFilterMonitoringClusterReplacementProductStruct>?
-    )
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readConditionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeConditionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDegradationDirectionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDegradationDirectionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readChangeIndicationAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChangeIndicationAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInPlaceIndicatorAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInPlaceIndicatorAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastChangedTimeAttribute(callback: LastChangedTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLastChangedTimeAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLastChangedTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastChangedTimeAttribute(
-    callback: LastChangedTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReplacementProductListAttribute(callback: ReplacementProductListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReplacementProductListAttribute(
-    callback: ReplacementProductListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AdministratorCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AdministratorCommissioningCluster.kt
@@ -20,187 +20,128 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class AdministratorCommissioningCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 60u
-  }
+  class AdminFabricIndexAttribute(val value: UByte?)
 
-  fun openCommissioningWindow(
-    callback: DefaultClusterCallback,
-    commissioningTimeout: Integer,
+  class AdminVendorIdAttribute(val value: UShort?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun openCommissioningWindow(
+    commissioningTimeout: UShort,
     PAKEPasscodeVerifier: ByteArray,
-    discriminator: Integer,
-    iterations: Long,
+    discriminator: UShort,
+    iterations: UInt,
     salt: ByteArray,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun openBasicCommissioningWindow(
-    callback: DefaultClusterCallback,
-    commissioningTimeout: Integer,
+  suspend fun openBasicCommissioningWindow(
+    commissioningTimeout: UShort,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun revokeCommissioning(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun revokeCommissioning(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  interface AdminFabricIndexAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AdminVendorIdAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readWindowStatusAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readWindowStatusAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeWindowStatusAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeWindowStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAdminFabricIndexAttribute(): AdminFabricIndexAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAdminFabricIndexAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AdminFabricIndexAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAdminFabricIndexAttribute(callback: AdminFabricIndexAttributeCallback) {
+  suspend fun readAdminVendorIdAttribute(): AdminVendorIdAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAdminFabricIndexAttribute(
-    callback: AdminFabricIndexAttributeCallback,
+  suspend fun subscribeAdminVendorIdAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AdminVendorIdAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAdminVendorIdAttribute(callback: AdminVendorIdAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAdminVendorIdAttribute(
-    callback: AdminVendorIdAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 60u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AirQualityCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AirQualityCluster.kt
@@ -20,123 +20,80 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class AirQualityCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readAirQualityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAirQualityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 91u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readAirQualityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAirQualityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationBasicCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationBasicCluster.kt
@@ -20,223 +20,146 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ApplicationBasicCluster(private val endpointId: UShort) {
+  class ApplicationAttribute(val value: ChipStructs.ApplicationBasicClusterApplicationStruct)
+
+  class AllowedVendorListAttribute(val value: ArrayList<UShort>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readVendorNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readVendorIDAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorIDAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readApplicationNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeApplicationNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductIDAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductIDAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readApplicationAttribute(): ApplicationAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeApplicationAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ApplicationAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readApplicationVersionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeApplicationVersionAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAllowedVendorListAttribute(): AllowedVendorListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAllowedVendorListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AllowedVendorListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1293u
-  }
-
-  interface ApplicationAttributeCallback {
-    fun onSuccess(value: ChipStructs.ApplicationBasicClusterApplicationStruct)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AllowedVendorListAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readVendorNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readVendorIDAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorIDAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readApplicationNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeApplicationNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductIDAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductIDAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readApplicationAttribute(callback: ApplicationAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeApplicationAttribute(
-    callback: ApplicationAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readApplicationVersionAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeApplicationVersionAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAllowedVendorListAttribute(callback: AllowedVendorListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAllowedVendorListAttribute(
-    callback: AllowedVendorListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationLauncherCluster.kt
@@ -20,219 +20,154 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ApplicationLauncherCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 1292u
-  }
+  class LauncherResponse(val status: UInt, val data: ByteArray?)
 
-  fun launchApp(
-    callback: LauncherResponseCallback,
+  class CatalogListAttribute(val value: ArrayList<UShort>?)
+
+  class CurrentAppAttribute(val value: ChipStructs.ApplicationLauncherClusterApplicationEPStruct?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun launchApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?,
     data: ByteArray?
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun launchApp(
-    callback: LauncherResponseCallback,
+  suspend fun launchApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?,
     data: ByteArray?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun stopApp(
-    callback: LauncherResponseCallback,
+  suspend fun stopApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun stopApp(
-    callback: LauncherResponseCallback,
+  suspend fun stopApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun hideApp(
-    callback: LauncherResponseCallback,
+  suspend fun hideApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun hideApp(
-    callback: LauncherResponseCallback,
+  suspend fun hideApp(
     application: ChipStructs.ApplicationLauncherClusterApplicationStruct?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  interface LauncherResponseCallback {
-    fun onSuccess(status: Integer, data: ByteArray?)
-
-    fun onError(error: Exception)
-  }
-
-  interface CatalogListAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentAppAttributeCallback {
-    fun onSuccess(value: ChipStructs.ApplicationLauncherClusterApplicationEPStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readCatalogListAttribute(callback: CatalogListAttributeCallback) {
+  suspend fun readCatalogListAttribute(): CatalogListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeCatalogListAttribute(
-    callback: CatalogListAttributeCallback,
+  suspend fun subscribeCatalogListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): CatalogListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readCurrentAppAttribute(callback: CurrentAppAttributeCallback) {
+  suspend fun readCurrentAppAttribute(): CurrentAppAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeCurrentAppAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeCurrentAppAttribute(
     value: ChipStructs.ApplicationLauncherClusterApplicationEPStruct
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeCurrentAppAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeCurrentAppAttribute(
     value: ChipStructs.ApplicationLauncherClusterApplicationEPStruct,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeCurrentAppAttribute(
-    callback: CurrentAppAttributeCallback,
+  suspend fun subscribeCurrentAppAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): CurrentAppAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 1292u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AudioOutputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AudioOutputCluster.kt
@@ -20,164 +20,109 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class AudioOutputCluster(private val endpointId: UShort) {
+  class OutputListAttribute(val value: ArrayList<ChipStructs.AudioOutputClusterOutputInfoStruct>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun selectOutput(index: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun selectOutput(index: UByte, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun renameOutput(index: UByte, name: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun renameOutput(index: UByte, name: String, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOutputListAttribute(): OutputListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOutputListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OutputListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentOutputAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentOutputAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1291u
-  }
-
-  fun selectOutput(callback: DefaultClusterCallback, index: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun selectOutput(callback: DefaultClusterCallback, index: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun renameOutput(callback: DefaultClusterCallback, index: Integer, name: String) {
-    // Implementation needs to be added here
-  }
-
-  fun renameOutput(
-    callback: DefaultClusterCallback,
-    index: Integer,
-    name: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface OutputListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.AudioOutputClusterOutputInfoStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readOutputListAttribute(callback: OutputListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOutputListAttribute(
-    callback: OutputListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentOutputAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentOutputAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BallastConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BallastConfigurationCluster.kt
@@ -20,439 +20,289 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BallastConfigurationCluster(private val endpointId: UShort) {
+  class IntrinsicBallastFactorAttribute(val value: UByte?)
+
+  class BallastFactorAdjustmentAttribute(val value: UByte?)
+
+  class LampRatedHoursAttribute(val value: UInt?)
+
+  class LampBurnHoursAttribute(val value: UInt?)
+
+  class LampBurnHoursTripPointAttribute(val value: UInt?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readPhysicalMinLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalMinLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalMaxLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalMaxLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBallastStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBallastStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinLevelAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxLevelAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readIntrinsicBallastFactorAttribute(): IntrinsicBallastFactorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeIntrinsicBallastFactorAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeIntrinsicBallastFactorAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeIntrinsicBallastFactorAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): IntrinsicBallastFactorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBallastFactorAdjustmentAttribute(): BallastFactorAdjustmentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBallastFactorAdjustmentAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBallastFactorAdjustmentAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBallastFactorAdjustmentAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BallastFactorAdjustmentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampQuantityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampQuantityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampTypeAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampTypeAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampTypeAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampTypeAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampManufacturerAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampManufacturerAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampManufacturerAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampManufacturerAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampRatedHoursAttribute(): LampRatedHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampRatedHoursAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampRatedHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampRatedHoursAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LampRatedHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampBurnHoursAttribute(): LampBurnHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampBurnHoursAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampBurnHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampBurnHoursAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LampBurnHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampAlarmModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampAlarmModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampAlarmModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampAlarmModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLampBurnHoursTripPointAttribute(): LampBurnHoursTripPointAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampBurnHoursTripPointAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLampBurnHoursTripPointAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLampBurnHoursTripPointAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LampBurnHoursTripPointAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 769u
-  }
-
-  interface IntrinsicBallastFactorAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BallastFactorAdjustmentAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LampRatedHoursAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LampBurnHoursAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LampBurnHoursTripPointAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readPhysicalMinLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalMinLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalMaxLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalMaxLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBallastStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBallastStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMinLevelAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMinLevelAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMaxLevelAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMaxLevelAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readIntrinsicBallastFactorAttribute(callback: IntrinsicBallastFactorAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeIntrinsicBallastFactorAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeIntrinsicBallastFactorAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeIntrinsicBallastFactorAttribute(
-    callback: IntrinsicBallastFactorAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBallastFactorAdjustmentAttribute(callback: BallastFactorAdjustmentAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBallastFactorAdjustmentAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBallastFactorAdjustmentAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBallastFactorAdjustmentAttribute(
-    callback: BallastFactorAdjustmentAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampQuantityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampQuantityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampTypeAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampTypeAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampTypeAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampTypeAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampManufacturerAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampManufacturerAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampManufacturerAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampManufacturerAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampRatedHoursAttribute(callback: LampRatedHoursAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampRatedHoursAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampRatedHoursAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampRatedHoursAttribute(
-    callback: LampRatedHoursAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampBurnHoursAttribute(callback: LampBurnHoursAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampBurnHoursAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampBurnHoursAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampBurnHoursAttribute(
-    callback: LampBurnHoursAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampAlarmModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampAlarmModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampAlarmModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampAlarmModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLampBurnHoursTripPointAttribute(callback: LampBurnHoursTripPointAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampBurnHoursTripPointAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLampBurnHoursTripPointAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLampBurnHoursTripPointAttribute(
-    callback: LampBurnHoursTripPointAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BarrierControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BarrierControlCluster.kt
@@ -20,323 +20,222 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BarrierControlCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun barrierControlGoToPercent(percentOpen: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun barrierControlGoToPercent(percentOpen: UByte, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun barrierControlStop() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun barrierControlStop(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierMovingStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierMovingStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierSafetyStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierSafetyStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierCapabilitiesAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierCapabilitiesAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierOpenEventsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierOpenEventsAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierOpenEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierOpenEventsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierCloseEventsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCloseEventsAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCloseEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierCloseEventsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierCommandOpenEventsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCommandOpenEventsAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCommandOpenEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierCommandOpenEventsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierCommandCloseEventsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCommandCloseEventsAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierCommandCloseEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierCommandCloseEventsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierOpenPeriodAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierOpenPeriodAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierOpenPeriodAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierClosePeriodAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierClosePeriodAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBarrierClosePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierClosePeriodAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBarrierPositionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBarrierPositionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 259u
-  }
-
-  fun barrierControlGoToPercent(callback: DefaultClusterCallback, percentOpen: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun barrierControlGoToPercent(
-    callback: DefaultClusterCallback,
-    percentOpen: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun barrierControlStop(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun barrierControlStop(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readBarrierMovingStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierMovingStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierSafetyStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierSafetyStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierCapabilitiesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierCapabilitiesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierOpenEventsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierOpenEventsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierOpenEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierOpenEventsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierCloseEventsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCloseEventsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCloseEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierCloseEventsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierCommandOpenEventsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCommandOpenEventsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCommandOpenEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierCommandOpenEventsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierCommandCloseEventsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCommandCloseEventsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierCommandCloseEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierCommandCloseEventsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierOpenPeriodAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierOpenPeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierOpenPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierOpenPeriodAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierClosePeriodAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierClosePeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBarrierClosePeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierClosePeriodAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBarrierPositionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBarrierPositionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BasicInformationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BasicInformationCluster.kt
@@ -20,423 +20,292 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BasicInformationCluster(private val endpointId: UShort) {
+  class CapabilityMinimaAttribute(
+    val value: ChipStructs.BasicInformationClusterCapabilityMinimaStruct
+  )
+
+  class ProductAppearanceAttribute(
+    val value: ChipStructs.BasicInformationClusterProductAppearanceStruct?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun mfgSpecificPing() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun mfgSpecificPing(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDataModelRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDataModelRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readVendorNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readVendorIDAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorIDAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductIDAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductIDAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNodeLabelAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNodeLabelAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNodeLabelAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLocationAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocationAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocationAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocationAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHardwareVersionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHardwareVersionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHardwareVersionStringAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHardwareVersionStringAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSoftwareVersionAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSoftwareVersionAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSoftwareVersionStringAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSoftwareVersionStringAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readManufacturingDateAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeManufacturingDateAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPartNumberAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePartNumberAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductURLAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductURLAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductLabelAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductLabelAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSerialNumberAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSerialNumberAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLocalConfigDisabledAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocalConfigDisabledAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocalConfigDisabledAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocalConfigDisabledAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readReachableAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeReachableAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUniqueIDAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUniqueIDAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCapabilityMinimaAttribute(): CapabilityMinimaAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCapabilityMinimaAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CapabilityMinimaAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductAppearanceAttribute(): ProductAppearanceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductAppearanceAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ProductAppearanceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 40u
-  }
-
-  fun mfgSpecificPing(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun mfgSpecificPing(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface CapabilityMinimaAttributeCallback {
-    fun onSuccess(value: ChipStructs.BasicInformationClusterCapabilityMinimaStruct)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ProductAppearanceAttributeCallback {
-    fun onSuccess(value: ChipStructs.BasicInformationClusterProductAppearanceStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readDataModelRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDataModelRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readVendorNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readVendorIDAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorIDAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductIDAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductIDAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNodeLabelAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNodeLabelAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNodeLabelAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNodeLabelAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLocationAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocationAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocationAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLocationAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHardwareVersionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHardwareVersionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHardwareVersionStringAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHardwareVersionStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSoftwareVersionAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSoftwareVersionAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSoftwareVersionStringAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSoftwareVersionStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readManufacturingDateAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeManufacturingDateAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPartNumberAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePartNumberAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductURLAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductURLAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductLabelAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductLabelAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSerialNumberAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSerialNumberAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLocalConfigDisabledAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocalConfigDisabledAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocalConfigDisabledAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLocalConfigDisabledAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReachableAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReachableAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUniqueIDAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUniqueIDAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCapabilityMinimaAttribute(callback: CapabilityMinimaAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCapabilityMinimaAttribute(
-    callback: CapabilityMinimaAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductAppearanceAttribute(callback: ProductAppearanceAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductAppearanceAttribute(
-    callback: ProductAppearanceAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BinaryInputBasicCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BinaryInputBasicCluster.kt
@@ -20,291 +20,192 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BinaryInputBasicCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readActiveTextAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveTextAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveTextAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveTextAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDescriptionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDescriptionAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDescriptionAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDescriptionAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInactiveTextAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInactiveTextAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInactiveTextAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInactiveTextAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOutOfServiceAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOutOfServiceAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOutOfServiceAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOutOfServiceAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPolarityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePolarityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPresentValueAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePresentValueAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePresentValueAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePresentValueAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readReliabilityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeReliabilityAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeReliabilityAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeReliabilityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStatusFlagsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStatusFlagsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readApplicationTypeAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeApplicationTypeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 15u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readActiveTextAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveTextAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveTextAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveTextAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDescriptionAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDescriptionAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDescriptionAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDescriptionAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInactiveTextAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInactiveTextAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInactiveTextAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInactiveTextAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOutOfServiceAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOutOfServiceAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOutOfServiceAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOutOfServiceAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPolarityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePolarityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPresentValueAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePresentValueAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writePresentValueAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePresentValueAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReliabilityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeReliabilityAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeReliabilityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReliabilityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStatusFlagsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStatusFlagsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readApplicationTypeAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeApplicationTypeAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BindingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BindingCluster.kt
@@ -20,153 +20,97 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BindingCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 30u
-  }
+  class BindingAttribute(val value: ArrayList<ChipStructs.BindingClusterTargetStruct>)
 
-  interface BindingAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.BindingClusterTargetStruct>)
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-    fun onError(ex: Exception)
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
 
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
+  class EventListAttribute(val value: ArrayList<UInt>)
 
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
+  class AttributeListAttribute(val value: ArrayList<UInt>)
 
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readBindingAttribute(callback: BindingAttributeCallback) {
+  suspend fun readBindingAttribute(): BindingAttribute {
     // Implementation needs to be added here
   }
 
-  fun readBindingAttributeWithFabricFilter(
-    callback: BindingAttributeCallback,
-    isFabricFiltered: Boolean
-  ) {
+  suspend fun readBindingAttributeWithFabricFilter(isFabricFiltered: Boolean): BindingAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeBindingAttribute(
-    callback: DefaultClusterCallback,
-    value: ArrayList<ChipStructs.BindingClusterTargetStruct>
-  ) {
+  suspend fun writeBindingAttribute(value: ArrayList<ChipStructs.BindingClusterTargetStruct>) {
     // Implementation needs to be added here
   }
 
-  fun writeBindingAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeBindingAttribute(
     value: ArrayList<ChipStructs.BindingClusterTargetStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeBindingAttribute(
-    callback: BindingAttributeCallback,
+  suspend fun subscribeBindingAttribute(minInterval: Int, maxInterval: Int): BindingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 30u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BooleanStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BooleanStateCluster.kt
@@ -20,123 +20,80 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BooleanStateCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readStateValueAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStateValueAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 69u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readStateValueAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStateValueAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BridgedDeviceBasicInformationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BridgedDeviceBasicInformationCluster.kt
@@ -20,323 +20,221 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class BridgedDeviceBasicInformationCluster(private val endpointId: UShort) {
+  class ProductAppearanceAttribute(
+    val value: ChipStructs.BridgedDeviceBasicInformationClusterProductAppearanceStruct?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readVendorNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readVendorIDAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeVendorIDAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductNameAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductNameAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNodeLabelAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNodeLabelAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNodeLabelAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHardwareVersionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHardwareVersionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHardwareVersionStringAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHardwareVersionStringAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSoftwareVersionAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSoftwareVersionAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSoftwareVersionStringAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSoftwareVersionStringAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readManufacturingDateAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeManufacturingDateAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPartNumberAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePartNumberAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductURLAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductURLAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductLabelAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductLabelAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSerialNumberAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSerialNumberAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readReachableAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeReachableAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUniqueIDAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUniqueIDAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readProductAppearanceAttribute(): ProductAppearanceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeProductAppearanceAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ProductAppearanceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 57u
-  }
-
-  interface ProductAppearanceAttributeCallback {
-    fun onSuccess(value: ChipStructs.BridgedDeviceBasicInformationClusterProductAppearanceStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readVendorNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readVendorIDAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeVendorIDAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductNameAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductNameAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNodeLabelAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNodeLabelAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNodeLabelAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNodeLabelAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHardwareVersionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHardwareVersionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHardwareVersionStringAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHardwareVersionStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSoftwareVersionAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSoftwareVersionAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSoftwareVersionStringAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSoftwareVersionStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readManufacturingDateAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeManufacturingDateAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPartNumberAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePartNumberAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductURLAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductURLAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductLabelAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductLabelAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSerialNumberAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSerialNumberAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReachableAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReachableAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUniqueIDAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUniqueIDAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readProductAppearanceAttribute(callback: ProductAppearanceAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeProductAppearanceAttribute(
-    callback: ProductAppearanceAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonDioxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonDioxideConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class CarbonDioxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1037u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonMonoxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonMonoxideConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class CarbonMonoxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1036u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ChannelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ChannelCluster.kt
@@ -20,214 +20,138 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ChannelCluster(private val endpointId: UShort) {
+  class ChangeChannelResponse(val status: UInt, val data: String?)
+
+  class ChannelListAttribute(val value: ArrayList<ChipStructs.ChannelClusterChannelInfoStruct>?)
+
+  class LineupAttribute(val value: ChipStructs.ChannelClusterLineupInfoStruct?)
+
+  class CurrentChannelAttribute(val value: ChipStructs.ChannelClusterChannelInfoStruct?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeChannel(match: String): ChangeChannelResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeChannel(match: String, timedInvokeTimeoutMs: Int): ChangeChannelResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeChannelByNumber(majorNumber: UShort, minorNumber: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeChannelByNumber(
+    majorNumber: UShort,
+    minorNumber: UShort,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipChannel(count: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipChannel(count: Short, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChannelListAttribute(): ChannelListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChannelListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ChannelListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLineupAttribute(): LineupAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLineupAttribute(minInterval: Int, maxInterval: Int): LineupAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentChannelAttribute(): CurrentChannelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentChannelAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentChannelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1284u
-  }
-
-  fun changeChannel(callback: ChangeChannelResponseCallback, match: String) {
-    // Implementation needs to be added here
-  }
-
-  fun changeChannel(
-    callback: ChangeChannelResponseCallback,
-    match: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun changeChannelByNumber(
-    callback: DefaultClusterCallback,
-    majorNumber: Integer,
-    minorNumber: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun changeChannelByNumber(
-    callback: DefaultClusterCallback,
-    majorNumber: Integer,
-    minorNumber: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun skipChannel(callback: DefaultClusterCallback, count: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun skipChannel(callback: DefaultClusterCallback, count: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeChannelResponseCallback {
-    fun onSuccess(status: Integer, data: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface ChannelListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ChannelClusterChannelInfoStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LineupAttributeCallback {
-    fun onSuccess(value: ChipStructs.ChannelClusterLineupInfoStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentChannelAttributeCallback {
-    fun onSuccess(value: ChipStructs.ChannelClusterChannelInfoStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readChannelListAttribute(callback: ChannelListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChannelListAttribute(
-    callback: ChannelListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLineupAttribute(callback: LineupAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLineupAttribute(
-    callback: LineupAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentChannelAttribute(callback: CurrentChannelAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentChannelAttribute(
-    callback: CurrentChannelAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ColorControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ColorControlCluster.kt
@@ -20,1413 +20,1039 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ColorControlCluster(private val endpointId: UShort) {
+  class NumberOfPrimariesAttribute(val value: UByte?)
+
+  class Primary1IntensityAttribute(val value: UByte?)
+
+  class Primary2IntensityAttribute(val value: UByte?)
+
+  class Primary3IntensityAttribute(val value: UByte?)
+
+  class Primary4IntensityAttribute(val value: UByte?)
+
+  class Primary5IntensityAttribute(val value: UByte?)
+
+  class Primary6IntensityAttribute(val value: UByte?)
+
+  class ColorPointRIntensityAttribute(val value: UByte?)
+
+  class ColorPointGIntensityAttribute(val value: UByte?)
+
+  class ColorPointBIntensityAttribute(val value: UByte?)
+
+  class StartUpColorTemperatureMiredsAttribute(val value: UShort?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun moveToHue(
+    hue: UByte,
+    direction: UInt,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToHue(
+    hue: UByte,
+    direction: UInt,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveHue(moveMode: UInt, rate: UByte, optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveHue(
+    moveMode: UInt,
+    rate: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepHue(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepHue(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToSaturation(
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToSaturation(
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveSaturation(
+    moveMode: UInt,
+    rate: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveSaturation(
+    moveMode: UInt,
+    rate: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepSaturation(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepSaturation(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UByte,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToHueAndSaturation(
+    hue: UByte,
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToHueAndSaturation(
+    hue: UByte,
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToColor(
+    colorX: UShort,
+    colorY: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToColor(
+    colorX: UShort,
+    colorY: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveColor(rateX: Short, rateY: Short, optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveColor(
+    rateX: Short,
+    rateY: Short,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepColor(
+    stepX: Short,
+    stepY: Short,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepColor(
+    stepX: Short,
+    stepY: Short,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToColorTemperature(
+    colorTemperatureMireds: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToColorTemperature(
+    colorTemperatureMireds: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveToHue(
+    enhancedHue: UShort,
+    direction: UInt,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveToHue(
+    enhancedHue: UShort,
+    direction: UInt,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveHue(
+    moveMode: UInt,
+    rate: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveHue(
+    moveMode: UInt,
+    rate: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedStepHue(
+    stepMode: UInt,
+    stepSize: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedStepHue(
+    stepMode: UInt,
+    stepSize: UShort,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveToHueAndSaturation(
+    enhancedHue: UShort,
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedMoveToHueAndSaturation(
+    enhancedHue: UShort,
+    saturation: UByte,
+    transitionTime: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun colorLoopSet(
+    updateFlags: UInt,
+    action: UInt,
+    direction: UInt,
+    time: UShort,
+    startHue: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun colorLoopSet(
+    updateFlags: UInt,
+    action: UInt,
+    direction: UInt,
+    time: UShort,
+    startHue: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopMoveStep(optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopMoveStep(optionsMask: UInt, optionsOverride: UInt, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveColorTemperature(
+    moveMode: UInt,
+    rate: UShort,
+    colorTemperatureMinimumMireds: UShort,
+    colorTemperatureMaximumMireds: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveColorTemperature(
+    moveMode: UInt,
+    rate: UShort,
+    colorTemperatureMinimumMireds: UShort,
+    colorTemperatureMaximumMireds: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepColorTemperature(
+    stepMode: UInt,
+    stepSize: UShort,
+    transitionTime: UShort,
+    colorTemperatureMinimumMireds: UShort,
+    colorTemperatureMaximumMireds: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepColorTemperature(
+    stepMode: UInt,
+    stepSize: UShort,
+    transitionTime: UShort,
+    colorTemperatureMinimumMireds: UShort,
+    colorTemperatureMaximumMireds: UShort,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentHueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentHueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentSaturationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentSaturationAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRemainingTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRemainingTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentXAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentXAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentYAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentYAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDriftCompensationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDriftCompensationAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCompensationTextAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCompensationTextAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorTemperatureMiredsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorTemperatureMiredsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOptionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOptionsAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOptionsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfPrimariesAttribute(): NumberOfPrimariesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfPrimariesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): NumberOfPrimariesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary1XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary1XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary1YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary1YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary1IntensityAttribute(): Primary1IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary1IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary1IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary2XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary2XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary2YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary2YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary2IntensityAttribute(): Primary2IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary2IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary2IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary3XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary3XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary3YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary3YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary3IntensityAttribute(): Primary3IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary3IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary3IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary4XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary4XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary4YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary4YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary4IntensityAttribute(): Primary4IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary4IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary4IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary5XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary5XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary5YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary5YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary5IntensityAttribute(): Primary5IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary5IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary5IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary6XAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary6XAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary6YAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary6YAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPrimary6IntensityAttribute(): Primary6IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePrimary6IntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Primary6IntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWhitePointXAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWhitePointXAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWhitePointXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWhitePointXAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWhitePointYAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWhitePointYAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWhitePointYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWhitePointYAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointRXAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRXAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointRXAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointRYAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRYAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointRYAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointRIntensityAttribute(): ColorPointRIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRIntensityAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointRIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointRIntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ColorPointRIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointGXAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGXAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointGXAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointGYAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGYAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointGYAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointGIntensityAttribute(): ColorPointGIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGIntensityAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointGIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointGIntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ColorPointGIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointBXAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBXAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointBXAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointBYAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBYAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointBYAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorPointBIntensityAttribute(): ColorPointBIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBIntensityAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeColorPointBIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorPointBIntensityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ColorPointBIntensityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnhancedCurrentHueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnhancedCurrentHueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnhancedColorModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnhancedColorModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorLoopActiveAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorLoopActiveAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorLoopDirectionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorLoopDirectionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorLoopTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorLoopTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorLoopStartEnhancedHueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorLoopStartEnhancedHueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorLoopStoredEnhancedHueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorLoopStoredEnhancedHueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorCapabilitiesAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorCapabilitiesAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorTempPhysicalMinMiredsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorTempPhysicalMinMiredsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readColorTempPhysicalMaxMiredsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeColorTempPhysicalMaxMiredsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCoupleColorTempToLevelMinMiredsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCoupleColorTempToLevelMinMiredsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpColorTemperatureMiredsAttribute(): StartUpColorTemperatureMiredsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpColorTemperatureMiredsAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpColorTemperatureMiredsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpColorTemperatureMiredsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpColorTemperatureMiredsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 768u
-  }
-
-  fun moveToHue(
-    callback: DefaultClusterCallback,
-    hue: Integer,
-    direction: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToHue(
-    callback: DefaultClusterCallback,
-    hue: Integer,
-    direction: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveHue(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveHue(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepHue(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepHue(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToSaturation(
-    callback: DefaultClusterCallback,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToSaturation(
-    callback: DefaultClusterCallback,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveSaturation(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveSaturation(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepSaturation(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepSaturation(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToHueAndSaturation(
-    callback: DefaultClusterCallback,
-    hue: Integer,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToHueAndSaturation(
-    callback: DefaultClusterCallback,
-    hue: Integer,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToColor(
-    callback: DefaultClusterCallback,
-    colorX: Integer,
-    colorY: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToColor(
-    callback: DefaultClusterCallback,
-    colorX: Integer,
-    colorY: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveColor(
-    callback: DefaultClusterCallback,
-    rateX: Integer,
-    rateY: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveColor(
-    callback: DefaultClusterCallback,
-    rateX: Integer,
-    rateY: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepColor(
-    callback: DefaultClusterCallback,
-    stepX: Integer,
-    stepY: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepColor(
-    callback: DefaultClusterCallback,
-    stepX: Integer,
-    stepY: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToColorTemperature(
-    callback: DefaultClusterCallback,
-    colorTemperatureMireds: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToColorTemperature(
-    callback: DefaultClusterCallback,
-    colorTemperatureMireds: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveToHue(
-    callback: DefaultClusterCallback,
-    enhancedHue: Integer,
-    direction: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveToHue(
-    callback: DefaultClusterCallback,
-    enhancedHue: Integer,
-    direction: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveHue(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveHue(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedStepHue(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedStepHue(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveToHueAndSaturation(
-    callback: DefaultClusterCallback,
-    enhancedHue: Integer,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedMoveToHueAndSaturation(
-    callback: DefaultClusterCallback,
-    enhancedHue: Integer,
-    saturation: Integer,
-    transitionTime: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun colorLoopSet(
-    callback: DefaultClusterCallback,
-    updateFlags: Integer,
-    action: Integer,
-    direction: Integer,
-    time: Integer,
-    startHue: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun colorLoopSet(
-    callback: DefaultClusterCallback,
-    updateFlags: Integer,
-    action: Integer,
-    direction: Integer,
-    time: Integer,
-    startHue: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stopMoveStep(
-    callback: DefaultClusterCallback,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stopMoveStep(
-    callback: DefaultClusterCallback,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveColorTemperature(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    colorTemperatureMinimumMireds: Integer,
-    colorTemperatureMaximumMireds: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveColorTemperature(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer,
-    colorTemperatureMinimumMireds: Integer,
-    colorTemperatureMaximumMireds: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepColorTemperature(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    colorTemperatureMinimumMireds: Integer,
-    colorTemperatureMaximumMireds: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepColorTemperature(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer,
-    colorTemperatureMinimumMireds: Integer,
-    colorTemperatureMaximumMireds: Integer,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface NumberOfPrimariesAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary1IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary2IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary3IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary4IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary5IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface Primary6IntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ColorPointRIntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ColorPointGIntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ColorPointBIntensityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpColorTemperatureMiredsAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readCurrentHueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentHueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentSaturationAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentSaturationAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRemainingTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRemainingTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentXAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentXAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentYAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentYAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDriftCompensationAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDriftCompensationAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCompensationTextAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCompensationTextAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorTemperatureMiredsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorTemperatureMiredsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOptionsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOptionsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOptionsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOptionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNumberOfPrimariesAttribute(callback: NumberOfPrimariesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfPrimariesAttribute(
-    callback: NumberOfPrimariesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary1XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary1XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary1YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary1YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary1IntensityAttribute(callback: Primary1IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary1IntensityAttribute(
-    callback: Primary1IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary2XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary2XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary2YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary2YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary2IntensityAttribute(callback: Primary2IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary2IntensityAttribute(
-    callback: Primary2IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary3XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary3XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary3YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary3YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary3IntensityAttribute(callback: Primary3IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary3IntensityAttribute(
-    callback: Primary3IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary4XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary4XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary4YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary4YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary4IntensityAttribute(callback: Primary4IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary4IntensityAttribute(
-    callback: Primary4IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary5XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary5XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary5YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary5YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary5IntensityAttribute(callback: Primary5IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary5IntensityAttribute(
-    callback: Primary5IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary6XAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary6XAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary6YAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary6YAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPrimary6IntensityAttribute(callback: Primary6IntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePrimary6IntensityAttribute(
-    callback: Primary6IntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWhitePointXAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWhitePointXAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWhitePointXAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWhitePointXAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWhitePointYAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWhitePointYAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWhitePointYAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWhitePointYAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointRXAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRXAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRXAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointRXAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointRYAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRYAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRYAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointRYAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointRIntensityAttribute(callback: ColorPointRIntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRIntensityAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointRIntensityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointRIntensityAttribute(
-    callback: ColorPointRIntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointGXAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGXAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGXAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointGXAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointGYAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGYAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGYAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointGYAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointGIntensityAttribute(callback: ColorPointGIntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGIntensityAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointGIntensityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointGIntensityAttribute(
-    callback: ColorPointGIntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointBXAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBXAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBXAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointBXAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointBYAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBYAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBYAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointBYAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorPointBIntensityAttribute(callback: ColorPointBIntensityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBIntensityAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeColorPointBIntensityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorPointBIntensityAttribute(
-    callback: ColorPointBIntensityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnhancedCurrentHueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnhancedCurrentHueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnhancedColorModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnhancedColorModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorLoopActiveAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorLoopActiveAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorLoopDirectionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorLoopDirectionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorLoopTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorLoopTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorLoopStartEnhancedHueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorLoopStartEnhancedHueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorLoopStoredEnhancedHueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorLoopStoredEnhancedHueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorCapabilitiesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorCapabilitiesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorTempPhysicalMinMiredsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorTempPhysicalMinMiredsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readColorTempPhysicalMaxMiredsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeColorTempPhysicalMaxMiredsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCoupleColorTempToLevelMinMiredsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCoupleColorTempToLevelMinMiredsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpColorTemperatureMiredsAttribute(
-    callback: StartUpColorTemperatureMiredsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpColorTemperatureMiredsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpColorTemperatureMiredsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpColorTemperatureMiredsAttribute(
-    callback: StartUpColorTemperatureMiredsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ContentLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ContentLauncherCluster.kt
@@ -20,199 +20,140 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ContentLauncherCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 1290u
-  }
+  class LauncherResponse(val status: UInt, val data: String?)
 
-  fun launchContent(
-    callback: LauncherResponseCallback,
+  class AcceptHeaderAttribute(val value: ArrayList<String>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun launchContent(
     search: ChipStructs.ContentLauncherClusterContentSearchStruct,
     autoPlay: Boolean,
     data: String?
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun launchContent(
-    callback: LauncherResponseCallback,
+  suspend fun launchContent(
     search: ChipStructs.ContentLauncherClusterContentSearchStruct,
     autoPlay: Boolean,
     data: String?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun launchURL(
-    callback: LauncherResponseCallback,
+  suspend fun launchURL(
     contentURL: String,
     displayString: String?,
     brandingInformation: ChipStructs.ContentLauncherClusterBrandingInformationStruct?
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  fun launchURL(
-    callback: LauncherResponseCallback,
+  suspend fun launchURL(
     contentURL: String,
     displayString: String?,
     brandingInformation: ChipStructs.ContentLauncherClusterBrandingInformationStruct?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): LauncherResponse {
     // Implementation needs to be added here
   }
 
-  interface LauncherResponseCallback {
-    fun onSuccess(status: Integer, data: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface AcceptHeaderAttributeCallback {
-    fun onSuccess(value: ArrayList<String>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readAcceptHeaderAttribute(callback: AcceptHeaderAttributeCallback) {
+  suspend fun readAcceptHeaderAttribute(): AcceptHeaderAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptHeaderAttribute(
-    callback: AcceptHeaderAttributeCallback,
+  suspend fun subscribeAcceptHeaderAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptHeaderAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSupportedStreamingProtocolsAttribute(callback: LongAttributeCallback) {
+  suspend fun readSupportedStreamingProtocolsAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun writeSupportedStreamingProtocolsAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeSupportedStreamingProtocolsAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeSupportedStreamingProtocolsAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeSupportedStreamingProtocolsAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeSupportedStreamingProtocolsAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeSupportedStreamingProtocolsAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Long {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 1290u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DescriptorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DescriptorCluster.kt
@@ -20,211 +20,133 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class DescriptorCluster(private val endpointId: UShort) {
+  class DeviceTypeListAttribute(
+    val value: ArrayList<ChipStructs.DescriptorClusterDeviceTypeStruct>
+  )
+
+  class ServerListAttribute(val value: ArrayList<UInt>)
+
+  class ClientListAttribute(val value: ArrayList<UInt>)
+
+  class PartsListAttribute(val value: ArrayList<UShort>)
+
+  class TagListAttribute(val value: ArrayList<ChipStructs.DescriptorClusterSemanticTagStruct>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readDeviceTypeListAttribute(): DeviceTypeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDeviceTypeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): DeviceTypeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readServerListAttribute(): ServerListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeServerListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ServerListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClientListAttribute(): ClientListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClientListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ClientListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPartsListAttribute(): PartsListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePartsListAttribute(minInterval: Int, maxInterval: Int): PartsListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTagListAttribute(): TagListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTagListAttribute(minInterval: Int, maxInterval: Int): TagListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 29u
-  }
-
-  interface DeviceTypeListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.DescriptorClusterDeviceTypeStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ServerListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ClientListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PartsListAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TagListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.DescriptorClusterSemanticTagStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readDeviceTypeListAttribute(callback: DeviceTypeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDeviceTypeListAttribute(
-    callback: DeviceTypeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readServerListAttribute(callback: ServerListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeServerListAttribute(
-    callback: ServerListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClientListAttribute(callback: ClientListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClientListAttribute(
-    callback: ClientListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPartsListAttribute(callback: PartsListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePartsListAttribute(
-    callback: PartsListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTagListAttribute(callback: TagListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTagListAttribute(
-    callback: TagListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DiagnosticLogsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DiagnosticLogsCluster.kt
@@ -20,136 +20,96 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class DiagnosticLogsCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 50u
-  }
+  class RetrieveLogsResponse(
+    val status: UInt,
+    val logContent: ByteArray,
+    val UTCTimeStamp: ULong?,
+    val timeSinceBoot: ULong?
+  )
 
-  fun retrieveLogsRequest(
-    callback: RetrieveLogsResponseCallback,
-    intent: Integer,
-    requestedProtocol: Integer,
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun retrieveLogsRequest(
+    intent: UInt,
+    requestedProtocol: UInt,
     transferFileDesignator: String?
-  ) {
+  ): RetrieveLogsResponse {
     // Implementation needs to be added here
   }
 
-  fun retrieveLogsRequest(
-    callback: RetrieveLogsResponseCallback,
-    intent: Integer,
-    requestedProtocol: Integer,
+  suspend fun retrieveLogsRequest(
+    intent: UInt,
+    requestedProtocol: UInt,
     transferFileDesignator: String?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): RetrieveLogsResponse {
     // Implementation needs to be added here
   }
 
-  interface RetrieveLogsResponseCallback {
-    fun onSuccess(status: Integer, logContent: ByteArray, UTCTimeStamp: Long?, timeSinceBoot: Long?)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 50u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherAlarmCluster.kt
@@ -20,163 +20,120 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class DishwasherAlarmCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun reset(alarms: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun reset(alarms: ULong, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun modifyEnabledAlarms(mask: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun modifyEnabledAlarms(mask: ULong, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaskAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaskAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLatchAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLatchAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStateAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStateAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 93u
-  }
-
-  fun reset(callback: DefaultClusterCallback, alarms: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun reset(callback: DefaultClusterCallback, alarms: Long, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun modifyEnabledAlarms(callback: DefaultClusterCallback, mask: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun modifyEnabledAlarms(callback: DefaultClusterCallback, mask: Long, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMaskAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaskAttribute(callback: LongAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readLatchAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLatchAttribute(callback: LongAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readStateAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStateAttribute(callback: LongAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherModeCluster.kt
@@ -20,225 +20,144 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class DishwasherModeCluster(private val endpointId: UShort) {
+  class ChangeToModeResponse(val status: UInt, val statusText: String?)
+
+  class SupportedModesAttribute(
+    val value: ArrayList<ChipStructs.DishwasherModeClusterModeOptionStruct>
+  )
+
+  class StartUpModeAttribute(val value: UByte?)
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpModeAttribute(): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 89u
-  }
-
-  fun changeToMode(callback: ChangeToModeResponseCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(
-    callback: ChangeToModeResponseCallback,
-    newMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeToModeResponseCallback {
-    fun onSuccess(status: Integer, statusText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.DishwasherModeClusterModeOptionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpModeAttribute(callback: StartUpModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpModeAttribute(
-    callback: StartUpModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DoorLockCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DoorLockCluster.kt
@@ -20,1093 +20,816 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class DoorLockCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 257u
-  }
+  class GetWeekDayScheduleResponse(
+    val weekDayIndex: UByte,
+    val userIndex: UShort,
+    val status: UInt,
+    val daysMask: UInt?,
+    val startHour: UByte?,
+    val startMinute: UByte?,
+    val endHour: UByte?,
+    val endMinute: UByte?
+  )
 
-  fun lockDoor(callback: DefaultClusterCallback, PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+  class GetYearDayScheduleResponse(
+    val yearDayIndex: UByte,
+    val userIndex: UShort,
+    val status: UInt,
+    val localStartTime: UInt?,
+    val localEndTime: UInt?
+  )
+
+  class GetHolidayScheduleResponse(
+    val holidayIndex: UByte,
+    val status: UInt,
+    val localStartTime: UInt?,
+    val localEndTime: UInt?,
+    val operatingMode: UInt?
+  )
+
+  class GetUserResponse(
+    val userIndex: UShort,
+    val userName: String?,
+    val userUniqueID: UInt?,
+    val userStatus: UInt?,
+    val userType: UInt?,
+    val credentialRule: UInt?,
+    val credentials: ArrayList<ChipStructs.DoorLockClusterCredentialStruct>?,
+    val creatorFabricIndex: UByte?,
+    val lastModifiedFabricIndex: UByte?,
+    val nextUserIndex: UShort?
+  )
+
+  class SetCredentialResponse(
+    val status: UInt,
+    val userIndex: UShort?,
+    val nextCredentialIndex: UShort?
+  )
+
+  class GetCredentialStatusResponse(
+    val credentialExists: Boolean,
+    val userIndex: UShort?,
+    val creatorFabricIndex: UByte?,
+    val lastModifiedFabricIndex: UByte?,
+    val nextCredentialIndex: UShort?
+  )
+
+  class LockStateAttribute(val value: UInt?)
+
+  class DoorStateAttribute(val value: UInt?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun lockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun unlockDoor(callback: DefaultClusterCallback, PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+  suspend fun unlockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun unlockWithTimeout(
-    callback: DefaultClusterCallback,
-    timeout: Integer,
-    PINCode: ByteArray?,
+  suspend fun unlockWithTimeout(timeout: UShort, PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun setWeekDaySchedule(
+    weekDayIndex: UByte,
+    userIndex: UShort,
+    daysMask: UInt,
+    startHour: UByte,
+    startMinute: UByte,
+    endHour: UByte,
+    endMinute: UByte
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun setWeekDaySchedule(
+    weekDayIndex: UByte,
+    userIndex: UShort,
+    daysMask: UInt,
+    startHour: UByte,
+    startMinute: UByte,
+    endHour: UByte,
+    endMinute: UByte,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun setWeekDaySchedule(
-    callback: DefaultClusterCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer,
-    daysMask: Integer,
-    startHour: Integer,
-    startMinute: Integer,
-    endHour: Integer,
-    endMinute: Integer
-  ) {
+  suspend fun getWeekDaySchedule(
+    weekDayIndex: UByte,
+    userIndex: UShort
+  ): GetWeekDayScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun setWeekDaySchedule(
-    callback: DefaultClusterCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer,
-    daysMask: Integer,
-    startHour: Integer,
-    startMinute: Integer,
-    endHour: Integer,
-    endMinute: Integer,
+  suspend fun getWeekDaySchedule(
+    weekDayIndex: UByte,
+    userIndex: UShort,
+    timedInvokeTimeoutMs: Int
+  ): GetWeekDayScheduleResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun clearWeekDaySchedule(weekDayIndex: UByte, userIndex: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun clearWeekDaySchedule(
+    weekDayIndex: UByte,
+    userIndex: UShort,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun getWeekDaySchedule(
-    callback: GetWeekDayScheduleResponseCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer
+  suspend fun setYearDaySchedule(
+    yearDayIndex: UByte,
+    userIndex: UShort,
+    localStartTime: UInt,
+    localEndTime: UInt
   ) {
     // Implementation needs to be added here
   }
 
-  fun getWeekDaySchedule(
-    callback: GetWeekDayScheduleResponseCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer,
+  suspend fun setYearDaySchedule(
+    yearDayIndex: UByte,
+    userIndex: UShort,
+    localStartTime: UInt,
+    localEndTime: UInt,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun clearWeekDaySchedule(
-    callback: DefaultClusterCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer
-  ) {
+  suspend fun getYearDaySchedule(
+    yearDayIndex: UByte,
+    userIndex: UShort
+  ): GetYearDayScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun clearWeekDaySchedule(
-    callback: DefaultClusterCallback,
-    weekDayIndex: Integer,
-    userIndex: Integer,
+  suspend fun getYearDaySchedule(
+    yearDayIndex: UByte,
+    userIndex: UShort,
+    timedInvokeTimeoutMs: Int
+  ): GetYearDayScheduleResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun clearYearDaySchedule(yearDayIndex: UByte, userIndex: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun clearYearDaySchedule(
+    yearDayIndex: UByte,
+    userIndex: UShort,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun setYearDaySchedule(
-    callback: DefaultClusterCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer,
-    localStartTime: Long,
-    localEndTime: Long
+  suspend fun setHolidaySchedule(
+    holidayIndex: UByte,
+    localStartTime: UInt,
+    localEndTime: UInt,
+    operatingMode: UInt
   ) {
     // Implementation needs to be added here
   }
 
-  fun setYearDaySchedule(
-    callback: DefaultClusterCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer,
-    localStartTime: Long,
-    localEndTime: Long,
+  suspend fun setHolidaySchedule(
+    holidayIndex: UByte,
+    localStartTime: UInt,
+    localEndTime: UInt,
+    operatingMode: UInt,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun getYearDaySchedule(
-    callback: GetYearDayScheduleResponseCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer
-  ) {
+  suspend fun getHolidaySchedule(holidayIndex: UByte): GetHolidayScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun getYearDaySchedule(
-    callback: GetYearDayScheduleResponseCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer,
+  suspend fun getHolidaySchedule(
+    holidayIndex: UByte,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): GetHolidayScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun clearYearDaySchedule(
-    callback: DefaultClusterCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer
-  ) {
+  suspend fun clearHolidaySchedule(holidayIndex: UByte) {
     // Implementation needs to be added here
   }
 
-  fun clearYearDaySchedule(
-    callback: DefaultClusterCallback,
-    yearDayIndex: Integer,
-    userIndex: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun clearHolidaySchedule(holidayIndex: UByte, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun setHolidaySchedule(
-    callback: DefaultClusterCallback,
-    holidayIndex: Integer,
-    localStartTime: Long,
-    localEndTime: Long,
-    operatingMode: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun setHolidaySchedule(
-    callback: DefaultClusterCallback,
-    holidayIndex: Integer,
-    localStartTime: Long,
-    localEndTime: Long,
-    operatingMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun getHolidaySchedule(callback: GetHolidayScheduleResponseCallback, holidayIndex: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun getHolidaySchedule(
-    callback: GetHolidayScheduleResponseCallback,
-    holidayIndex: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun clearHolidaySchedule(callback: DefaultClusterCallback, holidayIndex: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun clearHolidaySchedule(
-    callback: DefaultClusterCallback,
-    holidayIndex: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun setUser(
-    callback: DefaultClusterCallback,
-    operationType: Integer,
-    userIndex: Integer,
+  suspend fun setUser(
+    operationType: UInt,
+    userIndex: UShort,
     userName: String?,
-    userUniqueID: Long?,
-    userStatus: Integer?,
-    userType: Integer?,
-    credentialRule: Integer?,
+    userUniqueID: UInt?,
+    userStatus: UInt?,
+    userType: UInt?,
+    credentialRule: UInt?,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun getUser(callback: GetUserResponseCallback, userIndex: Integer) {
+  suspend fun getUser(userIndex: UShort): GetUserResponse {
     // Implementation needs to be added here
   }
 
-  fun getUser(callback: GetUserResponseCallback, userIndex: Integer, timedInvokeTimeoutMs: Int) {
+  suspend fun getUser(userIndex: UShort, timedInvokeTimeoutMs: Int): GetUserResponse {
     // Implementation needs to be added here
   }
 
-  fun clearUser(callback: DefaultClusterCallback, userIndex: Integer, timedInvokeTimeoutMs: Int) {
+  suspend fun clearUser(userIndex: UShort, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun setCredential(
-    callback: SetCredentialResponseCallback,
-    operationType: Integer,
+  suspend fun setCredential(
+    operationType: UInt,
     credential: ChipStructs.DoorLockClusterCredentialStruct,
     credentialData: ByteArray,
-    userIndex: Integer?,
-    userStatus: Integer?,
-    userType: Integer?,
+    userIndex: UShort?,
+    userStatus: UInt?,
+    userType: UInt?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): SetCredentialResponse {
     // Implementation needs to be added here
   }
 
-  fun getCredentialStatus(
-    callback: GetCredentialStatusResponseCallback,
+  suspend fun getCredentialStatus(
     credential: ChipStructs.DoorLockClusterCredentialStruct
-  ) {
+  ): GetCredentialStatusResponse {
     // Implementation needs to be added here
   }
 
-  fun getCredentialStatus(
-    callback: GetCredentialStatusResponseCallback,
+  suspend fun getCredentialStatus(
     credential: ChipStructs.DoorLockClusterCredentialStruct,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): GetCredentialStatusResponse {
     // Implementation needs to be added here
   }
 
-  fun clearCredential(
-    callback: DefaultClusterCallback,
+  suspend fun clearCredential(
     credential: ChipStructs.DoorLockClusterCredentialStruct?,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun unboltDoor(callback: DefaultClusterCallback, PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+  suspend fun unboltDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  interface GetWeekDayScheduleResponseCallback {
-    fun onSuccess(
-      weekDayIndex: Integer,
-      userIndex: Integer,
-      status: Integer,
-      daysMask: Integer?,
-      startHour: Integer?,
-      startMinute: Integer?,
-      endHour: Integer?,
-      endMinute: Integer?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface GetYearDayScheduleResponseCallback {
-    fun onSuccess(
-      yearDayIndex: Integer,
-      userIndex: Integer,
-      status: Integer,
-      localStartTime: Long?,
-      localEndTime: Long?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface GetHolidayScheduleResponseCallback {
-    fun onSuccess(
-      holidayIndex: Integer,
-      status: Integer,
-      localStartTime: Long?,
-      localEndTime: Long?,
-      operatingMode: Integer?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface GetUserResponseCallback {
-    fun onSuccess(
-      userIndex: Integer,
-      userName: String?,
-      userUniqueID: Long?,
-      userStatus: Integer?,
-      userType: Integer?,
-      credentialRule: Integer?,
-      credentials: ArrayList<ChipStructs.DoorLockClusterCredentialStruct>?,
-      creatorFabricIndex: Integer?,
-      lastModifiedFabricIndex: Integer?,
-      nextUserIndex: Integer?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface SetCredentialResponseCallback {
-    fun onSuccess(status: Integer, userIndex: Integer?, nextCredentialIndex: Integer?)
-
-    fun onError(error: Exception)
-  }
-
-  interface GetCredentialStatusResponseCallback {
-    fun onSuccess(
-      credentialExists: Boolean,
-      userIndex: Integer?,
-      creatorFabricIndex: Integer?,
-      lastModifiedFabricIndex: Integer?,
-      nextCredentialIndex: Integer?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface LockStateAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DoorStateAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readLockStateAttribute(callback: LockStateAttributeCallback) {
+  suspend fun readLockStateAttribute(): LockStateAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeLockStateAttribute(
-    callback: LockStateAttributeCallback,
+  suspend fun subscribeLockStateAttribute(minInterval: Int, maxInterval: Int): LockStateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLockTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLockTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActuatorEnabledAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActuatorEnabledAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDoorStateAttribute(): DoorStateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDoorStateAttribute(minInterval: Int, maxInterval: Int): DoorStateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDoorOpenEventsAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDoorOpenEventsAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDoorOpenEventsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDoorOpenEventsAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDoorClosedEventsAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDoorClosedEventsAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDoorClosedEventsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDoorClosedEventsAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOpenPeriodAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOpenPeriodAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOpenPeriodAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfTotalUsersSupportedAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfTotalUsersSupportedAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readLockTypeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readNumberOfPINUsersSupportedAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeLockTypeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeNumberOfPINUsersSupportedAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActuatorEnabledAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readNumberOfRFIDUsersSupportedAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActuatorEnabledAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeNumberOfRFIDUsersSupportedAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDoorStateAttribute(callback: DoorStateAttributeCallback) {
+  suspend fun readNumberOfWeekDaySchedulesSupportedPerUserAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDoorStateAttribute(
-    callback: DoorStateAttributeCallback,
+  suspend fun subscribeNumberOfWeekDaySchedulesSupportedPerUserAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDoorOpenEventsAttribute(callback: LongAttributeCallback) {
+  suspend fun readNumberOfYearDaySchedulesSupportedPerUserAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeDoorOpenEventsAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDoorOpenEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDoorOpenEventsAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeNumberOfYearDaySchedulesSupportedPerUserAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDoorClosedEventsAttribute(callback: LongAttributeCallback) {
+  suspend fun readNumberOfHolidaySchedulesSupportedAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeDoorClosedEventsAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDoorClosedEventsAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDoorClosedEventsAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeNumberOfHolidaySchedulesSupportedAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readOpenPeriodAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMaxPINCodeLengthAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOpenPeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun subscribeMaxPINCodeLengthAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOpenPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun readMinPINCodeLengthAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeOpenPeriodAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMinPINCodeLengthAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxRFIDCodeLengthAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxRFIDCodeLengthAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinRFIDCodeLengthAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinRFIDCodeLengthAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCredentialRulesSupportAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCredentialRulesSupportAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfTotalUsersSupportedAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readNumberOfCredentialsSupportedPerUserAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfTotalUsersSupportedAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeNumberOfCredentialsSupportedPerUserAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfPINUsersSupportedAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readLanguageAttribute(): CharString {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfPINUsersSupportedAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeLanguageAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLanguageAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLanguageAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLEDSettingsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLEDSettingsAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLEDSettingsAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLEDSettingsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAutoRelockTimeAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeAutoRelockTimeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeAutoRelockTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAutoRelockTimeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSoundVolumeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSoundVolumeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSoundVolumeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSoundVolumeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperatingModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOperatingModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOperatingModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperatingModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedOperatingModesAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedOperatingModesAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfRFIDUsersSupportedAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readDefaultConfigurationRegisterAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfRFIDUsersSupportedAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeDefaultConfigurationRegisterAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfWeekDaySchedulesSupportedPerUserAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEnableLocalProgrammingAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfWeekDaySchedulesSupportedPerUserAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeEnableLocalProgrammingAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnableLocalProgrammingAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnableLocalProgrammingAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Boolean {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfYearDaySchedulesSupportedPerUserAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEnableOneTouchLockingAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfYearDaySchedulesSupportedPerUserAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeEnableOneTouchLockingAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnableOneTouchLockingAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnableOneTouchLockingAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnableInsideStatusLEDAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnableInsideStatusLEDAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnableInsideStatusLEDAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnableInsideStatusLEDAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnablePrivacyModeButtonAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnablePrivacyModeButtonAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnablePrivacyModeButtonAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnablePrivacyModeButtonAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Boolean {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfHolidaySchedulesSupportedAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readLocalProgrammingFeaturesAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfHolidaySchedulesSupportedAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeLocalProgrammingFeaturesAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocalProgrammingFeaturesAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocalProgrammingFeaturesAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMaxPINCodeLengthAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readWrongCodeEntryLimitAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMaxPINCodeLengthAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeWrongCodeEntryLimitAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWrongCodeEntryLimitAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWrongCodeEntryLimitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUserCodeTemporaryDisableTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUserCodeTemporaryDisableTimeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUserCodeTemporaryDisableTimeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUserCodeTemporaryDisableTimeAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMinPINCodeLengthAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readSendPINOverTheAirAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun subscribeMinPINCodeLengthAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeSendPINOverTheAirAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSendPINOverTheAirAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSendPINOverTheAirAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRequirePINforRemoteOperationAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRequirePINforRemoteOperationAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRequirePINforRemoteOperationAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRequirePINforRemoteOperationAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Boolean {
     // Implementation needs to be added here
   }
 
-  fun readMaxRFIDCodeLengthAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readExpiringUserTimeoutAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMaxRFIDCodeLengthAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeExpiringUserTimeoutAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeExpiringUserTimeoutAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeExpiringUserTimeoutAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMinRFIDCodeLengthAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeMinRFIDCodeLengthAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readCredentialRulesSupportAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeCredentialRulesSupportAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfCredentialsSupportedPerUserAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfCredentialsSupportedPerUserAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readLanguageAttribute(callback: CharStringAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeLanguageAttribute(callback: DefaultClusterCallback, value: String) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeLanguageAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLanguageAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLEDSettingsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLEDSettingsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLEDSettingsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLEDSettingsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAutoRelockTimeAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAutoRelockTimeAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAutoRelockTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAutoRelockTimeAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSoundVolumeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSoundVolumeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSoundVolumeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSoundVolumeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperatingModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOperatingModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOperatingModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperatingModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedOperatingModesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedOperatingModesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDefaultConfigurationRegisterAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDefaultConfigurationRegisterAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnableLocalProgrammingAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableLocalProgrammingAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableLocalProgrammingAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnableLocalProgrammingAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnableOneTouchLockingAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableOneTouchLockingAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableOneTouchLockingAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnableOneTouchLockingAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnableInsideStatusLEDAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableInsideStatusLEDAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnableInsideStatusLEDAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnableInsideStatusLEDAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnablePrivacyModeButtonAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnablePrivacyModeButtonAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnablePrivacyModeButtonAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnablePrivacyModeButtonAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLocalProgrammingFeaturesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocalProgrammingFeaturesAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLocalProgrammingFeaturesAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLocalProgrammingFeaturesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWrongCodeEntryLimitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWrongCodeEntryLimitAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWrongCodeEntryLimitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWrongCodeEntryLimitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUserCodeTemporaryDisableTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUserCodeTemporaryDisableTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUserCodeTemporaryDisableTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUserCodeTemporaryDisableTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSendPINOverTheAirAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSendPINOverTheAirAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSendPINOverTheAirAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSendPINOverTheAirAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRequirePINforRemoteOperationAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeRequirePINforRemoteOperationAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeRequirePINforRemoteOperationAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRequirePINforRemoteOperationAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readExpiringUserTimeoutAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeExpiringUserTimeoutAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeExpiringUserTimeoutAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeExpiringUserTimeoutAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 257u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ElectricalMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ElectricalMeasurementCluster.kt
@@ -20,1776 +20,1302 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ElectricalMeasurementCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 2820u
-  }
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-  fun getProfileInfoCommand(callback: DefaultClusterCallback) {
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun getProfileInfoCommand() {
     // Implementation needs to be added here
   }
 
-  fun getProfileInfoCommand(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun getProfileInfoCommand(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun getMeasurementProfileCommand(
-    callback: DefaultClusterCallback,
-    attributeId: Integer,
-    startTime: Long,
-    numberOfIntervals: Integer
+  suspend fun getMeasurementProfileCommand(
+    attributeId: UShort,
+    startTime: UInt,
+    numberOfIntervals: UInt
   ) {
     // Implementation needs to be added here
   }
 
-  fun getMeasurementProfileCommand(
-    callback: DefaultClusterCallback,
-    attributeId: Integer,
-    startTime: Long,
-    numberOfIntervals: Integer,
+  suspend fun getMeasurementProfileCommand(
+    attributeId: UShort,
+    startTime: UInt,
+    numberOfIntervals: UInt,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasurementTypeAttribute(callback: LongAttributeCallback) {
+  suspend fun readMeasurementTypeAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasurementTypeAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeMeasurementTypeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcVoltageAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcVoltageAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcVoltageMinAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcVoltageMinAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcVoltageMaxAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcVoltageMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcCurrentAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcCurrentAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcCurrentMinAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcCurrentMinAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcCurrentMaxAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcCurrentMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcPowerAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcPowerAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcPowerMinAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcPowerMinAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcPowerMaxAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcPowerMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcVoltageMultiplierAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcVoltageMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcVoltageDivisorAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcVoltageDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcCurrentMultiplierAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcCurrentMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcCurrentDivisorAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcCurrentDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcPowerMultiplierAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcPowerMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDcPowerDivisorAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDcPowerDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcFrequencyAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcFrequencyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcFrequencyMinAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcFrequencyMinAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcFrequencyMaxAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcFrequencyMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNeutralCurrentAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNeutralCurrentAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTotalActivePowerAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTotalActivePowerAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTotalReactivePowerAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTotalReactivePowerAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTotalApparentPowerAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTotalApparentPowerAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasured1stHarmonicCurrentAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasured1stHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcVoltageAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasured3rdHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcVoltageAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasured3rdHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcVoltageMinAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasured5thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcVoltageMinAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasured5thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcVoltageMaxAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasured7thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcVoltageMaxAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasured7thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasured9thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcCurrentAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasured9thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcCurrentMinAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasured11thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcCurrentMinAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasured11thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcCurrentMaxAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase1stHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcCurrentMaxAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase1stHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcPowerAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase3rdHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcPowerAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase3rdHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcPowerMinAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase5thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcPowerMinAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase5thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcPowerMaxAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase7thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcPowerMaxAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase7thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcVoltageMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase9thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcVoltageMultiplierAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase9thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcVoltageDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMeasuredPhase11thHarmonicCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcVoltageDivisorAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMeasuredPhase11thHarmonicCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcCurrentMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcFrequencyMultiplierAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcCurrentMultiplierAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcFrequencyMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcFrequencyDivisorAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcFrequencyDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPowerMultiplierAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePowerMultiplierAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPowerDivisorAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePowerDivisorAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHarmonicCurrentMultiplierAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHarmonicCurrentMultiplierAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcCurrentDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPhaseHarmonicCurrentMultiplierAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcCurrentDivisorAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribePhaseHarmonicCurrentMultiplierAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcPowerMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readInstantaneousVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcPowerMultiplierAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeInstantaneousVoltageAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInstantaneousLineCurrentAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInstantaneousLineCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readDcPowerDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readInstantaneousActiveCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDcPowerDivisorAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeInstantaneousActiveCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcFrequencyAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readInstantaneousReactiveCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcFrequencyAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeInstantaneousReactiveCurrentAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcFrequencyMinAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readInstantaneousPowerAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcFrequencyMinAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeInstantaneousPowerAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcFrequencyMaxAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcFrequencyMaxAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNeutralCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageMinAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeNeutralCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMinAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readTotalActivePowerAttribute(callback: LongAttributeCallback) {
+  suspend fun readRmsVoltageMaxAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeTotalActivePowerAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readTotalReactivePowerAttribute(callback: LongAttributeCallback) {
+  suspend fun readRmsCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeTotalReactivePowerAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readTotalApparentPowerAttribute(callback: LongAttributeCallback) {
+  suspend fun readRmsCurrentMinAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeTotalApparentPowerAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMinAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured1stHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentMaxAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured1stHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured3rdHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured3rdHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured5thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMinAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured5thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMinAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured7thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMaxAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured7thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured9thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readReactivePowerAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured9thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeReactivePowerAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasured11thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readApparentPowerAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasured11thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeApparentPowerAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasuredPhase1stHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPowerFactorAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasuredPhase1stHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribePowerFactorAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMeasuredPhase3rdHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsVoltageMeasurementPeriodAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMeasuredPhase3rdHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun writeAverageRmsVoltageMeasurementPeriodAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun readMeasuredPhase5thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredPhase5thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasuredPhase7thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredPhase7thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasuredPhase9thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredPhase9thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasuredPhase11thHarmonicCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredPhase11thHarmonicCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcFrequencyMultiplierAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcFrequencyMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcFrequencyDivisorAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcFrequencyDivisorAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPowerMultiplierAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePowerMultiplierAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPowerDivisorAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePowerDivisorAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHarmonicCurrentMultiplierAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHarmonicCurrentMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhaseHarmonicCurrentMultiplierAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhaseHarmonicCurrentMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstantaneousVoltageAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstantaneousVoltageAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstantaneousLineCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstantaneousLineCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstantaneousActiveCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstantaneousActiveCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstantaneousReactiveCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstantaneousReactiveCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstantaneousPowerAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstantaneousPowerAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsVoltageAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsVoltageAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsVoltageMinAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsVoltageMinAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsVoltageMaxAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsVoltageMaxAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsCurrentMinAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsCurrentMinAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRmsCurrentMaxAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRmsCurrentMaxAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActivePowerAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActivePowerAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActivePowerMinAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActivePowerMinAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActivePowerMaxAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActivePowerMaxAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReactivePowerAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReactivePowerAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readApparentPowerAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeApparentPowerAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPowerFactorAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePowerFactorAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageRmsVoltageMeasurementPeriodAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAverageRmsVoltageMeasurementPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAverageRmsVoltageMeasurementPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
+  suspend fun writeAverageRmsVoltageMeasurementPeriodAttribute(
+    value: UShort,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsVoltageMeasurementPeriodAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsVoltageMeasurementPeriodAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsUnderVoltageCounterAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsUnderVoltageCounterAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeAverageRmsUnderVoltageCounterAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
+  suspend fun writeAverageRmsUnderVoltageCounterAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeAverageRmsUnderVoltageCounterAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeAverageRmsUnderVoltageCounterAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsUnderVoltageCounterAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsUnderVoltageCounterAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeOverVoltagePeriodAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeOverVoltagePeriodAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRmsExtremeOverVoltagePeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRmsExtremeOverVoltagePeriodAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeRmsExtremeOverVoltagePeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRmsExtremeOverVoltagePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeOverVoltagePeriodAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeOverVoltagePeriodAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeUnderVoltagePeriodAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeUnderVoltagePeriodAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRmsExtremeUnderVoltagePeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRmsExtremeUnderVoltagePeriodAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeRmsExtremeUnderVoltagePeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRmsExtremeUnderVoltagePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeUnderVoltagePeriodAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeUnderVoltagePeriodAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSagPeriodAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSagPeriodAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRmsVoltageSagPeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRmsVoltageSagPeriodAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeRmsVoltageSagPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRmsVoltageSagPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSagPeriodAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageSagPeriodAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSwellPeriodAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSwellPeriodAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRmsVoltageSwellPeriodAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRmsVoltageSwellPeriodAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeRmsVoltageSwellPeriodAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRmsVoltageSwellPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSwellPeriodAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageSwellPeriodAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcVoltageMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcVoltageMultiplierAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcVoltageMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcVoltageMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcVoltageDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcVoltageDivisorAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcVoltageDivisorAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcVoltageDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcCurrentMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcCurrentMultiplierAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcCurrentMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcCurrentMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcCurrentDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcCurrentDivisorAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcCurrentDivisorAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcCurrentDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcPowerMultiplierAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcPowerMultiplierAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcPowerMultiplierAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcPowerMultiplierAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcPowerDivisorAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcPowerDivisorAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcPowerDivisorAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcPowerDivisorAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readOverloadAlarmsMaskAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOverloadAlarmsMaskAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOverloadAlarmsMaskAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeOverloadAlarmsMaskAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeOverloadAlarmsMaskAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeOverloadAlarmsMaskAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeOverloadAlarmsMaskAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readVoltageOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readVoltageOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeVoltageOverloadAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeVoltageOverloadAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readCurrentOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readCurrentOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeCurrentOverloadAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeCurrentOverloadAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcOverloadAlarmsMaskAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcOverloadAlarmsMaskAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeAcOverloadAlarmsMaskAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeAcOverloadAlarmsMaskAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeAcOverloadAlarmsMaskAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeAcOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcOverloadAlarmsMaskAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcOverloadAlarmsMaskAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcVoltageOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcVoltageOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcVoltageOverloadAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcVoltageOverloadAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcCurrentOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcCurrentOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcCurrentOverloadAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcCurrentOverloadAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcActivePowerOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcActivePowerOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcActivePowerOverloadAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAcActivePowerOverloadAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcReactivePowerOverloadAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcReactivePowerOverloadAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcReactivePowerOverloadAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcReactivePowerOverloadAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsOverVoltageAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsOverVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsOverVoltageAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeAverageRmsOverVoltageAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsUnderVoltageAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsUnderVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsUnderVoltageAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsUnderVoltageAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeOverVoltageAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeOverVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeOverVoltageAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsExtremeOverVoltageAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeUnderVoltageAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeUnderVoltageAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeUnderVoltageAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeUnderVoltageAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSagAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSagAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSagAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageSagAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSwellAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSwellAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSwellAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageSwellAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readLineCurrentPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readLineCurrentPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeLineCurrentPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeLineCurrentPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActiveCurrentPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActiveCurrentPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActiveCurrentPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActiveCurrentPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readReactiveCurrentPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readReactiveCurrentPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeReactiveCurrentPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeReactiveCurrentPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltagePhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltagePhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltagePhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltagePhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageMinPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageMinPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageMinPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMinPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageMaxPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageMaxPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageMaxPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMaxPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentMinPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentMinPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentMinPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMinPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentMaxPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentMaxPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentMaxPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMaxPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerMinPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMinPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerMinPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMinPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerMaxPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMaxPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerMaxPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMaxPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readReactivePowerPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readReactivePowerPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeReactivePowerPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeReactivePowerPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readApparentPowerPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readApparentPowerPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeApparentPowerPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeApparentPowerPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readPowerFactorPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPowerFactorPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribePowerFactorPhaseBAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribePowerFactorPhaseBAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsVoltageMeasurementPeriodPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsVoltageMeasurementPeriodPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsVoltageMeasurementPeriodPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsVoltageMeasurementPeriodPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsOverVoltageCounterPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsOverVoltageCounterPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsOverVoltageCounterPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsOverVoltageCounterPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsUnderVoltageCounterPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsUnderVoltageCounterPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsUnderVoltageCounterPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsUnderVoltageCounterPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeOverVoltagePeriodPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeOverVoltagePeriodPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeOverVoltagePeriodPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeOverVoltagePeriodPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeUnderVoltagePeriodPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeUnderVoltagePeriodPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeUnderVoltagePeriodPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeUnderVoltagePeriodPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSagPeriodPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSagPeriodPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSagPeriodPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsVoltageSagPeriodPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSwellPeriodPhaseBAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSwellPeriodPhaseBAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSwellPeriodPhaseBAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsVoltageSwellPeriodPhaseBAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readLineCurrentPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readLineCurrentPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeLineCurrentPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeLineCurrentPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActiveCurrentPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActiveCurrentPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActiveCurrentPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActiveCurrentPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readReactiveCurrentPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readReactiveCurrentPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeReactiveCurrentPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeReactiveCurrentPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltagePhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltagePhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltagePhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltagePhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageMinPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageMinPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageMinPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMinPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageMaxPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageMaxPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageMaxPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsVoltageMaxPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentMinPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentMinPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentMinPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMinPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsCurrentMaxPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsCurrentMaxPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsCurrentMaxPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRmsCurrentMaxPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerMinPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMinPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerMinPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMinPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readActivePowerMaxPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readActivePowerMaxPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeActivePowerMaxPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeActivePowerMaxPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readReactivePowerPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readReactivePowerPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeReactivePowerPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeReactivePowerPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readApparentPowerPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readApparentPowerPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeApparentPowerPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeApparentPowerPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readPowerFactorPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPowerFactorPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribePowerFactorPhaseCAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribePowerFactorPhaseCAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsVoltageMeasurementPeriodPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsVoltageMeasurementPeriodPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsVoltageMeasurementPeriodPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsVoltageMeasurementPeriodPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsOverVoltageCounterPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsOverVoltageCounterPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsOverVoltageCounterPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsOverVoltageCounterPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAverageRmsUnderVoltageCounterPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAverageRmsUnderVoltageCounterPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageRmsUnderVoltageCounterPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAverageRmsUnderVoltageCounterPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeOverVoltagePeriodPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeOverVoltagePeriodPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeOverVoltagePeriodPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeOverVoltagePeriodPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsExtremeUnderVoltagePeriodPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsExtremeUnderVoltagePeriodPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsExtremeUnderVoltagePeriodPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsExtremeUnderVoltagePeriodPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSagPeriodPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSagPeriodPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSagPeriodPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsVoltageSagPeriodPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRmsVoltageSwellPeriodPhaseCAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRmsVoltageSwellPeriodPhaseCAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRmsVoltageSwellPeriodPhaseCAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRmsVoltageSwellPeriodPhaseCAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
+  }
+
+  companion object {
+    const val CLUSTER_ID: UInt = 2820u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/EthernetNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/EthernetNetworkDiagnosticsCluster.kt
@@ -20,251 +20,164 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class EthernetNetworkDiagnosticsCluster(private val endpointId: UShort) {
+  class PHYRateAttribute(val value: UInt?)
+
+  class FullDuplexAttribute(val value: Boolean?)
+
+  class CarrierDetectAttribute(val value: Boolean?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetCounts() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetCounts(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPHYRateAttribute(): PHYRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePHYRateAttribute(minInterval: Int, maxInterval: Int): PHYRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFullDuplexAttribute(): FullDuplexAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFullDuplexAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): FullDuplexAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketRxCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketRxCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketTxCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketTxCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxErrCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxErrCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCollisionCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCollisionCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOverrunCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOverrunCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCarrierDetectAttribute(): CarrierDetectAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCarrierDetectAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CarrierDetectAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTimeSinceResetAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTimeSinceResetAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 55u
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface PHYRateAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface FullDuplexAttributeCallback {
-    fun onSuccess(value: Boolean?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CarrierDetectAttributeCallback {
-    fun onSuccess(value: Boolean?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readPHYRateAttribute(callback: PHYRateAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePHYRateAttribute(
-    callback: PHYRateAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFullDuplexAttribute(callback: FullDuplexAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFullDuplexAttribute(
-    callback: FullDuplexAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketRxCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketRxCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketTxCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketTxCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxErrCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxErrCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCollisionCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCollisionCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOverrunCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOverrunCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCarrierDetectAttribute(callback: CarrierDetectAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCarrierDetectAttribute(
-    callback: CarrierDetectAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTimeSinceResetAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTimeSinceResetAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FanControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FanControlCluster.kt
@@ -20,22 +20,24 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class FanControlCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 514u
-  }
+  class PercentSettingAttribute(val value: UByte?)
 
-  fun step(
-    callback: DefaultClusterCallback,
-    direction: Integer,
-    wrap: Boolean?,
-    lowestOff: Boolean?
-  ) {
+  class SpeedSettingAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun step(direction: UInt, wrap: Boolean?, lowestOff: Boolean?) {
     // Implementation needs to be added here
   }
 
-  fun step(
-    callback: DefaultClusterCallback,
-    direction: Integer,
+  suspend fun step(
+    direction: UInt,
     wrap: Boolean?,
     lowestOff: Boolean?,
     timedInvokeTimeoutMs: Int
@@ -43,351 +45,222 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  interface PercentSettingAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SpeedSettingAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readFanModeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readFanModeAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeFanModeAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeFanModeAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeFanModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeFanModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeFanModeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeFanModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFanModeSequenceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFanModeSequenceAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFanModeSequenceAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFanModeSequenceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPercentSettingAttribute(): PercentSettingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePercentSettingAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePercentSettingAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePercentSettingAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): PercentSettingAttribute {
     // Implementation needs to be added here
   }
 
-  fun readFanModeSequenceAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPercentCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeFanModeSequenceAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun subscribePercentCurrentAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeFanModeSequenceAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun readSpeedMaxAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFanModeSequenceAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeSpeedMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSpeedSettingAttribute(): SpeedSettingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSpeedSettingAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSpeedSettingAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSpeedSettingAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): SpeedSettingAttribute {
     // Implementation needs to be added here
   }
 
-  fun readPercentSettingAttribute(callback: PercentSettingAttributeCallback) {
+  suspend fun readSpeedCurrentAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writePercentSettingAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun subscribeSpeedCurrentAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun writePercentSettingAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun readRockSupportAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribePercentSettingAttribute(
-    callback: PercentSettingAttributeCallback,
+  suspend fun subscribeRockSupportAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRockSettingAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRockSettingAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRockSettingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRockSettingAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWindSupportAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWindSupportAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWindSettingAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWindSettingAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeWindSettingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWindSettingAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAirflowDirectionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeAirflowDirectionAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeAirflowDirectionAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAirflowDirectionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readPercentCurrentAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribePercentCurrentAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSpeedMaxAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeSpeedMaxAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSpeedSettingAttribute(callback: SpeedSettingAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun writeSpeedSettingAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun writeSpeedSettingAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeSpeedSettingAttribute(
-    callback: SpeedSettingAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readSpeedCurrentAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSpeedCurrentAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRockSupportAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRockSupportAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRockSettingAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeRockSettingAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeRockSettingAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRockSettingAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWindSupportAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWindSupportAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWindSettingAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWindSettingAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeWindSettingAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWindSettingAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAirflowDirectionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAirflowDirectionAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeAirflowDirectionAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAirflowDirectionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 514u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FaultInjectionCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FaultInjectionCluster.kt
@@ -20,153 +20,106 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class FaultInjectionCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 4294048774u
-  }
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-  fun failAtFault(
-    callback: DefaultClusterCallback,
-    type: Integer,
-    id: Long,
-    numCallsToSkip: Long,
-    numCallsToFail: Long,
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun failAtFault(
+    type: UInt,
+    id: UInt,
+    numCallsToSkip: UInt,
+    numCallsToFail: UInt,
     takeMutex: Boolean
   ) {
     // Implementation needs to be added here
   }
 
-  fun failAtFault(
-    callback: DefaultClusterCallback,
-    type: Integer,
-    id: Long,
-    numCallsToSkip: Long,
-    numCallsToFail: Long,
+  suspend fun failAtFault(
+    type: UInt,
+    id: UInt,
+    numCallsToSkip: UInt,
+    numCallsToFail: UInt,
     takeMutex: Boolean,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun failRandomlyAtFault(
-    callback: DefaultClusterCallback,
-    type: Integer,
-    id: Long,
-    percentage: Integer
-  ) {
+  suspend fun failRandomlyAtFault(type: UInt, id: UInt, percentage: UByte) {
     // Implementation needs to be added here
   }
 
-  fun failRandomlyAtFault(
-    callback: DefaultClusterCallback,
-    type: Integer,
-    id: Long,
-    percentage: Integer,
+  suspend fun failRandomlyAtFault(
+    type: UInt,
+    id: UInt,
+    percentage: UByte,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 4294048774u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FixedLabelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FixedLabelCluster.kt
@@ -20,131 +20,82 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class FixedLabelCluster(private val endpointId: UShort) {
+  class LabelListAttribute(val value: ArrayList<ChipStructs.FixedLabelClusterLabelStruct>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readLabelListAttribute(): LabelListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLabelListAttribute(minInterval: Int, maxInterval: Int): LabelListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 64u
-  }
-
-  interface LabelListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.FixedLabelClusterLabelStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readLabelListAttribute(callback: LabelListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLabelListAttribute(
-    callback: LabelListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FlowMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FlowMeasurementCluster.kt
@@ -20,183 +20,119 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class FlowMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: UShort?)
+
+  class MinMeasuredValueAttribute(val value: UShort?)
+
+  class MaxMeasuredValueAttribute(val value: UShort?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1028u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FormaldehydeConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FormaldehydeConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class FormaldehydeConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1067u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralCommissioningCluster.kt
@@ -20,256 +20,173 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class GeneralCommissioningCluster(private val endpointId: UShort) {
+  class ArmFailSafeResponse(val errorCode: UInt, val debugText: String)
+
+  class SetRegulatoryConfigResponse(val errorCode: UInt, val debugText: String)
+
+  class CommissioningCompleteResponse(val errorCode: UInt, val debugText: String)
+
+  class BasicCommissioningInfoAttribute(
+    val value: ChipStructs.GeneralCommissioningClusterBasicCommissioningInfo
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun armFailSafe(expiryLengthSeconds: UShort, breadcrumb: ULong): ArmFailSafeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun armFailSafe(
+    expiryLengthSeconds: UShort,
+    breadcrumb: ULong,
+    timedInvokeTimeoutMs: Int
+  ): ArmFailSafeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun setRegulatoryConfig(
+    newRegulatoryConfig: UInt,
+    countryCode: String,
+    breadcrumb: ULong
+  ): SetRegulatoryConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun setRegulatoryConfig(
+    newRegulatoryConfig: UInt,
+    countryCode: String,
+    breadcrumb: ULong,
+    timedInvokeTimeoutMs: Int
+  ): SetRegulatoryConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun commissioningComplete(): CommissioningCompleteResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun commissioningComplete(timedInvokeTimeoutMs: Int): CommissioningCompleteResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBreadcrumbAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBreadcrumbAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBreadcrumbAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBreadcrumbAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBasicCommissioningInfoAttribute(): BasicCommissioningInfoAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBasicCommissioningInfoAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BasicCommissioningInfoAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRegulatoryConfigAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRegulatoryConfigAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLocationCapabilityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocationCapabilityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportsConcurrentConnectionAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportsConcurrentConnectionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 48u
-  }
-
-  fun armFailSafe(
-    callback: ArmFailSafeResponseCallback,
-    expiryLengthSeconds: Integer,
-    breadcrumb: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun armFailSafe(
-    callback: ArmFailSafeResponseCallback,
-    expiryLengthSeconds: Integer,
-    breadcrumb: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun setRegulatoryConfig(
-    callback: SetRegulatoryConfigResponseCallback,
-    newRegulatoryConfig: Integer,
-    countryCode: String,
-    breadcrumb: Long
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun setRegulatoryConfig(
-    callback: SetRegulatoryConfigResponseCallback,
-    newRegulatoryConfig: Integer,
-    countryCode: String,
-    breadcrumb: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun commissioningComplete(callback: CommissioningCompleteResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun commissioningComplete(
-    callback: CommissioningCompleteResponseCallback,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ArmFailSafeResponseCallback {
-    fun onSuccess(errorCode: Integer, debugText: String)
-
-    fun onError(error: Exception)
-  }
-
-  interface SetRegulatoryConfigResponseCallback {
-    fun onSuccess(errorCode: Integer, debugText: String)
-
-    fun onError(error: Exception)
-  }
-
-  interface CommissioningCompleteResponseCallback {
-    fun onSuccess(errorCode: Integer, debugText: String)
-
-    fun onError(error: Exception)
-  }
-
-  interface BasicCommissioningInfoAttributeCallback {
-    fun onSuccess(value: ChipStructs.GeneralCommissioningClusterBasicCommissioningInfo)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readBreadcrumbAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBreadcrumbAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBreadcrumbAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBreadcrumbAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBasicCommissioningInfoAttribute(callback: BasicCommissioningInfoAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBasicCommissioningInfoAttribute(
-    callback: BasicCommissioningInfoAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRegulatoryConfigAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRegulatoryConfigAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLocationCapabilityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLocationCapabilityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportsConcurrentConnectionAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportsConcurrentConnectionAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralDiagnosticsCluster.kt
@@ -20,276 +20,189 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class GeneralDiagnosticsCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 51u
-  }
+  class NetworkInterfacesAttribute(
+    val value: ArrayList<ChipStructs.GeneralDiagnosticsClusterNetworkInterface>
+  )
 
-  fun testEventTrigger(callback: DefaultClusterCallback, enableKey: ByteArray, eventTrigger: Long) {
+  class ActiveHardwareFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class ActiveRadioFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class ActiveNetworkFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun testEventTrigger(enableKey: ByteArray, eventTrigger: ULong) {
     // Implementation needs to be added here
   }
 
-  fun testEventTrigger(
-    callback: DefaultClusterCallback,
+  suspend fun testEventTrigger(
     enableKey: ByteArray,
-    eventTrigger: Long,
+    eventTrigger: ULong,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface NetworkInterfacesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.GeneralDiagnosticsClusterNetworkInterface>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveHardwareFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveRadioFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveNetworkFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readNetworkInterfacesAttribute(callback: NetworkInterfacesAttributeCallback) {
+  suspend fun readNetworkInterfacesAttribute(): NetworkInterfacesAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeNetworkInterfacesAttribute(
-    callback: NetworkInterfacesAttributeCallback,
+  suspend fun subscribeNetworkInterfacesAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NetworkInterfacesAttribute {
     // Implementation needs to be added here
   }
 
-  fun readRebootCountAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRebootCountAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeRebootCountAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeRebootCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUpTimeAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUpTimeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTotalOperationalHoursAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTotalOperationalHoursAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBootReasonAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBootReasonAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveHardwareFaultsAttribute(): ActiveHardwareFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveHardwareFaultsAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ActiveHardwareFaultsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readUpTimeAttribute(callback: LongAttributeCallback) {
+  suspend fun readActiveRadioFaultsAttribute(): ActiveRadioFaultsAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeUpTimeAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeActiveRadioFaultsAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ActiveRadioFaultsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTotalOperationalHoursAttribute(callback: LongAttributeCallback) {
+  suspend fun readActiveNetworkFaultsAttribute(): ActiveNetworkFaultsAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeTotalOperationalHoursAttribute(
-    callback: LongAttributeCallback,
+  suspend fun subscribeActiveNetworkFaultsAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ActiveNetworkFaultsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readBootReasonAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readTestEventTriggersEnabledAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun subscribeBootReasonAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeTestEventTriggersEnabledAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Boolean {
     // Implementation needs to be added here
   }
 
-  fun readActiveHardwareFaultsAttribute(callback: ActiveHardwareFaultsAttributeCallback) {
+  suspend fun readAverageWearCountAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeActiveHardwareFaultsAttribute(
-    callback: ActiveHardwareFaultsAttributeCallback,
+  suspend fun subscribeAverageWearCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readActiveRadioFaultsAttribute(callback: ActiveRadioFaultsAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeActiveRadioFaultsAttribute(
-    callback: ActiveRadioFaultsAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readActiveNetworkFaultsAttribute(callback: ActiveNetworkFaultsAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeActiveNetworkFaultsAttribute(
-    callback: ActiveNetworkFaultsAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTestEventTriggersEnabledAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeTestEventTriggersEnabledAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAverageWearCountAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAverageWearCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 51u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupKeyManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupKeyManagementCluster.kt
@@ -20,266 +20,182 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class GroupKeyManagementCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 63u
-  }
+  class KeySetReadResponse(val groupKeySet: ChipStructs.GroupKeyManagementClusterGroupKeySetStruct)
 
-  fun keySetWrite(
-    callback: DefaultClusterCallback,
-    groupKeySet: ChipStructs.GroupKeyManagementClusterGroupKeySetStruct
-  ) {
+  class KeySetReadAllIndicesResponse(val groupKeySetIDs: ArrayList<UShort>)
+
+  class GroupKeyMapAttribute(
+    val value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupKeyMapStruct>
+  )
+
+  class GroupTableAttribute(
+    val value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupInfoMapStruct>
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun keySetWrite(groupKeySet: ChipStructs.GroupKeyManagementClusterGroupKeySetStruct) {
     // Implementation needs to be added here
   }
 
-  fun keySetWrite(
-    callback: DefaultClusterCallback,
+  suspend fun keySetWrite(
     groupKeySet: ChipStructs.GroupKeyManagementClusterGroupKeySetStruct,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun keySetRead(callback: KeySetReadResponseCallback, groupKeySetID: Integer) {
+  suspend fun keySetRead(groupKeySetID: UShort): KeySetReadResponse {
     // Implementation needs to be added here
   }
 
-  fun keySetRead(
-    callback: KeySetReadResponseCallback,
-    groupKeySetID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun keySetRead(groupKeySetID: UShort, timedInvokeTimeoutMs: Int): KeySetReadResponse {
     // Implementation needs to be added here
   }
 
-  fun keySetRemove(callback: DefaultClusterCallback, groupKeySetID: Integer) {
+  suspend fun keySetRemove(groupKeySetID: UShort) {
     // Implementation needs to be added here
   }
 
-  fun keySetRemove(
-    callback: DefaultClusterCallback,
-    groupKeySetID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun keySetRemove(groupKeySetID: UShort, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun keySetReadAllIndices(callback: KeySetReadAllIndicesResponseCallback) {
+  suspend fun keySetReadAllIndices(): KeySetReadAllIndicesResponse {
     // Implementation needs to be added here
   }
 
-  fun keySetReadAllIndices(
-    callback: KeySetReadAllIndicesResponseCallback,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun keySetReadAllIndices(timedInvokeTimeoutMs: Int): KeySetReadAllIndicesResponse {
     // Implementation needs to be added here
   }
 
-  interface KeySetReadResponseCallback {
-    fun onSuccess(groupKeySet: ChipStructs.GroupKeyManagementClusterGroupKeySetStruct)
-
-    fun onError(error: Exception)
-  }
-
-  interface KeySetReadAllIndicesResponseCallback {
-    fun onSuccess(groupKeySetIDs: ArrayList<Integer>)
-
-    fun onError(error: Exception)
-  }
-
-  interface GroupKeyMapAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupKeyMapStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GroupTableAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupInfoMapStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGroupKeyMapAttribute(callback: GroupKeyMapAttributeCallback) {
+  suspend fun readGroupKeyMapAttribute(): GroupKeyMapAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGroupKeyMapAttributeWithFabricFilter(
-    callback: GroupKeyMapAttributeCallback,
+  suspend fun readGroupKeyMapAttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): GroupKeyMapAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeGroupKeyMapAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeGroupKeyMapAttribute(
     value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupKeyMapStruct>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeGroupKeyMapAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeGroupKeyMapAttribute(
     value: ArrayList<ChipStructs.GroupKeyManagementClusterGroupKeyMapStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeGroupKeyMapAttribute(
-    callback: GroupKeyMapAttributeCallback,
+  suspend fun subscribeGroupKeyMapAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GroupKeyMapAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGroupTableAttribute(callback: GroupTableAttributeCallback) {
+  suspend fun readGroupTableAttribute(): GroupTableAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGroupTableAttributeWithFabricFilter(
-    callback: GroupTableAttributeCallback,
+  suspend fun readGroupTableAttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): GroupTableAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGroupTableAttribute(
-    callback: GroupTableAttributeCallback,
+  suspend fun subscribeGroupTableAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GroupTableAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMaxGroupsPerFabricAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readMaxGroupsPerFabricAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeMaxGroupsPerFabricAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeMaxGroupsPerFabricAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxGroupKeysPerFabricAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxGroupKeysPerFabricAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMaxGroupKeysPerFabricAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeMaxGroupKeysPerFabricAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 63u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupsCluster.kt
@@ -20,216 +20,143 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class GroupsCluster(private val endpointId: UShort) {
+  class AddGroupResponse(val status: UInt, val groupID: UShort)
+
+  class ViewGroupResponse(val status: UInt, val groupID: UShort, val groupName: String)
+
+  class GetGroupMembershipResponse(val capacity: UByte?, val groupList: ArrayList<UShort>)
+
+  class RemoveGroupResponse(val status: UInt, val groupID: UShort)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun addGroup(groupID: UShort, groupName: String): AddGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addGroup(
+    groupID: UShort,
+    groupName: String,
+    timedInvokeTimeoutMs: Int
+  ): AddGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun viewGroup(groupID: UShort): ViewGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun viewGroup(groupID: UShort, timedInvokeTimeoutMs: Int): ViewGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun getGroupMembership(groupList: ArrayList<UShort>): GetGroupMembershipResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun getGroupMembership(
+    groupList: ArrayList<UShort>,
+    timedInvokeTimeoutMs: Int
+  ): GetGroupMembershipResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeGroup(groupID: UShort): RemoveGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeGroup(groupID: UShort, timedInvokeTimeoutMs: Int): RemoveGroupResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeAllGroups() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeAllGroups(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addGroupIfIdentifying(groupID: UShort, groupName: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addGroupIfIdentifying(groupID: UShort, groupName: String, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNameSupportAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNameSupportAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 4u
-  }
-
-  fun addGroup(callback: AddGroupResponseCallback, groupID: Integer, groupName: String) {
-    // Implementation needs to be added here
-  }
-
-  fun addGroup(
-    callback: AddGroupResponseCallback,
-    groupID: Integer,
-    groupName: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun viewGroup(callback: ViewGroupResponseCallback, groupID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun viewGroup(callback: ViewGroupResponseCallback, groupID: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun getGroupMembership(
-    callback: GetGroupMembershipResponseCallback,
-    groupList: ArrayList<Integer>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun getGroupMembership(
-    callback: GetGroupMembershipResponseCallback,
-    groupList: ArrayList<Integer>,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeGroup(callback: RemoveGroupResponseCallback, groupID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun removeGroup(
-    callback: RemoveGroupResponseCallback,
-    groupID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeAllGroups(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun removeAllGroups(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun addGroupIfIdentifying(callback: DefaultClusterCallback, groupID: Integer, groupName: String) {
-    // Implementation needs to be added here
-  }
-
-  fun addGroupIfIdentifying(
-    callback: DefaultClusterCallback,
-    groupID: Integer,
-    groupName: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface AddGroupResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface ViewGroupResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer, groupName: String)
-
-    fun onError(error: Exception)
-  }
-
-  interface GetGroupMembershipResponseCallback {
-    fun onSuccess(capacity: Integer?, groupList: ArrayList<Integer>)
-
-    fun onError(error: Exception)
-  }
-
-  interface RemoveGroupResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readNameSupportAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNameSupportAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/HepaFilterMonitoringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/HepaFilterMonitoringCluster.kt
@@ -20,221 +20,148 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class HepaFilterMonitoringCluster(private val endpointId: UShort) {
+  class LastChangedTimeAttribute(val value: UInt?)
+
+  class ReplacementProductListAttribute(
+    val value: ArrayList<ChipStructs.HepaFilterMonitoringClusterReplacementProductStruct>?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetCondition() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetCondition(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readConditionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeConditionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDegradationDirectionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDegradationDirectionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChangeIndicationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChangeIndicationAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInPlaceIndicatorAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInPlaceIndicatorAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastChangedTimeAttribute(): LastChangedTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLastChangedTimeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastChangedTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastChangedTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readReplacementProductListAttribute(): ReplacementProductListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeReplacementProductListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ReplacementProductListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 113u
-  }
-
-  fun resetCondition(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetCondition(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface LastChangedTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ReplacementProductListAttributeCallback {
-    fun onSuccess(
-      value: ArrayList<ChipStructs.HepaFilterMonitoringClusterReplacementProductStruct>?
-    )
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readConditionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeConditionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDegradationDirectionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDegradationDirectionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readChangeIndicationAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChangeIndicationAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInPlaceIndicatorAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInPlaceIndicatorAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastChangedTimeAttribute(callback: LastChangedTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLastChangedTimeAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLastChangedTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastChangedTimeAttribute(
-    callback: LastChangedTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readReplacementProductListAttribute(callback: ReplacementProductListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeReplacementProductListAttribute(
-    callback: ReplacementProductListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IcdManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IcdManagementCluster.kt
@@ -20,250 +20,199 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class IcdManagementCluster(private val endpointId: UShort) {
+  class RegisterClientResponse(val ICDCounter: UInt)
+
+  class RegisteredClientsAttribute(
+    val value: ArrayList<ChipStructs.IcdManagementClusterMonitoringRegistrationStruct>?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun registerClient(
+    checkInNodeID: ULong,
+    monitoredSubject: ULong,
+    key: ByteArray,
+    verificationKey: ByteArray?
+  ): RegisterClientResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun registerClient(
+    checkInNodeID: ULong,
+    monitoredSubject: ULong,
+    key: ByteArray,
+    verificationKey: ByteArray?,
+    timedInvokeTimeoutMs: Int
+  ): RegisterClientResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun unregisterClient(checkInNodeID: ULong, verificationKey: ByteArray?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun unregisterClient(
+    checkInNodeID: ULong,
+    verificationKey: ByteArray?,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stayActiveRequest() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stayActiveRequest(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readIdleModeDurationAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeIdleModeDurationAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveModeDurationAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveModeDurationAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveModeThresholdAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveModeThresholdAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRegisteredClientsAttribute(): RegisteredClientsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRegisteredClientsAttributeWithFabricFilter(
+    isFabricFiltered: Boolean
+  ): RegisteredClientsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRegisteredClientsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): RegisteredClientsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readICDCounterAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeICDCounterAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClientsSupportedPerFabricAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClientsSupportedPerFabricAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUserActiveModeTriggerHintAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUserActiveModeTriggerHintAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUserActiveModeTriggerInstructionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUserActiveModeTriggerInstructionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 70u
-  }
-
-  fun registerClient(
-    callback: RegisterClientResponseCallback,
-    checkInNodeID: Long,
-    monitoredSubject: Long,
-    key: ByteArray,
-    verificationKey: ByteArray?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun registerClient(
-    callback: RegisterClientResponseCallback,
-    checkInNodeID: Long,
-    monitoredSubject: Long,
-    key: ByteArray,
-    verificationKey: ByteArray?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun unregisterClient(
-    callback: DefaultClusterCallback,
-    checkInNodeID: Long,
-    verificationKey: ByteArray?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun unregisterClient(
-    callback: DefaultClusterCallback,
-    checkInNodeID: Long,
-    verificationKey: ByteArray?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stayActiveRequest(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun stayActiveRequest(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface RegisterClientResponseCallback {
-    fun onSuccess(ICDCounter: Long)
-
-    fun onError(error: Exception)
-  }
-
-  interface RegisteredClientsAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.IcdManagementClusterMonitoringRegistrationStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readIdleModeDurationAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeIdleModeDurationAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveModeDurationAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveModeDurationAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveModeThresholdAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveModeThresholdAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRegisteredClientsAttribute(callback: RegisteredClientsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun readRegisteredClientsAttributeWithFabricFilter(
-    callback: RegisteredClientsAttributeCallback,
-    isFabricFiltered: Boolean
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRegisteredClientsAttribute(
-    callback: RegisteredClientsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readICDCounterAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeICDCounterAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClientsSupportedPerFabricAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClientsSupportedPerFabricAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
@@ -20,172 +20,116 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class IdentifyCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 3u
-  }
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-  fun identify(callback: DefaultClusterCallback, identifyTime: Integer) {
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun identify(identifyTime: UShort) {
     // Implementation needs to be added here
   }
 
-  fun identify(callback: DefaultClusterCallback, identifyTime: Integer, timedInvokeTimeoutMs: Int) {
+  suspend fun identify(identifyTime: UShort, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun triggerEffect(
-    callback: DefaultClusterCallback,
-    effectIdentifier: Integer,
-    effectVariant: Integer
-  ) {
+  suspend fun triggerEffect(effectIdentifier: UInt, effectVariant: UInt) {
     // Implementation needs to be added here
   }
 
-  fun triggerEffect(
-    callback: DefaultClusterCallback,
-    effectIdentifier: Integer,
-    effectVariant: Integer,
+  suspend fun triggerEffect(
+    effectIdentifier: UInt,
+    effectVariant: UInt,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readIdentifyTimeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readIdentifyTimeAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeIdentifyTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeIdentifyTimeAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeIdentifyTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeIdentifyTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeIdentifyTimeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeIdentifyTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readIdentifyTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeIdentifyTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readIdentifyTypeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeIdentifyTypeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 3u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IlluminanceMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IlluminanceMeasurementCluster.kt
@@ -20,203 +20,132 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class IlluminanceMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: UShort?)
+
+  class MinMeasuredValueAttribute(val value: UShort?)
+
+  class MaxMeasuredValueAttribute(val value: UShort?)
+
+  class LightSensorTypeAttribute(val value: UInt?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLightSensorTypeAttribute(): LightSensorTypeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLightSensorTypeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LightSensorTypeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1024u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LightSensorTypeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLightSensorTypeAttribute(callback: LightSensorTypeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLightSensorTypeAttribute(
-    callback: LightSensorTypeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/KeypadInputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/KeypadInputCluster.kt
@@ -20,125 +20,82 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class KeypadInputCluster(private val endpointId: UShort) {
+  class SendKeyResponse(val status: UInt)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun sendKey(keyCode: UInt): SendKeyResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun sendKey(keyCode: UInt, timedInvokeTimeoutMs: Int): SendKeyResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1289u
-  }
-
-  fun sendKey(callback: SendKeyResponseCallback, keyCode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun sendKey(callback: SendKeyResponseCallback, keyCode: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface SendKeyResponseCallback {
-    fun onSuccess(status: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherControlsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherControlsCluster.kt
@@ -20,207 +20,135 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class LaundryWasherControlsCluster(private val endpointId: UShort) {
+  class SpinSpeedsAttribute(val value: ArrayList<String>?)
+
+  class SpinSpeedCurrentAttribute(val value: UByte?)
+
+  class SupportedRinsesAttribute(val value: ArrayList<UInt>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readSpinSpeedsAttribute(): SpinSpeedsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSpinSpeedsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SpinSpeedsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSpinSpeedCurrentAttribute(): SpinSpeedCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSpinSpeedCurrentAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSpinSpeedCurrentAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSpinSpeedCurrentAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SpinSpeedCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfRinsesAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNumberOfRinsesAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNumberOfRinsesAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfRinsesAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedRinsesAttribute(): SupportedRinsesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedRinsesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedRinsesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 83u
-  }
-
-  interface SpinSpeedsAttributeCallback {
-    fun onSuccess(value: ArrayList<String>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SpinSpeedCurrentAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SupportedRinsesAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSpinSpeedsAttribute(callback: SpinSpeedsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSpinSpeedsAttribute(
-    callback: SpinSpeedsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSpinSpeedCurrentAttribute(callback: SpinSpeedCurrentAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSpinSpeedCurrentAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSpinSpeedCurrentAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSpinSpeedCurrentAttribute(
-    callback: SpinSpeedCurrentAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNumberOfRinsesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNumberOfRinsesAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNumberOfRinsesAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfRinsesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedRinsesAttribute(callback: SupportedRinsesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedRinsesAttribute(
-    callback: SupportedRinsesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherModeCluster.kt
@@ -20,225 +20,144 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class LaundryWasherModeCluster(private val endpointId: UShort) {
+  class ChangeToModeResponse(val status: UInt, val statusText: String?)
+
+  class SupportedModesAttribute(
+    val value: ArrayList<ChipStructs.LaundryWasherModeClusterModeOptionStruct>
+  )
+
+  class StartUpModeAttribute(val value: UByte?)
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpModeAttribute(): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 81u
-  }
-
-  fun changeToMode(callback: ChangeToModeResponseCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(
-    callback: ChangeToModeResponseCallback,
-    newMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeToModeResponseCallback {
-    fun onSuccess(status: Integer, statusText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.LaundryWasherModeClusterModeOptionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpModeAttribute(callback: StartUpModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpModeAttribute(
-    callback: StartUpModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LevelControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LevelControlCluster.kt
@@ -20,583 +20,404 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class LevelControlCluster(private val endpointId: UShort) {
+  class CurrentLevelAttribute(val value: UByte?)
+
+  class OnLevelAttribute(val value: UByte?)
+
+  class OnTransitionTimeAttribute(val value: UShort?)
+
+  class OffTransitionTimeAttribute(val value: UShort?)
+
+  class DefaultMoveRateAttribute(val value: UByte?)
+
+  class StartUpCurrentLevelAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun moveToLevel(
+    level: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToLevel(
+    level: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun move(moveMode: UInt, rate: UByte?, optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun move(
+    moveMode: UInt,
+    rate: UByte?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun step(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun step(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(optionsMask: UInt, optionsOverride: UInt, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToLevelWithOnOff(
+    level: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToLevelWithOnOff(
+    level: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveWithOnOff(
+    moveMode: UInt,
+    rate: UByte?,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveWithOnOff(
+    moveMode: UInt,
+    rate: UByte?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepWithOnOff(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stepWithOnOff(
+    stepMode: UInt,
+    stepSize: UByte,
+    transitionTime: UShort?,
+    optionsMask: UInt,
+    optionsOverride: UInt,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopWithOnOff(optionsMask: UInt, optionsOverride: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopWithOnOff(optionsMask: UInt, optionsOverride: UInt, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToClosestFrequency(frequency: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun moveToClosestFrequency(frequency: UShort, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentLevelAttribute(): CurrentLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentLevelAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRemainingTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRemainingTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentFrequencyAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentFrequencyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinFrequencyAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinFrequencyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxFrequencyAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxFrequencyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOptionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOptionsAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOptionsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnOffTransitionTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnOffTransitionTimeAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnOffTransitionTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnLevelAttribute(): OnLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnLevelAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnLevelAttribute(minInterval: Int, maxInterval: Int): OnLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnTransitionTimeAttribute(): OnTransitionTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnTransitionTimeAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnTransitionTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OnTransitionTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOffTransitionTimeAttribute(): OffTransitionTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOffTransitionTimeAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOffTransitionTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OffTransitionTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDefaultMoveRateAttribute(): DefaultMoveRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDefaultMoveRateAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeDefaultMoveRateAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDefaultMoveRateAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): DefaultMoveRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpCurrentLevelAttribute(): StartUpCurrentLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpCurrentLevelAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpCurrentLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpCurrentLevelAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpCurrentLevelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 8u
-  }
-
-  fun moveToLevel(
-    callback: DefaultClusterCallback,
-    level: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToLevel(
-    callback: DefaultClusterCallback,
-    level: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun move(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun move(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun step(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun step(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: DefaultClusterCallback, optionsMask: Integer, optionsOverride: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(
-    callback: DefaultClusterCallback,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToLevelWithOnOff(
-    callback: DefaultClusterCallback,
-    level: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToLevelWithOnOff(
-    callback: DefaultClusterCallback,
-    level: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveWithOnOff(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveWithOnOff(
-    callback: DefaultClusterCallback,
-    moveMode: Integer,
-    rate: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepWithOnOff(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stepWithOnOff(
-    callback: DefaultClusterCallback,
-    stepMode: Integer,
-    stepSize: Integer,
-    transitionTime: Integer?,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stopWithOnOff(
-    callback: DefaultClusterCallback,
-    optionsMask: Integer,
-    optionsOverride: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun stopWithOnOff(
-    callback: DefaultClusterCallback,
-    optionsMask: Integer,
-    optionsOverride: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToClosestFrequency(callback: DefaultClusterCallback, frequency: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun moveToClosestFrequency(
-    callback: DefaultClusterCallback,
-    frequency: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface CurrentLevelAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnLevelAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnTransitionTimeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OffTransitionTimeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DefaultMoveRateAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpCurrentLevelAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readCurrentLevelAttribute(callback: CurrentLevelAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentLevelAttribute(
-    callback: CurrentLevelAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRemainingTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRemainingTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentFrequencyAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentFrequencyAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinFrequencyAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinFrequencyAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxFrequencyAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxFrequencyAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOptionsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOptionsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOptionsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOptionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnOffTransitionTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnOffTransitionTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnOffTransitionTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnOffTransitionTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnLevelAttribute(callback: OnLevelAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnLevelAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnLevelAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnLevelAttribute(
-    callback: OnLevelAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnTransitionTimeAttribute(callback: OnTransitionTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnTransitionTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnTransitionTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnTransitionTimeAttribute(
-    callback: OnTransitionTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOffTransitionTimeAttribute(callback: OffTransitionTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOffTransitionTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOffTransitionTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOffTransitionTimeAttribute(
-    callback: OffTransitionTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDefaultMoveRateAttribute(callback: DefaultMoveRateAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDefaultMoveRateAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeDefaultMoveRateAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDefaultMoveRateAttribute(
-    callback: DefaultMoveRateAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpCurrentLevelAttribute(callback: StartUpCurrentLevelAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpCurrentLevelAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpCurrentLevelAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpCurrentLevelAttribute(
-    callback: StartUpCurrentLevelAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LocalizationConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LocalizationConfigurationCluster.kt
@@ -20,155 +20,101 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class LocalizationConfigurationCluster(private val endpointId: UShort) {
+  class SupportedLocalesAttribute(val value: ArrayList<String>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readActiveLocaleAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveLocaleAttribute(value: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveLocaleAttribute(value: String, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveLocaleAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedLocalesAttribute(): SupportedLocalesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedLocalesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedLocalesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 43u
-  }
-
-  interface SupportedLocalesAttributeCallback {
-    fun onSuccess(value: ArrayList<String>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readActiveLocaleAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveLocaleAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveLocaleAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveLocaleAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedLocalesAttribute(callback: SupportedLocalesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedLocalesAttribute(
-    callback: SupportedLocalesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LowPowerCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LowPowerCluster.kt
@@ -20,119 +20,80 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class LowPowerCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun sleep() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun sleep(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1288u
-  }
-
-  fun sleep(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun sleep(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaInputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaInputCluster.kt
@@ -20,180 +20,122 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class MediaInputCluster(private val endpointId: UShort) {
+  class InputListAttribute(val value: ArrayList<ChipStructs.MediaInputClusterInputInfoStruct>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun selectInput(index: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun selectInput(index: UByte, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun showInputStatus() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun showInputStatus(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun hideInputStatus() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun hideInputStatus(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun renameInput(index: UByte, name: String) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun renameInput(index: UByte, name: String, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInputListAttribute(): InputListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInputListAttribute(minInterval: Int, maxInterval: Int): InputListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentInputAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentInputAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1287u
-  }
-
-  fun selectInput(callback: DefaultClusterCallback, index: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun selectInput(callback: DefaultClusterCallback, index: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun showInputStatus(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun showInputStatus(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun hideInputStatus(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun hideInputStatus(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun renameInput(callback: DefaultClusterCallback, index: Integer, name: String) {
-    // Implementation needs to be added here
-  }
-
-  fun renameInput(
-    callback: DefaultClusterCallback,
-    index: Integer,
-    name: String,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface InputListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.MediaInputClusterInputInfoStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readInputListAttribute(callback: InputListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInputListAttribute(
-    callback: InputListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentInputAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentInputAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaPlaybackCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaPlaybackCluster.kt
@@ -20,337 +20,245 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class MediaPlaybackCluster(private val endpointId: UShort) {
+  class PlaybackResponse(val status: UInt, val data: String?)
+
+  class StartTimeAttribute(val value: ULong?)
+
+  class DurationAttribute(val value: ULong?)
+
+  class SampledPositionAttribute(
+    val value: ChipStructs.MediaPlaybackClusterPlaybackPositionStruct?
+  )
+
+  class SeekRangeEndAttribute(val value: ULong?)
+
+  class SeekRangeStartAttribute(val value: ULong?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun play(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun play(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pause(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pause(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startOver(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun startOver(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun previous(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun previous(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun next(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun next(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun rewind(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun rewind(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun fastForward(): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun fastForward(timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipForward(deltaPositionMilliseconds: ULong): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipForward(
+    deltaPositionMilliseconds: ULong,
+    timedInvokeTimeoutMs: Int
+  ): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipBackward(deltaPositionMilliseconds: ULong): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun skipBackward(
+    deltaPositionMilliseconds: ULong,
+    timedInvokeTimeoutMs: Int
+  ): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun seek(position: ULong): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun seek(position: ULong, timedInvokeTimeoutMs: Int): PlaybackResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartTimeAttribute(): StartTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartTimeAttribute(minInterval: Int, maxInterval: Int): StartTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDurationAttribute(): DurationAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDurationAttribute(minInterval: Int, maxInterval: Int): DurationAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSampledPositionAttribute(): SampledPositionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSampledPositionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SampledPositionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPlaybackSpeedAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePlaybackSpeedAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSeekRangeEndAttribute(): SeekRangeEndAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSeekRangeEndAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SeekRangeEndAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSeekRangeStartAttribute(): SeekRangeStartAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSeekRangeStartAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SeekRangeStartAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1286u
-  }
-
-  fun play(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun play(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun pause(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun pause(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun startOver(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun startOver(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun previous(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun previous(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun next(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun next(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun rewind(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun rewind(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun fastForward(callback: PlaybackResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun fastForward(callback: PlaybackResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun skipForward(callback: PlaybackResponseCallback, deltaPositionMilliseconds: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun skipForward(
-    callback: PlaybackResponseCallback,
-    deltaPositionMilliseconds: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun skipBackward(callback: PlaybackResponseCallback, deltaPositionMilliseconds: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun skipBackward(
-    callback: PlaybackResponseCallback,
-    deltaPositionMilliseconds: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun seek(callback: PlaybackResponseCallback, position: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun seek(callback: PlaybackResponseCallback, position: Long, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface PlaybackResponseCallback {
-    fun onSuccess(status: Integer, data: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface StartTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DurationAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SampledPositionAttributeCallback {
-    fun onSuccess(value: ChipStructs.MediaPlaybackClusterPlaybackPositionStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SeekRangeEndAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SeekRangeStartAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readCurrentStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartTimeAttribute(callback: StartTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartTimeAttribute(
-    callback: StartTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDurationAttribute(callback: DurationAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDurationAttribute(
-    callback: DurationAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSampledPositionAttribute(callback: SampledPositionAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSampledPositionAttribute(
-    callback: SampledPositionAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPlaybackSpeedAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePlaybackSpeedAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSeekRangeEndAttribute(callback: SeekRangeEndAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSeekRangeEndAttribute(
-    callback: SeekRangeEndAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSeekRangeStartAttribute(callback: SeekRangeStartAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSeekRangeStartAttribute(
-    callback: SeekRangeStartAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ModeSelectCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ModeSelectCluster.kt
@@ -20,247 +20,163 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ModeSelectCluster(private val endpointId: UShort) {
+  class StandardNamespaceAttribute(val value: UInt?)
+
+  class SupportedModesAttribute(
+    val value: ArrayList<ChipStructs.ModeSelectClusterModeOptionStruct>
+  )
+
+  class StartUpModeAttribute(val value: UByte?)
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDescriptionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDescriptionAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStandardNamespaceAttribute(): StandardNamespaceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStandardNamespaceAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StandardNamespaceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpModeAttribute(): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 80u
-  }
-
-  fun changeToMode(callback: DefaultClusterCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(callback: DefaultClusterCallback, newMode: Integer, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface StandardNamespaceAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ModeSelectClusterModeOptionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readDescriptionAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDescriptionAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStandardNamespaceAttribute(callback: StandardNamespaceAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStandardNamespaceAttribute(
-    callback: StandardNamespaceAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpModeAttribute(callback: StartUpModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpModeAttribute(
-    callback: StartUpModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NetworkCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NetworkCommissioningCluster.kt
@@ -20,422 +20,301 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class NetworkCommissioningCluster(private val endpointId: UShort) {
+  class ScanNetworksResponse(
+    val networkingStatus: UInt,
+    val debugText: String?,
+    val wiFiScanResults:
+      ArrayList<ChipStructs.NetworkCommissioningClusterWiFiInterfaceScanResultStruct>?,
+    val threadScanResults:
+      ArrayList<ChipStructs.NetworkCommissioningClusterThreadInterfaceScanResultStruct>?
+  )
+
+  class NetworkConfigResponse(
+    val networkingStatus: UInt,
+    val debugText: String?,
+    val networkIndex: UByte?
+  )
+
+  class ConnectNetworkResponse(
+    val networkingStatus: UInt,
+    val debugText: String?,
+    val errorValue: Int?
+  )
+
+  class NetworksAttribute(
+    val value: ArrayList<ChipStructs.NetworkCommissioningClusterNetworkInfoStruct>
+  )
+
+  class LastNetworkingStatusAttribute(val value: UInt?)
+
+  class LastNetworkIDAttribute(val value: ByteArray?)
+
+  class LastConnectErrorValueAttribute(val value: Int?)
+
+  class SupportedWiFiBandsAttribute(val value: ArrayList<UInt>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun scanNetworks(ssid: ByteArray?, breadcrumb: ULong?): ScanNetworksResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun scanNetworks(
+    ssid: ByteArray?,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): ScanNetworksResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addOrUpdateWiFiNetwork(
+    ssid: ByteArray,
+    credentials: ByteArray,
+    breadcrumb: ULong?
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addOrUpdateWiFiNetwork(
+    ssid: ByteArray,
+    credentials: ByteArray,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addOrUpdateThreadNetwork(
+    operationalDataset: ByteArray,
+    breadcrumb: ULong?
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addOrUpdateThreadNetwork(
+    operationalDataset: ByteArray,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeNetwork(networkID: ByteArray, breadcrumb: ULong?): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeNetwork(
+    networkID: ByteArray,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun connectNetwork(networkID: ByteArray, breadcrumb: ULong?): ConnectNetworkResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun connectNetwork(
+    networkID: ByteArray,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): ConnectNetworkResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun reorderNetwork(
+    networkID: ByteArray,
+    networkIndex: UByte,
+    breadcrumb: ULong?
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun reorderNetwork(
+    networkID: ByteArray,
+    networkIndex: UByte,
+    breadcrumb: ULong?,
+    timedInvokeTimeoutMs: Int
+  ): NetworkConfigResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxNetworksAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxNetworksAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNetworksAttribute(): NetworksAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNetworksAttribute(minInterval: Int, maxInterval: Int): NetworksAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readScanMaxTimeSecondsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeScanMaxTimeSecondsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readConnectMaxTimeSecondsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeConnectMaxTimeSecondsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInterfaceEnabledAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInterfaceEnabledAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInterfaceEnabledAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInterfaceEnabledAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastNetworkingStatusAttribute(): LastNetworkingStatusAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastNetworkingStatusAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastNetworkingStatusAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastNetworkIDAttribute(): LastNetworkIDAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastNetworkIDAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastNetworkIDAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastConnectErrorValueAttribute(): LastConnectErrorValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastConnectErrorValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastConnectErrorValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedWiFiBandsAttribute(): SupportedWiFiBandsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedWiFiBandsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedWiFiBandsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedThreadFeaturesAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedThreadFeaturesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readThreadVersionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeThreadVersionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 49u
-  }
-
-  fun scanNetworks(callback: ScanNetworksResponseCallback, ssid: ByteArray?, breadcrumb: Long?) {
-    // Implementation needs to be added here
-  }
-
-  fun scanNetworks(
-    callback: ScanNetworksResponseCallback,
-    ssid: ByteArray?,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun addOrUpdateWiFiNetwork(
-    callback: NetworkConfigResponseCallback,
-    ssid: ByteArray,
-    credentials: ByteArray,
-    breadcrumb: Long?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun addOrUpdateWiFiNetwork(
-    callback: NetworkConfigResponseCallback,
-    ssid: ByteArray,
-    credentials: ByteArray,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun addOrUpdateThreadNetwork(
-    callback: NetworkConfigResponseCallback,
-    operationalDataset: ByteArray,
-    breadcrumb: Long?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun addOrUpdateThreadNetwork(
-    callback: NetworkConfigResponseCallback,
-    operationalDataset: ByteArray,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeNetwork(
-    callback: NetworkConfigResponseCallback,
-    networkID: ByteArray,
-    breadcrumb: Long?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeNetwork(
-    callback: NetworkConfigResponseCallback,
-    networkID: ByteArray,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun connectNetwork(
-    callback: ConnectNetworkResponseCallback,
-    networkID: ByteArray,
-    breadcrumb: Long?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun connectNetwork(
-    callback: ConnectNetworkResponseCallback,
-    networkID: ByteArray,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun reorderNetwork(
-    callback: NetworkConfigResponseCallback,
-    networkID: ByteArray,
-    networkIndex: Integer,
-    breadcrumb: Long?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun reorderNetwork(
-    callback: NetworkConfigResponseCallback,
-    networkID: ByteArray,
-    networkIndex: Integer,
-    breadcrumb: Long?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ScanNetworksResponseCallback {
-    fun onSuccess(
-      networkingStatus: Integer,
-      debugText: String?,
-      wiFiScanResults:
-        ArrayList<ChipStructs.NetworkCommissioningClusterWiFiInterfaceScanResultStruct>?,
-      threadScanResults:
-        ArrayList<ChipStructs.NetworkCommissioningClusterThreadInterfaceScanResultStruct>?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface NetworkConfigResponseCallback {
-    fun onSuccess(networkingStatus: Integer, debugText: String?, networkIndex: Integer?)
-
-    fun onError(error: Exception)
-  }
-
-  interface ConnectNetworkResponseCallback {
-    fun onSuccess(networkingStatus: Integer, debugText: String?, errorValue: Long?)
-
-    fun onError(error: Exception)
-  }
-
-  interface NetworksAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.NetworkCommissioningClusterNetworkInfoStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LastNetworkingStatusAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LastNetworkIDAttributeCallback {
-    fun onSuccess(value: ByteArray?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LastConnectErrorValueAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SupportedWiFiBandsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMaxNetworksAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxNetworksAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNetworksAttribute(callback: NetworksAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNetworksAttribute(
-    callback: NetworksAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readScanMaxTimeSecondsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeScanMaxTimeSecondsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readConnectMaxTimeSecondsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeConnectMaxTimeSecondsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInterfaceEnabledAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInterfaceEnabledAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInterfaceEnabledAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInterfaceEnabledAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastNetworkingStatusAttribute(callback: LastNetworkingStatusAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastNetworkingStatusAttribute(
-    callback: LastNetworkingStatusAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastNetworkIDAttribute(callback: LastNetworkIDAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastNetworkIDAttribute(
-    callback: LastNetworkIDAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastConnectErrorValueAttribute(callback: LastConnectErrorValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastConnectErrorValueAttribute(
-    callback: LastConnectErrorValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedWiFiBandsAttribute(callback: SupportedWiFiBandsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedWiFiBandsAttribute(
-    callback: SupportedWiFiBandsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedThreadFeaturesAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedThreadFeaturesAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readThreadVersionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeThreadVersionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NitrogenDioxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NitrogenDioxideConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class NitrogenDioxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1043u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OccupancySensingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OccupancySensingCluster.kt
@@ -20,386 +20,291 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OccupancySensingCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readOccupancyAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOccupancyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOccupancySensorTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOccupancySensorTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOccupancySensorTypeBitmapAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOccupancySensorTypeBitmapAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPIROccupiedToUnoccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIROccupiedToUnoccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIROccupiedToUnoccupiedDelayAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePIROccupiedToUnoccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPIRUnoccupiedToOccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIRUnoccupiedToOccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIRUnoccupiedToOccupiedDelayAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePIRUnoccupiedToOccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPIRUnoccupiedToOccupiedThresholdAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIRUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePIRUnoccupiedToOccupiedThresholdAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePIRUnoccupiedToOccupiedThresholdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUltrasonicOccupiedToUnoccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUltrasonicOccupiedToUnoccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUltrasonicUnoccupiedToOccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUltrasonicUnoccupiedToOccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUltrasonicUnoccupiedToOccupiedThresholdAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalContactOccupiedToUnoccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalContactOccupiedToUnoccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalContactUnoccupiedToOccupiedDelayAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalContactUnoccupiedToOccupiedDelayAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalContactUnoccupiedToOccupiedThresholdAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1030u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readOccupancyAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupancyAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOccupancySensorTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupancySensorTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOccupancySensorTypeBitmapAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupancySensorTypeBitmapAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPIROccupiedToUnoccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIROccupiedToUnoccupiedDelayAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIROccupiedToUnoccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePIROccupiedToUnoccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPIRUnoccupiedToOccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIRUnoccupiedToOccupiedDelayAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIRUnoccupiedToOccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePIRUnoccupiedToOccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPIRUnoccupiedToOccupiedThresholdAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIRUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writePIRUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePIRUnoccupiedToOccupiedThresholdAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUltrasonicOccupiedToUnoccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUltrasonicOccupiedToUnoccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUltrasonicUnoccupiedToOccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUltrasonicUnoccupiedToOccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUltrasonicUnoccupiedToOccupiedThresholdAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalContactOccupiedToUnoccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalContactOccupiedToUnoccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalContactUnoccupiedToOccupiedDelayAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalContactUnoccupiedToOccupiedDelayAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalContactUnoccupiedToOccupiedThresholdAttribute(
-    callback: IntegerAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffCluster.kt
@@ -20,283 +20,198 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OnOffCluster(private val endpointId: UShort) {
+  class StartUpOnOffAttribute(val value: UInt?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun off() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun off(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun on() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun on(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun toggle() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun toggle(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun offWithEffect(effectIdentifier: UInt, effectVariant: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun offWithEffect(
+    effectIdentifier: UInt,
+    effectVariant: UByte,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun onWithRecallGlobalScene() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun onWithRecallGlobalScene(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun onWithTimedOff(onOffControl: UInt, onTime: UShort, offWaitTime: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun onWithTimedOff(
+    onOffControl: UInt,
+    onTime: UShort,
+    offWaitTime: UShort,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnOffAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnOffAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGlobalSceneControlAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGlobalSceneControlAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnTimeAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOffWaitTimeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOffWaitTimeAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOffWaitTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOffWaitTimeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpOnOffAttribute(): StartUpOnOffAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpOnOffAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpOnOffAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpOnOffAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpOnOffAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 6u
-  }
-
-  fun off(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun off(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun on(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun on(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun toggle(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun toggle(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun offWithEffect(
-    callback: DefaultClusterCallback,
-    effectIdentifier: Integer,
-    effectVariant: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun offWithEffect(
-    callback: DefaultClusterCallback,
-    effectIdentifier: Integer,
-    effectVariant: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun onWithRecallGlobalScene(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun onWithRecallGlobalScene(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun onWithTimedOff(
-    callback: DefaultClusterCallback,
-    onOffControl: Integer,
-    onTime: Integer,
-    offWaitTime: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun onWithTimedOff(
-    callback: DefaultClusterCallback,
-    onOffControl: Integer,
-    onTime: Integer,
-    offWaitTime: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface StartUpOnOffAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readOnOffAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnOffAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGlobalSceneControlAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGlobalSceneControlAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOffWaitTimeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOffWaitTimeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOffWaitTimeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOffWaitTimeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpOnOffAttribute(callback: StartUpOnOffAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpOnOffAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpOnOffAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpOnOffAttribute(
-    callback: StartUpOnOffAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffSwitchConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffSwitchConfigurationCluster.kt
@@ -20,147 +20,96 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OnOffSwitchConfigurationCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readSwitchTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSwitchTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSwitchActionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSwitchActionsAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSwitchActionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSwitchActionsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 7u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSwitchTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSwitchTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSwitchActionsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSwitchActionsAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSwitchActionsAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSwitchActionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalCredentialsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalCredentialsCluster.kt
@@ -20,345 +20,241 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OperationalCredentialsCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 62u
-  }
+  class AttestationResponse(
+    val attestationElements: ByteArray,
+    val attestationSignature: ByteArray
+  )
 
-  fun attestationRequest(callback: AttestationResponseCallback, attestationNonce: ByteArray) {
+  class CertificateChainResponse(val certificate: ByteArray)
+
+  class CSRResponse(val NOCSRElements: ByteArray, val attestationSignature: ByteArray)
+
+  class NOCResponse(val statusCode: UInt, val fabricIndex: UByte?, val debugText: String?)
+
+  class NOCsAttribute(val value: ArrayList<ChipStructs.OperationalCredentialsClusterNOCStruct>)
+
+  class FabricsAttribute(
+    val value: ArrayList<ChipStructs.OperationalCredentialsClusterFabricDescriptorStruct>
+  )
+
+  class TrustedRootCertificatesAttribute(val value: ArrayList<ByteArray>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun attestationRequest(attestationNonce: ByteArray): AttestationResponse {
     // Implementation needs to be added here
   }
 
-  fun attestationRequest(
-    callback: AttestationResponseCallback,
+  suspend fun attestationRequest(
     attestationNonce: ByteArray,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): AttestationResponse {
     // Implementation needs to be added here
   }
 
-  fun certificateChainRequest(
-    callback: CertificateChainResponseCallback,
-    certificateType: Integer
-  ) {
+  suspend fun certificateChainRequest(certificateType: UInt): CertificateChainResponse {
     // Implementation needs to be added here
   }
 
-  fun certificateChainRequest(
-    callback: CertificateChainResponseCallback,
-    certificateType: Integer,
+  suspend fun certificateChainRequest(
+    certificateType: UInt,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): CertificateChainResponse {
     // Implementation needs to be added here
   }
 
-  fun CSRRequest(callback: CSRResponseCallback, CSRNonce: ByteArray, isForUpdateNOC: Boolean?) {
+  suspend fun CSRRequest(CSRNonce: ByteArray, isForUpdateNOC: Boolean?): CSRResponse {
     // Implementation needs to be added here
   }
 
-  fun CSRRequest(
-    callback: CSRResponseCallback,
+  suspend fun CSRRequest(
     CSRNonce: ByteArray,
     isForUpdateNOC: Boolean?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): CSRResponse {
     // Implementation needs to be added here
   }
 
-  fun addNOC(
-    callback: NOCResponseCallback,
+  suspend fun addNOC(
     NOCValue: ByteArray,
     ICACValue: ByteArray?,
     IPKValue: ByteArray,
-    caseAdminSubject: Long,
-    adminVendorId: Integer
-  ) {
+    caseAdminSubject: ULong,
+    adminVendorId: UShort
+  ): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun addNOC(
-    callback: NOCResponseCallback,
+  suspend fun addNOC(
     NOCValue: ByteArray,
     ICACValue: ByteArray?,
     IPKValue: ByteArray,
-    caseAdminSubject: Long,
-    adminVendorId: Integer,
+    caseAdminSubject: ULong,
+    adminVendorId: UShort,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun updateNOC(callback: NOCResponseCallback, NOCValue: ByteArray, ICACValue: ByteArray?) {
+  suspend fun updateNOC(NOCValue: ByteArray, ICACValue: ByteArray?): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun updateNOC(
-    callback: NOCResponseCallback,
+  suspend fun updateNOC(
     NOCValue: ByteArray,
     ICACValue: ByteArray?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun updateFabricLabel(callback: NOCResponseCallback, label: String) {
+  suspend fun updateFabricLabel(label: String): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun updateFabricLabel(callback: NOCResponseCallback, label: String, timedInvokeTimeoutMs: Int) {
+  suspend fun updateFabricLabel(label: String, timedInvokeTimeoutMs: Int): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun removeFabric(callback: NOCResponseCallback, fabricIndex: Integer) {
+  suspend fun removeFabric(fabricIndex: UByte): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun removeFabric(callback: NOCResponseCallback, fabricIndex: Integer, timedInvokeTimeoutMs: Int) {
+  suspend fun removeFabric(fabricIndex: UByte, timedInvokeTimeoutMs: Int): NOCResponse {
     // Implementation needs to be added here
   }
 
-  fun addTrustedRootCertificate(callback: DefaultClusterCallback, rootCACertificate: ByteArray) {
+  suspend fun addTrustedRootCertificate(rootCACertificate: ByteArray) {
     // Implementation needs to be added here
   }
 
-  fun addTrustedRootCertificate(
-    callback: DefaultClusterCallback,
-    rootCACertificate: ByteArray,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun addTrustedRootCertificate(rootCACertificate: ByteArray, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  interface AttestationResponseCallback {
-    fun onSuccess(attestationElements: ByteArray, attestationSignature: ByteArray)
-
-    fun onError(error: Exception)
-  }
-
-  interface CertificateChainResponseCallback {
-    fun onSuccess(certificate: ByteArray)
-
-    fun onError(error: Exception)
-  }
-
-  interface CSRResponseCallback {
-    fun onSuccess(NOCSRElements: ByteArray, attestationSignature: ByteArray)
-
-    fun onError(error: Exception)
-  }
-
-  interface NOCResponseCallback {
-    fun onSuccess(statusCode: Integer, fabricIndex: Integer?, debugText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface NOCsAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.OperationalCredentialsClusterNOCStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface FabricsAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.OperationalCredentialsClusterFabricDescriptorStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TrustedRootCertificatesAttributeCallback {
-    fun onSuccess(value: ArrayList<ByteArray>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readNOCsAttribute(callback: NOCsAttributeCallback) {
+  suspend fun readNOCsAttribute(): NOCsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNOCsAttributeWithFabricFilter(
-    callback: NOCsAttributeCallback,
-    isFabricFiltered: Boolean
-  ) {
+  suspend fun readNOCsAttributeWithFabricFilter(isFabricFiltered: Boolean): NOCsAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeNOCsAttribute(callback: NOCsAttributeCallback, minInterval: Int, maxInterval: Int) {
+  suspend fun subscribeNOCsAttribute(minInterval: Int, maxInterval: Int): NOCsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readFabricsAttribute(callback: FabricsAttributeCallback) {
+  suspend fun readFabricsAttribute(): FabricsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readFabricsAttributeWithFabricFilter(
-    callback: FabricsAttributeCallback,
-    isFabricFiltered: Boolean
-  ) {
+  suspend fun readFabricsAttributeWithFabricFilter(isFabricFiltered: Boolean): FabricsAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeFabricsAttribute(
-    callback: FabricsAttributeCallback,
+  suspend fun subscribeFabricsAttribute(minInterval: Int, maxInterval: Int): FabricsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedFabricsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedFabricsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCommissionedFabricsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCommissionedFabricsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTrustedRootCertificatesAttribute(): TrustedRootCertificatesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTrustedRootCertificatesAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): TrustedRootCertificatesAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSupportedFabricsAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readCurrentFabricIndexAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeSupportedFabricsAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeCurrentFabricIndexAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readCommissionedFabricsAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeCommissionedFabricsAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTrustedRootCertificatesAttribute(callback: TrustedRootCertificatesAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeTrustedRootCertificatesAttribute(
-    callback: TrustedRootCertificatesAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readCurrentFabricIndexAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeCurrentFabricIndexAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 62u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalStateCluster.kt
@@ -20,261 +20,180 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OperationalStateCluster(private val endpointId: UShort) {
+  class OperationalCommandResponse(
+    val commandResponseState: ChipStructs.OperationalStateClusterErrorStateStruct
+  )
+
+  class PhaseListAttribute(val value: ArrayList<String>?)
+
+  class CurrentPhaseAttribute(val value: UByte?)
+
+  class CountdownTimeAttribute(val value: UInt?)
+
+  class OperationalStateListAttribute(
+    val value: ArrayList<ChipStructs.OperationalStateClusterOperationalStateStruct>
+  )
+
+  class OperationalErrorAttribute(val value: ChipStructs.OperationalStateClusterErrorStateStruct)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun pause(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pause(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun start(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun start(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resume(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resume(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhaseListAttribute(): PhaseListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhaseListAttribute(minInterval: Int, maxInterval: Int): PhaseListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPhaseAttribute(): CurrentPhaseAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPhaseAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPhaseAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCountdownTimeAttribute(): CountdownTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCountdownTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CountdownTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalStateListAttribute(): OperationalStateListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalStateListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OperationalStateListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalErrorAttribute(): OperationalErrorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalErrorAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OperationalErrorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 96u
-  }
-
-  fun pause(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun pause(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun start(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun start(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun resume(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resume(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface OperationalCommandResponseCallback {
-    fun onSuccess(commandResponseState: ChipStructs.OperationalStateClusterErrorStateStruct)
-
-    fun onError(error: Exception)
-  }
-
-  interface PhaseListAttributeCallback {
-    fun onSuccess(value: ArrayList<String>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPhaseAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CountdownTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OperationalStateListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.OperationalStateClusterOperationalStateStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OperationalErrorAttributeCallback {
-    fun onSuccess(value: ChipStructs.OperationalStateClusterErrorStateStruct)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readPhaseListAttribute(callback: PhaseListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhaseListAttribute(
-    callback: PhaseListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPhaseAttribute(callback: CurrentPhaseAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPhaseAttribute(
-    callback: CurrentPhaseAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCountdownTimeAttribute(callback: CountdownTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCountdownTimeAttribute(
-    callback: CountdownTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalStateListAttribute(callback: OperationalStateListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalStateListAttribute(
-    callback: OperationalStateListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalErrorAttribute(callback: OperationalErrorAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalErrorAttribute(
-    callback: OperationalErrorAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
@@ -20,195 +20,136 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OtaSoftwareUpdateProviderCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 41u
-  }
+  class QueryImageResponse(
+    val status: UInt,
+    val delayedActionTime: UInt?,
+    val imageURI: String?,
+    val softwareVersion: UInt?,
+    val softwareVersionString: String?,
+    val updateToken: ByteArray?,
+    val userConsentNeeded: Boolean?,
+    val metadataForRequestor: ByteArray?
+  )
 
-  fun queryImage(
-    callback: QueryImageResponseCallback,
-    vendorID: Integer,
-    productID: Integer,
-    softwareVersion: Long,
-    protocolsSupported: ArrayList<Integer>,
-    hardwareVersion: Integer?,
+  class ApplyUpdateResponse(val action: UInt, val delayedActionTime: UInt)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun queryImage(
+    vendorID: UShort,
+    productID: UShort,
+    softwareVersion: UInt,
+    protocolsSupported: ArrayList<UInt>,
+    hardwareVersion: UShort?,
     location: String?,
     requestorCanConsent: Boolean?,
     metadataForProvider: ByteArray?
-  ) {
+  ): QueryImageResponse {
     // Implementation needs to be added here
   }
 
-  fun queryImage(
-    callback: QueryImageResponseCallback,
-    vendorID: Integer,
-    productID: Integer,
-    softwareVersion: Long,
-    protocolsSupported: ArrayList<Integer>,
-    hardwareVersion: Integer?,
+  suspend fun queryImage(
+    vendorID: UShort,
+    productID: UShort,
+    softwareVersion: UInt,
+    protocolsSupported: ArrayList<UInt>,
+    hardwareVersion: UShort?,
     location: String?,
     requestorCanConsent: Boolean?,
     metadataForProvider: ByteArray?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): QueryImageResponse {
     // Implementation needs to be added here
   }
 
-  fun applyUpdateRequest(
-    callback: ApplyUpdateResponseCallback,
-    updateToken: ByteArray,
-    newVersion: Long
-  ) {
+  suspend fun applyUpdateRequest(updateToken: ByteArray, newVersion: UInt): ApplyUpdateResponse {
     // Implementation needs to be added here
   }
 
-  fun applyUpdateRequest(
-    callback: ApplyUpdateResponseCallback,
+  suspend fun applyUpdateRequest(
     updateToken: ByteArray,
-    newVersion: Long,
+    newVersion: UInt,
+    timedInvokeTimeoutMs: Int
+  ): ApplyUpdateResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun notifyUpdateApplied(updateToken: ByteArray, softwareVersion: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun notifyUpdateApplied(
+    updateToken: ByteArray,
+    softwareVersion: UInt,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun notifyUpdateApplied(
-    callback: DefaultClusterCallback,
-    updateToken: ByteArray,
-    softwareVersion: Long
-  ) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun notifyUpdateApplied(
-    callback: DefaultClusterCallback,
-    updateToken: ByteArray,
-    softwareVersion: Long,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface QueryImageResponseCallback {
-    fun onSuccess(
-      status: Integer,
-      delayedActionTime: Long?,
-      imageURI: String?,
-      softwareVersion: Long?,
-      softwareVersionString: String?,
-      updateToken: ByteArray?,
-      userConsentNeeded: Boolean?,
-      metadataForRequestor: ByteArray?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface ApplyUpdateResponseCallback {
-    fun onSuccess(action: Integer, delayedActionTime: Long)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 41u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateRequestorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateRequestorCluster.kt
@@ -20,220 +20,156 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OtaSoftwareUpdateRequestorCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 42u
-  }
+  class DefaultOTAProvidersAttribute(
+    val value: ArrayList<ChipStructs.OtaSoftwareUpdateRequestorClusterProviderLocation>
+  )
 
-  fun announceOTAProvider(
-    callback: DefaultClusterCallback,
-    providerNodeID: Long,
-    vendorID: Integer,
-    announcementReason: Integer,
+  class UpdateStateProgressAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun announceOTAProvider(
+    providerNodeID: ULong,
+    vendorID: UShort,
+    announcementReason: UInt,
     metadataForNode: ByteArray?,
-    endpoint: Integer
+    endpoint: UShort
   ) {
     // Implementation needs to be added here
   }
 
-  fun announceOTAProvider(
-    callback: DefaultClusterCallback,
-    providerNodeID: Long,
-    vendorID: Integer,
-    announcementReason: Integer,
+  suspend fun announceOTAProvider(
+    providerNodeID: ULong,
+    vendorID: UShort,
+    announcementReason: UInt,
     metadataForNode: ByteArray?,
-    endpoint: Integer,
+    endpoint: UShort,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface DefaultOTAProvidersAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.OtaSoftwareUpdateRequestorClusterProviderLocation>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface UpdateStateProgressAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readDefaultOTAProvidersAttribute(callback: DefaultOTAProvidersAttributeCallback) {
+  suspend fun readDefaultOTAProvidersAttribute(): DefaultOTAProvidersAttribute {
     // Implementation needs to be added here
   }
 
-  fun readDefaultOTAProvidersAttributeWithFabricFilter(
-    callback: DefaultOTAProvidersAttributeCallback,
+  suspend fun readDefaultOTAProvidersAttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): DefaultOTAProvidersAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeDefaultOTAProvidersAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeDefaultOTAProvidersAttribute(
     value: ArrayList<ChipStructs.OtaSoftwareUpdateRequestorClusterProviderLocation>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeDefaultOTAProvidersAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeDefaultOTAProvidersAttribute(
     value: ArrayList<ChipStructs.OtaSoftwareUpdateRequestorClusterProviderLocation>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeDefaultOTAProvidersAttribute(
-    callback: DefaultOTAProvidersAttributeCallback,
+  suspend fun subscribeDefaultOTAProvidersAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): DefaultOTAProvidersAttribute {
     // Implementation needs to be added here
   }
 
-  fun readUpdatePossibleAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readUpdatePossibleAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun subscribeUpdatePossibleAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeUpdatePossibleAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUpdateStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUpdateStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUpdateStateProgressAttribute(): UpdateStateProgressAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUpdateStateProgressAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): UpdateStateProgressAttribute {
     // Implementation needs to be added here
   }
 
-  fun readUpdateStateAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeUpdateStateAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readUpdateStateProgressAttribute(callback: UpdateStateProgressAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeUpdateStateProgressAttribute(
-    callback: UpdateStateProgressAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 42u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OzoneConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OzoneConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class OzoneConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1045u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm10ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm10ConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class Pm10ConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1069u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm1ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm1ConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class Pm1ConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1068u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm25ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm25ConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class Pm25ConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1066u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceCluster.kt
@@ -20,593 +20,394 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class PowerSourceCluster(private val endpointId: UShort) {
+  class WiredAssessedInputVoltageAttribute(val value: UInt?)
+
+  class WiredAssessedInputFrequencyAttribute(val value: UShort?)
+
+  class WiredAssessedCurrentAttribute(val value: UInt?)
+
+  class ActiveWiredFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class BatVoltageAttribute(val value: UInt?)
+
+  class BatPercentRemainingAttribute(val value: UByte?)
+
+  class BatTimeRemainingAttribute(val value: UInt?)
+
+  class ActiveBatFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class BatTimeToFullChargeAttribute(val value: UInt?)
+
+  class BatChargingCurrentAttribute(val value: UInt?)
+
+  class ActiveBatChargeFaultsAttribute(val value: ArrayList<UInt>?)
+
+  class EndpointListAttribute(val value: ArrayList<UShort>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOrderAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOrderAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDescriptionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDescriptionAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredAssessedInputVoltageAttribute(): WiredAssessedInputVoltageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredAssessedInputVoltageAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): WiredAssessedInputVoltageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredAssessedInputFrequencyAttribute(): WiredAssessedInputFrequencyAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredAssessedInputFrequencyAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): WiredAssessedInputFrequencyAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredCurrentTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredCurrentTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredAssessedCurrentAttribute(): WiredAssessedCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredAssessedCurrentAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): WiredAssessedCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredNominalVoltageAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredNominalVoltageAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredMaximumCurrentAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredMaximumCurrentAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiredPresentAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiredPresentAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveWiredFaultsAttribute(): ActiveWiredFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveWiredFaultsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActiveWiredFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatVoltageAttribute(): BatVoltageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatVoltageAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BatVoltageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatPercentRemainingAttribute(): BatPercentRemainingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatPercentRemainingAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BatPercentRemainingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatTimeRemainingAttribute(): BatTimeRemainingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatTimeRemainingAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BatTimeRemainingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatChargeLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatChargeLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatReplacementNeededAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatReplacementNeededAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatReplaceabilityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatReplaceabilityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatPresentAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatPresentAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveBatFaultsAttribute(): ActiveBatFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveBatFaultsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActiveBatFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatReplacementDescriptionAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatReplacementDescriptionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatCommonDesignationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatCommonDesignationAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatANSIDesignationAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatANSIDesignationAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatIECDesignationAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatIECDesignationAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatApprovedChemistryAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatApprovedChemistryAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatCapacityAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatCapacityAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatQuantityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatQuantityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatChargeStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatChargeStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatTimeToFullChargeAttribute(): BatTimeToFullChargeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatTimeToFullChargeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BatTimeToFullChargeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatFunctionalWhileChargingAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatFunctionalWhileChargingAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatChargingCurrentAttribute(): BatChargingCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatChargingCurrentAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BatChargingCurrentAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveBatChargeFaultsAttribute(): ActiveBatChargeFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveBatChargeFaultsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActiveBatChargeFaultsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEndpointListAttribute(): EndpointListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEndpointListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): EndpointListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 47u
-  }
-
-  interface WiredAssessedInputVoltageAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface WiredAssessedInputFrequencyAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface WiredAssessedCurrentAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveWiredFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BatVoltageAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BatPercentRemainingAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BatTimeRemainingAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveBatFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BatTimeToFullChargeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BatChargingCurrentAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveBatChargeFaultsAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EndpointListAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOrderAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOrderAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDescriptionAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDescriptionAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredAssessedInputVoltageAttribute(callback: WiredAssessedInputVoltageAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredAssessedInputVoltageAttribute(
-    callback: WiredAssessedInputVoltageAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredAssessedInputFrequencyAttribute(
-    callback: WiredAssessedInputFrequencyAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredAssessedInputFrequencyAttribute(
-    callback: WiredAssessedInputFrequencyAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredCurrentTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredCurrentTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredAssessedCurrentAttribute(callback: WiredAssessedCurrentAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredAssessedCurrentAttribute(
-    callback: WiredAssessedCurrentAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredNominalVoltageAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredNominalVoltageAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredMaximumCurrentAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredMaximumCurrentAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiredPresentAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiredPresentAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveWiredFaultsAttribute(callback: ActiveWiredFaultsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveWiredFaultsAttribute(
-    callback: ActiveWiredFaultsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatVoltageAttribute(callback: BatVoltageAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatVoltageAttribute(
-    callback: BatVoltageAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatPercentRemainingAttribute(callback: BatPercentRemainingAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatPercentRemainingAttribute(
-    callback: BatPercentRemainingAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatTimeRemainingAttribute(callback: BatTimeRemainingAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatTimeRemainingAttribute(
-    callback: BatTimeRemainingAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatChargeLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatChargeLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatReplacementNeededAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatReplacementNeededAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatReplaceabilityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatReplaceabilityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatPresentAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatPresentAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveBatFaultsAttribute(callback: ActiveBatFaultsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveBatFaultsAttribute(
-    callback: ActiveBatFaultsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatReplacementDescriptionAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatReplacementDescriptionAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatCommonDesignationAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatCommonDesignationAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatANSIDesignationAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatANSIDesignationAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatIECDesignationAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatIECDesignationAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatApprovedChemistryAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatApprovedChemistryAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatCapacityAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatCapacityAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatQuantityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatQuantityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatChargeStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatChargeStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatTimeToFullChargeAttribute(callback: BatTimeToFullChargeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatTimeToFullChargeAttribute(
-    callback: BatTimeToFullChargeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatFunctionalWhileChargingAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatFunctionalWhileChargingAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatChargingCurrentAttribute(callback: BatChargingCurrentAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatChargingCurrentAttribute(
-    callback: BatChargingCurrentAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveBatChargeFaultsAttribute(callback: ActiveBatChargeFaultsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveBatChargeFaultsAttribute(
-    callback: ActiveBatChargeFaultsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEndpointListAttribute(callback: EndpointListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEndpointListAttribute(
-    callback: EndpointListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceConfigurationCluster.kt
@@ -20,131 +20,82 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class PowerSourceConfigurationCluster(private val endpointId: UShort) {
+  class SourcesAttribute(val value: ArrayList<UByte>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readSourcesAttribute(): SourcesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSourcesAttribute(minInterval: Int, maxInterval: Int): SourcesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 46u
-  }
-
-  interface SourcesAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSourcesAttribute(callback: SourcesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSourcesAttribute(
-    callback: SourcesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PressureMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PressureMeasurementCluster.kt
@@ -20,267 +20,174 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class PressureMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Short?)
+
+  class MinMeasuredValueAttribute(val value: Short?)
+
+  class MaxMeasuredValueAttribute(val value: Short?)
+
+  class ScaledValueAttribute(val value: Short?)
+
+  class MinScaledValueAttribute(val value: Short?)
+
+  class MaxScaledValueAttribute(val value: Short?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readScaledValueAttribute(): ScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeScaledValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinScaledValueAttribute(): MinScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinScaledValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxScaledValueAttribute(): MaxScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxScaledValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxScaledValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readScaledToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeScaledToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readScaleAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeScaleAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1027u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ScaledValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinScaledValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxScaledValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readScaledValueAttribute(callback: ScaledValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeScaledValueAttribute(
-    callback: ScaledValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinScaledValueAttribute(callback: MinScaledValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinScaledValueAttribute(
-    callback: MinScaledValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxScaledValueAttribute(callback: MaxScaledValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxScaledValueAttribute(
-    callback: MaxScaledValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readScaledToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeScaledToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readScaleAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeScaleAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyConfigurationCluster.kt
@@ -20,111 +20,72 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ProxyConfigurationCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 66u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyDiscoveryCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyDiscoveryCluster.kt
@@ -20,111 +20,72 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ProxyDiscoveryCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 67u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyValidCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyValidCluster.kt
@@ -20,111 +20,72 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ProxyValidCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 68u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PulseWidthModulationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PulseWidthModulationCluster.kt
@@ -20,111 +20,72 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class PulseWidthModulationCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 28u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PumpConfigurationAndControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PumpConfigurationAndControlCluster.kt
@@ -20,579 +20,366 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
+  class MaxPressureAttribute(val value: Short?)
+
+  class MaxSpeedAttribute(val value: UShort?)
+
+  class MaxFlowAttribute(val value: UShort?)
+
+  class MinConstPressureAttribute(val value: Short?)
+
+  class MaxConstPressureAttribute(val value: Short?)
+
+  class MinCompPressureAttribute(val value: Short?)
+
+  class MaxCompPressureAttribute(val value: Short?)
+
+  class MinConstSpeedAttribute(val value: UShort?)
+
+  class MaxConstSpeedAttribute(val value: UShort?)
+
+  class MinConstFlowAttribute(val value: UShort?)
+
+  class MaxConstFlowAttribute(val value: UShort?)
+
+  class MinConstTempAttribute(val value: Short?)
+
+  class MaxConstTempAttribute(val value: Short?)
+
+  class CapacityAttribute(val value: Short?)
+
+  class SpeedAttribute(val value: UShort?)
+
+  class LifetimeRunningHoursAttribute(val value: UInt?)
+
+  class PowerAttribute(val value: UInt?)
+
+  class LifetimeEnergyConsumedAttribute(val value: UInt?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMaxPressureAttribute(): MaxPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxPressureAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxSpeedAttribute(): MaxSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxSpeedAttribute(minInterval: Int, maxInterval: Int): MaxSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxFlowAttribute(): MaxFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxFlowAttribute(minInterval: Int, maxInterval: Int): MaxFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinConstPressureAttribute(): MinConstPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinConstPressureAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinConstPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxConstPressureAttribute(): MaxConstPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxConstPressureAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxConstPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinCompPressureAttribute(): MinCompPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinCompPressureAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinCompPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxCompPressureAttribute(): MaxCompPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxCompPressureAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxCompPressureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinConstSpeedAttribute(): MinConstSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinConstSpeedAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinConstSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxConstSpeedAttribute(): MaxConstSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxConstSpeedAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxConstSpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinConstFlowAttribute(): MinConstFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinConstFlowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinConstFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxConstFlowAttribute(): MaxConstFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxConstFlowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxConstFlowAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinConstTempAttribute(): MinConstTempAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinConstTempAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinConstTempAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxConstTempAttribute(): MaxConstTempAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxConstTempAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxConstTempAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPumpStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePumpStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEffectiveOperationModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEffectiveOperationModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEffectiveControlModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEffectiveControlModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCapacityAttribute(): CapacityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCapacityAttribute(minInterval: Int, maxInterval: Int): CapacityAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSpeedAttribute(): SpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSpeedAttribute(minInterval: Int, maxInterval: Int): SpeedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLifetimeRunningHoursAttribute(): LifetimeRunningHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLifetimeRunningHoursAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLifetimeRunningHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLifetimeRunningHoursAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LifetimeRunningHoursAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPowerAttribute(): PowerAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePowerAttribute(minInterval: Int, maxInterval: Int): PowerAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLifetimeEnergyConsumedAttribute(): LifetimeEnergyConsumedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLifetimeEnergyConsumedAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLifetimeEnergyConsumedAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLifetimeEnergyConsumedAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LifetimeEnergyConsumedAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOperationModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOperationModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readControlModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeControlModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeControlModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeControlModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 512u
-  }
-
-  interface MaxPressureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxSpeedAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxFlowAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinConstPressureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxConstPressureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinCompPressureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxCompPressureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinConstSpeedAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxConstSpeedAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinConstFlowAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxConstFlowAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinConstTempAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxConstTempAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CapacityAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SpeedAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LifetimeRunningHoursAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PowerAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LifetimeEnergyConsumedAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMaxPressureAttribute(callback: MaxPressureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxPressureAttribute(
-    callback: MaxPressureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxSpeedAttribute(callback: MaxSpeedAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxSpeedAttribute(
-    callback: MaxSpeedAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxFlowAttribute(callback: MaxFlowAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxFlowAttribute(
-    callback: MaxFlowAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinConstPressureAttribute(callback: MinConstPressureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinConstPressureAttribute(
-    callback: MinConstPressureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxConstPressureAttribute(callback: MaxConstPressureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxConstPressureAttribute(
-    callback: MaxConstPressureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinCompPressureAttribute(callback: MinCompPressureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinCompPressureAttribute(
-    callback: MinCompPressureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxCompPressureAttribute(callback: MaxCompPressureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxCompPressureAttribute(
-    callback: MaxCompPressureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinConstSpeedAttribute(callback: MinConstSpeedAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinConstSpeedAttribute(
-    callback: MinConstSpeedAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxConstSpeedAttribute(callback: MaxConstSpeedAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxConstSpeedAttribute(
-    callback: MaxConstSpeedAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinConstFlowAttribute(callback: MinConstFlowAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinConstFlowAttribute(
-    callback: MinConstFlowAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxConstFlowAttribute(callback: MaxConstFlowAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxConstFlowAttribute(
-    callback: MaxConstFlowAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinConstTempAttribute(callback: MinConstTempAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinConstTempAttribute(
-    callback: MinConstTempAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxConstTempAttribute(callback: MaxConstTempAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxConstTempAttribute(
-    callback: MaxConstTempAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPumpStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePumpStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEffectiveOperationModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEffectiveOperationModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEffectiveControlModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEffectiveControlModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCapacityAttribute(callback: CapacityAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCapacityAttribute(
-    callback: CapacityAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSpeedAttribute(callback: SpeedAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSpeedAttribute(
-    callback: SpeedAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLifetimeRunningHoursAttribute(callback: LifetimeRunningHoursAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLifetimeRunningHoursAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLifetimeRunningHoursAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLifetimeRunningHoursAttribute(
-    callback: LifetimeRunningHoursAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPowerAttribute(callback: PowerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePowerAttribute(
-    callback: PowerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLifetimeEnergyConsumedAttribute(callback: LifetimeEnergyConsumedAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLifetimeEnergyConsumedAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeLifetimeEnergyConsumedAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLifetimeEnergyConsumedAttribute(
-    callback: LifetimeEnergyConsumedAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOperationModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOperationModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readControlModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeControlModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeControlModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeControlModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RadonConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RadonConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RadonConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1071u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAlarmCluster.kt
@@ -20,139 +20,96 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RefrigeratorAlarmCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMaskAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaskAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStateAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStateAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 87u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMaskAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaskAttribute(callback: LongAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readStateAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStateAttribute(callback: LongAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
@@ -20,230 +20,145 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RefrigeratorAndTemperatureControlledCabinetModeCluster(private val endpointId: UShort) {
+  class ChangeToModeResponse(val status: UInt, val statusText: String?)
+
+  class SupportedModesAttribute(
+    val value:
+      ArrayList<ChipStructs.RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct>
+  )
+
+  class StartUpModeAttribute(val value: UByte?)
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartUpModeAttribute(): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartUpModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StartUpModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 82u
-  }
-
-  fun changeToMode(callback: ChangeToModeResponseCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(
-    callback: ChangeToModeResponseCallback,
-    newMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeToModeResponseCallback {
-    fun onSuccess(status: Integer, statusText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(
-      value:
-        ArrayList<
-          ChipStructs.RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct
-        >
-    )
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StartUpModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStartUpModeAttribute(callback: StartUpModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeStartUpModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStartUpModeAttribute(
-    callback: StartUpModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RelativeHumidityMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RelativeHumidityMeasurementCluster.kt
@@ -20,183 +20,119 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RelativeHumidityMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: UShort?)
+
+  class MinMeasuredValueAttribute(val value: UShort?)
+
+  class MaxMeasuredValueAttribute(val value: UShort?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1029u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcCleanModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcCleanModeCluster.kt
@@ -20,193 +20,123 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RvcCleanModeCluster(private val endpointId: UShort) {
+  class ChangeToModeResponse(val status: UInt, val statusText: String?)
+
+  class SupportedModesAttribute(
+    val value: ArrayList<ChipStructs.RvcCleanModeClusterModeOptionStruct>
+  )
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 85u
-  }
-
-  fun changeToMode(callback: ChangeToModeResponseCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(
-    callback: ChangeToModeResponseCallback,
-    newMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeToModeResponseCallback {
-    fun onSuccess(status: Integer, statusText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.RvcCleanModeClusterModeOptionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcOperationalStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcOperationalStateCluster.kt
@@ -20,261 +20,182 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RvcOperationalStateCluster(private val endpointId: UShort) {
+  class OperationalCommandResponse(
+    val commandResponseState: ChipStructs.RvcOperationalStateClusterErrorStateStruct
+  )
+
+  class PhaseListAttribute(val value: ArrayList<String>?)
+
+  class CurrentPhaseAttribute(val value: UByte?)
+
+  class CountdownTimeAttribute(val value: UInt?)
+
+  class OperationalStateListAttribute(
+    val value: ArrayList<ChipStructs.RvcOperationalStateClusterOperationalStateStruct>
+  )
+
+  class OperationalErrorAttribute(
+    val value: ChipStructs.RvcOperationalStateClusterErrorStateStruct
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun pause(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun pause(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stop(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun start(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun start(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resume(): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resume(timedInvokeTimeoutMs: Int): OperationalCommandResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhaseListAttribute(): PhaseListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhaseListAttribute(minInterval: Int, maxInterval: Int): PhaseListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPhaseAttribute(): CurrentPhaseAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPhaseAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPhaseAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCountdownTimeAttribute(): CountdownTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCountdownTimeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CountdownTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalStateListAttribute(): OperationalStateListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalStateListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OperationalStateListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalErrorAttribute(): OperationalErrorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalErrorAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OperationalErrorAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 97u
-  }
-
-  fun pause(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun pause(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun stop(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun start(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun start(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun resume(callback: OperationalCommandResponseCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resume(callback: OperationalCommandResponseCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface OperationalCommandResponseCallback {
-    fun onSuccess(commandResponseState: ChipStructs.RvcOperationalStateClusterErrorStateStruct)
-
-    fun onError(error: Exception)
-  }
-
-  interface PhaseListAttributeCallback {
-    fun onSuccess(value: ArrayList<String>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPhaseAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CountdownTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OperationalStateListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.RvcOperationalStateClusterOperationalStateStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OperationalErrorAttributeCallback {
-    fun onSuccess(value: ChipStructs.RvcOperationalStateClusterErrorStateStruct)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readPhaseListAttribute(callback: PhaseListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhaseListAttribute(
-    callback: PhaseListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPhaseAttribute(callback: CurrentPhaseAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPhaseAttribute(
-    callback: CurrentPhaseAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCountdownTimeAttribute(callback: CountdownTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCountdownTimeAttribute(
-    callback: CountdownTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalStateListAttribute(callback: OperationalStateListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalStateListAttribute(
-    callback: OperationalStateListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalErrorAttribute(callback: OperationalErrorAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalErrorAttribute(
-    callback: OperationalErrorAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcRunModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcRunModeCluster.kt
@@ -20,193 +20,123 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class RvcRunModeCluster(private val endpointId: UShort) {
+  class ChangeToModeResponse(val status: UInt, val statusText: String?)
+
+  class SupportedModesAttribute(
+    val value: ArrayList<ChipStructs.RvcRunModeClusterModeOptionStruct>
+  )
+
+  class OnModeAttribute(val value: UByte?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun changeToMode(newMode: UByte): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int): ChangeToModeResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedModesAttribute(): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedModesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedModesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOnModeAttribute(): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 84u
-  }
-
-  fun changeToMode(callback: ChangeToModeResponseCallback, newMode: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun changeToMode(
-    callback: ChangeToModeResponseCallback,
-    newMode: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface ChangeToModeResponseCallback {
-    fun onSuccess(status: Integer, statusText: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface SupportedModesAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.RvcRunModeClusterModeOptionStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OnModeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSupportedModesAttribute(callback: SupportedModesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedModesAttribute(
-    callback: SupportedModesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOnModeAttribute(callback: OnModeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOnModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOnModeAttribute(
-    callback: OnModeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SampleMeiCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SampleMeiCluster.kt
@@ -20,162 +20,110 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class SampleMeiCluster(private val endpointId: UShort) {
+  class AddArgumentsResponse(val returnValue: UByte)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun ping() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun ping(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addArguments(arg1: UByte, arg2: UByte): AddArgumentsResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addArguments(
+    arg1: UByte,
+    arg2: UByte,
+    timedInvokeTimeoutMs: Int
+  ): AddArgumentsResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFlipFlopAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFlipFlopAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFlipFlopAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFlipFlopAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 4294048800u
-  }
-
-  fun ping(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun ping(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun addArguments(callback: AddArgumentsResponseCallback, arg1: Integer, arg2: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun addArguments(
-    callback: AddArgumentsResponseCallback,
-    arg1: Integer,
-    arg2: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface AddArgumentsResponseCallback {
-    fun onSuccess(returnValue: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readFlipFlopAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFlipFlopAttribute(callback: DefaultClusterCallback, value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFlipFlopAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFlipFlopAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ScenesCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ScenesCluster.kt
@@ -20,456 +20,325 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ScenesCluster(private val endpointId: UShort) {
+  class AddSceneResponse(val status: UShort, val groupID: UShort, val sceneID: UByte)
+
+  class ViewSceneResponse(
+    val status: UShort,
+    val groupID: UShort,
+    val sceneID: UByte,
+    val transitionTime: UShort?,
+    val sceneName: String?,
+    val extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>?
+  )
+
+  class RemoveSceneResponse(val status: UShort, val groupID: UShort, val sceneID: UByte)
+
+  class RemoveAllScenesResponse(val status: UShort, val groupID: UShort)
+
+  class StoreSceneResponse(val status: UShort, val groupID: UShort, val sceneID: UByte)
+
+  class GetSceneMembershipResponse(
+    val status: UShort,
+    val capacity: UByte?,
+    val groupID: UShort,
+    val sceneList: ArrayList<UByte>?
+  )
+
+  class EnhancedAddSceneResponse(val status: UShort, val groupID: UShort, val sceneID: UByte)
+
+  class EnhancedViewSceneResponse(
+    val status: UShort,
+    val groupID: UShort,
+    val sceneID: UByte,
+    val transitionTime: UShort?,
+    val sceneName: String?,
+    val extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>?
+  )
+
+  class CopySceneResponse(
+    val status: UShort,
+    val groupIdentifierFrom: UShort,
+    val sceneIdentifierFrom: UByte
+  )
+
+  class LastConfiguredByAttribute(val value: ULong?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun addScene(
+    groupID: UShort,
+    sceneID: UByte,
+    transitionTime: UShort,
+    sceneName: String,
+    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>
+  ): AddSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun addScene(
+    groupID: UShort,
+    sceneID: UByte,
+    transitionTime: UShort,
+    sceneName: String,
+    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>,
+    timedInvokeTimeoutMs: Int
+  ): AddSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun viewScene(groupID: UShort, sceneID: UByte): ViewSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun viewScene(
+    groupID: UShort,
+    sceneID: UByte,
+    timedInvokeTimeoutMs: Int
+  ): ViewSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeScene(groupID: UShort, sceneID: UByte): RemoveSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeScene(
+    groupID: UShort,
+    sceneID: UByte,
+    timedInvokeTimeoutMs: Int
+  ): RemoveSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeAllScenes(groupID: UShort): RemoveAllScenesResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun removeAllScenes(groupID: UShort, timedInvokeTimeoutMs: Int): RemoveAllScenesResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun storeScene(groupID: UShort, sceneID: UByte): StoreSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun storeScene(
+    groupID: UShort,
+    sceneID: UByte,
+    timedInvokeTimeoutMs: Int
+  ): StoreSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun recallScene(groupID: UShort, sceneID: UByte, transitionTime: UShort?) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun recallScene(
+    groupID: UShort,
+    sceneID: UByte,
+    transitionTime: UShort?,
+    timedInvokeTimeoutMs: Int
+  ) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun getSceneMembership(groupID: UShort): GetSceneMembershipResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun getSceneMembership(
+    groupID: UShort,
+    timedInvokeTimeoutMs: Int
+  ): GetSceneMembershipResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedAddScene(
+    groupID: UShort,
+    sceneID: UByte,
+    transitionTime: UShort,
+    sceneName: String,
+    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>
+  ): EnhancedAddSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedAddScene(
+    groupID: UShort,
+    sceneID: UByte,
+    transitionTime: UShort,
+    sceneName: String,
+    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>,
+    timedInvokeTimeoutMs: Int
+  ): EnhancedAddSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedViewScene(groupID: UShort, sceneID: UByte): EnhancedViewSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun enhancedViewScene(
+    groupID: UShort,
+    sceneID: UByte,
+    timedInvokeTimeoutMs: Int
+  ): EnhancedViewSceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun copyScene(
+    mode: UInt,
+    groupIdentifierFrom: UShort,
+    sceneIdentifierFrom: UByte,
+    groupIdentifierTo: UShort,
+    sceneIdentifierTo: UByte
+  ): CopySceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun copyScene(
+    mode: UInt,
+    groupIdentifierFrom: UShort,
+    sceneIdentifierFrom: UByte,
+    groupIdentifierTo: UShort,
+    sceneIdentifierTo: UByte,
+    timedInvokeTimeoutMs: Int
+  ): CopySceneResponse {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSceneCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSceneCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentSceneAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentSceneAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentGroupAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentGroupAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSceneValidAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSceneValidAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNameSupportAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNameSupportAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLastConfiguredByAttribute(): LastConfiguredByAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLastConfiguredByAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LastConfiguredByAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSceneTableSizeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSceneTableSizeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRemainingCapacityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRemainingCapacityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 5u
-  }
-
-  fun addScene(
-    callback: AddSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer,
-    sceneName: String,
-    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun addScene(
-    callback: AddSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer,
-    sceneName: String,
-    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun viewScene(callback: ViewSceneResponseCallback, groupID: Integer, sceneID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun viewScene(
-    callback: ViewSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeScene(callback: RemoveSceneResponseCallback, groupID: Integer, sceneID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun removeScene(
-    callback: RemoveSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun removeAllScenes(callback: RemoveAllScenesResponseCallback, groupID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun removeAllScenes(
-    callback: RemoveAllScenesResponseCallback,
-    groupID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun storeScene(callback: StoreSceneResponseCallback, groupID: Integer, sceneID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun storeScene(
-    callback: StoreSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun recallScene(
-    callback: DefaultClusterCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer?
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun recallScene(
-    callback: DefaultClusterCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer?,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun getSceneMembership(callback: GetSceneMembershipResponseCallback, groupID: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun getSceneMembership(
-    callback: GetSceneMembershipResponseCallback,
-    groupID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedAddScene(
-    callback: EnhancedAddSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer,
-    sceneName: String,
-    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedAddScene(
-    callback: EnhancedAddSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    transitionTime: Integer,
-    sceneName: String,
-    extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedViewScene(
-    callback: EnhancedViewSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun enhancedViewScene(
-    callback: EnhancedViewSceneResponseCallback,
-    groupID: Integer,
-    sceneID: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun copyScene(
-    callback: CopySceneResponseCallback,
-    mode: Integer,
-    groupIdentifierFrom: Integer,
-    sceneIdentifierFrom: Integer,
-    groupIdentifierTo: Integer,
-    sceneIdentifierTo: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun copyScene(
-    callback: CopySceneResponseCallback,
-    mode: Integer,
-    groupIdentifierFrom: Integer,
-    sceneIdentifierFrom: Integer,
-    groupIdentifierTo: Integer,
-    sceneIdentifierTo: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface AddSceneResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer, sceneID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface ViewSceneResponseCallback {
-    fun onSuccess(
-      status: Integer,
-      groupID: Integer,
-      sceneID: Integer,
-      transitionTime: Integer?,
-      sceneName: String?,
-      extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface RemoveSceneResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer, sceneID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface RemoveAllScenesResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface StoreSceneResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer, sceneID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface GetSceneMembershipResponseCallback {
-    fun onSuccess(
-      status: Integer,
-      capacity: Integer?,
-      groupID: Integer,
-      sceneList: ArrayList<Integer>?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface EnhancedAddSceneResponseCallback {
-    fun onSuccess(status: Integer, groupID: Integer, sceneID: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface EnhancedViewSceneResponseCallback {
-    fun onSuccess(
-      status: Integer,
-      groupID: Integer,
-      sceneID: Integer,
-      transitionTime: Integer?,
-      sceneName: String?,
-      extensionFieldSets: ArrayList<ChipStructs.ScenesClusterExtensionFieldSet>?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface CopySceneResponseCallback {
-    fun onSuccess(status: Integer, groupIdentifierFrom: Integer, sceneIdentifierFrom: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface LastConfiguredByAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readSceneCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSceneCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentSceneAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentSceneAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentGroupAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentGroupAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSceneValidAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSceneValidAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNameSupportAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNameSupportAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLastConfiguredByAttribute(callback: LastConfiguredByAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLastConfiguredByAttribute(
-    callback: LastConfiguredByAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSceneTableSizeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSceneTableSizeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRemainingCapacityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRemainingCapacityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SmokeCoAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SmokeCoAlarmCluster.kt
@@ -20,287 +20,195 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class SmokeCoAlarmCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun selfTestRequest() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun selfTestRequest(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readExpressedStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeExpressedStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSmokeStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSmokeStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCOStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCOStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBatteryAlertAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBatteryAlertAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDeviceMutedAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDeviceMutedAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTestInProgressAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTestInProgressAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHardwareFaultAlertAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHardwareFaultAlertAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEndOfServiceAlertAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEndOfServiceAlertAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInterconnectSmokeAlarmAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInterconnectSmokeAlarmAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInterconnectCOAlarmAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInterconnectCOAlarmAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readContaminationStateAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeContaminationStateAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSmokeSensitivityLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSmokeSensitivityLevelAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSmokeSensitivityLevelAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSmokeSensitivityLevelAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readExpiryDateAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeExpiryDateAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 92u
-  }
-
-  fun selfTestRequest(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun selfTestRequest(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readExpressedStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeExpressedStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSmokeStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSmokeStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCOStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCOStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBatteryAlertAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBatteryAlertAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDeviceMutedAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDeviceMutedAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTestInProgressAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTestInProgressAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readHardwareFaultAlertAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHardwareFaultAlertAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEndOfServiceAlertAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEndOfServiceAlertAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInterconnectSmokeAlarmAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInterconnectSmokeAlarmAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInterconnectCOAlarmAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInterconnectCOAlarmAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readContaminationStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeContaminationStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSmokeSensitivityLevelAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSmokeSensitivityLevelAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSmokeSensitivityLevelAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSmokeSensitivityLevelAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readExpiryDateAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeExpiryDateAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SoftwareDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SoftwareDiagnosticsCluster.kt
@@ -20,175 +20,119 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class SoftwareDiagnosticsCluster(private val endpointId: UShort) {
+  class ThreadMetricsAttribute(
+    val value: ArrayList<ChipStructs.SoftwareDiagnosticsClusterThreadMetricsStruct>?
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetWatermarks() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetWatermarks(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readThreadMetricsAttribute(): ThreadMetricsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeThreadMetricsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ThreadMetricsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentHeapFreeAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentHeapFreeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentHeapUsedAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentHeapUsedAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentHeapHighWatermarkAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentHeapHighWatermarkAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 52u
-  }
-
-  fun resetWatermarks(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetWatermarks(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface ThreadMetricsAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.SoftwareDiagnosticsClusterThreadMetricsStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readThreadMetricsAttribute(callback: ThreadMetricsAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeThreadMetricsAttribute(
-    callback: ThreadMetricsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentHeapFreeAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentHeapFreeAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentHeapUsedAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentHeapUsedAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentHeapHighWatermarkAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentHeapHighWatermarkAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SwitchCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SwitchCluster.kt
@@ -20,147 +20,96 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class SwitchCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readNumberOfPositionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfPositionsAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMultiPressMaxAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMultiPressMaxAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 59u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readNumberOfPositionsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfPositionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMultiPressMaxAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMultiPressMaxAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TargetNavigatorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TargetNavigatorCluster.kt
@@ -20,162 +20,109 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TargetNavigatorCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 1285u
-  }
+  class NavigateTargetResponse(val status: UInt, val data: String?)
 
-  fun navigateTarget(callback: NavigateTargetResponseCallback, target: Integer, data: String?) {
+  class TargetListAttribute(
+    val value: ArrayList<ChipStructs.TargetNavigatorClusterTargetInfoStruct>
+  )
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun navigateTarget(target: UByte, data: String?): NavigateTargetResponse {
     // Implementation needs to be added here
   }
 
-  fun navigateTarget(
-    callback: NavigateTargetResponseCallback,
-    target: Integer,
+  suspend fun navigateTarget(
+    target: UByte,
     data: String?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): NavigateTargetResponse {
     // Implementation needs to be added here
   }
 
-  interface NavigateTargetResponseCallback {
-    fun onSuccess(status: Integer, data: String?)
-
-    fun onError(error: Exception)
-  }
-
-  interface TargetListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.TargetNavigatorClusterTargetInfoStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readTargetListAttribute(callback: TargetListAttributeCallback) {
+  suspend fun readTargetListAttribute(): TargetListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeTargetListAttribute(
-    callback: TargetListAttributeCallback,
+  suspend fun subscribeTargetListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): TargetListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readCurrentTargetAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readCurrentTargetAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeCurrentTargetAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeCurrentTargetAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 1285u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureControlCluster.kt
@@ -20,210 +20,140 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TemperatureControlCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 86u
-  }
+  class SupportedTemperatureLevelsAttribute(val value: ArrayList<String>?)
 
-  fun setTemperature(
-    callback: DefaultClusterCallback,
-    targetTemperature: Integer?,
-    targetTemperatureLevel: Integer?
-  ) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun setTemperature(targetTemperature: Short?, targetTemperatureLevel: UByte?) {
     // Implementation needs to be added here
   }
 
-  fun setTemperature(
-    callback: DefaultClusterCallback,
-    targetTemperature: Integer?,
-    targetTemperatureLevel: Integer?,
+  suspend fun setTemperature(
+    targetTemperature: Short?,
+    targetTemperatureLevel: UByte?,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  interface SupportedTemperatureLevelsAttributeCallback {
-    fun onSuccess(value: ArrayList<String>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readTemperatureSetpointAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readTemperatureSetpointAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeTemperatureSetpointAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeTemperatureSetpointAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinTemperatureAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinTemperatureAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxTemperatureAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxTemperatureAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStepAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStepAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSelectedTemperatureLevelAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSelectedTemperatureLevelAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readMinTemperatureAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readSupportedTemperatureLevelsAttribute(): SupportedTemperatureLevelsAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeMinTemperatureAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeSupportedTemperatureLevelsAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): SupportedTemperatureLevelsAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMaxTemperatureAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeMaxTemperatureAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readStepAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeStepAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSelectedTemperatureLevelAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeSelectedTemperatureLevelAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSupportedTemperatureLevelsAttribute(
-    callback: SupportedTemperatureLevelsAttributeCallback
-  ) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeSupportedTemperatureLevelsAttribute(
-    callback: SupportedTemperatureLevelsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 86u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureMeasurementCluster.kt
@@ -20,183 +20,119 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TemperatureMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Short?)
+
+  class MinMeasuredValueAttribute(val value: Short?)
+
+  class MaxMeasuredValueAttribute(val value: Short?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readToleranceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeToleranceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1026u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readToleranceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeToleranceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatCluster.kt
@@ -20,1189 +20,847 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ThermostatCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 513u
-  }
+  class GetWeeklyScheduleResponse(
+    val numberOfTransitionsForSequence: UByte,
+    val dayOfWeekForSequence: UInt,
+    val modeForSequence: UInt,
+    val transitions: ArrayList<ChipStructs.ThermostatClusterThermostatScheduleTransition>
+  )
 
-  fun setpointRaiseLower(callback: DefaultClusterCallback, mode: Integer, amount: Integer) {
+  class LocalTemperatureAttribute(val value: Short?)
+
+  class OutdoorTemperatureAttribute(val value: Short?)
+
+  class TemperatureSetpointHoldDurationAttribute(val value: UShort?)
+
+  class SetpointChangeAmountAttribute(val value: Short?)
+
+  class OccupiedSetbackAttribute(val value: UByte?)
+
+  class OccupiedSetbackMinAttribute(val value: UByte?)
+
+  class OccupiedSetbackMaxAttribute(val value: UByte?)
+
+  class UnoccupiedSetbackAttribute(val value: UByte?)
+
+  class UnoccupiedSetbackMinAttribute(val value: UByte?)
+
+  class UnoccupiedSetbackMaxAttribute(val value: UByte?)
+
+  class ACCoilTemperatureAttribute(val value: Short?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun setpointRaiseLower(mode: UInt, amount: Byte) {
     // Implementation needs to be added here
   }
 
-  fun setpointRaiseLower(
-    callback: DefaultClusterCallback,
-    mode: Integer,
-    amount: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun setpointRaiseLower(mode: UInt, amount: Byte, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun setWeeklySchedule(
-    callback: DefaultClusterCallback,
-    numberOfTransitionsForSequence: Integer,
-    dayOfWeekForSequence: Integer,
-    modeForSequence: Integer,
+  suspend fun setWeeklySchedule(
+    numberOfTransitionsForSequence: UByte,
+    dayOfWeekForSequence: UInt,
+    modeForSequence: UInt,
     transitions: ArrayList<ChipStructs.ThermostatClusterThermostatScheduleTransition>
   ) {
     // Implementation needs to be added here
   }
 
-  fun setWeeklySchedule(
-    callback: DefaultClusterCallback,
-    numberOfTransitionsForSequence: Integer,
-    dayOfWeekForSequence: Integer,
-    modeForSequence: Integer,
+  suspend fun setWeeklySchedule(
+    numberOfTransitionsForSequence: UByte,
+    dayOfWeekForSequence: UInt,
+    modeForSequence: UInt,
     transitions: ArrayList<ChipStructs.ThermostatClusterThermostatScheduleTransition>,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun getWeeklySchedule(
-    callback: GetWeeklyScheduleResponseCallback,
-    daysToReturn: Integer,
-    modeToReturn: Integer
-  ) {
+  suspend fun getWeeklySchedule(daysToReturn: UInt, modeToReturn: UInt): GetWeeklyScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun getWeeklySchedule(
-    callback: GetWeeklyScheduleResponseCallback,
-    daysToReturn: Integer,
-    modeToReturn: Integer,
+  suspend fun getWeeklySchedule(
+    daysToReturn: UInt,
+    modeToReturn: UInt,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): GetWeeklyScheduleResponse {
     // Implementation needs to be added here
   }
 
-  fun clearWeeklySchedule(callback: DefaultClusterCallback) {
+  suspend fun clearWeeklySchedule() {
     // Implementation needs to be added here
   }
 
-  fun clearWeeklySchedule(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun clearWeeklySchedule(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  interface GetWeeklyScheduleResponseCallback {
-    fun onSuccess(
-      numberOfTransitionsForSequence: Integer,
-      dayOfWeekForSequence: Integer,
-      modeForSequence: Integer,
-      transitions: ArrayList<ChipStructs.ThermostatClusterThermostatScheduleTransition>
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface LocalTemperatureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OutdoorTemperatureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TemperatureSetpointHoldDurationAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SetpointChangeAmountAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OccupiedSetbackAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OccupiedSetbackMinAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OccupiedSetbackMaxAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface UnoccupiedSetbackAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface UnoccupiedSetbackMinAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface UnoccupiedSetbackMaxAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ACCoilTemperatureAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readLocalTemperatureAttribute(callback: LocalTemperatureAttributeCallback) {
+  suspend fun readLocalTemperatureAttribute(): LocalTemperatureAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeLocalTemperatureAttribute(
-    callback: LocalTemperatureAttributeCallback,
+  suspend fun subscribeLocalTemperatureAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): LocalTemperatureAttribute {
     // Implementation needs to be added here
   }
 
-  fun readOutdoorTemperatureAttribute(callback: OutdoorTemperatureAttributeCallback) {
+  suspend fun readOutdoorTemperatureAttribute(): OutdoorTemperatureAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeOutdoorTemperatureAttribute(
-    callback: OutdoorTemperatureAttributeCallback,
+  suspend fun subscribeOutdoorTemperatureAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): OutdoorTemperatureAttribute {
     // Implementation needs to be added here
   }
 
-  fun readOccupancyAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupancyAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeOccupancyAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeOccupancyAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAbsMinHeatSetpointLimitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAbsMinHeatSetpointLimitAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAbsMinHeatSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAbsMaxHeatSetpointLimitAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAbsMinHeatSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAbsMaxHeatSetpointLimitAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAbsMaxHeatSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAbsMinCoolSetpointLimitAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAbsMaxHeatSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAbsMinCoolSetpointLimitAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAbsMinCoolSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAbsMaxCoolSetpointLimitAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAbsMinCoolSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAbsMaxCoolSetpointLimitAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readAbsMaxCoolSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readPICoolingDemandAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAbsMaxCoolSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribePICoolingDemandAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPIHeatingDemandAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePIHeatingDemandAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readHVACSystemTypeConfigurationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeHVACSystemTypeConfigurationAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeHVACSystemTypeConfigurationAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHVACSystemTypeConfigurationAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readPICoolingDemandAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readLocalTemperatureCalibrationAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribePICoolingDemandAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeLocalTemperatureCalibrationAttribute(value: Byte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeLocalTemperatureCalibrationAttribute(value: Byte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocalTemperatureCalibrationAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readPIHeatingDemandAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupiedCoolingSetpointAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribePIHeatingDemandAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun writeOccupiedCoolingSetpointAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOccupiedCoolingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOccupiedCoolingSetpointAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readHVACSystemTypeConfigurationAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupiedHeatingSetpointAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeHVACSystemTypeConfigurationAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeOccupiedHeatingSetpointAttribute(value: Short) {
     // Implementation needs to be added here
   }
 
-  fun writeHVACSystemTypeConfigurationAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
+  suspend fun writeOccupiedHeatingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOccupiedHeatingSetpointAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUnoccupiedCoolingSetpointAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnoccupiedCoolingSetpointAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnoccupiedCoolingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUnoccupiedCoolingSetpointAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUnoccupiedHeatingSetpointAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnoccupiedHeatingSetpointAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnoccupiedHeatingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUnoccupiedHeatingSetpointAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinHeatSetpointLimitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinHeatSetpointLimitAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinHeatSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxHeatSetpointLimitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxHeatSetpointLimitAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxHeatSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinCoolSetpointLimitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinCoolSetpointLimitAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinCoolSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxCoolSetpointLimitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxCoolSetpointLimitAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMaxCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxCoolSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinSetpointDeadBandAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinSetpointDeadBandAttribute(value: Byte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeMinSetpointDeadBandAttribute(value: Byte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinSetpointDeadBandAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRemoteSensingAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRemoteSensingAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeRemoteSensingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRemoteSensingAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readControlSequenceOfOperationAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeControlSequenceOfOperationAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeControlSequenceOfOperationAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeControlSequenceOfOperationAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSystemModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSystemModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeSystemModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSystemModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readThermostatRunningModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeThermostatRunningModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStartOfWeekAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStartOfWeekAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfWeeklyTransitionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfWeeklyTransitionsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfDailyTransitionsAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfDailyTransitionsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTemperatureSetpointHoldAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureSetpointHoldAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureSetpointHoldAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTemperatureSetpointHoldAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTemperatureSetpointHoldDurationAttribute():
+    TemperatureSetpointHoldDurationAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureSetpointHoldDurationAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureSetpointHoldDurationAttribute(
+    value: UShort,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeHVACSystemTypeConfigurationAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeTemperatureSetpointHoldDurationAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): TemperatureSetpointHoldDurationAttribute {
     // Implementation needs to be added here
   }
 
-  fun readLocalTemperatureCalibrationAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readThermostatProgrammingOperationModeAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeLocalTemperatureCalibrationAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeThermostatProgrammingOperationModeAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeLocalTemperatureCalibrationAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
+  suspend fun writeThermostatProgrammingOperationModeAttribute(
+    value: UInt,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeLocalTemperatureCalibrationAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeThermostatProgrammingOperationModeAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readOccupiedCoolingSetpointAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readThermostatRunningStateAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOccupiedCoolingSetpointAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOccupiedCoolingSetpointAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupiedCoolingSetpointAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeThermostatRunningStateAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Integer {
     // Implementation needs to be added here
   }
 
-  fun readOccupiedHeatingSetpointAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readSetpointChangeSourceAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOccupiedHeatingSetpointAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun subscribeSetpointChangeSourceAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeOccupiedHeatingSetpointAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun readSetpointChangeAmountAttribute(): SetpointChangeAmountAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeOccupiedHeatingSetpointAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeSetpointChangeAmountAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): SetpointChangeAmountAttribute {
     // Implementation needs to be added here
   }
 
-  fun readUnoccupiedCoolingSetpointAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readSetpointChangeSourceTimestampAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun writeUnoccupiedCoolingSetpointAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUnoccupiedCoolingSetpointAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUnoccupiedCoolingSetpointAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeSetpointChangeSourceTimestampAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): Long {
     // Implementation needs to be added here
   }
 
-  fun readUnoccupiedHeatingSetpointAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupiedSetbackAttribute(): OccupiedSetbackAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeUnoccupiedHeatingSetpointAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeOccupiedSetbackAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeUnoccupiedHeatingSetpointAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeOccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeUnoccupiedHeatingSetpointAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeOccupiedSetbackAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): OccupiedSetbackAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMinHeatSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupiedSetbackMinAttribute(): OccupiedSetbackMinAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeMinHeatSetpointLimitAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMinHeatSetpointLimitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinHeatSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeOccupiedSetbackMinAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): OccupiedSetbackMinAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMaxHeatSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readOccupiedSetbackMaxAttribute(): OccupiedSetbackMaxAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeMaxHeatSetpointLimitAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMaxHeatSetpointLimitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxHeatSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeOccupiedSetbackMaxAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): OccupiedSetbackMaxAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMinCoolSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readUnoccupiedSetbackAttribute(): UnoccupiedSetbackAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeMinCoolSetpointLimitAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeUnoccupiedSetbackAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeMinCoolSetpointLimitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeUnoccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeMinCoolSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeUnoccupiedSetbackAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): UnoccupiedSetbackAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMaxCoolSetpointLimitAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readUnoccupiedSetbackMinAttribute(): UnoccupiedSetbackMinAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeMaxCoolSetpointLimitAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMaxCoolSetpointLimitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxCoolSetpointLimitAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeUnoccupiedSetbackMinAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): UnoccupiedSetbackMinAttribute {
     // Implementation needs to be added here
   }
 
-  fun readMinSetpointDeadBandAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readUnoccupiedSetbackMaxAttribute(): UnoccupiedSetbackMaxAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeMinSetpointDeadBandAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeMinSetpointDeadBandAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinSetpointDeadBandAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeUnoccupiedSetbackMaxAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): UnoccupiedSetbackMaxAttribute {
     // Implementation needs to be added here
   }
 
-  fun readRemoteSensingAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEmergencyHeatDeltaAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRemoteSensingAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeEmergencyHeatDeltaAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeRemoteSensingAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeEmergencyHeatDeltaAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRemoteSensingAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeEmergencyHeatDeltaAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACTypeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACCapacityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACCapacityAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACCapacityAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACCapacityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACRefrigerantTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACRefrigerantTypeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACRefrigerantTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACRefrigerantTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACCompressorTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACCompressorTypeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACCompressorTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACCompressorTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACErrorCodeAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACErrorCodeAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACErrorCodeAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACErrorCodeAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACLouverPositionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACLouverPositionAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeACLouverPositionAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACLouverPositionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readACCoilTemperatureAttribute(): ACCoilTemperatureAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeACCoilTemperatureAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ACCoilTemperatureAttribute {
     // Implementation needs to be added here
   }
 
-  fun readControlSequenceOfOperationAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readACCapacityformatAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeControlSequenceOfOperationAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeACCapacityformatAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeControlSequenceOfOperationAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeACCapacityformatAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeControlSequenceOfOperationAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeACCapacityformatAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readSystemModeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeSystemModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeSystemModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSystemModeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readThermostatRunningModeAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeThermostatRunningModeAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readStartOfWeekAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeStartOfWeekAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfWeeklyTransitionsAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeNumberOfWeeklyTransitionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readNumberOfDailyTransitionsAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfDailyTransitionsAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTemperatureSetpointHoldAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureSetpointHoldAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureSetpointHoldAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTemperatureSetpointHoldAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTemperatureSetpointHoldDurationAttribute(
-    callback: TemperatureSetpointHoldDurationAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureSetpointHoldDurationAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureSetpointHoldDurationAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTemperatureSetpointHoldDurationAttribute(
-    callback: TemperatureSetpointHoldDurationAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readThermostatProgrammingOperationModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeThermostatProgrammingOperationModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeThermostatProgrammingOperationModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeThermostatProgrammingOperationModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readThermostatRunningStateAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeThermostatRunningStateAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSetpointChangeSourceAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSetpointChangeSourceAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSetpointChangeAmountAttribute(callback: SetpointChangeAmountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSetpointChangeAmountAttribute(
-    callback: SetpointChangeAmountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSetpointChangeSourceTimestampAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSetpointChangeSourceTimestampAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOccupiedSetbackAttribute(callback: OccupiedSetbackAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOccupiedSetbackAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOccupiedSetbackAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupiedSetbackAttribute(
-    callback: OccupiedSetbackAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOccupiedSetbackMinAttribute(callback: OccupiedSetbackMinAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupiedSetbackMinAttribute(
-    callback: OccupiedSetbackMinAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOccupiedSetbackMaxAttribute(callback: OccupiedSetbackMaxAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOccupiedSetbackMaxAttribute(
-    callback: OccupiedSetbackMaxAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUnoccupiedSetbackAttribute(callback: UnoccupiedSetbackAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUnoccupiedSetbackAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeUnoccupiedSetbackAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUnoccupiedSetbackAttribute(
-    callback: UnoccupiedSetbackAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUnoccupiedSetbackMinAttribute(callback: UnoccupiedSetbackMinAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUnoccupiedSetbackMinAttribute(
-    callback: UnoccupiedSetbackMinAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUnoccupiedSetbackMaxAttribute(callback: UnoccupiedSetbackMaxAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUnoccupiedSetbackMaxAttribute(
-    callback: UnoccupiedSetbackMaxAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEmergencyHeatDeltaAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEmergencyHeatDeltaAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEmergencyHeatDeltaAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEmergencyHeatDeltaAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACTypeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACTypeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACCapacityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCapacityAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCapacityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACCapacityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACRefrigerantTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACRefrigerantTypeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACRefrigerantTypeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACRefrigerantTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACCompressorTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCompressorTypeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCompressorTypeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACCompressorTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACErrorCodeAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACErrorCodeAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACErrorCodeAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACErrorCodeAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACLouverPositionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACLouverPositionAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACLouverPositionAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACLouverPositionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACCoilTemperatureAttribute(callback: ACCoilTemperatureAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACCoilTemperatureAttribute(
-    callback: ACCoilTemperatureAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readACCapacityformatAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCapacityformatAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeACCapacityformatAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeACCapacityformatAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 513u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatUserInterfaceConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatUserInterfaceConfigurationCluster.kt
@@ -20,186 +20,126 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ThermostatUserInterfaceConfigurationCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readTemperatureDisplayModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureDisplayModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureDisplayModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTemperatureDisplayModeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readKeypadLockoutAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeKeypadLockoutAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeKeypadLockoutAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeKeypadLockoutAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readScheduleProgrammingVisibilityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeScheduleProgrammingVisibilityAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeScheduleProgrammingVisibilityAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeScheduleProgrammingVisibilityAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 516u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readTemperatureDisplayModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureDisplayModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureDisplayModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTemperatureDisplayModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readKeypadLockoutAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeKeypadLockoutAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeKeypadLockoutAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeKeypadLockoutAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readScheduleProgrammingVisibilityAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeScheduleProgrammingVisibilityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeScheduleProgrammingVisibilityAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeScheduleProgrammingVisibilityAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThreadNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThreadNetworkDiagnosticsCluster.kt
@@ -20,1037 +20,695 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class ThreadNetworkDiagnosticsCluster(private val endpointId: UShort) {
+  class ChannelAttribute(val value: UShort?)
+
+  class RoutingRoleAttribute(val value: UInt?)
+
+  class NetworkNameAttribute(val value: String?)
+
+  class PanIdAttribute(val value: UShort?)
+
+  class ExtendedPanIdAttribute(val value: ULong?)
+
+  class MeshLocalPrefixAttribute(val value: ByteArray?)
+
+  class NeighborTableAttribute(
+    val value: ArrayList<ChipStructs.ThreadNetworkDiagnosticsClusterNeighborTableStruct>
+  )
+
+  class RouteTableAttribute(
+    val value: ArrayList<ChipStructs.ThreadNetworkDiagnosticsClusterRouteTableStruct>
+  )
+
+  class PartitionIdAttribute(val value: UInt?)
+
+  class WeightingAttribute(val value: UByte?)
+
+  class DataVersionAttribute(val value: UByte?)
+
+  class StableDataVersionAttribute(val value: UByte?)
+
+  class LeaderRouterIdAttribute(val value: UByte?)
+
+  class ActiveTimestampAttribute(val value: ULong?)
+
+  class PendingTimestampAttribute(val value: ULong?)
+
+  class DelayAttribute(val value: UInt?)
+
+  class SecurityPolicyAttribute(
+    val value: ChipStructs.ThreadNetworkDiagnosticsClusterSecurityPolicy?
+  )
+
+  class ChannelPage0MaskAttribute(val value: ByteArray?)
+
+  class OperationalDatasetComponentsAttribute(
+    val value: ChipStructs.ThreadNetworkDiagnosticsClusterOperationalDatasetComponents?
+  )
+
+  class ActiveNetworkFaultsListAttribute(val value: ArrayList<UInt>)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetCounts() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetCounts(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChannelAttribute(): ChannelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChannelAttribute(minInterval: Int, maxInterval: Int): ChannelAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRoutingRoleAttribute(): RoutingRoleAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRoutingRoleAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): RoutingRoleAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNetworkNameAttribute(): NetworkNameAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNetworkNameAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): NetworkNameAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPanIdAttribute(): PanIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePanIdAttribute(minInterval: Int, maxInterval: Int): PanIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readExtendedPanIdAttribute(): ExtendedPanIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeExtendedPanIdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ExtendedPanIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeshLocalPrefixAttribute(): MeshLocalPrefixAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeshLocalPrefixAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeshLocalPrefixAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOverrunCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOverrunCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNeighborTableAttribute(): NeighborTableAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNeighborTableAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): NeighborTableAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRouteTableAttribute(): RouteTableAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRouteTableAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): RouteTableAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPartitionIdAttribute(): PartitionIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePartitionIdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PartitionIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWeightingAttribute(): WeightingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWeightingAttribute(minInterval: Int, maxInterval: Int): WeightingAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDataVersionAttribute(): DataVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDataVersionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): DataVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readStableDataVersionAttribute(): StableDataVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeStableDataVersionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): StableDataVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLeaderRouterIdAttribute(): LeaderRouterIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLeaderRouterIdAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): LeaderRouterIdAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDetachedRoleCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDetachedRoleCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChildRoleCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChildRoleCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRouterRoleCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRouterRoleCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLeaderRoleCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLeaderRoleCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttachAttemptCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttachAttemptCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPartitionIdChangeCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePartitionIdChangeCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBetterPartitionAttachAttemptCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBetterPartitionAttachAttemptCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readParentChangeCountAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeParentChangeCountAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxTotalCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxTotalCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxUnicastCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxUnicastCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxBroadcastCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxBroadcastCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxAckRequestedCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxAckRequestedCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxAckedCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxAckedCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxNoAckRequestedCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxNoAckRequestedCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxDataCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxDataCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxDataPollCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxDataPollCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxBeaconCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxBeaconCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxBeaconRequestCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxBeaconRequestCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxOtherCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxOtherCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxRetryCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxRetryCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxDirectMaxRetryExpiryCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxDirectMaxRetryExpiryCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxIndirectMaxRetryExpiryCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxIndirectMaxRetryExpiryCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxErrCcaCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxErrCcaCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxErrAbortCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxErrAbortCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTxErrBusyChannelCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTxErrBusyChannelCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxTotalCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxTotalCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxUnicastCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxUnicastCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxBroadcastCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxBroadcastCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxDataCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxDataCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxDataPollCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxDataPollCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxBeaconCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxBeaconCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxBeaconRequestCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxBeaconRequestCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxOtherCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxOtherCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxAddressFilteredCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxAddressFilteredCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxDestAddrFilteredCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxDestAddrFilteredCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxDuplicatedCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxDuplicatedCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrNoFrameCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrNoFrameCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrUnknownNeighborCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrUnknownNeighborCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrInvalidSrcAddrCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrInvalidSrcAddrCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrSecCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrSecCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrFcsCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrFcsCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRxErrOtherCountAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRxErrOtherCountAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveTimestampAttribute(): ActiveTimestampAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveTimestampAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActiveTimestampAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPendingTimestampAttribute(): PendingTimestampAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePendingTimestampAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PendingTimestampAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDelayAttribute(): DelayAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDelayAttribute(minInterval: Int, maxInterval: Int): DelayAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSecurityPolicyAttribute(): SecurityPolicyAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSecurityPolicyAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SecurityPolicyAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChannelPage0MaskAttribute(): ChannelPage0MaskAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChannelPage0MaskAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ChannelPage0MaskAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalDatasetComponentsAttribute(): OperationalDatasetComponentsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalDatasetComponentsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OperationalDatasetComponentsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveNetworkFaultsListAttribute(): ActiveNetworkFaultsListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveNetworkFaultsListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ActiveNetworkFaultsListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 53u
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface ChannelAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface RoutingRoleAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NetworkNameAttributeCallback {
-    fun onSuccess(value: String?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PanIdAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ExtendedPanIdAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MeshLocalPrefixAttributeCallback {
-    fun onSuccess(value: ByteArray?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NeighborTableAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ThreadNetworkDiagnosticsClusterNeighborTableStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface RouteTableAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.ThreadNetworkDiagnosticsClusterRouteTableStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PartitionIdAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface WeightingAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DataVersionAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StableDataVersionAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LeaderRouterIdAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveTimestampAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PendingTimestampAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DelayAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SecurityPolicyAttributeCallback {
-    fun onSuccess(value: ChipStructs.ThreadNetworkDiagnosticsClusterSecurityPolicy?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ChannelPage0MaskAttributeCallback {
-    fun onSuccess(value: ByteArray?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OperationalDatasetComponentsAttributeCallback {
-    fun onSuccess(value: ChipStructs.ThreadNetworkDiagnosticsClusterOperationalDatasetComponents?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ActiveNetworkFaultsListAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readChannelAttribute(callback: ChannelAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChannelAttribute(
-    callback: ChannelAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRoutingRoleAttribute(callback: RoutingRoleAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRoutingRoleAttribute(
-    callback: RoutingRoleAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNetworkNameAttribute(callback: NetworkNameAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNetworkNameAttribute(
-    callback: NetworkNameAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPanIdAttribute(callback: PanIdAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePanIdAttribute(
-    callback: PanIdAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readExtendedPanIdAttribute(callback: ExtendedPanIdAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeExtendedPanIdAttribute(
-    callback: ExtendedPanIdAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeshLocalPrefixAttribute(callback: MeshLocalPrefixAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeshLocalPrefixAttribute(
-    callback: MeshLocalPrefixAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOverrunCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOverrunCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNeighborTableAttribute(callback: NeighborTableAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNeighborTableAttribute(
-    callback: NeighborTableAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRouteTableAttribute(callback: RouteTableAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRouteTableAttribute(
-    callback: RouteTableAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPartitionIdAttribute(callback: PartitionIdAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePartitionIdAttribute(
-    callback: PartitionIdAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWeightingAttribute(callback: WeightingAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWeightingAttribute(
-    callback: WeightingAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDataVersionAttribute(callback: DataVersionAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDataVersionAttribute(
-    callback: DataVersionAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readStableDataVersionAttribute(callback: StableDataVersionAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeStableDataVersionAttribute(
-    callback: StableDataVersionAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLeaderRouterIdAttribute(callback: LeaderRouterIdAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLeaderRouterIdAttribute(
-    callback: LeaderRouterIdAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDetachedRoleCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDetachedRoleCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readChildRoleCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChildRoleCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRouterRoleCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRouterRoleCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLeaderRoleCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLeaderRoleCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttachAttemptCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttachAttemptCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPartitionIdChangeCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePartitionIdChangeCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBetterPartitionAttachAttemptCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBetterPartitionAttachAttemptCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readParentChangeCountAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeParentChangeCountAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxTotalCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxTotalCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxUnicastCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxUnicastCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxBroadcastCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxBroadcastCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxAckRequestedCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxAckRequestedCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxAckedCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxAckedCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxNoAckRequestedCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxNoAckRequestedCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxDataCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxDataCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxDataPollCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxDataPollCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxBeaconCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxBeaconCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxBeaconRequestCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxBeaconRequestCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxOtherCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxOtherCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxRetryCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxRetryCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxDirectMaxRetryExpiryCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxDirectMaxRetryExpiryCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxIndirectMaxRetryExpiryCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxIndirectMaxRetryExpiryCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxErrCcaCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxErrCcaCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxErrAbortCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxErrAbortCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTxErrBusyChannelCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTxErrBusyChannelCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxTotalCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxTotalCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxUnicastCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxUnicastCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxBroadcastCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxBroadcastCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxDataCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxDataCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxDataPollCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxDataPollCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxBeaconCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxBeaconCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxBeaconRequestCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxBeaconRequestCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxOtherCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxOtherCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxAddressFilteredCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxAddressFilteredCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxDestAddrFilteredCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxDestAddrFilteredCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxDuplicatedCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxDuplicatedCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrNoFrameCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrNoFrameCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrUnknownNeighborCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrUnknownNeighborCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrInvalidSrcAddrCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrInvalidSrcAddrCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrSecCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrSecCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrFcsCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrFcsCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRxErrOtherCountAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRxErrOtherCountAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveTimestampAttribute(callback: ActiveTimestampAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveTimestampAttribute(
-    callback: ActiveTimestampAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPendingTimestampAttribute(callback: PendingTimestampAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePendingTimestampAttribute(
-    callback: PendingTimestampAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDelayAttribute(callback: DelayAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDelayAttribute(
-    callback: DelayAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSecurityPolicyAttribute(callback: SecurityPolicyAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSecurityPolicyAttribute(
-    callback: SecurityPolicyAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readChannelPage0MaskAttribute(callback: ChannelPage0MaskAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChannelPage0MaskAttribute(
-    callback: ChannelPage0MaskAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalDatasetComponentsAttribute(
-    callback: OperationalDatasetComponentsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalDatasetComponentsAttribute(
-    callback: OperationalDatasetComponentsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveNetworkFaultsListAttribute(callback: ActiveNetworkFaultsListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveNetworkFaultsListAttribute(
-    callback: ActiveNetworkFaultsListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeFormatLocalizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeFormatLocalizationCluster.kt
@@ -20,179 +20,117 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TimeFormatLocalizationCluster(private val endpointId: UShort) {
+  class SupportedCalendarTypesAttribute(val value: ArrayList<UInt>?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readHourFormatAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeHourFormatAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeHourFormatAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeHourFormatAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readActiveCalendarTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveCalendarTypeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeActiveCalendarTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeActiveCalendarTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportedCalendarTypesAttribute(): SupportedCalendarTypesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportedCalendarTypesAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SupportedCalendarTypesAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 44u
-  }
-
-  interface SupportedCalendarTypesAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readHourFormatAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeHourFormatAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeHourFormatAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeHourFormatAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readActiveCalendarTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveCalendarTypeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeActiveCalendarTypeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeActiveCalendarTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportedCalendarTypesAttribute(callback: SupportedCalendarTypesAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportedCalendarTypesAttribute(
-    callback: SupportedCalendarTypesAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeSynchronizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeSynchronizationCluster.kt
@@ -20,397 +20,262 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TimeSynchronizationCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 56u
-  }
+  class SetTimeZoneResponse(val DSTOffsetRequired: Boolean)
 
-  fun setUTCTime(
-    callback: DefaultClusterCallback,
-    UTCTime: Long,
-    granularity: Integer,
-    timeSource: Integer?
-  ) {
+  class UTCTimeAttribute(val value: ULong?)
+
+  class TrustedTimeSourceAttribute(
+    val value: ChipStructs.TimeSynchronizationClusterTrustedTimeSourceStruct?
+  )
+
+  class DefaultNTPAttribute(val value: String?)
+
+  class TimeZoneAttribute(
+    val value: ArrayList<ChipStructs.TimeSynchronizationClusterTimeZoneStruct>?
+  )
+
+  class DSTOffsetAttribute(
+    val value: ArrayList<ChipStructs.TimeSynchronizationClusterDSTOffsetStruct>?
+  )
+
+  class LocalTimeAttribute(val value: ULong?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun setUTCTime(UTCTime: ULong, granularity: UInt, timeSource: UInt?) {
     // Implementation needs to be added here
   }
 
-  fun setUTCTime(
-    callback: DefaultClusterCallback,
-    UTCTime: Long,
-    granularity: Integer,
-    timeSource: Integer?,
+  suspend fun setUTCTime(
+    UTCTime: ULong,
+    granularity: UInt,
+    timeSource: UInt?,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun setTrustedTimeSource(
-    callback: DefaultClusterCallback,
+  suspend fun setTrustedTimeSource(
     trustedTimeSource: ChipStructs.TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct?
   ) {
     // Implementation needs to be added here
   }
 
-  fun setTrustedTimeSource(
-    callback: DefaultClusterCallback,
+  suspend fun setTrustedTimeSource(
     trustedTimeSource: ChipStructs.TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct?,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun setTimeZone(
-    callback: SetTimeZoneResponseCallback,
+  suspend fun setTimeZone(
     timeZone: ArrayList<ChipStructs.TimeSynchronizationClusterTimeZoneStruct>
-  ) {
+  ): SetTimeZoneResponse {
     // Implementation needs to be added here
   }
 
-  fun setTimeZone(
-    callback: SetTimeZoneResponseCallback,
+  suspend fun setTimeZone(
     timeZone: ArrayList<ChipStructs.TimeSynchronizationClusterTimeZoneStruct>,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): SetTimeZoneResponse {
     // Implementation needs to be added here
   }
 
-  fun setDSTOffset(
-    callback: DefaultClusterCallback,
+  suspend fun setDSTOffset(
     DSTOffset: ArrayList<ChipStructs.TimeSynchronizationClusterDSTOffsetStruct>
   ) {
     // Implementation needs to be added here
   }
 
-  fun setDSTOffset(
-    callback: DefaultClusterCallback,
+  suspend fun setDSTOffset(
     DSTOffset: ArrayList<ChipStructs.TimeSynchronizationClusterDSTOffsetStruct>,
     timedInvokeTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun setDefaultNTP(callback: DefaultClusterCallback, defaultNTP: String?) {
+  suspend fun setDefaultNTP(defaultNTP: String?) {
     // Implementation needs to be added here
   }
 
-  fun setDefaultNTP(
-    callback: DefaultClusterCallback,
-    defaultNTP: String?,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun setDefaultNTP(defaultNTP: String?, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  interface SetTimeZoneResponseCallback {
-    fun onSuccess(DSTOffsetRequired: Boolean)
-
-    fun onError(error: Exception)
-  }
-
-  interface UTCTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TrustedTimeSourceAttributeCallback {
-    fun onSuccess(value: ChipStructs.TimeSynchronizationClusterTrustedTimeSourceStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DefaultNTPAttributeCallback {
-    fun onSuccess(value: String?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TimeZoneAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.TimeSynchronizationClusterTimeZoneStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface DSTOffsetAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.TimeSynchronizationClusterDSTOffsetStruct>?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface LocalTimeAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readUTCTimeAttribute(callback: UTCTimeAttributeCallback) {
+  suspend fun readUTCTimeAttribute(): UTCTimeAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeUTCTimeAttribute(
-    callback: UTCTimeAttributeCallback,
+  suspend fun subscribeUTCTimeAttribute(minInterval: Int, maxInterval: Int): UTCTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGranularityAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGranularityAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTimeSourceAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTimeSourceAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTrustedTimeSourceAttribute(): TrustedTimeSourceAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTrustedTimeSourceAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): TrustedTimeSourceAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGranularityAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readDefaultNTPAttribute(): DefaultNTPAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGranularityAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeDefaultNTPAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): DefaultNTPAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTimeSourceAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readTimeZoneAttribute(): TimeZoneAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeTimeSourceAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeTimeZoneAttribute(minInterval: Int, maxInterval: Int): TimeZoneAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDSTOffsetAttribute(): DSTOffsetAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDSTOffsetAttribute(minInterval: Int, maxInterval: Int): DSTOffsetAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLocalTimeAttribute(): LocalTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLocalTimeAttribute(minInterval: Int, maxInterval: Int): LocalTimeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTimeZoneDatabaseAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTimeZoneDatabaseAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNTPServerAvailableAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNTPServerAvailableAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTimeZoneListMaxSizeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTimeZoneListMaxSizeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readDSTOffsetListMaxSizeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeDSTOffsetListMaxSizeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSupportsDNSResolveAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSupportsDNSResolveAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTrustedTimeSourceAttribute(callback: TrustedTimeSourceAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeTrustedTimeSourceAttribute(
-    callback: TrustedTimeSourceAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readDefaultNTPAttribute(callback: DefaultNTPAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeDefaultNTPAttribute(
-    callback: DefaultNTPAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTimeZoneAttribute(callback: TimeZoneAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeTimeZoneAttribute(
-    callback: TimeZoneAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readDSTOffsetAttribute(callback: DSTOffsetAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeDSTOffsetAttribute(
-    callback: DSTOffsetAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readLocalTimeAttribute(callback: LocalTimeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLocalTimeAttribute(
-    callback: LocalTimeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTimeZoneDatabaseAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTimeZoneDatabaseAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNTPServerAvailableAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNTPServerAvailableAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTimeZoneListMaxSizeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTimeZoneListMaxSizeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readDSTOffsetListMaxSizeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeDSTOffsetListMaxSizeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSupportsDNSResolveAttribute(callback: BooleanAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSupportsDNSResolveAttribute(
-    callback: BooleanAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 56u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurementCluster.kt
@@ -20,283 +20,188 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class TotalVolatileOrganicCompoundsConcentrationMeasurementCluster(private val endpointId: UShort) {
+  class MeasuredValueAttribute(val value: Float?)
+
+  class MinMeasuredValueAttribute(val value: Float?)
+
+  class MaxMeasuredValueAttribute(val value: Float?)
+
+  class PeakMeasuredValueAttribute(val value: Float?)
+
+  class AverageMeasuredValueAttribute(val value: Float?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMeasuredValueAttribute(): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMinMeasuredValueAttribute(): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMinMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MinMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMaxMeasuredValueAttribute(): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMaxMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): MaxMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueAttribute(): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PeakMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPeakMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePeakMeasuredValueWindowAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueAttribute(): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AverageMeasuredValueAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAverageMeasuredValueWindowAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAverageMeasuredValueWindowAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUncertaintyAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUncertaintyAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readMeasurementMediumAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMeasurementMediumAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readLevelValueAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeLevelValueAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1070u
-  }
-
-  interface MeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MinMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface MaxMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PeakMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AverageMeasuredValueAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMeasuredValueAttribute(callback: MeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasuredValueAttribute(
-    callback: MeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMinMeasuredValueAttribute(callback: MinMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMinMeasuredValueAttribute(
-    callback: MinMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMaxMeasuredValueAttribute(callback: MaxMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMaxMeasuredValueAttribute(
-    callback: MaxMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueAttribute(callback: PeakMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueAttribute(
-    callback: PeakMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPeakMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePeakMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueAttribute(callback: AverageMeasuredValueAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueAttribute(
-    callback: AverageMeasuredValueAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAverageMeasuredValueWindowAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAverageMeasuredValueWindowAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readUncertaintyAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeUncertaintyAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readMeasurementMediumAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMeasurementMediumAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readLevelValueAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeLevelValueAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitLocalizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitLocalizationCluster.kt
@@ -20,135 +20,88 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class UnitLocalizationCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readTemperatureUnitAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureUnitAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeTemperatureUnitAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTemperatureUnitAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 45u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readTemperatureUnitAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureUnitAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeTemperatureUnitAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTemperatureUnitAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitTestingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitTestingCluster.kt
@@ -20,2855 +20,1957 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class UnitTestingCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 4294048773u
-  }
+  class TestSpecificResponse(val returnValue: UByte)
 
-  fun test(callback: DefaultClusterCallback) {
+  class TestAddArgumentsResponse(val returnValue: UByte)
+
+  class TestSimpleArgumentResponse(val returnValue: Boolean)
+
+  class TestStructArrayArgumentResponse(
+    val arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>,
+    val arg2: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>,
+    val arg3: ArrayList<UInt>,
+    val arg4: ArrayList<Boolean>,
+    val arg5: UInt,
+    val arg6: Boolean
+  )
+
+  class BooleanResponse(val value: Boolean)
+
+  class TestListInt8UReverseResponse(val arg1: ArrayList<UByte>)
+
+  class TestEnumsResponse(val arg1: UShort, val arg2: UInt)
+
+  class TestNullableOptionalResponse(
+    val wasPresent: Boolean,
+    val wasNull: Boolean?,
+    val value: UByte?,
+    val originalValue: UByte?
+  )
+
+  class TestComplexNullableOptionalResponse(
+    val nullableIntWasNull: Boolean,
+    val nullableIntValue: UShort?,
+    val optionalIntWasPresent: Boolean,
+    val optionalIntValue: UShort?,
+    val nullableOptionalIntWasPresent: Boolean,
+    val nullableOptionalIntWasNull: Boolean?,
+    val nullableOptionalIntValue: UShort?,
+    val nullableStringWasNull: Boolean,
+    val nullableStringValue: String?,
+    val optionalStringWasPresent: Boolean,
+    val optionalStringValue: String?,
+    val nullableOptionalStringWasPresent: Boolean,
+    val nullableOptionalStringWasNull: Boolean?,
+    val nullableOptionalStringValue: String?,
+    val nullableStructWasNull: Boolean,
+    val nullableStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
+    val optionalStructWasPresent: Boolean,
+    val optionalStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
+    val nullableOptionalStructWasPresent: Boolean,
+    val nullableOptionalStructWasNull: Boolean?,
+    val nullableOptionalStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
+    val nullableListWasNull: Boolean,
+    val nullableListValue: ArrayList<UInt>?,
+    val optionalListWasPresent: Boolean,
+    val optionalListValue: ArrayList<UInt>?,
+    val nullableOptionalListWasPresent: Boolean,
+    val nullableOptionalListWasNull: Boolean?,
+    val nullableOptionalListValue: ArrayList<UInt>?
+  )
+
+  class SimpleStructResponse(val arg1: ChipStructs.UnitTestingClusterSimpleStruct)
+
+  class TestEmitTestEventResponse(val value: ULong)
+
+  class TestEmitTestFabricScopedEventResponse(val value: ULong)
+
+  class ListInt8uAttribute(val value: ArrayList<UByte>)
+
+  class ListOctetStringAttribute(val value: ArrayList<ByteArray>)
+
+  class ListStructOctetStringAttribute(
+    val value: ArrayList<ChipStructs.UnitTestingClusterTestListStructOctet>
+  )
+
+  class ListNullablesAndOptionalsStructAttribute(
+    val value: ArrayList<ChipStructs.UnitTestingClusterNullablesAndOptionalsStruct>
+  )
+
+  class StructAttrAttribute(val value: ChipStructs.UnitTestingClusterSimpleStruct)
+
+  class ListLongOctetStringAttribute(val value: ArrayList<ByteArray>)
+
+  class ListFabricScopedAttribute(
+    val value: ArrayList<ChipStructs.UnitTestingClusterTestFabricScoped>
+  )
+
+  class NullableBooleanAttribute(val value: Boolean?)
+
+  class NullableBitmap8Attribute(val value: UInt?)
+
+  class NullableBitmap16Attribute(val value: UInt?)
+
+  class NullableBitmap32Attribute(val value: ULong?)
+
+  class NullableBitmap64Attribute(val value: ULong?)
+
+  class NullableInt8uAttribute(val value: UByte?)
+
+  class NullableInt16uAttribute(val value: UShort?)
+
+  class NullableInt24uAttribute(val value: UInt?)
+
+  class NullableInt32uAttribute(val value: UInt?)
+
+  class NullableInt40uAttribute(val value: ULong?)
+
+  class NullableInt48uAttribute(val value: ULong?)
+
+  class NullableInt56uAttribute(val value: ULong?)
+
+  class NullableInt64uAttribute(val value: ULong?)
+
+  class NullableInt8sAttribute(val value: Byte?)
+
+  class NullableInt16sAttribute(val value: Short?)
+
+  class NullableInt24sAttribute(val value: Int?)
+
+  class NullableInt32sAttribute(val value: Int?)
+
+  class NullableInt40sAttribute(val value: Long?)
+
+  class NullableInt48sAttribute(val value: Long?)
+
+  class NullableInt56sAttribute(val value: Long?)
+
+  class NullableInt64sAttribute(val value: Long?)
+
+  class NullableEnum8Attribute(val value: UInt?)
+
+  class NullableEnum16Attribute(val value: UInt?)
+
+  class NullableFloatSingleAttribute(val value: Float?)
+
+  class NullableFloatDoubleAttribute(val value: Double?)
+
+  class NullableOctetStringAttribute(val value: ByteArray?)
+
+  class NullableCharStringAttribute(val value: String?)
+
+  class NullableEnumAttrAttribute(val value: UInt?)
+
+  class NullableStructAttribute(val value: ChipStructs.UnitTestingClusterSimpleStruct?)
+
+  class NullableRangeRestrictedInt8uAttribute(val value: UByte?)
+
+  class NullableRangeRestrictedInt8sAttribute(val value: Byte?)
+
+  class NullableRangeRestrictedInt16uAttribute(val value: UShort?)
+
+  class NullableRangeRestrictedInt16sAttribute(val value: Short?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun test() {
     // Implementation needs to be added here
   }
 
-  fun test(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun test(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun testNotHandled(callback: DefaultClusterCallback) {
+  suspend fun testNotHandled() {
     // Implementation needs to be added here
   }
 
-  fun testNotHandled(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun testNotHandled(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun testSpecific(callback: TestSpecificResponseCallback) {
+  suspend fun testSpecific(): TestSpecificResponse {
     // Implementation needs to be added here
   }
 
-  fun testSpecific(callback: TestSpecificResponseCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun testSpecific(timedInvokeTimeoutMs: Int): TestSpecificResponse {
     // Implementation needs to be added here
   }
 
-  fun testUnknownCommand(callback: DefaultClusterCallback) {
+  suspend fun testUnknownCommand() {
     // Implementation needs to be added here
   }
 
-  fun testUnknownCommand(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun testUnknownCommand(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun testAddArguments(callback: TestAddArgumentsResponseCallback, arg1: Integer, arg2: Integer) {
+  suspend fun testAddArguments(arg1: UByte, arg2: UByte): TestAddArgumentsResponse {
     // Implementation needs to be added here
   }
 
-  fun testAddArguments(
-    callback: TestAddArgumentsResponseCallback,
-    arg1: Integer,
-    arg2: Integer,
+  suspend fun testAddArguments(
+    arg1: UByte,
+    arg2: UByte,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestAddArgumentsResponse {
     // Implementation needs to be added here
   }
 
-  fun testSimpleArgumentRequest(callback: TestSimpleArgumentResponseCallback, arg1: Boolean) {
+  suspend fun testSimpleArgumentRequest(arg1: Boolean): TestSimpleArgumentResponse {
     // Implementation needs to be added here
   }
 
-  fun testSimpleArgumentRequest(
-    callback: TestSimpleArgumentResponseCallback,
+  suspend fun testSimpleArgumentRequest(
     arg1: Boolean,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestSimpleArgumentResponse {
     // Implementation needs to be added here
   }
 
-  fun testStructArrayArgumentRequest(
-    callback: TestStructArrayArgumentResponseCallback,
+  suspend fun testStructArrayArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>,
     arg2: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>,
-    arg3: ArrayList<Integer>,
+    arg3: ArrayList<UInt>,
     arg4: ArrayList<Boolean>,
-    arg5: Integer,
+    arg5: UInt,
     arg6: Boolean
-  ) {
+  ): TestStructArrayArgumentResponse {
     // Implementation needs to be added here
   }
 
-  fun testStructArrayArgumentRequest(
-    callback: TestStructArrayArgumentResponseCallback,
+  suspend fun testStructArrayArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>,
     arg2: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>,
-    arg3: ArrayList<Integer>,
+    arg3: ArrayList<UInt>,
     arg4: ArrayList<Boolean>,
-    arg5: Integer,
+    arg5: UInt,
     arg6: Boolean,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestStructArrayArgumentResponse {
     // Implementation needs to be added here
   }
 
-  fun testStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testStructArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterSimpleStruct
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testStructArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterSimpleStruct,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testNestedStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testNestedStructArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterNestedStruct
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testNestedStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testNestedStructArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterNestedStruct,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testListStructArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListStructArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testListStructArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListInt8UArgumentRequest(callback: BooleanResponseCallback, arg1: ArrayList<Integer>) {
+  suspend fun testListInt8UArgumentRequest(arg1: ArrayList<UByte>): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListInt8UArgumentRequest(
-    callback: BooleanResponseCallback,
-    arg1: ArrayList<Integer>,
+  suspend fun testListInt8UArgumentRequest(
+    arg1: ArrayList<UByte>,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testNestedStructListArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testNestedStructListArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterNestedStructList
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testNestedStructListArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testNestedStructListArgumentRequest(
     arg1: ChipStructs.UnitTestingClusterNestedStructList,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListNestedStructListArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testListNestedStructListArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListNestedStructListArgumentRequest(
-    callback: BooleanResponseCallback,
+  suspend fun testListNestedStructListArgumentRequest(
     arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): BooleanResponse {
     // Implementation needs to be added here
   }
 
-  fun testListInt8UReverseRequest(
-    callback: TestListInt8UReverseResponseCallback,
-    arg1: ArrayList<Integer>
-  ) {
+  suspend fun testListInt8UReverseRequest(arg1: ArrayList<UByte>): TestListInt8UReverseResponse {
     // Implementation needs to be added here
   }
 
-  fun testListInt8UReverseRequest(
-    callback: TestListInt8UReverseResponseCallback,
-    arg1: ArrayList<Integer>,
+  suspend fun testListInt8UReverseRequest(
+    arg1: ArrayList<UByte>,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestListInt8UReverseResponse {
     // Implementation needs to be added here
   }
 
-  fun testEnumsRequest(callback: TestEnumsResponseCallback, arg1: Integer, arg2: Integer) {
+  suspend fun testEnumsRequest(arg1: UShort, arg2: UInt): TestEnumsResponse {
     // Implementation needs to be added here
   }
 
-  fun testEnumsRequest(
-    callback: TestEnumsResponseCallback,
-    arg1: Integer,
-    arg2: Integer,
+  suspend fun testEnumsRequest(
+    arg1: UShort,
+    arg2: UInt,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestEnumsResponse {
     // Implementation needs to be added here
   }
 
-  fun testNullableOptionalRequest(callback: TestNullableOptionalResponseCallback, arg1: Integer?) {
+  suspend fun testNullableOptionalRequest(arg1: UByte?): TestNullableOptionalResponse {
     // Implementation needs to be added here
   }
 
-  fun testNullableOptionalRequest(
-    callback: TestNullableOptionalResponseCallback,
-    arg1: Integer?,
+  suspend fun testNullableOptionalRequest(
+    arg1: UByte?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestNullableOptionalResponse {
     // Implementation needs to be added here
   }
 
-  fun testComplexNullableOptionalRequest(
-    callback: TestComplexNullableOptionalResponseCallback,
-    nullableInt: Integer?,
-    optionalInt: Integer?,
-    nullableOptionalInt: Integer?,
+  suspend fun testComplexNullableOptionalRequest(
+    nullableInt: UShort?,
+    optionalInt: UShort?,
+    nullableOptionalInt: UShort?,
     nullableString: String?,
     optionalString: String?,
     nullableOptionalString: String?,
     nullableStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
     optionalStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
     nullableOptionalStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
-    nullableList: ArrayList<Integer>?,
-    optionalList: ArrayList<Integer>?,
-    nullableOptionalList: ArrayList<Integer>?
-  ) {
+    nullableList: ArrayList<UInt>?,
+    optionalList: ArrayList<UInt>?,
+    nullableOptionalList: ArrayList<UInt>?
+  ): TestComplexNullableOptionalResponse {
     // Implementation needs to be added here
   }
 
-  fun testComplexNullableOptionalRequest(
-    callback: TestComplexNullableOptionalResponseCallback,
-    nullableInt: Integer?,
-    optionalInt: Integer?,
-    nullableOptionalInt: Integer?,
+  suspend fun testComplexNullableOptionalRequest(
+    nullableInt: UShort?,
+    optionalInt: UShort?,
+    nullableOptionalInt: UShort?,
     nullableString: String?,
     optionalString: String?,
     nullableOptionalString: String?,
     nullableStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
     optionalStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
     nullableOptionalStruct: ChipStructs.UnitTestingClusterSimpleStruct?,
-    nullableList: ArrayList<Integer>?,
-    optionalList: ArrayList<Integer>?,
-    nullableOptionalList: ArrayList<Integer>?,
+    nullableList: ArrayList<UInt>?,
+    optionalList: ArrayList<UInt>?,
+    nullableOptionalList: ArrayList<UInt>?,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestComplexNullableOptionalResponse {
     // Implementation needs to be added here
   }
 
-  fun simpleStructEchoRequest(
-    callback: SimpleStructResponseCallback,
+  suspend fun simpleStructEchoRequest(
     arg1: ChipStructs.UnitTestingClusterSimpleStruct
-  ) {
+  ): SimpleStructResponse {
     // Implementation needs to be added here
   }
 
-  fun simpleStructEchoRequest(
-    callback: SimpleStructResponseCallback,
+  suspend fun simpleStructEchoRequest(
     arg1: ChipStructs.UnitTestingClusterSimpleStruct,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): SimpleStructResponse {
     // Implementation needs to be added here
   }
 
-  fun timedInvokeRequest(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
+  suspend fun timedInvokeRequest(timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun testSimpleOptionalArgumentRequest(callback: DefaultClusterCallback, arg1: Boolean?) {
+  suspend fun testSimpleOptionalArgumentRequest(arg1: Boolean?) {
     // Implementation needs to be added here
   }
 
-  fun testSimpleOptionalArgumentRequest(
-    callback: DefaultClusterCallback,
-    arg1: Boolean?,
-    timedInvokeTimeoutMs: Int
-  ) {
+  suspend fun testSimpleOptionalArgumentRequest(arg1: Boolean?, timedInvokeTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun testEmitTestEventRequest(
-    callback: TestEmitTestEventResponseCallback,
-    arg1: Integer,
-    arg2: Integer,
+  suspend fun testEmitTestEventRequest(
+    arg1: UByte,
+    arg2: UInt,
     arg3: Boolean
-  ) {
+  ): TestEmitTestEventResponse {
     // Implementation needs to be added here
   }
 
-  fun testEmitTestEventRequest(
-    callback: TestEmitTestEventResponseCallback,
-    arg1: Integer,
-    arg2: Integer,
+  suspend fun testEmitTestEventRequest(
+    arg1: UByte,
+    arg2: UInt,
     arg3: Boolean,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestEmitTestEventResponse {
     // Implementation needs to be added here
   }
 
-  fun testEmitTestFabricScopedEventRequest(
-    callback: TestEmitTestFabricScopedEventResponseCallback,
-    arg1: Integer
-  ) {
+  suspend fun testEmitTestFabricScopedEventRequest(
+    arg1: UByte
+  ): TestEmitTestFabricScopedEventResponse {
     // Implementation needs to be added here
   }
 
-  fun testEmitTestFabricScopedEventRequest(
-    callback: TestEmitTestFabricScopedEventResponseCallback,
-    arg1: Integer,
+  suspend fun testEmitTestFabricScopedEventRequest(
+    arg1: UByte,
     timedInvokeTimeoutMs: Int
-  ) {
+  ): TestEmitTestFabricScopedEventResponse {
     // Implementation needs to be added here
   }
 
-  interface TestSpecificResponseCallback {
-    fun onSuccess(returnValue: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestAddArgumentsResponseCallback {
-    fun onSuccess(returnValue: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestSimpleArgumentResponseCallback {
-    fun onSuccess(returnValue: Boolean)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestStructArrayArgumentResponseCallback {
-    fun onSuccess(
-      arg1: ArrayList<ChipStructs.UnitTestingClusterNestedStructList>,
-      arg2: ArrayList<ChipStructs.UnitTestingClusterSimpleStruct>,
-      arg3: ArrayList<Integer>,
-      arg4: ArrayList<Boolean>,
-      arg5: Integer,
-      arg6: Boolean
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface BooleanResponseCallback {
-    fun onSuccess(value: Boolean)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestListInt8UReverseResponseCallback {
-    fun onSuccess(arg1: ArrayList<Integer>)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestEnumsResponseCallback {
-    fun onSuccess(arg1: Integer, arg2: Integer)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestNullableOptionalResponseCallback {
-    fun onSuccess(wasPresent: Boolean, wasNull: Boolean?, value: Integer?, originalValue: Integer?)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestComplexNullableOptionalResponseCallback {
-    fun onSuccess(
-      nullableIntWasNull: Boolean,
-      nullableIntValue: Integer?,
-      optionalIntWasPresent: Boolean,
-      optionalIntValue: Integer?,
-      nullableOptionalIntWasPresent: Boolean,
-      nullableOptionalIntWasNull: Boolean?,
-      nullableOptionalIntValue: Integer?,
-      nullableStringWasNull: Boolean,
-      nullableStringValue: String?,
-      optionalStringWasPresent: Boolean,
-      optionalStringValue: String?,
-      nullableOptionalStringWasPresent: Boolean,
-      nullableOptionalStringWasNull: Boolean?,
-      nullableOptionalStringValue: String?,
-      nullableStructWasNull: Boolean,
-      nullableStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
-      optionalStructWasPresent: Boolean,
-      optionalStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
-      nullableOptionalStructWasPresent: Boolean,
-      nullableOptionalStructWasNull: Boolean?,
-      nullableOptionalStructValue: ChipStructs.UnitTestingClusterSimpleStruct?,
-      nullableListWasNull: Boolean,
-      nullableListValue: ArrayList<Integer>?,
-      optionalListWasPresent: Boolean,
-      optionalListValue: ArrayList<Integer>?,
-      nullableOptionalListWasPresent: Boolean,
-      nullableOptionalListWasNull: Boolean?,
-      nullableOptionalListValue: ArrayList<Integer>?
-    )
-
-    fun onError(error: Exception)
-  }
-
-  interface SimpleStructResponseCallback {
-    fun onSuccess(arg1: ChipStructs.UnitTestingClusterSimpleStruct)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestEmitTestEventResponseCallback {
-    fun onSuccess(value: Long)
-
-    fun onError(error: Exception)
-  }
-
-  interface TestEmitTestFabricScopedEventResponseCallback {
-    fun onSuccess(value: Long)
-
-    fun onError(error: Exception)
-  }
-
-  interface ListInt8uAttributeCallback {
-    fun onSuccess(value: ArrayList<Integer>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ListOctetStringAttributeCallback {
-    fun onSuccess(value: ArrayList<ByteArray>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ListStructOctetStringAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.UnitTestingClusterTestListStructOctet>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ListNullablesAndOptionalsStructAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.UnitTestingClusterNullablesAndOptionalsStruct>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface StructAttrAttributeCallback {
-    fun onSuccess(value: ChipStructs.UnitTestingClusterSimpleStruct)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ListLongOctetStringAttributeCallback {
-    fun onSuccess(value: ArrayList<ByteArray>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ListFabricScopedAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.UnitTestingClusterTestFabricScoped>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableBooleanAttributeCallback {
-    fun onSuccess(value: Boolean?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableBitmap8AttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableBitmap16AttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableBitmap32AttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableBitmap64AttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt8uAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt16uAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt24uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt32uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt40uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt48uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt56uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt64uAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt8sAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt16sAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt24sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt32sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt40sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt48sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt56sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableInt64sAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableEnum8AttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableEnum16AttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableFloatSingleAttributeCallback {
-    fun onSuccess(value: Float?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableFloatDoubleAttributeCallback {
-    fun onSuccess(value: Double?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableOctetStringAttributeCallback {
-    fun onSuccess(value: ByteArray?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableCharStringAttributeCallback {
-    fun onSuccess(value: String?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableEnumAttrAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableStructAttributeCallback {
-    fun onSuccess(value: ChipStructs.UnitTestingClusterSimpleStruct?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableRangeRestrictedInt8uAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableRangeRestrictedInt8sAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableRangeRestrictedInt16uAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface NullableRangeRestrictedInt16sAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readBooleanAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readBooleanAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun writeBooleanAttribute(callback: DefaultClusterCallback, value: Boolean) {
+  suspend fun writeBooleanAttribute(value: Boolean) {
     // Implementation needs to be added here
   }
 
-  fun writeBooleanAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeBooleanAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBitmap8Attribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap8Attribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBitmap8Attribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBitmap16Attribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap16Attribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBitmap16Attribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBitmap32Attribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap32Attribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBitmap32Attribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBitmap64Attribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap64Attribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBitmap64Attribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt8uAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt8uAttribute(value: UByte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt8uAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt16uAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt16uAttribute(value: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt16uAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt24uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt24uAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt24uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt32uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt32uAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt32uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt40uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt40uAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt40uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt48uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt48uAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt48uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt56uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt56uAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt56uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt64uAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt64uAttribute(value: ULong) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt64uAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt8sAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt8sAttribute(value: Byte) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt8sAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt16sAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt16sAttribute(value: Short) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt16sAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt24sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt24sAttribute(value: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt24sAttribute(value: Int, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt24sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt32sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt32sAttribute(value: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt32sAttribute(value: Int, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt32sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt40sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt40sAttribute(value: Long) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt40sAttribute(value: Long, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt40sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt48sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt48sAttribute(value: Long) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt48sAttribute(value: Long, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt48sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt56sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt56sAttribute(value: Long) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt56sAttribute(value: Long, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt56sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInt64sAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt64sAttribute(value: Long) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeInt64sAttribute(value: Long, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInt64sAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnum8Attribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnum8Attribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnum8Attribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEnum16Attribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnum16Attribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEnum16Attribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFloatSingleAttribute(): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFloatSingleAttribute(value: Float) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFloatSingleAttribute(minInterval: Int, maxInterval: Int): Float {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFloatDoubleAttribute(): Double {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFloatDoubleAttribute(value: Double) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFloatDoubleAttribute(minInterval: Int, maxInterval: Int): Double {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOctetStringAttribute(): OctetString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOctetStringAttribute(value: ByteArray) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOctetStringAttribute(minInterval: Int, maxInterval: Int): OctetString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readListInt8uAttribute(): ListInt8uAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeListInt8uAttribute(value: ArrayList<UByte>) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeListInt8uAttribute(value: ArrayList<UByte>, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeListInt8uAttribute(minInterval: Int, maxInterval: Int): ListInt8uAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readListOctetStringAttribute(): ListOctetStringAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeListOctetStringAttribute(value: ArrayList<ByteArray>) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeListOctetStringAttribute(value: ArrayList<ByteArray>, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeListOctetStringAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ListOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun readBitmap8Attribute(callback: IntegerAttributeCallback) {
+  suspend fun readListStructOctetStringAttribute(): ListStructOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeBitmap8Attribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap8Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBitmap8Attribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBitmap16Attribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap16Attribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap16Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBitmap16Attribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBitmap32Attribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap32Attribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap32Attribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBitmap32Attribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBitmap64Attribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap64Attribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeBitmap64Attribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBitmap64Attribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt8uAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt8uAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt8uAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt16uAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt16uAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt16uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt16uAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt24uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt24uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt24uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt24uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt32uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt32uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt32uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt32uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt40uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt40uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt40uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt40uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt48uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt48uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt48uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt48uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt56uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt56uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt56uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt56uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt64uAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt64uAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt64uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt64uAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt8sAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt8sAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt8sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt8sAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt16sAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt16sAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt16sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt16sAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt24sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt24sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt24sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt24sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt32sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt32sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt32sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt32sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt40sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt40sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt40sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt40sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt48sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt48sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt48sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt48sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt56sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt56sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt56sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt56sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInt64sAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt64sAttribute(callback: DefaultClusterCallback, value: Long) {
-    // Implementation needs to be added here
-  }
-
-  fun writeInt64sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInt64sAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnum8Attribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnum8Attribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnum8Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnum8Attribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEnum16Attribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnum16Attribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeEnum16Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEnum16Attribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFloatSingleAttribute(callback: FloatAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFloatSingleAttribute(callback: DefaultClusterCallback, value: Float) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFloatSingleAttribute(
-    callback: DefaultClusterCallback,
-    value: Float,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFloatSingleAttribute(
-    callback: FloatAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFloatDoubleAttribute(callback: DoubleAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFloatDoubleAttribute(callback: DefaultClusterCallback, value: Double) {
-    // Implementation needs to be added here
-  }
-
-  fun writeFloatDoubleAttribute(
-    callback: DefaultClusterCallback,
-    value: Double,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFloatDoubleAttribute(
-    callback: DoubleAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOctetStringAttribute(callback: OctetStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOctetStringAttribute(callback: DefaultClusterCallback, value: ByteArray) {
-    // Implementation needs to be added here
-  }
-
-  fun writeOctetStringAttribute(
-    callback: DefaultClusterCallback,
-    value: ByteArray,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOctetStringAttribute(
-    callback: OctetStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readListInt8uAttribute(callback: ListInt8uAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeListInt8uAttribute(callback: DefaultClusterCallback, value: ArrayList<Integer>) {
-    // Implementation needs to be added here
-  }
-
-  fun writeListInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: ArrayList<Integer>,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeListInt8uAttribute(
-    callback: ListInt8uAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readListOctetStringAttribute(callback: ListOctetStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeListOctetStringAttribute(callback: DefaultClusterCallback, value: ArrayList<ByteArray>) {
-    // Implementation needs to be added here
-  }
-
-  fun writeListOctetStringAttribute(
-    callback: DefaultClusterCallback,
-    value: ArrayList<ByteArray>,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeListOctetStringAttribute(
-    callback: ListOctetStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readListStructOctetStringAttribute(callback: ListStructOctetStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeListStructOctetStringAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListStructOctetStringAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterTestListStructOctet>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeListStructOctetStringAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListStructOctetStringAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterTestListStructOctet>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeListStructOctetStringAttribute(
-    callback: ListStructOctetStringAttributeCallback,
+  suspend fun subscribeListStructOctetStringAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ListStructOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun readLongOctetStringAttribute(callback: OctetStringAttributeCallback) {
+  suspend fun readLongOctetStringAttribute(): OctetString {
     // Implementation needs to be added here
   }
 
-  fun writeLongOctetStringAttribute(callback: DefaultClusterCallback, value: ByteArray) {
+  suspend fun writeLongOctetStringAttribute(value: ByteArray) {
     // Implementation needs to be added here
   }
 
-  fun writeLongOctetStringAttribute(
-    callback: DefaultClusterCallback,
-    value: ByteArray,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeLongOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeLongOctetStringAttribute(
-    callback: OctetStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeLongOctetStringAttribute(minInterval: Int, maxInterval: Int): OctetString {
     // Implementation needs to be added here
   }
 
-  fun readCharStringAttribute(callback: CharStringAttributeCallback) {
+  suspend fun readCharStringAttribute(): CharString {
     // Implementation needs to be added here
   }
 
-  fun writeCharStringAttribute(callback: DefaultClusterCallback, value: String) {
+  suspend fun writeCharStringAttribute(value: String) {
     // Implementation needs to be added here
   }
 
-  fun writeCharStringAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeCharStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeCharStringAttribute(minInterval: Int, maxInterval: Int): CharString {
     // Implementation needs to be added here
   }
 
-  fun readLongCharStringAttribute(callback: CharStringAttributeCallback) {
+  suspend fun readLongCharStringAttribute(): CharString {
     // Implementation needs to be added here
   }
 
-  fun writeLongCharStringAttribute(callback: DefaultClusterCallback, value: String) {
+  suspend fun writeLongCharStringAttribute(value: String) {
     // Implementation needs to be added here
   }
 
-  fun writeLongCharStringAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeLongCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeLongCharStringAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeLongCharStringAttribute(minInterval: Int, maxInterval: Int): CharString {
     // Implementation needs to be added here
   }
 
-  fun readEpochUsAttribute(callback: LongAttributeCallback) {
+  suspend fun readEpochUsAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun writeEpochUsAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeEpochUsAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeEpochUsAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeEpochUsAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeEpochUsAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeEpochUsAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readEpochSAttribute(callback: LongAttributeCallback) {
+  suspend fun readEpochSAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun writeEpochSAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeEpochSAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeEpochSAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeEpochSAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeEpochSAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeEpochSAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readVendorIdAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readVendorIdAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeVendorIdAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeVendorIdAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeVendorIdAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeVendorIdAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeVendorIdAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeVendorIdAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readListNullablesAndOptionalsStructAttribute(
-    callback: ListNullablesAndOptionalsStructAttributeCallback
-  ) {
+  suspend fun readListNullablesAndOptionalsStructAttribute():
+    ListNullablesAndOptionalsStructAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeListNullablesAndOptionalsStructAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListNullablesAndOptionalsStructAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterNullablesAndOptionalsStruct>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeListNullablesAndOptionalsStructAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListNullablesAndOptionalsStructAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterNullablesAndOptionalsStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeListNullablesAndOptionalsStructAttribute(
-    callback: ListNullablesAndOptionalsStructAttributeCallback,
+  suspend fun subscribeListNullablesAndOptionalsStructAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ListNullablesAndOptionalsStructAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEnumAttrAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readEnumAttrAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeEnumAttrAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeEnumAttrAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeEnumAttrAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeEnumAttrAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeEnumAttrAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readStructAttrAttribute(callback: StructAttrAttributeCallback) {
+  suspend fun readStructAttrAttribute(): StructAttrAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeStructAttrAttribute(
-    callback: DefaultClusterCallback,
-    value: ChipStructs.UnitTestingClusterSimpleStruct
-  ) {
+  suspend fun writeStructAttrAttribute(value: ChipStructs.UnitTestingClusterSimpleStruct) {
     // Implementation needs to be added here
   }
 
-  fun writeStructAttrAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeStructAttrAttribute(
     value: ChipStructs.UnitTestingClusterSimpleStruct,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeStructAttrAttribute(
-    callback: StructAttrAttributeCallback,
+  suspend fun subscribeStructAttrAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): StructAttrAttribute {
     // Implementation needs to be added here
   }
 
-  fun readRangeRestrictedInt8uAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRangeRestrictedInt8uAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt8uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRangeRestrictedInt8uAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRangeRestrictedInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRangeRestrictedInt8uAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRangeRestrictedInt8uAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRangeRestrictedInt8sAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRangeRestrictedInt8sAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt8sAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRangeRestrictedInt8sAttribute(value: Byte) {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt8sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRangeRestrictedInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRangeRestrictedInt8sAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRangeRestrictedInt8sAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRangeRestrictedInt16uAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRangeRestrictedInt16uAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt16uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRangeRestrictedInt16uAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt16uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRangeRestrictedInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRangeRestrictedInt16uAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRangeRestrictedInt16uAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readRangeRestrictedInt16sAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readRangeRestrictedInt16sAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt16sAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeRangeRestrictedInt16sAttribute(value: Short) {
     // Implementation needs to be added here
   }
 
-  fun writeRangeRestrictedInt16sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeRangeRestrictedInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeRangeRestrictedInt16sAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeRangeRestrictedInt16sAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readListLongOctetStringAttribute(callback: ListLongOctetStringAttributeCallback) {
+  suspend fun readListLongOctetStringAttribute(): ListLongOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeListLongOctetStringAttribute(
-    callback: DefaultClusterCallback,
-    value: ArrayList<ByteArray>
-  ) {
+  suspend fun writeListLongOctetStringAttribute(value: ArrayList<ByteArray>) {
     // Implementation needs to be added here
   }
 
-  fun writeListLongOctetStringAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListLongOctetStringAttribute(
     value: ArrayList<ByteArray>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeListLongOctetStringAttribute(
-    callback: ListLongOctetStringAttributeCallback,
+  suspend fun subscribeListLongOctetStringAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ListLongOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun readListFabricScopedAttribute(callback: ListFabricScopedAttributeCallback) {
+  suspend fun readListFabricScopedAttribute(): ListFabricScopedAttribute {
     // Implementation needs to be added here
   }
 
-  fun readListFabricScopedAttributeWithFabricFilter(
-    callback: ListFabricScopedAttributeCallback,
+  suspend fun readListFabricScopedAttributeWithFabricFilter(
     isFabricFiltered: Boolean
-  ) {
+  ): ListFabricScopedAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeListFabricScopedAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListFabricScopedAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterTestFabricScoped>
   ) {
     // Implementation needs to be added here
   }
 
-  fun writeListFabricScopedAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeListFabricScopedAttribute(
     value: ArrayList<ChipStructs.UnitTestingClusterTestFabricScoped>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeListFabricScopedAttribute(
-    callback: ListFabricScopedAttributeCallback,
+  suspend fun subscribeListFabricScopedAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): ListFabricScopedAttribute {
     // Implementation needs to be added here
   }
 
-  fun readTimedWriteBooleanAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readTimedWriteBooleanAttribute(): Boolean {
     // Implementation needs to be added here
   }
 
-  fun writeTimedWriteBooleanAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeTimedWriteBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeTimedWriteBooleanAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeTimedWriteBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneralErrorBooleanAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeGeneralErrorBooleanAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeGeneralErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneralErrorBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterErrorBooleanAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeClusterErrorBooleanAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeClusterErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterErrorBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readUnsupportedAttribute(): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnsupportedAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeUnsupportedAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeUnsupportedAttribute(minInterval: Int, maxInterval: Int): Boolean {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNullableBooleanAttribute(): NullableBooleanAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNullableBooleanAttribute(value: Boolean) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeNullableBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNullableBooleanAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableBooleanAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneralErrorBooleanAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readNullableBitmap8Attribute(): NullableBitmap8Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeGeneralErrorBooleanAttribute(callback: DefaultClusterCallback, value: Boolean) {
+  suspend fun writeNullableBitmap8Attribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeGeneralErrorBooleanAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneralErrorBooleanAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeNullableBitmap8Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableBitmap8Attribute {
     // Implementation needs to be added here
   }
 
-  fun readClusterErrorBooleanAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readNullableBitmap16Attribute(): NullableBitmap16Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeClusterErrorBooleanAttribute(callback: DefaultClusterCallback, value: Boolean) {
+  suspend fun writeNullableBitmap16Attribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeClusterErrorBooleanAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeClusterErrorBooleanAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeNullableBitmap16Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableBitmap16Attribute {
     // Implementation needs to be added here
   }
 
-  fun readUnsupportedAttribute(callback: BooleanAttributeCallback) {
+  suspend fun readNullableBitmap32Attribute(): NullableBitmap32Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeUnsupportedAttribute(callback: DefaultClusterCallback, value: Boolean) {
+  suspend fun writeNullableBitmap32Attribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeUnsupportedAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeUnsupportedAttribute(
-    callback: BooleanAttributeCallback,
+  suspend fun subscribeNullableBitmap32Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableBitmap32Attribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableBooleanAttribute(callback: NullableBooleanAttributeCallback) {
+  suspend fun readNullableBitmap64Attribute(): NullableBitmap64Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBooleanAttribute(callback: DefaultClusterCallback, value: Boolean) {
+  suspend fun writeNullableBitmap64Attribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBooleanAttribute(
-    callback: DefaultClusterCallback,
-    value: Boolean,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableBooleanAttribute(
-    callback: NullableBooleanAttributeCallback,
+  suspend fun subscribeNullableBitmap64Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableBitmap64Attribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableBitmap8Attribute(callback: NullableBitmap8AttributeCallback) {
+  suspend fun readNullableInt8uAttribute(): NullableInt8uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap8Attribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt8uAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap8Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableBitmap8Attribute(
-    callback: NullableBitmap8AttributeCallback,
+  suspend fun subscribeNullableInt8uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt8uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableBitmap16Attribute(callback: NullableBitmap16AttributeCallback) {
+  suspend fun readNullableInt16uAttribute(): NullableInt16uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap16Attribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt16uAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap16Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableBitmap16Attribute(
-    callback: NullableBitmap16AttributeCallback,
+  suspend fun subscribeNullableInt16uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt16uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableBitmap32Attribute(callback: NullableBitmap32AttributeCallback) {
+  suspend fun readNullableInt24uAttribute(): NullableInt24uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap32Attribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt24uAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap32Attribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableBitmap32Attribute(
-    callback: NullableBitmap32AttributeCallback,
+  suspend fun subscribeNullableInt24uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt24uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableBitmap64Attribute(callback: NullableBitmap64AttributeCallback) {
+  suspend fun readNullableInt32uAttribute(): NullableInt32uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap64Attribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt32uAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableBitmap64Attribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableBitmap64Attribute(
-    callback: NullableBitmap64AttributeCallback,
+  suspend fun subscribeNullableInt32uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt32uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt8uAttribute(callback: NullableInt8uAttributeCallback) {
+  suspend fun readNullableInt40uAttribute(): NullableInt40uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt8uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt40uAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt8uAttribute(
-    callback: NullableInt8uAttributeCallback,
+  suspend fun subscribeNullableInt40uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt40uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt16uAttribute(callback: NullableInt16uAttributeCallback) {
+  suspend fun readNullableInt48uAttribute(): NullableInt48uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt16uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt48uAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt16uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt16uAttribute(
-    callback: NullableInt16uAttributeCallback,
+  suspend fun subscribeNullableInt48uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt48uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt24uAttribute(callback: NullableInt24uAttributeCallback) {
+  suspend fun readNullableInt56uAttribute(): NullableInt56uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt24uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt56uAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt24uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt24uAttribute(
-    callback: NullableInt24uAttributeCallback,
+  suspend fun subscribeNullableInt56uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt56uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt32uAttribute(callback: NullableInt32uAttributeCallback) {
+  suspend fun readNullableInt64uAttribute(): NullableInt64uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt32uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt64uAttribute(value: ULong) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt32uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt32uAttribute(
-    callback: NullableInt32uAttributeCallback,
+  suspend fun subscribeNullableInt64uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt64uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt40uAttribute(callback: NullableInt40uAttributeCallback) {
+  suspend fun readNullableInt8sAttribute(): NullableInt8sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt40uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt8sAttribute(value: Byte) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt40uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt40uAttribute(
-    callback: NullableInt40uAttributeCallback,
+  suspend fun subscribeNullableInt8sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt8sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt48uAttribute(callback: NullableInt48uAttributeCallback) {
+  suspend fun readNullableInt16sAttribute(): NullableInt16sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt48uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt16sAttribute(value: Short) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt48uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt48uAttribute(
-    callback: NullableInt48uAttributeCallback,
+  suspend fun subscribeNullableInt16sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt16sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt56uAttribute(callback: NullableInt56uAttributeCallback) {
+  suspend fun readNullableInt24sAttribute(): NullableInt24sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt56uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt24sAttribute(value: Int) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt56uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt24sAttribute(value: Int, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt56uAttribute(
-    callback: NullableInt56uAttributeCallback,
+  suspend fun subscribeNullableInt24sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt24sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt64uAttribute(callback: NullableInt64uAttributeCallback) {
+  suspend fun readNullableInt32sAttribute(): NullableInt32sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt64uAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt32sAttribute(value: Int) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt64uAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt32sAttribute(value: Int, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt64uAttribute(
-    callback: NullableInt64uAttributeCallback,
+  suspend fun subscribeNullableInt32sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt32sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt8sAttribute(callback: NullableInt8sAttributeCallback) {
+  suspend fun readNullableInt40sAttribute(): NullableInt40sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt8sAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt40sAttribute(value: Long) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt8sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt40sAttribute(value: Long, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt8sAttribute(
-    callback: NullableInt8sAttributeCallback,
+  suspend fun subscribeNullableInt40sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt40sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt16sAttribute(callback: NullableInt16sAttributeCallback) {
+  suspend fun readNullableInt48sAttribute(): NullableInt48sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt16sAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableInt48sAttribute(value: Long) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt16sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt48sAttribute(value: Long, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt16sAttribute(
-    callback: NullableInt16sAttributeCallback,
+  suspend fun subscribeNullableInt48sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt48sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt24sAttribute(callback: NullableInt24sAttributeCallback) {
+  suspend fun readNullableInt56sAttribute(): NullableInt56sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt24sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt56sAttribute(value: Long) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt24sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt56sAttribute(value: Long, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt24sAttribute(
-    callback: NullableInt24sAttributeCallback,
+  suspend fun subscribeNullableInt56sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt56sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt32sAttribute(callback: NullableInt32sAttributeCallback) {
+  suspend fun readNullableInt64sAttribute(): NullableInt64sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt32sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableInt64sAttribute(value: Long) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt32sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableInt64sAttribute(value: Long, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt32sAttribute(
-    callback: NullableInt32sAttributeCallback,
+  suspend fun subscribeNullableInt64sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableInt64sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt40sAttribute(callback: NullableInt40sAttributeCallback) {
+  suspend fun readNullableEnum8Attribute(): NullableEnum8Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt40sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableEnum8Attribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt40sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt40sAttribute(
-    callback: NullableInt40sAttributeCallback,
+  suspend fun subscribeNullableEnum8Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableEnum8Attribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt48sAttribute(callback: NullableInt48sAttributeCallback) {
+  suspend fun readNullableEnum16Attribute(): NullableEnum16Attribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt48sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableEnum16Attribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt48sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt48sAttribute(
-    callback: NullableInt48sAttributeCallback,
+  suspend fun subscribeNullableEnum16Attribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableEnum16Attribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt56sAttribute(callback: NullableInt56sAttributeCallback) {
+  suspend fun readNullableFloatSingleAttribute(): NullableFloatSingleAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt56sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableFloatSingleAttribute(value: Float) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt56sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt56sAttribute(
-    callback: NullableInt56sAttributeCallback,
+  suspend fun subscribeNullableFloatSingleAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableFloatSingleAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableInt64sAttribute(callback: NullableInt64sAttributeCallback) {
+  suspend fun readNullableFloatDoubleAttribute(): NullableFloatDoubleAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt64sAttribute(callback: DefaultClusterCallback, value: Long) {
+  suspend fun writeNullableFloatDoubleAttribute(value: Double) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableInt64sAttribute(
-    callback: DefaultClusterCallback,
-    value: Long,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableInt64sAttribute(
-    callback: NullableInt64sAttributeCallback,
+  suspend fun subscribeNullableFloatDoubleAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableFloatDoubleAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableEnum8Attribute(callback: NullableEnum8AttributeCallback) {
+  suspend fun readNullableOctetStringAttribute(): NullableOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableEnum8Attribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableOctetStringAttribute(value: ByteArray) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableEnum8Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableEnum8Attribute(
-    callback: NullableEnum8AttributeCallback,
+  suspend fun subscribeNullableOctetStringAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableOctetStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableEnum16Attribute(callback: NullableEnum16AttributeCallback) {
+  suspend fun readNullableCharStringAttribute(): NullableCharStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableEnum16Attribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableCharStringAttribute(value: String) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableEnum16Attribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableEnum16Attribute(
-    callback: NullableEnum16AttributeCallback,
+  suspend fun subscribeNullableCharStringAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableCharStringAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableFloatSingleAttribute(callback: NullableFloatSingleAttributeCallback) {
+  suspend fun readNullableEnumAttrAttribute(): NullableEnumAttrAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableFloatSingleAttribute(callback: DefaultClusterCallback, value: Float) {
+  suspend fun writeNullableEnumAttrAttribute(value: UInt) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableFloatSingleAttribute(
-    callback: DefaultClusterCallback,
-    value: Float,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableFloatSingleAttribute(
-    callback: NullableFloatSingleAttributeCallback,
+  suspend fun subscribeNullableEnumAttrAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableEnumAttrAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableFloatDoubleAttribute(callback: NullableFloatDoubleAttributeCallback) {
+  suspend fun readNullableStructAttribute(): NullableStructAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableFloatDoubleAttribute(callback: DefaultClusterCallback, value: Double) {
+  suspend fun writeNullableStructAttribute(value: ChipStructs.UnitTestingClusterSimpleStruct) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableFloatDoubleAttribute(
-    callback: DefaultClusterCallback,
-    value: Double,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNullableFloatDoubleAttribute(
-    callback: NullableFloatDoubleAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNullableOctetStringAttribute(callback: NullableOctetStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableOctetStringAttribute(callback: DefaultClusterCallback, value: ByteArray) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableOctetStringAttribute(
-    callback: DefaultClusterCallback,
-    value: ByteArray,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNullableOctetStringAttribute(
-    callback: NullableOctetStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNullableCharStringAttribute(callback: NullableCharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableCharStringAttribute(callback: DefaultClusterCallback, value: String) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableCharStringAttribute(
-    callback: DefaultClusterCallback,
-    value: String,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNullableCharStringAttribute(
-    callback: NullableCharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNullableEnumAttrAttribute(callback: NullableEnumAttrAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableEnumAttrAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableEnumAttrAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNullableEnumAttrAttribute(
-    callback: NullableEnumAttrAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNullableStructAttribute(callback: NullableStructAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableStructAttribute(
-    callback: DefaultClusterCallback,
-    value: ChipStructs.UnitTestingClusterSimpleStruct
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun writeNullableStructAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeNullableStructAttribute(
     value: ChipStructs.UnitTestingClusterSimpleStruct,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableStructAttribute(
-    callback: NullableStructAttributeCallback,
+  suspend fun subscribeNullableStructAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableStructAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableRangeRestrictedInt8uAttribute(
-    callback: NullableRangeRestrictedInt8uAttributeCallback
-  ) {
+  suspend fun readNullableRangeRestrictedInt8uAttribute(): NullableRangeRestrictedInt8uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt8uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableRangeRestrictedInt8uAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableRangeRestrictedInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableRangeRestrictedInt8uAttribute(
-    callback: NullableRangeRestrictedInt8uAttributeCallback,
+  suspend fun subscribeNullableRangeRestrictedInt8uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableRangeRestrictedInt8uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableRangeRestrictedInt8sAttribute(
-    callback: NullableRangeRestrictedInt8sAttributeCallback
-  ) {
+  suspend fun readNullableRangeRestrictedInt8sAttribute(): NullableRangeRestrictedInt8sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt8sAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeNullableRangeRestrictedInt8sAttribute(value: Byte) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt8sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableRangeRestrictedInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableRangeRestrictedInt8sAttribute(
-    callback: NullableRangeRestrictedInt8sAttributeCallback,
+  suspend fun subscribeNullableRangeRestrictedInt8sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableRangeRestrictedInt8sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableRangeRestrictedInt16uAttribute(
-    callback: NullableRangeRestrictedInt16uAttributeCallback
-  ) {
+  suspend fun readNullableRangeRestrictedInt16uAttribute(): NullableRangeRestrictedInt16uAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt16uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
+  suspend fun writeNullableRangeRestrictedInt16uAttribute(value: UShort) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt16uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableRangeRestrictedInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableRangeRestrictedInt16uAttribute(
-    callback: NullableRangeRestrictedInt16uAttributeCallback,
+  suspend fun subscribeNullableRangeRestrictedInt16uAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableRangeRestrictedInt16uAttribute {
     // Implementation needs to be added here
   }
 
-  fun readNullableRangeRestrictedInt16sAttribute(
-    callback: NullableRangeRestrictedInt16sAttributeCallback
-  ) {
+  suspend fun readNullableRangeRestrictedInt16sAttribute(): NullableRangeRestrictedInt16sAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt16sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer
-  ) {
+  suspend fun writeNullableRangeRestrictedInt16sAttribute(value: Short) {
     // Implementation needs to be added here
   }
 
-  fun writeNullableRangeRestrictedInt16sAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeNullableRangeRestrictedInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeNullableRangeRestrictedInt16sAttribute(
-    callback: NullableRangeRestrictedInt16sAttributeCallback,
+  suspend fun subscribeNullableRangeRestrictedInt16sAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): NullableRangeRestrictedInt16sAttribute {
     // Implementation needs to be added here
   }
 
-  fun readWriteOnlyInt8uAttribute(callback: IntegerAttributeCallback) {
+  suspend fun readWriteOnlyInt8uAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun writeWriteOnlyInt8uAttribute(callback: DefaultClusterCallback, value: Integer) {
+  suspend fun writeWriteOnlyInt8uAttribute(value: UByte) {
     // Implementation needs to be added here
   }
 
-  fun writeWriteOnlyInt8uAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
+  suspend fun writeWriteOnlyInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
     // Implementation needs to be added here
   }
 
-  fun subscribeWriteOnlyInt8uAttribute(
-    callback: IntegerAttributeCallback,
+  suspend fun subscribeWriteOnlyInt8uAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 4294048773u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UserLabelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UserLabelCluster.kt
@@ -20,146 +20,93 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class UserLabelCluster(private val endpointId: UShort) {
-  companion object {
-    const val CLUSTER_ID: UInt = 65u
-  }
+  class LabelListAttribute(val value: ArrayList<ChipStructs.UserLabelClusterLabelStruct>)
 
-  interface LabelListAttributeCallback {
-    fun onSuccess(value: ArrayList<ChipStructs.UserLabelClusterLabelStruct>)
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
 
-    fun onError(ex: Exception)
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
 
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
+  class EventListAttribute(val value: ArrayList<UInt>)
 
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
+  class AttributeListAttribute(val value: ArrayList<UInt>)
 
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readLabelListAttribute(callback: LabelListAttributeCallback) {
+  suspend fun readLabelListAttribute(): LabelListAttribute {
     // Implementation needs to be added here
   }
 
-  fun writeLabelListAttribute(
-    callback: DefaultClusterCallback,
-    value: ArrayList<ChipStructs.UserLabelClusterLabelStruct>
-  ) {
+  suspend fun writeLabelListAttribute(value: ArrayList<ChipStructs.UserLabelClusterLabelStruct>) {
     // Implementation needs to be added here
   }
 
-  fun writeLabelListAttribute(
-    callback: DefaultClusterCallback,
+  suspend fun writeLabelListAttribute(
     value: ArrayList<ChipStructs.UserLabelClusterLabelStruct>,
     timedWriteTimeoutMs: Int
   ) {
     // Implementation needs to be added here
   }
 
-  fun subscribeLabelListAttribute(
-    callback: LabelListAttributeCallback,
+  suspend fun subscribeLabelListAttribute(minInterval: Int, maxInterval: Int): LabelListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): GeneratedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
+  suspend fun subscribeAcceptedCommandListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AcceptedCommandListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
+  suspend fun readEventListAttribute(): EventListAttribute {
     // Implementation needs to be added here
   }
 
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
     minInterval: Int,
     maxInterval: Int
-  ) {
+  ): AttributeListAttribute {
     // Implementation needs to be added here
   }
 
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
+  suspend fun readFeatureMapAttribute(): Long {
     // Implementation needs to be added here
   }
 
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
     // Implementation needs to be added here
   }
 
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
+  suspend fun readClusterRevisionAttribute(): Integer {
     // Implementation needs to be added here
   }
 
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
     // Implementation needs to be added here
   }
 
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
+  companion object {
+    const val CLUSTER_ID: UInt = 65u
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WakeOnLanCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WakeOnLanCluster.kt
@@ -20,123 +20,80 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class WakeOnLanCluster(private val endpointId: UShort) {
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun readMACAddressAttribute(): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeMACAddressAttribute(minInterval: Int, maxInterval: Int): CharString {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 1283u
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readMACAddressAttribute(callback: CharStringAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeMACAddressAttribute(
-    callback: CharStringAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WiFiNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WiFiNetworkDiagnosticsCluster.kt
@@ -20,375 +20,243 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class WiFiNetworkDiagnosticsCluster(private val endpointId: UShort) {
+  class BssidAttribute(val value: ByteArray?)
+
+  class SecurityTypeAttribute(val value: UInt?)
+
+  class WiFiVersionAttribute(val value: UInt?)
+
+  class ChannelNumberAttribute(val value: UShort?)
+
+  class RssiAttribute(val value: Byte?)
+
+  class BeaconLostCountAttribute(val value: UInt?)
+
+  class BeaconRxCountAttribute(val value: UInt?)
+
+  class PacketMulticastRxCountAttribute(val value: UInt?)
+
+  class PacketMulticastTxCountAttribute(val value: UInt?)
+
+  class PacketUnicastRxCountAttribute(val value: UInt?)
+
+  class PacketUnicastTxCountAttribute(val value: UInt?)
+
+  class CurrentMaxRateAttribute(val value: ULong?)
+
+  class OverrunCountAttribute(val value: ULong?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun resetCounts() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun resetCounts(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBssidAttribute(): BssidAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBssidAttribute(minInterval: Int, maxInterval: Int): BssidAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSecurityTypeAttribute(): SecurityTypeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSecurityTypeAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): SecurityTypeAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readWiFiVersionAttribute(): WiFiVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeWiFiVersionAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): WiFiVersionAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readChannelNumberAttribute(): ChannelNumberAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeChannelNumberAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): ChannelNumberAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readRssiAttribute(): RssiAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeRssiAttribute(minInterval: Int, maxInterval: Int): RssiAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBeaconLostCountAttribute(): BeaconLostCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBeaconLostCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BeaconLostCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readBeaconRxCountAttribute(): BeaconRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeBeaconRxCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): BeaconRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketMulticastRxCountAttribute(): PacketMulticastRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketMulticastRxCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PacketMulticastRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketMulticastTxCountAttribute(): PacketMulticastTxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketMulticastTxCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PacketMulticastTxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketUnicastRxCountAttribute(): PacketUnicastRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketUnicastRxCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PacketUnicastRxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPacketUnicastTxCountAttribute(): PacketUnicastTxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePacketUnicastTxCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): PacketUnicastTxCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentMaxRateAttribute(): CurrentMaxRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentMaxRateAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentMaxRateAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOverrunCountAttribute(): OverrunCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOverrunCountAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): OverrunCountAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 54u
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun resetCounts(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  interface BssidAttributeCallback {
-    fun onSuccess(value: ByteArray?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface SecurityTypeAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface WiFiVersionAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface ChannelNumberAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface RssiAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BeaconLostCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface BeaconRxCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PacketMulticastRxCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PacketMulticastTxCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PacketUnicastRxCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface PacketUnicastTxCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentMaxRateAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface OverrunCountAttributeCallback {
-    fun onSuccess(value: Long?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readBssidAttribute(callback: BssidAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBssidAttribute(
-    callback: BssidAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSecurityTypeAttribute(callback: SecurityTypeAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSecurityTypeAttribute(
-    callback: SecurityTypeAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readWiFiVersionAttribute(callback: WiFiVersionAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeWiFiVersionAttribute(
-    callback: WiFiVersionAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readChannelNumberAttribute(callback: ChannelNumberAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeChannelNumberAttribute(
-    callback: ChannelNumberAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readRssiAttribute(callback: RssiAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeRssiAttribute(callback: RssiAttributeCallback, minInterval: Int, maxInterval: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun readBeaconLostCountAttribute(callback: BeaconLostCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBeaconLostCountAttribute(
-    callback: BeaconLostCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readBeaconRxCountAttribute(callback: BeaconRxCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeBeaconRxCountAttribute(
-    callback: BeaconRxCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketMulticastRxCountAttribute(callback: PacketMulticastRxCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketMulticastRxCountAttribute(
-    callback: PacketMulticastRxCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketMulticastTxCountAttribute(callback: PacketMulticastTxCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketMulticastTxCountAttribute(
-    callback: PacketMulticastTxCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketUnicastRxCountAttribute(callback: PacketUnicastRxCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketUnicastRxCountAttribute(
-    callback: PacketUnicastRxCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPacketUnicastTxCountAttribute(callback: PacketUnicastTxCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePacketUnicastTxCountAttribute(
-    callback: PacketUnicastTxCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentMaxRateAttribute(callback: CurrentMaxRateAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentMaxRateAttribute(
-    callback: CurrentMaxRateAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOverrunCountAttribute(callback: OverrunCountAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOverrunCountAttribute(
-    callback: OverrunCountAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WindowCoveringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WindowCoveringCluster.kt
@@ -20,535 +20,380 @@ package matter.devicecontroller.cluster.clusters
 import java.util.ArrayList
 
 class WindowCoveringCluster(private val endpointId: UShort) {
+  class CurrentPositionLiftAttribute(val value: UShort?)
+
+  class CurrentPositionTiltAttribute(val value: UShort?)
+
+  class CurrentPositionLiftPercentageAttribute(val value: UByte?)
+
+  class CurrentPositionTiltPercentageAttribute(val value: UByte?)
+
+  class TargetPositionLiftPercent100thsAttribute(val value: UShort?)
+
+  class TargetPositionTiltPercent100thsAttribute(val value: UShort?)
+
+  class CurrentPositionLiftPercent100thsAttribute(val value: UShort?)
+
+  class CurrentPositionTiltPercent100thsAttribute(val value: UShort?)
+
+  class GeneratedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class AcceptedCommandListAttribute(val value: ArrayList<UInt>)
+
+  class EventListAttribute(val value: ArrayList<UInt>)
+
+  class AttributeListAttribute(val value: ArrayList<UInt>)
+
+  suspend fun upOrOpen() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun upOrOpen(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun downOrClose() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun downOrClose(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopMotion() {
+    // Implementation needs to be added here
+  }
+
+  suspend fun stopMotion(timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToLiftValue(liftValue: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToLiftValue(liftValue: UShort, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToLiftPercentage(liftPercent100thsValue: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToLiftPercentage(liftPercent100thsValue: UShort, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToTiltValue(tiltValue: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToTiltValue(tiltValue: UShort, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToTiltPercentage(tiltPercent100thsValue: UShort) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun goToTiltPercentage(tiltPercent100thsValue: UShort, timedInvokeTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalClosedLimitLiftAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalClosedLimitLiftAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readPhysicalClosedLimitTiltAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribePhysicalClosedLimitTiltAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionLiftAttribute(): CurrentPositionLiftAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionLiftAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionLiftAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionTiltAttribute(): CurrentPositionTiltAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionTiltAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionTiltAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfActuationsLiftAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfActuationsLiftAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readNumberOfActuationsTiltAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeNumberOfActuationsTiltAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readConfigStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeConfigStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionLiftPercentageAttribute(): CurrentPositionLiftPercentageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionLiftPercentageAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionLiftPercentageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionTiltPercentageAttribute(): CurrentPositionTiltPercentageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionTiltPercentageAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionTiltPercentageAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readOperationalStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeOperationalStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTargetPositionLiftPercent100thsAttribute():
+    TargetPositionLiftPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTargetPositionLiftPercent100thsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): TargetPositionLiftPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readTargetPositionTiltPercent100thsAttribute():
+    TargetPositionTiltPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeTargetPositionTiltPercent100thsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): TargetPositionTiltPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEndProductTypeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEndProductTypeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionLiftPercent100thsAttribute():
+    CurrentPositionLiftPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionLiftPercent100thsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionLiftPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readCurrentPositionTiltPercent100thsAttribute():
+    CurrentPositionTiltPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeCurrentPositionTiltPercent100thsAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): CurrentPositionTiltPercent100thsAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInstalledOpenLimitLiftAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInstalledOpenLimitLiftAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInstalledClosedLimitLiftAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInstalledClosedLimitLiftAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInstalledOpenLimitTiltAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInstalledOpenLimitTiltAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readInstalledClosedLimitTiltAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeInstalledClosedLimitTiltAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readModeAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeModeAttribute(value: UInt) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun writeModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeModeAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readSafetyStatusAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeSafetyStatusAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeGeneratedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): GeneratedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAcceptedCommandListAttribute(): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAcceptedCommandListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AcceptedCommandListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readEventListAttribute(): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeEventListAttribute(minInterval: Int, maxInterval: Int): EventListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readAttributeListAttribute(): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeAttributeListAttribute(
+    minInterval: Int,
+    maxInterval: Int
+  ): AttributeListAttribute {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readFeatureMapAttribute(): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeFeatureMapAttribute(minInterval: Int, maxInterval: Int): Long {
+    // Implementation needs to be added here
+  }
+
+  suspend fun readClusterRevisionAttribute(): Integer {
+    // Implementation needs to be added here
+  }
+
+  suspend fun subscribeClusterRevisionAttribute(minInterval: Int, maxInterval: Int): Integer {
+    // Implementation needs to be added here
+  }
+
   companion object {
     const val CLUSTER_ID: UInt = 258u
-  }
-
-  fun upOrOpen(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun upOrOpen(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun downOrClose(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun downOrClose(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun stopMotion(callback: DefaultClusterCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun stopMotion(callback: DefaultClusterCallback, timedInvokeTimeoutMs: Int) {
-    // Implementation needs to be added here
-  }
-
-  fun goToLiftValue(callback: DefaultClusterCallback, liftValue: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun goToLiftValue(
-    callback: DefaultClusterCallback,
-    liftValue: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun goToLiftPercentage(callback: DefaultClusterCallback, liftPercent100thsValue: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun goToLiftPercentage(
-    callback: DefaultClusterCallback,
-    liftPercent100thsValue: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun goToTiltValue(callback: DefaultClusterCallback, tiltValue: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun goToTiltValue(
-    callback: DefaultClusterCallback,
-    tiltValue: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun goToTiltPercentage(callback: DefaultClusterCallback, tiltPercent100thsValue: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun goToTiltPercentage(
-    callback: DefaultClusterCallback,
-    tiltPercent100thsValue: Integer,
-    timedInvokeTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  interface CurrentPositionLiftAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPositionTiltAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPositionLiftPercentageAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPositionTiltPercentageAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TargetPositionLiftPercent100thsAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface TargetPositionTiltPercent100thsAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPositionLiftPercent100thsAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface CurrentPositionTiltPercent100thsAttributeCallback {
-    fun onSuccess(value: Integer?)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface GeneratedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AcceptedCommandListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface EventListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  interface AttributeListAttributeCallback {
-    fun onSuccess(value: ArrayList<Long>)
-
-    fun onError(ex: Exception)
-
-    fun onSubscriptionEstablished(subscriptionId: Long)
-  }
-
-  fun readTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalClosedLimitLiftAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalClosedLimitLiftAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readPhysicalClosedLimitTiltAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribePhysicalClosedLimitTiltAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionLiftAttribute(callback: CurrentPositionLiftAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionLiftAttribute(
-    callback: CurrentPositionLiftAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionTiltAttribute(callback: CurrentPositionTiltAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionTiltAttribute(
-    callback: CurrentPositionTiltAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNumberOfActuationsLiftAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfActuationsLiftAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readNumberOfActuationsTiltAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeNumberOfActuationsTiltAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readConfigStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeConfigStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionLiftPercentageAttribute(
-    callback: CurrentPositionLiftPercentageAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionLiftPercentageAttribute(
-    callback: CurrentPositionLiftPercentageAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionTiltPercentageAttribute(
-    callback: CurrentPositionTiltPercentageAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionTiltPercentageAttribute(
-    callback: CurrentPositionTiltPercentageAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readOperationalStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeOperationalStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTargetPositionLiftPercent100thsAttribute(
-    callback: TargetPositionLiftPercent100thsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTargetPositionLiftPercent100thsAttribute(
-    callback: TargetPositionLiftPercent100thsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readTargetPositionTiltPercent100thsAttribute(
-    callback: TargetPositionTiltPercent100thsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeTargetPositionTiltPercent100thsAttribute(
-    callback: TargetPositionTiltPercent100thsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEndProductTypeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEndProductTypeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionLiftPercent100thsAttribute(
-    callback: CurrentPositionLiftPercent100thsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionLiftPercent100thsAttribute(
-    callback: CurrentPositionLiftPercent100thsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readCurrentPositionTiltPercent100thsAttribute(
-    callback: CurrentPositionTiltPercent100thsAttributeCallback
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeCurrentPositionTiltPercent100thsAttribute(
-    callback: CurrentPositionTiltPercent100thsAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstalledOpenLimitLiftAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstalledOpenLimitLiftAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstalledClosedLimitLiftAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstalledClosedLimitLiftAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstalledOpenLimitTiltAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstalledOpenLimitTiltAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readInstalledClosedLimitTiltAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeInstalledClosedLimitTiltAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readModeAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun writeModeAttribute(callback: DefaultClusterCallback, value: Integer) {
-    // Implementation needs to be added here
-  }
-
-  fun writeModeAttribute(
-    callback: DefaultClusterCallback,
-    value: Integer,
-    timedWriteTimeoutMs: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeModeAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readSafetyStatusAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeSafetyStatusAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readGeneratedCommandListAttribute(callback: GeneratedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeGeneratedCommandListAttribute(
-    callback: GeneratedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAcceptedCommandListAttribute(callback: AcceptedCommandListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAcceptedCommandListAttribute(
-    callback: AcceptedCommandListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readEventListAttribute(callback: EventListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeEventListAttribute(
-    callback: EventListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readAttributeListAttribute(callback: AttributeListAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeAttributeListAttribute(
-    callback: AttributeListAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readFeatureMapAttribute(callback: LongAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeFeatureMapAttribute(
-    callback: LongAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
-  }
-
-  fun readClusterRevisionAttribute(callback: IntegerAttributeCallback) {
-    // Implementation needs to be added here
-  }
-
-  fun subscribeClusterRevisionAttribute(
-    callback: IntegerAttributeCallback,
-    minInterval: Int,
-    maxInterval: Int
-  ) {
-    // Implementation needs to be added here
   }
 }


### PR DESCRIPTION






Currently, Kotlin API uses a callback (ChangeChannelResponseCallback) to handle the asynchronous result (or error).

```
 fun changeChannel(
    callback: ChangeChannelResponseCallback,
    match: String,
    timedInvokeTimeoutMs: Int
  ) {
    // Implementation needs to be added here
  }
```
  
Refactor the function to use Kotlin's coroutines (indicated by the suspend keyword) to handle the asynchronous operation and returns the result directly (ChangeChannelResponse).

```
  suspend fun changeChannel(match: String, timedInvokeTimeoutMs: Int): ChangeChannelResponse {
    // Implementation needs to be added here
  }
```

