### PR TITLE
Update Kotlin json and tlv library name to match with its package name

### DIFF
--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -237,8 +237,8 @@ class AndroidBuilder(Builder):
             "CHIPController.jar": "src/controller/java/CHIPController.jar",
             "OnboardingPayload.jar": "src/controller/java/OnboardingPayload.jar",
             "AndroidPlatform.jar": "src/platform/android/AndroidPlatform.jar",
-            "libCHIPJson.jar": "src/controller/java/libCHIPJson.jar",
-            "libCHIPTlv.jar": "src/controller/java/libCHIPTlv.jar",
+            "libMatterJson.jar": "src/controller/java/libMatterJson.jar",
+            "libMatterTlv.jar": "src/controller/java/libMatterTlv.jar",
             "CHIPClusters.jar": "src/controller/java/CHIPClusters.jar",
             "CHIPClusterID.jar": "src/controller/java/CHIPClusterID.jar",
         }
@@ -568,8 +568,8 @@ class AndroidBuilder(Builder):
                 "CHIPController.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/CHIPController.jar"
                 ),
-                "libCHIPTlv.jar": os.path.join(
-                    self.output_dir, "lib", "src/controller/java/libCHIPTlv.jar"
+                "libMatterTlv.jar": os.path.join(
+                    self.output_dir, "lib", "src/controller/java/libMatterTlv.jar"
                 ),
                 "AndroidPlatform.jar": os.path.join(
                     self.output_dir, "lib", "src/platform/android/AndroidPlatform.jar"

--- a/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
+++ b/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
@@ -29,9 +29,9 @@ cp {out}/android-arm64-chip-tool/lib/src/controller/java/OnboardingPayload.jar {
 
 cp {out}/android-arm64-chip-tool/lib/src/platform/android/AndroidPlatform.jar {root}/examples/android/CHIPTool/app/libs/AndroidPlatform.jar
 
-cp {out}/android-arm64-chip-tool/lib/src/controller/java/libCHIPJson.jar {root}/examples/android/CHIPTool/app/libs/libCHIPJson.jar
+cp {out}/android-arm64-chip-tool/lib/src/controller/java/libMatterJson.jar {root}/examples/android/CHIPTool/app/libs/libMatterJson.jar
 
-cp {out}/android-arm64-chip-tool/lib/src/controller/java/libCHIPTlv.jar {root}/examples/android/CHIPTool/app/libs/libCHIPTlv.jar
+cp {out}/android-arm64-chip-tool/lib/src/controller/java/libMatterTlv.jar {root}/examples/android/CHIPTool/app/libs/libMatterTlv.jar
 
 cp {out}/android-arm64-chip-tool/lib/src/controller/java/CHIPClusters.jar {root}/examples/android/CHIPTool/app/libs/CHIPClusters.jar
 

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -177,7 +177,7 @@ if (chip_link_tests) {
 }
 
 kotlin_library("tlv") {
-  output_name = "libCHIPTlv.jar"
+  output_name = "libMatterTlv.jar"
 
   sources = [
     "src/matter/tlv/Element.kt",
@@ -236,7 +236,7 @@ kotlin_library("tlv_read_write_test") {
 }
 
 kotlin_library("jsontlv") {
-  output_name = "libCHIPJson.jar"
+  output_name = "libMatterJson.jar"
 
   deps = [
     ":tlv",


### PR DESCRIPTION
Kotlin jsontlv and tlv libraries has been moved to package matter.jsontlv, update json and tlv library name to match with its namespace

