### PR TITLE
[Linux][BLE] Remove handlers for StartNotify() and StopNotify()

### DIFF
--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -302,15 +302,6 @@ static gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, G
     return TRUE;
 }
 
-static gboolean BluezCharacteristicWriteValueError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                                   GVariant * aValue, GVariant * aOptions, gpointer apClosure)
-{
-    ChipLogDetail(DeviceLayer, "BluezCharacteristicWriteValueError");
-    g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotSupported",
-                                               "Write for characteristic is unsupported");
-    return TRUE;
-}
-
 static void Bluez_gatt_characteristic1_complete_acquire_write_with_fd(GDBusMethodInvocation * invocation, int fd, guint16 mtu)
 {
     GUnixFDList * fd_list = g_unix_fd_list_new();
@@ -442,73 +433,6 @@ static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 *
     return TRUE;
 }
 
-static gboolean BluezCharacteristicStartNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                               gpointer apEndpoint)
-{
-    bool isSuccess         = false;
-    BluezConnection * conn = nullptr;
-
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
-    VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
-
-    conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != nullptr,
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
-
-    if (bluez_gatt_characteristic1_get_notifying(aChar) == TRUE)
-    {
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "Characteristic is already subscribed");
-    }
-    else
-    {
-        bluez_gatt_characteristic1_complete_start_notify(aChar, aInvocation);
-        bluez_gatt_characteristic1_set_notifying(aChar, TRUE);
-        conn->SetNotifyAcquired(true);
-        BLEManagerImpl::HandleTXCharCCCDWrite(conn);
-    }
-    isSuccess = true;
-
-exit:
-    return isSuccess ? TRUE : FALSE;
-}
-
-static gboolean BluezCharacteristicStartNotifyError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)
-{
-    g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotSupported",
-                                               "Subscribing to characteristic is unsupported");
-    return TRUE;
-}
-
-static gboolean BluezCharacteristicStopNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
-                                              gpointer apEndpoint)
-{
-    bool isSuccess         = false;
-    BluezConnection * conn = nullptr;
-
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
-    VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
-
-    conn = GetBluezConnectionViaDevice(endpoint);
-    VerifyOrExit(conn != nullptr,
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No Chipoble connection"));
-
-    if (bluez_gatt_characteristic1_get_notifying(aChar) == FALSE)
-    {
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "Characteristic is already unsubscribed");
-    }
-    else
-    {
-        bluez_gatt_characteristic1_complete_start_notify(aChar, aInvocation);
-        bluez_gatt_characteristic1_set_notifying(aChar, FALSE);
-    }
-    conn->SetNotifyAcquired(false);
-
-    isSuccess = true;
-
-exit:
-    return isSuccess ? TRUE : FALSE;
-}
-
 static gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
                                            gpointer apClosure)
 {
@@ -518,13 +442,6 @@ static gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDB
     ChipLogDetail(Ble, "Indication confirmation, %p", conn);
     BLEManagerImpl::HandleTXComplete(conn);
 
-    return TRUE;
-}
-
-static gboolean BluezCharacteristicStopNotifyError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)
-{
-    g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed",
-                                               "Unsubscribing from characteristic is unsupported");
     return TRUE;
 }
 
@@ -915,21 +832,15 @@ static void BluezPeripheralObjectsSetup(BluezEndpoint * endpoint)
     bluez_gatt_characteristic1_set_flags(endpoint->mpC1, c1_flags);
 
     g_signal_connect(endpoint->mpC1, "handle-read-value", G_CALLBACK(BluezCharacteristicReadValue), endpoint);
-    g_signal_connect(endpoint->mpC1, "handle-write-value", G_CALLBACK(BluezCharacteristicWriteValueError), nullptr);
     g_signal_connect(endpoint->mpC1, "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWrite), endpoint);
     g_signal_connect(endpoint->mpC1, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotifyError), nullptr);
