### PR TITLE
Fix potential -Wmacro-redefined warning in TestInetCommonOptions.cpp

### DIFF
--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -26,7 +26,9 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include "TestInetCommonOptions.h"
 


### PR DESCRIPTION
Add a guard around force defining __STDC_FORMAT_MACROS, which may be defined centrally.