### PR TITLE
[Scenes] CHIP config table size 

### DIFF
--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -284,7 +284,7 @@ struct FabricSceneData : public PersistentData<kPersistentFabricBufferMax>
     uint8_t scene_count = 0;
     uint16_t max_scenes_per_fabric;
     uint16_t max_scenes_per_endpoint;
-    SceneStorageId scene_map[kMaxScenesPerFabric];
+    SceneStorageId scene_map[CHIP_CONFIG_MAX_SCENES_TABLE_SIZE];
 
     FabricSceneData(EndpointId endpoint = kInvalidEndpointId, FabricIndex fabric = kUndefinedFabricIndex,
                     uint16_t maxScenesPerFabric = kMaxScenesPerFabric, uint16_t maxScenesPerEndpoint = kMaxScenesPerEndpoint) :

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -37,7 +37,7 @@ static constexpr uint16_t kMaxScenesPerEndpoint = CHIP_CONFIG_MAX_SCENES_TABLE_S
 static_assert(kMaxScenesPerEndpoint <= CHIP_CONFIG_MAX_SCENES_TABLE_SIZE,
               "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE is smaller than the zap configuration, please increase "
               "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE in CHIPConfig.h if you really need more scenes");
-static_assert(kMaxScenesPerEndpoint >= 16, "Per spec, kMaxScenesPerEndpoint must be greater than 16");
+static_assert(kMaxScenesPerEndpoint >= 16, "Per spec, kMaxScenesPerEndpoint must be at least 16");
 static constexpr uint16_t kMaxScenesPerFabric = (kMaxScenesPerEndpoint - 1) / 2;
 
 using clusterId = chip::ClusterId;

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -28,8 +28,17 @@
 namespace chip {
 namespace scenes {
 
-static constexpr uint16_t kMaxScenesPerFabric   = (MATTER_SCENES_TABLE_SIZE - 1) / 2;
+#ifdef MATTER_SCENES_TABLE_SIZE
 static constexpr uint16_t kMaxScenesPerEndpoint = MATTER_SCENES_TABLE_SIZE;
+#else
+static constexpr uint16_t kMaxScenesPerEndpoint = CHIP_CONFIG_MAX_SCENES_TABLE_SIZE;
+#endif
+
+static_assert(kMaxScenesPerEndpoint <= CHIP_CONFIG_MAX_SCENES_TABLE_SIZE,
+              "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE is smaller than the zap configuration, please increase "
+              "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE in CHIPConfig.h if you really need more scenes");
+static_assert(kMaxScenesPerEndpoint >= 16, "Per spec, kMaxScenesPerEndpoint must be greater than 16");
+static constexpr uint16_t kMaxScenesPerFabric = (kMaxScenesPerEndpoint - 1) / 2;
 
 using clusterId = chip::ClusterId;
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1444,6 +1444,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @ def CHIP_CONFIG_MAX_SCENES_TABLE_SIZE
+ *
+ * @brief This defines how many scenes a single endpoint is allowed to allocate in flash memory. This value MUST be greater than 16
+ * per spec and MUST be increased to allow for configuring a greater scene table size from Zap.
+ */
+#ifndef CHIP_CONFIG_SCENES_TABLE_SIZE
+#define CHIP_CONFIG_MAX_SCENES_TABLE_SIZE 32
+#endif
+
+/**
  * @def CHIP_CONFIG_TIME_ZONE_LIST_MAX_SIZE
  *
  * Defines the size of the time zone list

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1449,9 +1449,13 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief This defines how many scenes a single endpoint is allowed to allocate in flash memory. This value MUST at least 16
  * per spec and MUST be increased to allow for configuring a greater scene table size from Zap.
  */
-#ifndef CHIP_CONFIG_SCENES_TABLE_SIZE
-#define CHIP_CONFIG_MAX_SCENES_TABLE_SIZE 32
-#endif
+#ifndef CHIP_CONFIG_MAX_SCENES_TABLE_SIZE
+#if CHIP_CONFIG_TEST
+#define CHIP_CONFIG_MAX_SCENES_TABLE_SIZE 24
+#else
+#define CHIP_CONFIG_MAX_SCENES_TABLE_SIZE 16
+#endif // CHIP_CONFIG_TEST
+#endif // CHIP_CONFIG_MAX_SCENES_TABLE_SIZE
 
 /**
  * @def CHIP_CONFIG_TIME_ZONE_LIST_MAX_SIZE

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1446,7 +1446,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 /**
  * @ def CHIP_CONFIG_MAX_SCENES_TABLE_SIZE
  *
- * @brief This defines how many scenes a single endpoint is allowed to allocate in flash memory. This value MUST be greater than 16
+ * @brief This defines how many scenes a single endpoint is allowed to allocate in flash memory. This value MUST at least 16
  * per spec and MUST be increased to allow for configuring a greater scene table size from Zap.
  */
 #ifndef CHIP_CONFIG_SCENES_TABLE_SIZE


### PR DESCRIPTION
Added a CHIP config allowing to configure the maximum number of scenes per endpoint in flash. This also behaves as a default scene table size in the event the zap config isn't used at build

fixes: https://github.com/project-chip/connectedhomeip/issues/28521