-    g_signal_connect(endpoint->mpC1, "handle-start-notify", G_CALLBACK(BluezCharacteristicStartNotifyError), nullptr);
-    g_signal_connect(endpoint->mpC1, "handle-stop-notify", G_CALLBACK(BluezCharacteristicStopNotifyError), nullptr);
     g_signal_connect(endpoint->mpC1, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirmError), nullptr);
 
     endpoint->mpC2 = BluezCharacteristicCreate(endpoint->mpService, "c2", CHIP_PLAT_BLE_UUID_C2_STRING, endpoint->mpRoot);
     bluez_gatt_characteristic1_set_flags(endpoint->mpC2, c2_flags);
     g_signal_connect(endpoint->mpC2, "handle-read-value", G_CALLBACK(BluezCharacteristicReadValue), endpoint);
-    g_signal_connect(endpoint->mpC2, "handle-write-value", G_CALLBACK(BluezCharacteristicWriteValueError), nullptr);
     g_signal_connect(endpoint->mpC2, "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
     g_signal_connect(endpoint->mpC2, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotify), endpoint);
-    g_signal_connect(endpoint->mpC2, "handle-start-notify", G_CALLBACK(BluezCharacteristicStartNotify), endpoint);
-    g_signal_connect(endpoint->mpC2, "handle-stop-notify", G_CALLBACK(BluezCharacteristicStopNotify), endpoint);
     g_signal_connect(endpoint->mpC2, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirm), endpoint);
 
     ChipLogDetail(DeviceLayer, "CHIP BTP C1 %s", bluez_gatt_characteristic1_get_service(endpoint->mpC1));
@@ -941,11 +852,8 @@ static void BluezPeripheralObjectsSetup(BluezEndpoint * endpoint)
     endpoint->mpC3 = BluezCharacteristicCreate(endpoint->mpService, "c3", CHIP_PLAT_BLE_UUID_C3_STRING, endpoint->mpRoot);
     bluez_gatt_characteristic1_set_flags(endpoint->mpC3, c3_flags);
     g_signal_connect(endpoint->mpC3, "handle-read-value", G_CALLBACK(BluezCharacteristicReadValue), endpoint);
-    g_signal_connect(endpoint->mpC3, "handle-write-value", G_CALLBACK(BluezCharacteristicWriteValueError), nullptr);
     g_signal_connect(endpoint->mpC3, "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
     g_signal_connect(endpoint->mpC3, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotify), endpoint);
-    g_signal_connect(endpoint->mpC3, "handle-start-notify", G_CALLBACK(BluezCharacteristicStartNotify), endpoint);
-    g_signal_connect(endpoint->mpC3, "handle-stop-notify", G_CALLBACK(BluezCharacteristicStopNotify), endpoint);
     g_signal_connect(endpoint->mpC3, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirm), endpoint);
     // update the characteristic value
     UpdateAdditionalDataCharacteristic(endpoint->mpC3);


### PR DESCRIPTION
### Problem

When `NotifyAcquired` and `WriteAcquired` properties are present, BlueZ does not use `StartNotify()`/`StopNotify()` nor `WriteValue()` D-Bus method calls, but instead starts notification and writing with `AcquireNotify()` and `AcquireWrite()` calls respectively. Attaching call handlers to these functions might give false impression that the logic in these functions will be called... but in fact it will be not. All logic for notification/write shall be in the corresponding acquire calls.

From BlueZ doc:
```
fd, uint16 AcquireWrite(dict options) [optional]
        Acquire file descriptor and MTU for writing. Only sockets are supported.
        Usage of WriteValue will be locked causing it to return NotPermitted
        error.

fd, uint16 AcquireNotify(dict options) [optional]
        Acquire file descriptor and MTU for notify. Only sockets are support.
        Usage of StartNotify will be locked causing it to return
        **org.bluez.Error.NotPermitted**.
        Only works with characteristic that has **NotifyAcquired** property

```

This PR is a code cleanup detected during work on #30063

### Testing

Manually tested linux-linux BLE commissioning.