### PR TITLE
[ICD] Enable ICD run for unit tests

### DIFF
--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -30,7 +30,7 @@ jobs:
 
         strategy:
             matrix:
-                type: [main, clang, mbedtls, rotating_device_id]
+                type: [main, clang, mbedtls, rotating_device_id, icd]
         env:
             BUILD_TYPE: ${{ matrix.type }}
 
@@ -65,6 +65,7 @@ jobs:
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
                      "rotating_device_id") GN_ARGS='chip_crypto="boringssl" chip_enable_rotating_device_id=true';;
+                     "icd") GN_ARGS='chip_enable_icd_server=true';;
                      *) ;;
                   esac
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1742,7 +1742,6 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMinInterval(nlTestSui
         NL_TEST_ASSERT(apSuite, minInterval == kMinInterval);
         NL_TEST_ASSERT(apSuite, maxInterval == (2 * idleModeDuration));
 
-
         printf("---------------------------- maxInterval : %d \n", maxInterval);
         printf("---------------------------- idleModeDuration : %d \n", idleModeDuration);
     }

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1687,8 +1687,8 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMinInterval(nlTestSui
     err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable(), app::reporting::GetDefaultReportScheduler());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint16_t kMinInterval        = 3;
-    uint16_t kMaxIntervalCeiling = 5;
+    uint16_t kMinInterval        = 305; // Default IdleModeDuration is 300
+    uint16_t kMaxIntervalCeiling = 605;
 
     Messaging::ExchangeContext * exchangeCtx = ctx.NewExchangeToAlice(nullptr, false);
 
@@ -1741,6 +1741,10 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMinInterval(nlTestSui
 
         NL_TEST_ASSERT(apSuite, minInterval == kMinInterval);
         NL_TEST_ASSERT(apSuite, maxInterval == (2 * idleModeDuration));
+
+
+        printf("---------------------------- maxInterval : %d \n", maxInterval);
+        printf("---------------------------- idleModeDuration : %d \n", idleModeDuration);
     }
     engine->Shutdown();
 
@@ -1837,8 +1841,8 @@ void TestReadInteraction::TestICDProcessSubscribeRequestInvalidIdleModeDuration(
     err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable(), app::reporting::GetDefaultReportScheduler());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint16_t kMinInterval        = 3;
-    uint16_t kMaxIntervalCeiling = 3;
+    uint16_t kMinInterval        = 400;
+    uint16_t kMaxIntervalCeiling = 400;
 
     Messaging::ExchangeContext * exchangeCtx = ctx.NewExchangeToAlice(nullptr, false);
 
@@ -2080,9 +2084,13 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         NL_TEST_ASSERT(apSuite, delegate.mGotReport);
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 2);
 
+        uint16_t minInterval;
+        uint16_t maxInterval;
+        delegate.mpReadHandler->GetReportingIntervals(minInterval, maxInterval);
+
         // Test empty report
         // Advance monotonic timestamp for min interval to elapse
-        gMockClock.AdvanceMonotonic(System::Clock::Seconds16(readPrepareParams.mMaxIntervalCeilingSeconds));
+        gMockClock.AdvanceMonotonic(System::Clock::Seconds16(maxInterval));
         ctx.GetIOContext().DriveIO();
 
         NL_TEST_ASSERT(apSuite, engine->GetReportingEngine().IsRunScheduled());
@@ -4969,9 +4977,9 @@ const nlTest sTests[] =
         can change the requested MaxInterval during the subscription response / request process
         https://github.com/project-chip/connectedhomeip/issues/28419
     */
-#if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
+// #if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
     NL_TEST_DEF("TestSubscribeUrgentWildcardEvent", chip::app::TestReadInteraction::TestSubscribeUrgentWildcardEvent),
