### PR TITLE
Update availability annotations for Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -7729,6 +7729,9 @@
 - release: "Future"
   versions: "future"
   introduced:
+      bitmaps:
+          AdministratorCommissioning:
+              - Feature
       bitmap values:
           PumpConfigurationAndControl:
               PumpStatusBitmap:
@@ -7736,6 +7739,9 @@
           SoftwareDiagnostics:
               Feature:
                   - Watermarks
+          AdministratorCommissioning:
+              Feature:
+                  - Basic
   deprecated:
       bitmap values:
           PumpConfigurationAndControl:
@@ -7744,6 +7750,22 @@
           SoftwareDiagnostics:
               Feature:
                   - WaterMarks
+  provisional:
+      attributes:
+          NetworkCommissioning:
+              # Targeting Spring 2024 Matter release
+              - SupportedWiFiBands
+              - SupportedThreadFeatures
+              - ThreadVersion
+      commands:
+          GeneralDiagnostics:
+              # Targeting Spring 2024 Matter release
+              - TimeSnapshot
+              - TimeSnapshotResponse
+      bitmaps:
+          NetworkCommissioning:
+              # Targeting Spring 2024 Matter release
+              - ThreadCapabilitiesBitmap
   renames:
       bitmap values:
           PumpConfigurationAndControl:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -14230,8 +14230,8 @@ typedef NS_ENUM(uint8_t, MTRAdministratorCommissioningStatusCode) {
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_OPTIONS(uint32_t, MTRAdministratorCommissioningFeature) {
-    MTRAdministratorCommissioningFeatureBasic MTR_PROVISIONALLY_AVAILABLE = 0x1,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRAdministratorCommissioningFeatureBasic MTR_NEWLY_AVAILABLE = 0x1,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTROperationalCredentialsCertificateChainType) {
     MTROperationalCredentialsCertificateChainTypeDACCertificate MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x01,


### PR DESCRIPTION
* Administrator Commissioning feature map has been around for a while, but finally got added to the SDK, so that's not marked provisional.
* Various things targeting Spring 2024 Matter release are explicitly marked provisional.
