### PR TITLE
Ensure that MRP logic is not executed for messages over other Transports

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
     // If session requires MRP, NoAutoRequestAck send flag is not specified and is not a group exchange context, request reliable
     // transmission.
     bool reliableTransmissionRequested =
-        GetSessionHandle()->RequireMRP() && !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck) && !IsGroupExchangeContext();
+        GetSessionHandle()->AllowsMRP() && !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck) && !IsGroupExchangeContext();
 
     bool currentMessageExpectResponse = false;
     // If a response message is expected...
@@ -322,8 +322,8 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, cons
 
     SetAckPending(false);
 
-    // Do not request Ack for multicast
-    SetAutoRequestAck(!session->IsGroupSession());
+    // Try to use MRP by default, if it is allowed.
+    SetAutoRequestAck(session->AllowsMRP());
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(app::ICDListener::KeepActiveFlags::kExchangeContextOpen);
@@ -531,34 +531,37 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
         MessageHandled();
     });
 
-    if (mDispatch.IsReliableTransmissionAllowed() && !IsGroupExchangeContext())
+    if (mSession->AllowsMRP())
     {
-        if (!msgFlags.Has(MessageFlagValues::kDuplicateMessage) && payloadHeader.IsAckMsg() &&
-            payloadHeader.GetAckMessageCounter().HasValue())
+        if (mDispatch.IsReliableTransmissionAllowed())
         {
-            HandleRcvdAck(payloadHeader.GetAckMessageCounter().Value());
+            if (!msgFlags.Has(MessageFlagValues::kDuplicateMessage) && payloadHeader.IsAckMsg() &&
+                payloadHeader.GetAckMessageCounter().HasValue())
+            {
+                HandleRcvdAck(payloadHeader.GetAckMessageCounter().Value());
+            }
+
+            if (payloadHeader.NeedsAck())
+            {
+                // An acknowledgment needs to be sent back to the peer for this message on this exchange,
+                HandleNeedsAck(messageCounter, msgFlags);
+            }
         }
 
-        if (payloadHeader.NeedsAck())
+        if (IsAckPending() && !mDelegate)
         {
-            // An acknowledgment needs to be sent back to the peer for this message on this exchange,
-            HandleNeedsAck(messageCounter, msgFlags);
+            // The incoming message wants an ack, but we have no delegate, so
+            // there's not going to be a response to piggyback on.  Just flush the
+            // ack out right now.
+            ReturnErrorOnFailure(FlushAcks());
         }
-    }
 
-    if (IsAckPending() && !mDelegate)
-    {
-        // The incoming message wants an ack, but we have no delegate, so
-        // there's not going to be a response to piggyback on.  Just flush the
-        // ack out right now.
-        ReturnErrorOnFailure(FlushAcks());
-    }
-
-    // The SecureChannel::StandaloneAck message type is only used for MRP; do not pass such messages to the application layer.
-    if (isStandaloneAck)
-    {
-        return CHIP_NO_ERROR;
-    }
+        // The SecureChannel::StandaloneAck message type is only used for MRP; do not pass such messages to the application layer.
+        if (isStandaloneAck)
+        {
+            return CHIP_NO_ERROR;
+        }
+    } // AllowsMRP
 
     // Since the message is duplicate, let's not forward it up the stack
     if (isDuplicate)
@@ -566,23 +569,26 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
         return CHIP_NO_ERROR;
     }
 
-    if (IsEphemeralExchange())
+    if (mSession->AllowsMRP())
     {
-        // The EphemeralExchange has done its job, since StandaloneAck is sent in previous FlushAcks() call.
-        return CHIP_NO_ERROR;
-    }
+        if (IsEphemeralExchange())
+        {
+            // The EphemeralExchange has done its job, since StandaloneAck is sent in previous FlushAcks() call.
+            return CHIP_NO_ERROR;
+        }
 
