### PR TITLE
Update ZAP to fix handling of Darwin provisional availability.

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.zap
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.zap
@@ -6822,7 +6822,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -6838,7 +6838,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -6854,7 +6854,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -6870,7 +6870,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -7543,6 +7543,5 @@
       "endpointId": 4,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
@@ -3992,7 +3992,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4008,7 +4008,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4024,7 +4024,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -5845,6 +5845,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -14792,7 +14792,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -14808,7 +14808,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -14824,7 +14824,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -14840,7 +14840,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -21885,6 +21885,5 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
@@ -7521,7 +7521,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -7537,7 +7537,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -7553,7 +7553,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -12316,6 +12316,5 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -5555,7 +5555,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "External",
               "singleton": 0,
@@ -5571,7 +5571,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "External",
               "singleton": 0,
@@ -5587,7 +5587,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "External",
               "singleton": 0,
@@ -5705,6 +5705,5 @@
       "endpointId": 2,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
@@ -4779,6 +4779,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.zap
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.zap
@@ -6565,7 +6565,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -6581,7 +6581,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -6597,7 +6597,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -7828,6 +7828,5 @@
       "endpointId": 5,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.zap
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.zap
@@ -2897,7 +2897,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "NVM",
               "singleton": 0,
@@ -2913,7 +2913,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "NVM",
               "singleton": 0,
@@ -2929,7 +2929,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "NVM",
               "singleton": 0,
@@ -2945,7 +2945,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "NVM",
               "singleton": 0,
@@ -6062,6 +6062,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.zap
+++ b/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.zap
@@ -3922,6 +3922,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
@@ -3902,6 +3902,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.zap
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.zap
@@ -3084,6 +3084,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.zap
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.zap
@@ -3516,6 +3516,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
+++ b/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
@@ -3517,6 +3517,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
@@ -3413,6 +3413,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
@@ -4006,6 +4006,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.zap
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.zap
@@ -3227,6 +3227,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.zap
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.zap
@@ -2986,6 +2986,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_genericswitch_9866e35d0b.zap
+++ b/examples/chef/devices/rootnode_genericswitch_9866e35d0b.zap
@@ -2390,6 +2390,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.zap
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.zap
@@ -3591,6 +3591,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.zap
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.zap
@@ -2986,6 +2986,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
@@ -3353,6 +3353,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
@@ -2954,6 +2954,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.zap
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.zap
@@ -2970,6 +2970,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
@@ -3426,6 +3426,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_onofflight_samplemei.zap
+++ b/examples/chef/devices/rootnode_onofflight_samplemei.zap
@@ -3558,6 +3558,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.zap
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.zap
@@ -3146,6 +3146,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.zap
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.zap
@@ -3174,6 +3174,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
@@ -2996,6 +2996,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_pump_5f904818cc.zap
+++ b/examples/chef/devices/rootnode_pump_5f904818cc.zap
@@ -3046,7 +3046,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -3062,7 +3062,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -3078,7 +3078,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -3513,6 +3513,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_pump_a811bb33a0.zap
+++ b/examples/chef/devices/rootnode_pump_a811bb33a0.zap
@@ -2971,6 +2971,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
+++ b/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
@@ -3777,6 +3777,5 @@
       "endpointId": 3,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.zap
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.zap
@@ -3035,6 +3035,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.zap
+++ b/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.zap
@@ -3132,6 +3132,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.zap
+++ b/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.zap
@@ -3069,6 +3069,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.zap
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.zap
@@ -3158,6 +3158,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.zap
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.zap
@@ -2827,7 +2827,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2843,7 +2843,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2859,7 +2859,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2970,6 +2970,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.zap
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.zap
@@ -3801,6 +3801,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.zap
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.zap
@@ -3462,6 +3462,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/chef/devices/template.zap
+++ b/examples/chef/devices/template.zap
@@ -2772,6 +2772,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.zap
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.zap
@@ -4698,6 +4698,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -312,9 +312,9 @@ public:
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-{{/if}}
 {{#if (isProvisional (asUpperCamelCase name preserveAcronyms=true))}}
 #endif // MTR_ENABLE_PROVISIONAL
+{{/if}}
 {{/if}}
 {{/zcl_clusters}}
 

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.zap
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.zap
@@ -3903,6 +3903,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -5832,6 +5832,5 @@
       "endpointId": 2,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.zap
@@ -4277,6 +4277,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.zap
@@ -5253,6 +5253,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
@@ -4460,6 +4460,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -5976,6 +5976,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/nxp/zap/lighting-on-off.zap
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.zap
@@ -3930,6 +3930,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/qpg/zap/light.zap
+++ b/examples/lighting-app/qpg/zap/light.zap
@@ -6207,6 +6207,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -5916,6 +5916,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -5092,6 +5092,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -6644,6 +6644,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lock-app/nxp/zap/lock-app.zap
+++ b/examples/lock-app/nxp/zap/lock-app.zap
@@ -3393,6 +3393,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lock-app/qpg/zap/lock.zap
+++ b/examples/lock-app/qpg/zap/lock.zap
@@ -5268,6 +5268,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/log-source-app/log-source-common/log-source-app.zap
+++ b/examples/log-source-app/log-source-common/log-source-app.zap
@@ -737,6 +737,5 @@
       "endpointId": 0,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.zap
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.zap
@@ -2267,6 +2267,5 @@
       "endpointId": 0,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
@@ -3424,6 +3424,5 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -9030,7 +9030,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9046,7 +9046,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9062,7 +9062,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9078,7 +9078,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -15189,6 +15189,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/placeholder/linux/apps/app2/config.zap
+++ b/examples/placeholder/linux/apps/app2/config.zap
@@ -9104,7 +9104,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9120,7 +9120,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9136,7 +9136,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -9152,7 +9152,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -14981,6 +14981,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-app/pump-common/pump-app.zap
+++ b/examples/pump-app/pump-common/pump-app.zap
@@ -4001,7 +4001,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4017,7 +4017,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4033,7 +4033,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4049,7 +4049,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4590,6 +4590,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-app/silabs/data_model/pump-thread-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.zap
@@ -4001,7 +4001,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4017,7 +4017,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4033,7 +4033,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4049,7 +4049,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4590,6 +4590,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.zap
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.zap
@@ -4001,7 +4001,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4017,7 +4017,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4033,7 +4033,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4049,7 +4049,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -4590,6 +4590,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
@@ -3416,6 +3416,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
+++ b/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
@@ -3717,6 +3717,5 @@
       "endpointId": 3,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.zap
+++ b/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.zap
@@ -5323,6 +5323,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/rvc-app/rvc-common/rvc-app.zap
+++ b/examples/rvc-app/rvc-common/rvc-app.zap
@@ -2783,6 +2783,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.zap
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.zap
@@ -4833,6 +4833,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.zap
+++ b/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.zap
@@ -2875,7 +2875,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2891,7 +2891,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2907,7 +2907,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -2970,6 +2970,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
@@ -4934,6 +4934,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
@@ -4076,6 +4076,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -5043,6 +5043,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -7621,6 +7621,5 @@
       "endpointId": 3,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -4366,6 +4366,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
@@ -6122,6 +6122,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -7057,6 +7057,5 @@
       "endpointId": 2,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2023.10.24-nightly.1"]
+            "tags": ["version:2@v2023.10.30-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2023.10.24-nightly.1"]
+            "tags": ["version:2@v2023.10.30-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2023.10.24-nightly
+v2023.10.30-nightly

--- a/scripts/tools/zap/tests/inputs/all-clusters-app.zap
+++ b/scripts/tools/zap/tests/inputs/all-clusters-app.zap
@@ -11586,7 +11586,7 @@
               "code": 0,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -11602,7 +11602,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -11618,7 +11618,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "type": "int16s",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -11634,7 +11634,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "type": "int16u",
+              "type": "temperature",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -16797,6 +16797,5 @@
       "endpointId": 65534,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/scripts/tools/zap/tests/inputs/lighting-app.zap
+++ b/scripts/tools/zap/tests/inputs/lighting-app.zap
@@ -5742,6 +5742,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2023.10.24'
+MIN_ZAP_VERSION = '2023.10.28'
 
 
 class ZapTool:

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -5081,6 +5081,5 @@
       "endpointId": 1,
       "networkId": 0
     }
-  ],
-  "log": []
+  ]
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -2518,6 +2518,7 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(Attribute
         }
         return value;
     }