-#endif
+// #endif
     NL_TEST_DEF("TestSubscribeWildcard", chip::app::TestReadInteraction::TestSubscribeWildcard),
     NL_TEST_DEF("TestSubscribePartialOverlap", chip::app::TestReadInteraction::TestSubscribePartialOverlap),
     NL_TEST_DEF("TestSubscribeSetDirtyFullyOverlap", chip::app::TestReadInteraction::TestSubscribeSetDirtyFullyOverlap),

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -4967,15 +4967,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadHandlerInvalidSubscribeRequest", chip::app::TestReadInteraction::TestReadHandlerInvalidSubscribeRequest),
     NL_TEST_DEF("TestSubscribeInvalidateFabric", chip::app::TestReadInteraction::TestSubscribeInvalidateFabric),
     NL_TEST_DEF("TestShutdownSubscription", chip::app::TestReadInteraction::TestShutdownSubscription),
-    /*
-        Disable test when running the ICD specific unit tests.
-        Test tests a eporting feature with hard coded time jumps which don't take into account that an ICD
-        can change the requested MaxInterval during the subscription response / request process
-        https://github.com/project-chip/connectedhomeip/issues/28419
-    */
-// #if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
     NL_TEST_DEF("TestSubscribeUrgentWildcardEvent", chip::app::TestReadInteraction::TestSubscribeUrgentWildcardEvent),
-// #endif
     NL_TEST_DEF("TestSubscribeWildcard", chip::app::TestReadInteraction::TestSubscribeWildcard),
     NL_TEST_DEF("TestSubscribePartialOverlap", chip::app::TestReadInteraction::TestSubscribePartialOverlap),
     NL_TEST_DEF("TestSubscribeSetDirtyFullyOverlap", chip::app::TestReadInteraction::TestSubscribeSetDirtyFullyOverlap),

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1741,9 +1741,6 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMinInterval(nlTestSui
 
         NL_TEST_ASSERT(apSuite, minInterval == kMinInterval);
         NL_TEST_ASSERT(apSuite, maxInterval == (2 * idleModeDuration));
-
-        printf("---------------------------- maxInterval : %d \n", maxInterval);
-        printf("---------------------------- idleModeDuration : %d \n", idleModeDuration);
     }
     engine->Shutdown();
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2218,8 +2218,7 @@ void TestReadInteraction::TestSubscribeEarlyReport(nlTestSuite * apSuite, void *
         node->SetIntervalTimeStamps(delegate.mpReadHandler, gMockClock.GetMonotonicTimestamp() + Milliseconds32(50));
         NL_TEST_ASSERT(apSuite,
                        reportScheduler->GetMaxTimestampForHandler(delegate.mpReadHandler) ==
-                           gMockClock.GetMonotonicTimestamp() + Seconds16(maxInterval) +
-                               Milliseconds32(50));
+                           gMockClock.GetMonotonicTimestamp() + Seconds16(maxInterval) + Milliseconds32(50));
 
         // Advance monotonic timestamp for min interval to elapse
         gMockClock.AdvanceMonotonic(Seconds16(maxInterval));

--- a/src/app/tests/suites/TestIcdManagementCluster.yaml
+++ b/src/app/tests/suites/TestIcdManagementCluster.yaml
@@ -32,7 +32,7 @@ tests:
       command: "readAttribute"
       attribute: "IdleModeDuration"
       response:
-          value: 2
+          value: 5
 
     - label: "Read ActiveModeDuration"
       command: "readAttribute"

--- a/src/app/tests/suites/TestIcdManagementCluster.yaml
+++ b/src/app/tests/suites/TestIcdManagementCluster.yaml
@@ -32,7 +32,7 @@ tests:
       command: "readAttribute"
       attribute: "IdleModeDuration"
       response:
-          value: 5
+          value: 300
 
     - label: "Read ActiveModeDuration"
       command: "readAttribute"

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -270,13 +270,17 @@ public:
     static void TestReadHandler_OneSubscribeMultipleReads(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_TwoSubscribesMultipleReads(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_MultipleSubscriptionsWithDataVersionFilter(nlTestSuite * apSuite, void * apContext);
+#if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
     static void TestReadHandler_SubscriptionReportingIntervalsTest1(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest2(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest3(nlTestSuite * apSuite, void * apContext);
-    static void TestReadHandler_SubscriptionReportingIntervalsTest4(nlTestSuite * apSuite, void * apContext);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+    static void TestReadHandler_SubscriptionReportingIntervalsTest4(nlTestSuite * apSuite, void * apContext);,
+#if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
     static void TestReadHandler_SubscriptionReportingIntervalsTest5(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest6(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest7(nlTestSuite * apSuite, void * apContext);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
     static void TestReadHandler_SubscriptionReportingIntervalsTest8(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest9(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandlerResourceExhaustion_MultipleReads(nlTestSuite * apSuite, void * apContext);
@@ -1966,6 +1970,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionAppRejection(nlTestSuite *
     gTestReadInteraction.mEmitSubscriptionError = false;
 }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+
 // Subscriber sends the request with particular max-interval value:
 // Max interval equal to client-requested min-interval.
 void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest1(nlTestSuite * apSuite, void * apContext)
@@ -2193,6 +2199,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest3(nl
     gTestReadInteraction.mAlterSubscriptionIntervals = false;
 }
 
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 // Subscriber sends the request with particular max-interval value:
 // Max interval greater than client-requested min-interval but lower than 60m:
 // server adjustment to a value greater than client-requested, but greater than 60 (not allowed).
@@ -2258,6 +2266,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest4(nl
     app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     gTestReadInteraction.mAlterSubscriptionIntervals = false;
 }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
 
 // Subscriber sends the request with particular max-interval value:
 // Max interval greater than client-requested min-interval but greater than 60m:
@@ -2485,6 +2495,8 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest7(nl
     app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     gTestReadInteraction.mAlterSubscriptionIntervals = false;
 }
+
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 // Subscriber sends the request with particular max-interval value:
 // Max interval greater than client-requested min-interval but greater than 60m:

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1970,7 +1970,7 @@ void TestReadInteraction::TestReadHandler_SubscriptionAppRejection(nlTestSuite *
     gTestReadInteraction.mEmitSubscriptionError = false;
 }
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+#if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
 
 // Subscriber sends the request with particular max-interval value:
 // Max interval equal to client-requested min-interval.
@@ -2267,7 +2267,7 @@ void TestReadInteraction::TestReadHandler_SubscriptionReportingIntervalsTest4(nl
     gTestReadInteraction.mAlterSubscriptionIntervals = false;
 }
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+#if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
 
 // Subscriber sends the request with particular max-interval value:
 // Max interval greater than client-requested min-interval but greater than 60m:

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -275,9 +275,10 @@ public:
     static void TestReadHandler_SubscriptionReportingIntervalsTest2(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest3(nlTestSuite * apSuite, void * apContext);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-    static void TestReadHandler_SubscriptionReportingIntervalsTest4(nlTestSuite * apSuite, void * apContext);,
+    static void TestReadHandler_SubscriptionReportingIntervalsTest4(nlTestSuite * apSuite, void * apContext);
+    ,
 #if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
-    static void TestReadHandler_SubscriptionReportingIntervalsTest5(nlTestSuite * apSuite, void * apContext);
+        static void TestReadHandler_SubscriptionReportingIntervalsTest5(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest6(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest7(nlTestSuite * apSuite, void * apContext);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -276,9 +276,8 @@ public:
     static void TestReadHandler_SubscriptionReportingIntervalsTest3(nlTestSuite * apSuite, void * apContext);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
     static void TestReadHandler_SubscriptionReportingIntervalsTest4(nlTestSuite * apSuite, void * apContext);
-    ,
 #if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
-        static void TestReadHandler_SubscriptionReportingIntervalsTest5(nlTestSuite * apSuite, void * apContext);
+    static void TestReadHandler_SubscriptionReportingIntervalsTest5(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest6(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandler_SubscriptionReportingIntervalsTest7(nlTestSuite * apSuite, void * apContext);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1503,7 +1503,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief Default value for the ICD Management cluster IdleModeDuration attribute, in seconds
  */
 #ifndef CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC
-#define CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC 2
+#define CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC 300
 #endif
 
 /**

--- a/src/messaging/tests/TestAbortExchangesForFabric.cpp
+++ b/src/messaging/tests/TestAbortExchangesForFabric.cpp
@@ -206,6 +206,12 @@ void CommonCheckAbortAllButOneExchange(nlTestSuite * inSuite, TestContext & ctx,
         // trigger a MRP failure due to timing out waiting for an ACK.
         //
         auto waitTimeout = System::Clock::Milliseconds32(1000);
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+        // If running as an ICD, increase waitTimeout to account for the polling interval
+        waitTimeout += CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
+#endif 
+
         // Account for the retry delay booster, so that we do not timeout our IO processing before the
         // retransmission failure is triggered.
         waitTimeout += CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS * CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;

--- a/src/messaging/tests/TestAbortExchangesForFabric.cpp
+++ b/src/messaging/tests/TestAbortExchangesForFabric.cpp
@@ -210,7 +210,7 @@ void CommonCheckAbortAllButOneExchange(nlTestSuite * inSuite, TestContext & ctx,
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
         // If running as an ICD, increase waitTimeout to account for the polling interval
         waitTimeout += CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
-#endif 
+#endif
 
         // Account for the retry delay booster, so that we do not timeout our IO processing before the
         // retransmission failure is triggered.

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1681,7 +1681,7 @@ void TestReliableMessageProtocol::CheckIsPeerActiveNotInitiator(nlTestSuite * in
     NL_TEST_ASSERT(inSuite, !mockSender.IsOnMessageReceivedCalled);
 
     // // Retrasnmit message
-    ctx.GetIOContext().DriveIOUntil(150_ms32, [&] { return loopback.mSentMessageCount >= 4; });
+    ctx.GetIOContext().DriveIOUntil(500_ms32, [&] { return loopback.mSentMessageCount >= 4; });
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -256,11 +256,20 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
         NL_TEST_ASSERT(inSuite, rm != nullptr);
         NL_TEST_ASSERT(inSuite, rc != nullptr);
 
+        // Adding an if-else to avoid affecting non-ICD tests
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+        // Increase local MRP retry intervals to take into account the increase response delay from an ICD
         contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
+            1000_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
+            1000_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+        });
+#else // CHIP_CONFIG_ENABLE_ICD_SERVER != 1
+    contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
             64_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
             64_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
         });
     }
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     NL_TEST_ASSERT(inSuite,
                    ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
@@ -279,8 +288,15 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
 
     while (delegate.mMessageDropped)
     {
+        auto waitTimeout = 100_ms + CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+        // If running as an ICD, increase waitTimeout to account for the polling interval
+        waitTimeout += CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
+#endif 
+
         // Wait some time so the dropped message will be retransmitted when we drain the IO.
-        chip::test_utils::SleepMillis((100_ms + CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST).count());
+        chip::test_utils::SleepMillis(waitTimeout.count());
         delegate.mMessageDropped = false;
         ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), ctx.GetExchangeManager().GetReliableMessageMgr());
         ctx.DrainAndServiceIO();

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -263,250 +263,253 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
             1000_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
             1000_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
         });
-#else // CHIP_CONFIG_ENABLE_ICD_SERVER != 1
-    contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
+#else  // CHIP_CONFIG_ENABLE_ICD_SERVER != 1
+        contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
             64_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
             64_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
         });
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
-    NL_TEST_ASSERT(inSuite,
-                   ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
-                       Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
+                           Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
-                                                   ByteSpan(sTestSpake2p01_Salt), mrpAccessoryConfig,
-                                                   &delegateAccessory) == CHIP_NO_ERROR);
-    ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(inSuite,
+                       pairingAccessory.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                                                       ByteSpan(sTestSpake2p01_Salt), mrpAccessoryConfig,
+                                                       &delegateAccessory) == CHIP_NO_ERROR);
+        ctx.DrainAndServiceIO();
 
-    NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(sessionManager, sTestSpake2p01_PinCode, mrpCommissionerConfig, contextCommissioner,
-                                            &delegateCommissioner) == CHIP_NO_ERROR);
-    ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(inSuite,
+                       pairingCommissioner.Pair(sessionManager, sTestSpake2p01_PinCode, mrpCommissionerConfig, contextCommissioner,
+                                                &delegateCommissioner) == CHIP_NO_ERROR);
+        ctx.DrainAndServiceIO();
 
-    while (delegate.mMessageDropped)
-    {
-        auto waitTimeout = 100_ms + CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;
+        while (delegate.mMessageDropped)
+        {
+            auto waitTimeout = 100_ms + CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
-        // If running as an ICD, increase waitTimeout to account for the polling interval
-        waitTimeout += CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
-#endif 
+            // If running as an ICD, increase waitTimeout to account for the polling interval
+            waitTimeout += CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
+#endif
 
-        // Wait some time so the dropped message will be retransmitted when we drain the IO.
-        chip::test_utils::SleepMillis(waitTimeout.count());
-        delegate.mMessageDropped = false;
-        ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), ctx.GetExchangeManager().GetReliableMessageMgr());
+            // Wait some time so the dropped message will be retransmitted when we drain the IO.
+            chip::test_utils::SleepMillis(waitTimeout.count());
+            delegate.mMessageDropped = false;
+            ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), ctx.GetExchangeManager().GetReliableMessageMgr());
+            ctx.DrainAndServiceIO();
+        };
+
+        // Standalone acks also increment the mSentMessageCount. But some messages could be acked
+        // via piggybacked acks. So we cannot check for a specific value of mSentMessageCount.
+        // Let's make sure atleast number is >= than the minimum messages required to complete the
+        // handshake.
+        NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= sTestPaseMessageCount);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 0);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
+
+        if (mrpCommissionerConfig.HasValue())
+        {
+            NL_TEST_ASSERT(inSuite,
+                           pairingAccessory.GetRemoteMRPConfig().mIdleRetransTimeout ==
+                               mrpCommissionerConfig.Value().mIdleRetransTimeout);
+            NL_TEST_ASSERT(inSuite,
+                           pairingAccessory.GetRemoteMRPConfig().mActiveRetransTimeout ==
+                               mrpCommissionerConfig.Value().mActiveRetransTimeout);
+        }
+
+        if (mrpAccessoryConfig.HasValue())
+        {
+            NL_TEST_ASSERT(inSuite,
+                           pairingCommissioner.GetRemoteMRPConfig().mIdleRetransTimeout ==
+                               mrpAccessoryConfig.Value().mIdleRetransTimeout);
+            NL_TEST_ASSERT(inSuite,
+                           pairingCommissioner.GetRemoteMRPConfig().mActiveRetransTimeout ==
+                               mrpAccessoryConfig.Value().mActiveRetransTimeout);
+        }
+
+        // Now evict the PASE sessions.
+        auto session = pairingCommissioner.CopySecureSession();
+        NL_TEST_ASSERT(inSuite, session.HasValue());
+        session.Value()->AsSecureSession()->MarkForEviction();
+
+        session = pairingAccessory.CopySecureSession();
+        NL_TEST_ASSERT(inSuite, session.HasValue());
+        session.Value()->AsSecureSession()->MarkForEviction();
+
+        // Evicting a session async notifies the PASESession's delegate.  Normally
+        // that notification is what would delete the PASESession, but in our case
+        // that will happen as soon as things come off the stack.  So make sure to
+        // process the async bits before that happens.
         ctx.DrainAndServiceIO();
-    };
 
-    // Standalone acks also increment the mSentMessageCount. But some messages could be acked
-    // via piggybacked acks. So we cannot check for a specific value of mSentMessageCount.
-    // Let's make sure atleast number is >= than the minimum messages required to complete the
-    // handshake.
-    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= sTestPaseMessageCount);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 0);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
+        // And check that this did not result in any new notifications.
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 0);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 
-    if (mrpCommissionerConfig.HasValue())
-    {
-        NL_TEST_ASSERT(inSuite,
-                       pairingAccessory.GetRemoteMRPConfig().mIdleRetransTimeout ==
-                           mrpCommissionerConfig.Value().mIdleRetransTimeout);
-        NL_TEST_ASSERT(inSuite,
-                       pairingAccessory.GetRemoteMRPConfig().mActiveRetransTimeout ==
-                           mrpCommissionerConfig.Value().mActiveRetransTimeout);
+        loopback.SetLoopbackTransportDelegate(nullptr);
     }
 
-    if (mrpAccessoryConfig.HasValue())
+    void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     {
-        NL_TEST_ASSERT(inSuite,
-                       pairingCommissioner.GetRemoteMRPConfig().mIdleRetransTimeout ==
-                           mrpAccessoryConfig.Value().mIdleRetransTimeout);
-        NL_TEST_ASSERT(inSuite,
-                       pairingCommissioner.GetRemoteMRPConfig().mActiveRetransTimeout ==
-                           mrpAccessoryConfig.Value().mActiveRetransTimeout);
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
+
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
+                                         Optional<ReliableMessageProtocolConfig>::Missing(),
+                                         Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
     }
 
-    // Now evict the PASE sessions.
-    auto session = pairingCommissioner.CopySecureSession();
-    NL_TEST_ASSERT(inSuite, session.HasValue());
-    session.Value()->AsSecureSession()->MarkForEviction();
+    void SecurePairingHandshakeWithCommissionerMRPTest(nlTestSuite * inSuite, void * inContext)
+    {
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
 
-    session = pairingAccessory.CopySecureSession();
-    NL_TEST_ASSERT(inSuite, session.HasValue());
-    session.Value()->AsSecureSession()->MarkForEviction();
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32, 4000_ms16);
+        SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
+                                         Optional<ReliableMessageProtocolConfig>::Value(config),
+                                         Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
+    }
 
-    // Evicting a session async notifies the PASESession's delegate.  Normally
-    // that notification is what would delete the PASESession, but in our case
-    // that will happen as soon as things come off the stack.  So make sure to
-    // process the async bits before that happens.
-    ctx.DrainAndServiceIO();
+    void SecurePairingHandshakeWithDeviceMRPTest(nlTestSuite * inSuite, void * inContext)
+    {
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
 
-    // And check that this did not result in any new notifications.
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 0);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 0);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32, 4000_ms16);
+        SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
+                                         Optional<ReliableMessageProtocolConfig>::Missing(),
+                                         Optional<ReliableMessageProtocolConfig>::Value(config), delegateCommissioner);
+    }
 
-    loopback.SetLoopbackTransportDelegate(nullptr);
-}
+    void SecurePairingHandshakeWithAllMRPTest(nlTestSuite * inSuite, void * inContext)
+    {
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
 
-void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        ReliableMessageProtocolConfig commissionerConfig(1000_ms32, 10000_ms32, 4000_ms16);
+        ReliableMessageProtocolConfig deviceConfig(2000_ms32, 7000_ms32, 4000_ms16);
+        SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
+                                         Optional<ReliableMessageProtocolConfig>::Value(commissionerConfig),
+                                         Optional<ReliableMessageProtocolConfig>::Value(deviceConfig), delegateCommissioner);
+    }
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
-                                     Optional<ReliableMessageProtocolConfig>::Missing(),
-                                     Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
-}
+    void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inContext)
+    {
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
 
-void SecurePairingHandshakeWithCommissionerMRPTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        loopback.mNumMessagesToDrop = 2;
+        SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
+                                         Optional<ReliableMessageProtocolConfig>::Missing(),
+                                         Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
+        NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
+        NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    }
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32, 4000_ms16);
-    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
-                                     Optional<ReliableMessageProtocolConfig>::Value(config),
-                                     Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
-}
+    void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
+    {
+        TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+        TemporarySessionManager sessionManager(inSuite, ctx);
 
-void SecurePairingHandshakeWithDeviceMRPTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        TestSecurePairingDelegate delegateCommissioner;
+        PASESession pairingCommissioner;
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32, 4000_ms16);
-    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
-                                     Optional<ReliableMessageProtocolConfig>::Missing(),
-                                     Optional<ReliableMessageProtocolConfig>::Value(config), delegateCommissioner);
-}
+        TestSecurePairingDelegate delegateAccessory;
+        PASESession pairingAccessory;
 
-void SecurePairingHandshakeWithAllMRPTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        auto & loopback = ctx.GetLoopback();
+        loopback.Reset();
+        loopback.mSentMessageCount = 0;
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    ReliableMessageProtocolConfig commissionerConfig(1000_ms32, 10000_ms32, 4000_ms16);
-    ReliableMessageProtocolConfig deviceConfig(2000_ms32, 7000_ms32, 4000_ms16);
-    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
-                                     Optional<ReliableMessageProtocolConfig>::Value(commissionerConfig),
-                                     Optional<ReliableMessageProtocolConfig>::Value(deviceConfig), delegateCommissioner);
-}
+        ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
-void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        ReliableMessageMgr * rm     = ctx.GetExchangeManager().GetReliableMessageMgr();
+        ReliableMessageContext * rc = contextCommissioner->GetReliableMessageContext();
+        NL_TEST_ASSERT(inSuite, rm != nullptr);
+        NL_TEST_ASSERT(inSuite, rc != nullptr);
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    loopback.mNumMessagesToDrop = 2;
-    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
-                                     Optional<ReliableMessageProtocolConfig>::Missing(),
-                                     Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
-    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
-}
+        contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
+            64_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
+            64_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+        });
 
-void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    TemporarySessionManager sessionManager(inSuite, ctx);
+        NL_TEST_ASSERT(inSuite,
+                       ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
+                           Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
-    TestSecurePairingDelegate delegateCommissioner;
-    PASESession pairingCommissioner;
+        NL_TEST_ASSERT(inSuite,
+                       pairingAccessory.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                                                       ByteSpan(sTestSpake2p01_Salt),
+                                                       Optional<ReliableMessageProtocolConfig>::Missing(),
+                                                       &delegateAccessory) == CHIP_NO_ERROR);
+        ctx.DrainAndServiceIO();
 
-    TestSecurePairingDelegate delegateAccessory;
-    PASESession pairingAccessory;
+        NL_TEST_ASSERT(inSuite,
+                       pairingCommissioner.Pair(sessionManager, 4321, Optional<ReliableMessageProtocolConfig>::Missing(),
+                                                contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
+        ctx.DrainAndServiceIO();
 
-    auto & loopback = ctx.GetLoopback();
-    loopback.Reset();
-    loopback.mSentMessageCount = 0;
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 0);
+        NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 1);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 0);
+        NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 1);
+    }
 
-    ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
+    void PASEVerifierSerializeTest(nlTestSuite * inSuite, void * inContext)
+    {
+        Spake2pVerifier verifier;
+        NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(sTestSpake2p01_SerializedVerifier)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&verifier, &sTestSpake2p01_PASEVerifier, sizeof(Spake2pVerifier)) == 0);
 
-    ReliableMessageMgr * rm     = ctx.GetExchangeManager().GetReliableMessageMgr();
-    ReliableMessageContext * rc = contextCommissioner->GetReliableMessageContext();
-    NL_TEST_ASSERT(inSuite, rm != nullptr);
-    NL_TEST_ASSERT(inSuite, rc != nullptr);
+        Spake2pVerifierSerialized serializedVerifier;
+        MutableByteSpan serializedVerifierSpan(serializedVerifier);
+        NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifierSpan) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, serializedVerifierSpan.size() == kSpake2p_VerifierSerialized_Length);
+        NL_TEST_ASSERT(inSuite,
+                       memcmp(serializedVerifier, sTestSpake2p01_SerializedVerifier, kSpake2p_VerifierSerialized_Length) == 0);
 
-    contextCommissioner->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteMRPConfig({
-        64_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
-        64_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
-    });
+        Spake2pVerifierSerialized serializedVerifier2;
+        MutableByteSpan serializedVerifier2Span(serializedVerifier2);
+        NL_TEST_ASSERT(inSuite,
+                       chip::Crypto::DRBG_get_bytes(serializedVerifier, kSpake2p_VerifierSerialized_Length) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(serializedVerifier)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifier2Span) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, serializedVerifier2, kSpake2p_VerifierSerialized_Length) == 0);
+    }
 
-    NL_TEST_ASSERT(inSuite,
-                   ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
-                       Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
+    // Test Suite
 
-    NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(
-                       sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount, ByteSpan(sTestSpake2p01_Salt),
-                       Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory) == CHIP_NO_ERROR);
-    ctx.DrainAndServiceIO();
-
-    NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(sessionManager, 4321, Optional<ReliableMessageProtocolConfig>::Missing(),
-                                            contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
-    ctx.DrainAndServiceIO();
-
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 0);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingErrors == 1);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 0);
-    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingErrors == 1);
-}
-
-void PASEVerifierSerializeTest(nlTestSuite * inSuite, void * inContext)
-{
-    Spake2pVerifier verifier;
-    NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(sTestSpake2p01_SerializedVerifier)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(&verifier, &sTestSpake2p01_PASEVerifier, sizeof(Spake2pVerifier)) == 0);
-
-    Spake2pVerifierSerialized serializedVerifier;
-    MutableByteSpan serializedVerifierSpan(serializedVerifier);
-    NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifierSpan) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, serializedVerifierSpan.size() == kSpake2p_VerifierSerialized_Length);
-    NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, sTestSpake2p01_SerializedVerifier, kSpake2p_VerifierSerialized_Length) == 0);
-
-    Spake2pVerifierSerialized serializedVerifier2;
-    MutableByteSpan serializedVerifier2Span(serializedVerifier2);
-    NL_TEST_ASSERT(inSuite, chip::Crypto::DRBG_get_bytes(serializedVerifier, kSpake2p_VerifierSerialized_Length) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(serializedVerifier)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifier2Span) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, serializedVerifier2, kSpake2p_VerifierSerialized_Length) == 0);
-}
-
-// Test Suite
-
-/**
- *  Test Suite that lists all the test functions.
- */
-// clang-format off
+    /**
+     *  Test Suite that lists all the test functions.
+     */
+    // clang-format off
 static const nlTest sTests[] =
 {
     NL_TEST_DEF("WaitInit",    SecurePairingWaitTest),
@@ -533,31 +536,31 @@ static nlTestSuite sSuite =
     TestSecurePairing_Setup,
     TestSecurePairing_Teardown,
 };
-// clang-format on
+    // clang-format on
 
-// clang-format on
-//
-/**
- *  Set up the test suite.
- */
-int TestSecurePairing_Setup(void * inContext)
-{
-    auto & ctx = *static_cast<TestContext *>(inContext);
+    // clang-format on
+    //
+    /**
+     *  Set up the test suite.
+     */
+    int TestSecurePairing_Setup(void * inContext)
+    {
+        auto & ctx = *static_cast<TestContext *>(inContext);
 
-    // Initialize System memory and resources
-    ctx.ConfigInitializeNodes(false);
-    VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
+        // Initialize System memory and resources
+        ctx.ConfigInitializeNodes(false);
+        VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
 
-    return SUCCESS;
-}
+        return SUCCESS;
+    }
 
-/**
- *  Tear down the test suite.
- */
-int TestSecurePairing_Teardown(void * inContext)
-{
-    return TestContext::Finalize(inContext);
-}
+    /**
+     *  Tear down the test suite.
+     */
+    int TestSecurePairing_Teardown(void * inContext)
+    {
+        return TestContext::Finalize(inContext);
+    }
 
 } // anonymous namespace
 


### PR DESCRIPTION
#### Description
* Adds a run of units while source built as an ICD to cover ICD specific tests / code paths
* Adapt uni test to be able to run as an ICD - Use the readhandler max interval and not the read client max interval since the ICD can select a different maxInterval for the subscription

fixes #28446
fixes #28419

#### Tests
CI run