-    if (IsWaitingForAck())
-    {
-        // The only way we can get here is a spec violation on the other side:
-        // we sent a message that needs an ack, and the other side responded
-        // with a message that does not contain an ack for the message we sent.
-        // Just drop this message; if we delivered it to our delegate it might
-        // try to send another message-needing-an-ack in response, which would
-        // violate our internal invariants.
-        ChipLogError(ExchangeManager, "Dropping message without piggyback ack when we are waiting for an ack.");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
+        if (IsWaitingForAck())
+        {
+            // The only way we can get here is a spec violation on the other side:
+            // we sent a message that needs an ack, and the other side responded
+            // with a message that does not contain an ack for the message we sent.
+            // Just drop this message; if we delivered it to our delegate it might
+            // try to send another message-needing-an-ack in response, which would
+            // violate our internal invariants.
+            ChipLogError(ExchangeManager, "Dropping message without piggyback ack when we are waiting for an ack.");
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+    } // AllowsMRP
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // message received

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -48,6 +48,10 @@ public:
 
     // TODO: remove IsReliableTransmissionAllowed, this function should be provided over session.
     virtual bool IsReliableTransmissionAllowed() const { return true; }
+
+private:
+    CHIP_ERROR PrepareAndSendNonMRPMessage(SessionManager * sessionManager, const SessionHandle & session,
+                                           PayloadHeader & payloadHeader, System::PacketBufferHandle && message);
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -372,8 +372,10 @@ void ExchangeManager::SendStandaloneAckIfNeeded(const PacketHeader & packetHeade
                                                 const SessionHandle & session, MessageFlags msgFlags,
                                                 System::PacketBufferHandle && msgBuf)
 {
-    // If we need to send a StandaloneAck, create a EphemeralExchange for the purpose to send the StandaloneAck
-    if (!payloadHeader.NeedsAck())
+
+    // If using the MRP protocol and we need to send a StandaloneAck, create an EphemeralExchange to send
+    // the StandaloneAck.
+    if (!session->AllowsMRP() || !payloadHeader.NeedsAck())
         return;
 
     // If rcvd msg is from initiator then this exchange is created as not Initiator.

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -57,7 +57,8 @@ public:
         return subjectDescriptor;
     }
 
-    bool RequireMRP() const override { return false; }
+    bool AllowsMRP() const override { return false; }
+    bool IsTransportTCP() const override { return false; }
 
     const SessionParameters & GetRemoteSessionParameters() const override
     {
@@ -108,7 +109,8 @@ public:
         return Access::SubjectDescriptor(); // no subject exists for outgoing group session.
     }
 
-    bool RequireMRP() const override { return false; }
+    bool AllowsMRP() const override { return false; }
+    bool IsTransportTCP() const override { return false; }
 
     const SessionParameters & GetRemoteSessionParameters() const override
     {

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -58,7 +58,7 @@ public:
     }
 
     bool AllowsMRP() const override { return false; }
-    bool IsTransportTCP() const override { return false; }
+    bool AllowsLargePayload() const override { return false; }
 
     const SessionParameters & GetRemoteSessionParameters() const override
     {
@@ -110,7 +110,7 @@ public:
     }
 
     bool AllowsMRP() const override { return false; }
-    bool IsTransportTCP() const override { return false; }
+    bool AllowsLargePayload() const override { return false; }
 
     const SessionParameters & GetRemoteSessionParameters() const override
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -156,7 +156,9 @@ public:
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
 
-    bool RequireMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+    bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+
+    bool IsTransportTCP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -158,7 +158,7 @@ public:
 
     bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
 
-    bool IsTransportTCP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
+    bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -195,7 +195,8 @@ public:
     virtual ScopedNodeId GetPeer() const                                 = 0;
     virtual ScopedNodeId GetLocalScopedNodeId() const                    = 0;
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const       = 0;
-    virtual bool RequireMRP() const                                      = 0;
+    virtual bool AllowsMRP() const                                       = 0;
+    virtual bool IsTransportTCP() const                                  = 0;
     virtual const SessionParameters & GetRemoteSessionParameters() const = 0;
     virtual System::Clock::Timestamp GetMRPBaseTimeout() const           = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const          = 0;

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -196,7 +196,7 @@ public:
     virtual ScopedNodeId GetLocalScopedNodeId() const                    = 0;
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const       = 0;
     virtual bool AllowsMRP() const                                       = 0;
-    virtual bool IsTransportTCP() const                                  = 0;
+    virtual bool AllowsLargePayload() const                              = 0;
     virtual const SessionParameters & GetRemoteSessionParameters() const = 0;
     virtual System::Clock::Timestamp GetMRPBaseTimeout() const           = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const          = 0;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -85,7 +85,7 @@ public:
 
     bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
 
-    bool IsTransportTCP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
+    bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -83,7 +83,9 @@ public:
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.
     }
 
-    bool RequireMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+    bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+
+    bool IsTransportTCP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {


### PR DESCRIPTION
MRP based Ack handling and retransmissions should not be performed when messages are not sent using MRP, e.g., over TCP.
Install guards on Send/Receive paths to steer traffic to bypass MRP logic when going over TCP.

Fixes #30104 