+#if MTR_ENABLE_PROVISIONAL
     case Attributes::SupportedWiFiBands::Id: {
         using TypeInfo = Attributes::SupportedWiFiBands::TypeInfo;
         TypeInfo::DecodableType cppValue;
@@ -2544,6 +2545,8 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(Attribute
         }
         return value;
     }
+#endif // MTR_ENABLE_PROVISIONAL
+#if MTR_ENABLE_PROVISIONAL
     case Attributes::SupportedThreadFeatures::Id: {
         using TypeInfo = Attributes::SupportedThreadFeatures::TypeInfo;
         TypeInfo::DecodableType cppValue;
@@ -2555,6 +2558,8 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(Attribute
         value = [NSNumber numberWithUnsignedShort:cppValue.Raw()];
         return value;
     }
+#endif // MTR_ENABLE_PROVISIONAL
+#if MTR_ENABLE_PROVISIONAL
     case Attributes::ThreadVersion::Id: {
         using TypeInfo = Attributes::ThreadVersion::TypeInfo;
         TypeInfo::DecodableType cppValue;
@@ -2566,6 +2571,7 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(Attribute
         value = [NSNumber numberWithUnsignedShort:cppValue];
         return value;
     }
+#endif // MTR_ENABLE_PROVISIONAL
     default: {
         break;
     }


### PR DESCRIPTION
The template change is fixing a place where we checked for "provisional" even
for things that are not supported at all, and they started coming back as
"provisional" now.

MIN_ZAP_VERSION is being set to the date the commit was merged (which is what we
are getting in the reported ZAP version), not to the tag date, which is later.