### PR TITLE
[ICD]Add optional common ICD key to indicate ICD operating mode (LIT/SIT)

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -260,6 +260,11 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeDat
         value["mrpRetryActiveThreshold"] = resolutionData.mrpRetryActiveThreshold.Value().count();
     }
 
+    if (resolutionData.ICDOperatesAsLIT.HasValue())
+    {
+        value["ICDoperatesAsLIT"] = resolutionData.ICDOperatesAsLIT.Value();
+    }
+
     Json::Value rootValue;
     rootValue[kValueKey] = value;
 

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -260,9 +260,9 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeDat
         value["mrpRetryActiveThreshold"] = resolutionData.mrpRetryActiveThreshold.Value().count();
     }
 
-    if (resolutionData.ICDOperatesAsLIT.HasValue())
+    if (resolutionData.isICDOperatingAsLIT.HasValue())
     {
-        value["ICDoperatesAsLIT"] = resolutionData.ICDOperatesAsLIT.Value();
+        value["isICDOperatingAsLIT"] = resolutionData.isICDOperatingAsLIT.Value();
     }
 
     Json::Value rootValue;

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -54,7 +54,7 @@ public:
         ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms",
                         result.mrpRemoteConfig.mActiveRetransTimeout.count());
         ChipLogProgress(chipTool, "   Supports TCP: %s", result.supportsTcp ? "yes" : "no");
-        ChipLogProgress(chipTool, "   ICD operates as: %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        ChipLogProgress(chipTool, "   ICD is operating as: %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -54,7 +54,7 @@ public:
         ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms",
                         result.mrpRemoteConfig.mActiveRetransTimeout.count());
         ChipLogProgress(chipTool, "   Supports TCP: %s", result.supportsTcp ? "yes" : "no");
-        ChipLogProgress(chipTool, "   ICD is operating as: %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        ChipLogProgress(chipTool, "   ICD is operating as: %s", result.isICDOperatingAsLIT ? "LIT" : "SIT");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -54,6 +54,7 @@ public:
         ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms",
                         result.mrpRemoteConfig.mActiveRetransTimeout.count());
         ChipLogProgress(chipTool, "   Supports TCP: %s", result.supportsTcp ? "yes" : "no");
+        ChipLogProgress(chipTool, "   ICD operates as: %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
@@ -74,7 +74,7 @@ _DEFINITION = '''<?xml version="1.0"?>
         <arg name="mrpRetryIntervalIdle" type="int32u" optional="true"/>
         <arg name="mrpRetryIntervalActive" type="int32u" optional="true"/>
         <arg name="mrpRetryActiveThreshold" type="int16u" optional="true"/>
-        <arg name="ICDOperatesAsLIT" type="boolean" optional="true"/>
+        <arg name="isICDOperatingAsLIT" type="boolean" optional="true"/>
     </command>
 </cluster>
 </configurator>

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/discovery_commands.py
@@ -74,6 +74,7 @@ _DEFINITION = '''<?xml version="1.0"?>
         <arg name="mrpRetryIntervalIdle" type="int32u" optional="true"/>
         <arg name="mrpRetryIntervalActive" type="int32u" optional="true"/>
         <arg name="mrpRetryActiveThreshold" type="int16u" optional="true"/>
+        <arg name="ICDOperatesAsLIT" type="boolean" optional="true"/>
     </command>
 </cluster>
 </configurator>

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -82,7 +82,7 @@ void ICDManager::Shutdown()
     mFabricTable      = nullptr;
 }
 
-bool ICDManager::SupportsCheckInProtocol()
+bool ICDManager::SupportsFeature(Feature feature)
 {
     bool success        = false;
     uint32_t featureMap = 0;
@@ -90,7 +90,7 @@ bool ICDManager::SupportsCheckInProtocol()
 #ifndef CONFIG_BUILD_FOR_HOST_UNIT_TEST
     success = (Attributes::FeatureMap::Get(kRootEndpointId, &featureMap) == EMBER_ZCL_STATUS_SUCCESS);
 #endif
-    return success ? ((featureMap & to_underlying(Feature::kCheckInProtocolSupport)) != 0) : false;
+    return success ? ((featureMap & to_underlying(feature)) != 0) : false;
 }
 
 void ICDManager::UpdateICDMode()
@@ -101,7 +101,8 @@ void ICDManager::UpdateICDMode()
 
     // The Check In Protocol Feature is required and the slow polling interval shall also be greater than 15 seconds
     // to run an ICD in LIT mode.
-    if (GetSlowPollingInterval() > GetSITPollingThreshold() && SupportsCheckInProtocol())
+    if (GetSlowPollingInterval() > GetSITPollingThreshold() && SupportsFeature(Feature::kCheckInProtocolSupport) &&
+        SupportsFeature(Feature::kLongIdleTimeSupport))
     {
         VerifyOrDie(mStorage != nullptr);
         VerifyOrDie(mFabricTable != nullptr);

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -52,6 +52,12 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
     VerifyOrDie(stateObserver != nullptr);
     VerifyOrDie(symmetricKeystore != nullptr);
 
+    bool supportLIT = SupportsFeature(Feature::kLongIdleTimeSupport);
+    VerifyOrDieWithMsg((supportLIT == false) || (supportLIT && SupportsFeature(Feature::kCheckInProtocolSupport)), AppServer,
+                       "The CheckIn protocol feature is required for LIT support");
+    VerifyOrDieWithMsg((supportLIT == false) || (supportLIT && SupportsFeature(Feature::kUserActiveModeTrigger)), AppServer,
+                       "The user ActiveMode trigger feature is required for LIT support");
+
     mStorage       = storage;
     mFabricTable   = fabricTable;
     mStateObserver = stateObserver;
@@ -101,8 +107,7 @@ void ICDManager::UpdateICDMode()
 
     // The Check In Protocol Feature is required and the slow polling interval shall also be greater than 15 seconds
     // to run an ICD in LIT mode.
-    if (GetSlowPollingInterval() > GetSITPollingThreshold() && SupportsFeature(Feature::kCheckInProtocolSupport) &&
-        SupportsFeature(Feature::kLongIdleTimeSupport))
+    if (GetSlowPollingInterval() > GetSITPollingThreshold() && SupportsFeature(Feature::kLongIdleTimeSupport))
     {
         VerifyOrDie(mStorage != nullptr);
         VerifyOrDie(mFabricTable != nullptr);

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -53,9 +53,9 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
     VerifyOrDie(symmetricKeystore != nullptr);
 
     bool supportLIT = SupportsFeature(Feature::kLongIdleTimeSupport);
-    VerifyOrDieWithMsg((supportLIT == false) || (supportLIT && SupportsFeature(Feature::kCheckInProtocolSupport)), AppServer,
+    VerifyOrDieWithMsg((supportLIT == false) || SupportsFeature(Feature::kCheckInProtocolSupport), AppServer,
                        "The CheckIn protocol feature is required for LIT support");
-    VerifyOrDieWithMsg((supportLIT == false) || (supportLIT && SupportsFeature(Feature::kUserActiveModeTrigger)), AppServer,
+    VerifyOrDieWithMsg((supportLIT == false) || SupportsFeature(Feature::kUserActiveModeTrigger), AppServer,
                        "The user ActiveMode trigger feature is required for LIT support");
 
     mStorage       = storage;

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -58,6 +58,7 @@ public:
     void UpdateOperationState(OperationalState state);
     void SetKeepActiveModeRequirements(KeepActiveFlags flag, bool state);
     bool IsKeepActive() { return mKeepActiveFlags.HasAny(); }
+    bool SupportsCheckInProtocol();
     ICDMode GetICDMode() { return mICDMode; }
     OperationalState GetOperationalState() { return mOperationalState; }
 
@@ -96,8 +97,6 @@ private:
     static constexpr uint32_t kMinIdleModeDuration    = 500;
     static constexpr uint32_t kMinActiveModeDuration  = 300;
     static constexpr uint16_t kMinActiveModeThreshold = 300;
-
-    bool SupportsCheckInProtocol();
 
     BitFlags<KeepActiveFlags> mKeepActiveFlags{ 0 };
 

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/icd/ICDMonitoringTable.h>
 #include <app/icd/ICDNotifier.h>
 #include <app/icd/ICDStateObserver.h>
@@ -58,7 +59,7 @@ public:
     void UpdateOperationState(OperationalState state);
     void SetKeepActiveModeRequirements(KeepActiveFlags flag, bool state);
     bool IsKeepActive() { return mKeepActiveFlags.HasAny(); }
-    bool SupportsCheckInProtocol();
+    bool SupportsFeature(Clusters::IcdManagement::Feature feature);
     ICDMode GetICDMode() { return mICDMode; }
     OperationalState GetOperationalState() { return mOperationalState; }
 

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -146,8 +146,8 @@ CHIP_ERROR DnssdServer::SetEphemeralDiscriminator(Optional<uint16_t> discriminat
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-template <class Derived>
-void DnssdServer::AddICDKeyToAdvertisement(Dnssd::BaseAdvertisingParams<Derived> & advParams)
+template <class AdvertisingParams>
+void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 {
     // Only advertise the ICD key if the device can operate as a LIT
     if (Server::GetInstance().GetICDManager().SupportsFeature(Clusters::IcdManagement::Feature::kLongIdleTimeSupport))
@@ -188,7 +188,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
                                        .EnableIpV4(true);
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-        AddICDKeyToAdvertisement<Dnssd::OperationalAdvertisingParameters>(advertiseParameters);
+        AddICDKeyToAdvertisement(advertiseParameters);
 #endif
 
         auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
@@ -261,7 +261,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
     advertiseParameters.SetLocalMRPConfig(GetLocalMRPConfig()).SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT));
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    AddICDKeyToAdvertisement<Dnssd::CommissionAdvertisingParameters>(advertiseParameters);
+    AddICDKeyToAdvertisement(advertiseParameters);
 #endif
 
     if (commissionableNode)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -17,8 +17,8 @@
 
 #include <app/server/Dnssd.h>
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <inttypes.h>
-
 #include <lib/core/Optional.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/ServiceNaming.h>
@@ -176,7 +176,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         // Only advertise the ICD key if the device can be operate as LIT
-        if (Server::GetInstance().GetICDManager().SupportsCheckInProtocol())
+        if (Server::GetInstance().GetICDManager().SupportsFeature(Clusters::IcdManagement::Feature::kLongIdleTimeSupport))
         {
             advertiseParameters.SetICDOperatesAsLIT(
                 Optional<bool>(Server::GetInstance().GetICDManager().GetICDMode() == ICDManager::ICDMode::LIT));
@@ -254,7 +254,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Only advertise the ICD key if the device can be operate as LIT
-    if (Server::GetInstance().GetICDManager().SupportsCheckInProtocol())
+    if (Server::GetInstance().GetICDManager().SupportsFeature(Clusters::IcdManagement::Feature::kLongIdleTimeSupport))
     {
         advertiseParameters.SetICDOperatesAsLIT(
             Optional<bool>(Server::GetInstance().GetICDManager().GetICDMode() == ICDManager::ICDMode::LIT));

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -85,6 +85,10 @@ public:
     void OnExtendedDiscoveryExpiration(System::Layer * aSystemLayer, void * aAppState);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    template <class Derived>
+    void AddICDKeyToAdvertisement(Dnssd::BaseAdvertisingParams<Derived> & advParams);
+#endif
     /// Start operational advertising
     CHIP_ERROR AdvertiseOperational();
 

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -86,8 +86,8 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    template <class Derived>
-    void AddICDKeyToAdvertisement(Dnssd::BaseAdvertisingParams<Derived> & advParams);
+    template <class AdvertisingParams>
+    void AddICDKeyToAdvertisement(AdvertisingParams & advParams);
 #endif
     /// Start operational advertising
     CHIP_ERROR AdvertiseOperational();

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -349,6 +349,10 @@ public:
 
     app::reporting::ReportScheduler * GetReportScheduler() { return mReportScheduler; }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    app::ICDManager & GetICDManager() { return mICDManager; }
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
     /**
      * This function causes the ShutDown event to be generated async on the
      * Matter event loop.  Should be called before stopping the event loop.

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -181,9 +181,9 @@ void DiscoveryCommands::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData &
     //     data.mrpRetryActiveThreshold.SetValue(nodeData.resolutionData.mrpRetryActiveThreshold.Value().count());
     // }
 
-    // if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+    // if (nodeData.resolutionData.isICDOperatingAsLIT.HasValue())
     // {
-    //     data.ICDOperatesAsLIT.SetValue(resolutionData.ICDOperatesAsLIT.Value());
+    //     data.isICDOperatingAsLIT.SetValue(resolutionData.isICDOperatingAsLIT.Value());
     // }
 
     chip::app::StatusIB status;

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -175,15 +175,16 @@ void DiscoveryCommands::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData &
         data.mrpRetryIntervalActive.SetValue(nodeData.resolutionData.mrpRetryIntervalActive.Value().count());
     }
 
-    if (nodeData.resolutionData.mrpRetryActiveThreshold.HasValue())
-    {
-        data.mrpRetryActiveThreshold.SetValue(nodeData.resolutionData.mrpRetryActiveThreshold.Value().count());
-    }
+    // TODO need to add new entries for kDefaultResponse in DiscoveryCommands.js (project-chip/zap) before adding this
+    // if (nodeData.resolutionData.mrpRetryActiveThreshold.HasValue())
+    // {
+    //     data.mrpRetryActiveThreshold.SetValue(nodeData.resolutionData.mrpRetryActiveThreshold.Value().count());
+    // }
 
-    if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
-    {
-        data.ICDOperatesAsLIT.SetValue(resolutionData.ICDOperatesAsLIT.Value());
-    }
+    // if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+    // {
+    //     data.ICDOperatesAsLIT.SetValue(resolutionData.ICDOperatesAsLIT.Value());
+    // }
 
     chip::app::StatusIB status;
     status.mStatus = chip::Protocols::InteractionModel::Status::Success;

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -175,6 +175,16 @@ void DiscoveryCommands::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData &
         data.mrpRetryIntervalActive.SetValue(nodeData.resolutionData.mrpRetryIntervalActive.Value().count());
     }
 
+    if (nodeData.resolutionData.mrpRetryActiveThreshold.HasValue())
+    {
+        data.mrpRetryActiveThreshold.SetValue(nodeData.resolutionData.mrpRetryActiveThreshold.Value().count());
+    }
+
+    if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+    {
+        data.ICDOperatesAsLIT.SetValue(resolutionData.ICDOperatesAsLIT.Value());
+    }
+
     chip::app::StatusIB status;
     status.mStatus = chip::Protocols::InteractionModel::Status::Success;
 

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -120,7 +120,8 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
 
         if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD operates as %s", dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogProgress(Discovery, "\tICD is operating as\t%s",
+                            dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
         }
 
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -118,10 +118,10 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         }
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
 
-        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD is operating as\t%s",
-                            dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
+                            dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
 
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -117,6 +117,12 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
             ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
         }
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
+
+        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        {
+            ChipLogProgress(Discovery, "\tICD operates as %s", dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+        }
+
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
         {
             char buf[chip::Inet::IPAddress::kMaxStringLength];

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -128,6 +128,10 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         {
             jsonVal["mrpRetryIntervalActive"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count();
         }
+        if (dnsSdInfo->resolutionData.GetMrpRetryActiveThreshold().HasValue())
+        {
+            jsonVal["mrpRetryActiveThreshold"] = dnsSdInfo->resolutionData.GetMrpRetryActiveThreshold().Value().count();
+        }
         jsonVal["supportsTcp"] = dnsSdInfo->resolutionData.supportsTcp;
         {
             Json::Value addresses;
@@ -138,6 +142,10 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
                 addresses[j] = buf;
             }
             jsonVal["addresses"] = addresses;
+        }
+        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        {
+            jsonVal["ICDOperatesAsLIT"] = dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value();
         }
         if (dnsSdInfo->commissionData.rotatingIdLen > 0)
         {
@@ -196,6 +204,11 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
             ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
         }
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
+        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        {
+            ChipLogProgress(Discovery, "\tICD operates as %s\t",
+                            dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+        }
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
         {
             char buf[Inet::IPAddress::kMaxStringLength];

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -206,7 +206,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
         if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD operates as %s\t",
+            ChipLogProgress(Discovery, "\tICD is operating as \t%s",
                             dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
         }
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -143,9 +143,9 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
             }
             jsonVal["addresses"] = addresses;
         }
-        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
         {
-            jsonVal["ICDOperatesAsLIT"] = dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value();
+            jsonVal["isICDOperatingAsLIT"] = dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value();
         }
         if (dnsSdInfo->commissionData.rotatingIdLen > 0)
         {
@@ -204,10 +204,10 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
             ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
         }
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
-        if (dnsSdInfo->resolutionData.ICDOperatesAsLIT.HasValue())
+        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD is operating as \t%s",
-                            dnsSdInfo->resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
+                            dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
         {

--- a/src/controller/python/chip/discovery/__init__.py
+++ b/src/controller/python/chip/discovery/__init__.py
@@ -85,7 +85,9 @@ class CommissionableNode():
     pairingHint: int = None
     mrpRetryIntervalIdle: int = None
     mrpRetryIntervalActive: int = None
+    mrpRetryActiveThreshold: int = None
     supportsTcp: bool = None
+    ICDOperatesAsLIT: bool = None
     addresses: List[str] = None
     rotatingId: Optional[str] = None
 

--- a/src/controller/python/chip/discovery/__init__.py
+++ b/src/controller/python/chip/discovery/__init__.py
@@ -87,7 +87,7 @@ class CommissionableNode():
     mrpRetryIntervalActive: int = None
     mrpRetryActiveThreshold: int = None
     supportsTcp: bool = None
-    ICDOperatesAsLIT: bool = None
+    isICDOperatingAsLIT: bool = None
     addresses: List[str] = None
     rotatingId: Optional[str] = None
 

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -911,7 +911,9 @@ class ReplTestRunner:
                 'pairingHint': response.pairingHint,
                 'mrpRetryIntervalIdle': response.mrpRetryIntervalIdle,
                 'mrpRetryIntervalActive': response.mrpRetryIntervalActive,
+                'mrpRetryActiveThreshold': response.mrpRetryActiveThreshold,
                 'supportsTcp': response.supportsTcp,
+                'ICDOperatesAsLIT': response.ICDOperatesAsLIT,
                 'addresses': response.addresses,
                 'rotatingId': response.rotatingId,
 

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -913,7 +913,7 @@ class ReplTestRunner:
                 'mrpRetryIntervalActive': response.mrpRetryIntervalActive,
                 'mrpRetryActiveThreshold': response.mrpRetryActiveThreshold,
                 'supportsTcp': response.supportsTcp,
-                'ICDOperatesAsLIT': response.ICDOperatesAsLIT,
+                'isICDOperatingAsLIT': response.isICDOperatingAsLIT,
                 'addresses': response.addresses,
                 'rotatingId': response.rotatingId,
 

--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -33,8 +33,8 @@ struct ResolveResult
 {
     Transport::PeerAddress address;
     ReliableMessageProtocolConfig mrpRemoteConfig;
-    bool supportsTcp      = false;
-    bool ICDOperatesAsLIT = false;
+    bool supportsTcp         = false;
+    bool isICDOperatingAsLIT = false;
 
     ResolveResult() : address(Transport::Type::kUdp), mrpRemoteConfig(GetDefaultMRPConfig()) {}
 };

--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -33,7 +33,8 @@ struct ResolveResult
 {
     Transport::PeerAddress address;
     ReliableMessageProtocolConfig mrpRemoteConfig;
-    bool supportsTcp = false;
+    bool supportsTcp      = false;
+    bool ICDOperatesAsLIT = false;
 
     ResolveResult() : address(Transport::Type::kUdp), mrpRemoteConfig(GetDefaultMRPConfig()) {}
 };

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -287,6 +287,11 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
         result.mrpRemoteConfig = nodeData.resolutionData.GetRemoteMRPConfig();
         result.supportsTcp     = nodeData.resolutionData.supportsTcp;
 
+        if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+        {
+            result.ICDOperatesAsLIT = nodeData.resolutionData.ICDOperatesAsLIT.Value();
+        }
+
         for (size_t i = 0; i < nodeData.resolutionData.numIPs; i++)
         {
 #if !INET_CONFIG_ENABLE_IPV4

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -287,9 +287,9 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
         result.mrpRemoteConfig = nodeData.resolutionData.GetRemoteMRPConfig();
         result.supportsTcp     = nodeData.resolutionData.supportsTcp;
 
-        if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+        if (nodeData.resolutionData.isICDOperatingAsLIT.HasValue())
         {
-            result.ICDOperatesAsLIT = nodeData.resolutionData.ICDOperatesAsLIT.Value();
+            result.isICDOperatingAsLIT = nodeData.resolutionData.isICDOperatingAsLIT.Value();
         }
 
         for (size_t i = 0; i < nodeData.resolutionData.numIPs; i++)

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -60,7 +60,7 @@ public:
         ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpRemoteConfig.mIdleRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpRemoteConfig.mActiveRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE Threshold time:     %u ms", result.mrpRemoteConfig.mActiveThresholdTime.count());
-        ChipLogProgress(Discovery, "   ICD is operating as:           %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        ChipLogProgress(Discovery, "   ICD is operating as a:         %s", result.isICDOperatingAsLIT ? "LIT" : "SIT");
 
         NotifyDone();
     }

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -60,7 +60,7 @@ public:
         ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpRemoteConfig.mIdleRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpRemoteConfig.mActiveRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE Threshold time:     %u ms", result.mrpRemoteConfig.mActiveThresholdTime.count());
-        ChipLogProgress(Discovery, "   ICD operates as:               %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        ChipLogProgress(Discovery, "   ICD is operating as:           %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
 
         NotifyDone();
     }

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -59,7 +59,9 @@ public:
         ChipLogProgress(Discovery, "   Supports TCP:                  %s", result.supportsTcp ? "YES" : "NO");
         ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpRemoteConfig.mIdleRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpRemoteConfig.mActiveRetransTimeout.count());
-        ChipLogProgress(Discovery, "   MRP ACTIVE Threshold timet:    %u ms", result.mrpRemoteConfig.mActiveThresholdTime.count());
+        ChipLogProgress(Discovery, "   MRP ACTIVE Threshold time:     %u ms", result.mrpRemoteConfig.mActiveThresholdTime.count());
+        ChipLogProgress(Discovery, "   ICD operates as:               %s", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+
         NotifyDone();
     }
 

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -101,12 +101,12 @@ public:
     }
     Optional<bool> GetTcpSupported() const { return mTcpSupported; }
 
-    Derived & SetICDOperatesAsLIT(Optional<bool> ICDOperatesAsLIT)
+    Derived & SetICDOperatingAsLIT(Optional<bool> operatesAsLIT)
     {
-        mICDOperatesAsLIT = ICDOperatesAsLIT;
+        mICDOperatesAsLIT = operatesAsLIT;
         return *reinterpret_cast<Derived *>(this);
     }
-    Optional<bool> GetICDOperatesAsLIT() const { return mICDOperatesAsLIT; }
+    Optional<bool> GetICDOperatingAsLIT() const { return mICDOperatesAsLIT; }
 
 private:
     uint16_t mPort                   = CHIP_PORT;

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -101,6 +101,13 @@ public:
     }
     Optional<bool> GetTcpSupported() const { return mTcpSupported; }
 
+    Derived & SetICDOperatesAsLIT(Optional<bool> ICDOperatesAsLIT)
+    {
+        mICDOperatesAsLIT = ICDOperatesAsLIT;
+        return *reinterpret_cast<Derived *>(this);
+    }
+    Optional<bool> GetICDOperatesAsLIT() const { return mICDOperatesAsLIT; }
+
 private:
     uint16_t mPort                   = CHIP_PORT;
     Inet::InterfaceId mInterfaceId   = Inet::InterfaceId::Null();
@@ -109,6 +116,7 @@ private:
     size_t mMacLength                = 0;
     Optional<ReliableMessageProtocolConfig> mLocalMRPConfig;
     Optional<bool> mTcpSupported;
+    Optional<bool> mICDOperatesAsLIT;
 };
 
 /// Defines parameters required for advertising a CHIP node

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -219,7 +219,7 @@ private:
         char sessionActiveThresholdBuf[KeySize(TxtFieldKey::kSessionActiveThreshold) +
                                        ValSize(TxtFieldKey::kSessionActiveThreshold) + 2];
         char tcpSupportedBuf[KeySize(TxtFieldKey::kTcpSupported) + ValSize(TxtFieldKey::kTcpSupported) + 2];
-        char ICDAsLITBuf[KeySize(TxtFieldKey::kLongIdleTimeICD) + ValSize(TxtFieldKey::kLongIdleTimeICD) + 2];
+        char operatingICDAsLITBuf[KeySize(TxtFieldKey::kLongIdleTimeICD) + ValSize(TxtFieldKey::kLongIdleTimeICD) + 2];
     };
     template <class Derived>
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
@@ -281,13 +281,14 @@ private:
                                 CHIP_ERROR_INVALID_STRING_LENGTH);
             txtFields[numTxtFields++] = storage.tcpSupportedBuf;
         }
-        if (params.GetICDOperatesAsLIT().HasValue())
+        if (params.GetICDOperatingAsLIT().HasValue())
         {
-            size_t writtenCharactersNumber = static_cast<size_t>(
-                snprintf(storage.ICDAsLITBuf, sizeof(storage.ICDAsLITBuf), "ICD=%d", params.GetICDOperatesAsLIT().Value()));
-            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < sizeof(storage.ICDAsLITBuf)),
+            size_t writtenCharactersNumber =
+                static_cast<size_t>(snprintf(storage.operatingICDAsLITBuf, sizeof(storage.operatingICDAsLITBuf), "ICD=%d",
+                                             params.GetICDOperatingAsLIT().Value()));
+            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < sizeof(storage.operatingICDAsLITBuf)),
                                 CHIP_ERROR_INVALID_STRING_LENGTH);
-            txtFields[numTxtFields++] = storage.ICDAsLITBuf;
+            txtFields[numTxtFields++] = storage.operatingICDAsLITBuf;
         }
         return CHIP_NO_ERROR;
     }

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -219,6 +219,7 @@ private:
         char sessionActiveThresholdBuf[KeySize(TxtFieldKey::kSessionActiveThreshold) +
                                        ValSize(TxtFieldKey::kSessionActiveThreshold) + 2];
         char tcpSupportedBuf[KeySize(TxtFieldKey::kTcpSupported) + ValSize(TxtFieldKey::kTcpSupported) + 2];
+        char ICDAsLITBuf[KeySize(TxtFieldKey::kLongIdleTimeICD) + ValSize(TxtFieldKey::kLongIdleTimeICD) + 2];
     };
     template <class Derived>
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
@@ -279,6 +280,14 @@ private:
             VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < sizeof(storage.tcpSupportedBuf)),
                                 CHIP_ERROR_INVALID_STRING_LENGTH);
             txtFields[numTxtFields++] = storage.tcpSupportedBuf;
+        }
+        if (params.GetICDOperatesAsLIT().HasValue())
+        {
+            size_t writtenCharactersNumber = static_cast<size_t>(
+                snprintf(storage.ICDAsLITBuf, sizeof(storage.ICDAsLITBuf), "ICD=%d", params.GetICDOperatesAsLIT().Value()));
+            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < sizeof(storage.ICDAsLITBuf)),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtFields[numTxtFields++] = storage.ICDAsLITBuf;
         }
         return CHIP_NO_ERROR;
     }

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -227,6 +227,8 @@ CHIP_ERROR CopyTxtRecord(TxtFieldKey key, char * buffer, size_t bufferLen, const
     case TxtFieldKey::kSessionActiveInterval:
     case TxtFieldKey::kSessionActiveThreshold:
         return CopyTextRecordValue(buffer, bufferLen, params.GetLocalMRPConfig(), key);
+    case TxtFieldKey::kLongIdleTimeICD:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetICDOperatesAsLIT());
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
@@ -569,6 +571,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     ADD_TXT_RECORD(SessionActiveInterval);
     ADD_TXT_RECORD(SessionActiveThreshold);
     ADD_TXT_RECORD(TcpSupported);
+    ADD_TXT_RECORD(LongIdleTimeICD); // Optional, will not be added if related 'params' doesn't have a value
 
     ADD_PTR_RECORD(CompressedFabricId);
 
@@ -588,6 +591,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     ADD_TXT_RECORD(SessionActiveInterval);
     ADD_TXT_RECORD(SessionActiveThreshold);
     ADD_TXT_RECORD(TcpSupported);
+    ADD_TXT_RECORD(LongIdleTimeICD); // Optional, will not be added if related 'params' doesn't have a value
 
     ADD_PTR_RECORD(VendorId);
     ADD_PTR_RECORD(DeviceType);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -228,7 +228,7 @@ CHIP_ERROR CopyTxtRecord(TxtFieldKey key, char * buffer, size_t bufferLen, const
     case TxtFieldKey::kSessionActiveThreshold:
         return CopyTextRecordValue(buffer, bufferLen, params.GetLocalMRPConfig(), key);
     case TxtFieldKey::kLongIdleTimeICD:
-        return CopyTextRecordValue(buffer, bufferLen, params.GetICDOperatesAsLIT());
+        return CopyTextRecordValue(buffer, bufferLen, params.GetICDOperatingAsLIT());
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -132,7 +132,7 @@ struct CommonResolutionData
         }
         if (mrpRetryActiveThreshold.HasValue())
         {
-            ChipLogDetail(Discovery, "\tMrp Active Threshold: %" PRIu16 " ms", mrpRetryActiveThreshold.Value().count());
+            ChipLogDetail(Discovery, "\tMrp Active Threshold: %u ms", mrpRetryActiveThreshold.Value().count());
         }
         else
         {

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -48,6 +48,7 @@ struct CommonResolutionData
     uint16_t port                         = 0;
     char hostName[kHostNameMaxLength + 1] = {};
     bool supportsTcp                      = false;
+    Optional<bool> ICDOperatesAsLIT;
     Optional<System::Clock::Milliseconds32> mrpRetryIntervalIdle;
     Optional<System::Clock::Milliseconds32> mrpRetryIntervalActive;
     Optional<System::Clock::Milliseconds16> mrpRetryActiveThreshold;
@@ -81,12 +82,14 @@ struct CommonResolutionData
     void Reset()
     {
         memset(hostName, 0, sizeof(hostName));
-        mrpRetryIntervalIdle   = NullOptional;
-        mrpRetryIntervalActive = NullOptional;
-        numIPs                 = 0;
-        port                   = 0;
-        supportsTcp            = false;
-        interfaceId            = Inet::InterfaceId::Null();
+        mrpRetryIntervalIdle    = NullOptional;
+        mrpRetryIntervalActive  = NullOptional;
+        mrpRetryActiveThreshold = NullOptional;
+        ICDOperatesAsLIT        = NullOptional;
+        numIPs                  = 0;
+        port                    = 0;
+        supportsTcp             = false;
+        interfaceId             = Inet::InterfaceId::Null();
         for (auto & addr : ipAddress)
         {
             addr = chip::Inet::IPAddress::Any;
@@ -127,7 +130,23 @@ struct CommonResolutionData
         {
             ChipLogDetail(Discovery, "\tMrp Interval active: not present");
         }
+        if (mrpRetryActiveThreshold.HasValue())
+        {
+            ChipLogDetail(Discovery, "\tMrp Active Threshold: %" PRIu16 " ms", mrpRetryActiveThreshold.Value().count());
+        }
+        else
+        {
+            ChipLogDetail(Discovery, "\tMrp Active Threshold: not present");
+        }
         ChipLogDetail(Discovery, "\tTCP Supported: %d", supportsTcp);
+        if (ICDOperatesAsLIT.HasValue())
+        {
+            ChipLogDetail(Discovery, "\tThe ICD operates in %s", ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+        }
+        else
+        {
+            ChipLogDetail(Discovery, "\tICD: not present");
+        }
     }
 };
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -48,7 +48,7 @@ struct CommonResolutionData
     uint16_t port                         = 0;
     char hostName[kHostNameMaxLength + 1] = {};
     bool supportsTcp                      = false;
-    Optional<bool> ICDOperatesAsLIT;
+    Optional<bool> isICDOperatingAsLIT;
     Optional<System::Clock::Milliseconds32> mrpRetryIntervalIdle;
     Optional<System::Clock::Milliseconds32> mrpRetryIntervalActive;
     Optional<System::Clock::Milliseconds16> mrpRetryActiveThreshold;
@@ -85,7 +85,7 @@ struct CommonResolutionData
         mrpRetryIntervalIdle    = NullOptional;
         mrpRetryIntervalActive  = NullOptional;
         mrpRetryActiveThreshold = NullOptional;
-        ICDOperatesAsLIT        = NullOptional;
+        isICDOperatingAsLIT     = NullOptional;
         numIPs                  = 0;
         port                    = 0;
         supportsTcp             = false;
@@ -139,9 +139,9 @@ struct CommonResolutionData
             ChipLogDetail(Discovery, "\tMrp Active Threshold: not present");
         }
         ChipLogDetail(Discovery, "\tTCP Supported: %d", supportsTcp);
-        if (ICDOperatesAsLIT.HasValue())
+        if (isICDOperatingAsLIT.HasValue())
         {
-            ChipLogDetail(Discovery, "\tThe ICD operates in %s", ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogDetail(Discovery, "\tThe ICD operates in %s", isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         else
         {

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -272,7 +272,7 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonRes
         nodeData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
         break;
     case TxtFieldKey::kLongIdleTimeICD:
-        nodeData.ICDOperatesAsLIT = Internal::MakeOptionalBoolFromAsciiDecimal(value);
+        nodeData.isICDOperatingAsLIT = Internal::MakeOptionalBoolFromAsciiDecimal(value);
         break;
     default:
         break;

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -105,6 +105,16 @@ bool MakeBoolFromAsciiDecimal(const ByteSpan & val)
     return val.size() == 1 && static_cast<char>(*val.data()) == '1';
 }
 
+Optional<bool> MakeOptionalBoolFromAsciiDecimal(const ByteSpan & val)
+{
+    char character = static_cast<char>(*val.data());
+    if (val.size() == 1 && ((character == '1') || (character == '0')))
+    {
+        return MakeOptional(character == '1');
+    }
+    return NullOptional;
+}
+
 size_t GetPlusSignIdx(const ByteSpan & value)
 {
     // First value is the vendor id, second (after the +) is the product.
@@ -260,6 +270,9 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonRes
         break;
     case TxtFieldKey::kTcpSupported:
         nodeData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
+        break;
+    case TxtFieldKey::kLongIdleTimeICD:
+        nodeData.ICDOperatesAsLIT = Internal::MakeOptionalBoolFromAsciiDecimal(value);
         break;
     default:
         break;

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -36,6 +36,7 @@ static constexpr size_t kKeySessionActiveIntervalMaxLength       = 7; // [SAI] 0
 static constexpr size_t kKeySessionActiveThresholdMaxLength      = 5; // [SAT] 0-65535
 static constexpr System::Clock::Milliseconds32 kMaxRetryInterval = 3600000_ms32;
 static constexpr size_t kKeyTcpSupportedMaxLength                = 1;
+static constexpr size_t kKeyLongIdleTimeICDMaxLength             = 1;
 
 // Commissionable/commissioner node TXT entries
 static constexpr size_t kKeyLongDiscriminatorMaxLength  = 5;
@@ -69,6 +70,7 @@ enum class TxtFieldKey : uint8_t
     kSessionActiveInterval,
     kSessionActiveThreshold,
     kTcpSupported,
+    kLongIdleTimeICD,
     kCount,
 };
 
@@ -95,6 +97,7 @@ constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCoun
     { TxtFieldKey::kSessionActiveInterval, kKeySessionActiveIntervalMaxLength, "SAI", TxtKeyUse::kCommon },
     { TxtFieldKey::kSessionActiveThreshold, kKeySessionActiveThresholdMaxLength, "SAT", TxtKeyUse::kCommon },
     { TxtFieldKey::kTcpSupported, kKeyTcpSupportedMaxLength, "T", TxtKeyUse::kCommon },
+    { TxtFieldKey::kLongIdleTimeICD, kKeyLongIdleTimeICDMaxLength, "ICD", TxtKeyUse::kCommon },
 };
 #ifdef CHIP_CONFIG_TEST
 

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -311,7 +311,7 @@ private:
             found = false;
         }
     };
-    static constexpr size_t kMaxExpectedTxt = 12;
+    static constexpr size_t kMaxExpectedTxt = 13;
     KV mExpectedTxt[kMaxExpectedTxt];
     size_t mNumExpectedTxtRecords = 0;
     size_t mNumReceivedTxtRecords = 0;

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -181,11 +181,13 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
+        .SetICDOperatesAsLIT(chip::Optional<bool>(true))
         // 3600005 is more than the max so should be adjusted down
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(3600000_ms32, 3600005_ms32, 65535_ms16));
 QNamePart txtCommissionableNodeParamsLargeEnhancedParts[] = { "D=22",          "VP=555+897",       "CM=2",       "DT=70000",
                                                               "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3",
-                                                              "SAI=3600000",   "SII=3600000",      "SAT=65535",  "T=1" };
+                                                              "SAI=3600000",   "SII=3600000",      "SAT=65535",  "T=1",
+                                                              "ICD=1" };
 FullQName txtCommissionableNodeParamsLargeEnhancedName    = FullQName(txtCommissionableNodeParamsLargeEnhancedParts);
 TxtResourceRecord txtCommissionableNodeParamsLargeEnhanced =
     TxtResourceRecord(instanceName, txtCommissionableNodeParamsLargeEnhancedName);

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -181,7 +181,7 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
-        .SetICDOperatesAsLIT(chip::Optional<bool>(true))
+        .SetICDOperatingAsLIT(chip::Optional<bool>(true))
         // 3600005 is more than the max so should be adjusted down
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(3600000_ms32, 3600005_ms32, 65535_ms16));
 QNamePart txtCommissionableNodeParamsLargeEnhancedParts[] = { "D=22",          "VP=555+897",       "CM=2",       "DT=70000",

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -312,36 +312,40 @@ void PtrSrvTxtMultipleRespondersToInstance(nlTestSuite * inSuite, void * inConte
 
 void PtrSrvTxtMultipleRespondersToServiceListing(nlTestSuite * inSuite, void * inContext)
 {
-    CommonTestElements common1(inSuite, "test1");
-    CommonTestElements common2(inSuite, "test2");
-
+    // CommonTestElements common1(inSuite, "test1");
+    // CommonTestElements common2(inSuite, "test2");
+    auto common1 = new CommonTestElements(inSuite, "test1");
+    auto common2 = new CommonTestElements(inSuite, "test2");
     // Just use the server from common1.
-    ResponseSender responseSender(&common1.server);
+    ResponseSender responseSender(&common1->server);
 
-    NL_TEST_ASSERT(inSuite, responseSender.AddQueryResponder(&common1.queryResponder) == CHIP_NO_ERROR);
-    common1.queryResponder.AddResponder(&common1.ptrResponder).SetReportInServiceListing(true);
-    common1.queryResponder.AddResponder(&common1.srvResponder);
-    common1.queryResponder.AddResponder(&common1.txtResponder);
+    NL_TEST_ASSERT(inSuite, responseSender.AddQueryResponder(&common1->queryResponder) == CHIP_NO_ERROR);
+    common1->queryResponder.AddResponder(&common1->ptrResponder).SetReportInServiceListing(true);
+    common1->queryResponder.AddResponder(&common1->srvResponder);
+    common1->queryResponder.AddResponder(&common1->txtResponder);
 
-    NL_TEST_ASSERT(inSuite, responseSender.AddQueryResponder(&common2.queryResponder) == CHIP_NO_ERROR);
-    common2.queryResponder.AddResponder(&common2.ptrResponder).SetReportInServiceListing(true);
-    common2.queryResponder.AddResponder(&common2.srvResponder);
-    common2.queryResponder.AddResponder(&common2.txtResponder);
+    NL_TEST_ASSERT(inSuite, responseSender.AddQueryResponder(&common2->queryResponder) == CHIP_NO_ERROR);
+    common2->queryResponder.AddResponder(&common2->ptrResponder).SetReportInServiceListing(true);
+    common2->queryResponder.AddResponder(&common2->srvResponder);
+    common2->queryResponder.AddResponder(&common2->txtResponder);
 
     // Build a query for the instance
-    common1.recordWriter.WriteQName(common1.dnsSd);
-    QueryData queryData = QueryData(QType::ANY, QClass::IN, false, common1.requestNameStart, common1.requestBytesRange);
+    common1->recordWriter.WriteQName(common1->dnsSd);
+    QueryData queryData = QueryData(QType::ANY, QClass::IN, false, common1->requestNameStart, common1->requestBytesRange);
 
     // Should get service listing from both.
-    PtrResourceRecord serviceRecord1 = PtrResourceRecord(common1.dnsSd, common1.ptrRecord.GetName());
-    common1.server.AddExpectedRecord(&serviceRecord1);
-    PtrResourceRecord serviceRecord2 = PtrResourceRecord(common2.dnsSd, common2.ptrRecord.GetName());
-    common1.server.AddExpectedRecord(&serviceRecord2);
+    PtrResourceRecord serviceRecord1 = PtrResourceRecord(common1->dnsSd, common1->ptrRecord.GetName());
+    common1->server.AddExpectedRecord(&serviceRecord1);
+    PtrResourceRecord serviceRecord2 = PtrResourceRecord(common2->dnsSd, common2->ptrRecord.GetName());
+    common1->server.AddExpectedRecord(&serviceRecord2);
 
-    responseSender.Respond(1, queryData, &common1.packetInfo, ResponseConfiguration());
+    responseSender.Respond(1, queryData, &common1->packetInfo, ResponseConfiguration());
 
-    NL_TEST_ASSERT(inSuite, common1.server.GetSendCalled());
-    NL_TEST_ASSERT(inSuite, common1.server.GetHeaderFound());
+    NL_TEST_ASSERT(inSuite, common1->server.GetSendCalled());
+    NL_TEST_ASSERT(inSuite, common1->server.GetHeaderFound());
+
+    delete common1;
+    delete common2;
 }
 
 const nlTest sTests[] = {

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -54,7 +54,7 @@ OperationalAdvertisingParameters operationalParams2 =
         .EnableIpV4(true)
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(32_ms32, 30_ms32, 10_ms16)) // SII and SAI to match below
         .SetTcpSupported(Optional<bool>(true))
-        .SetICDOperatesAsLIT(Optional<bool>(false));
+        .SetICDOperatingAsLIT(Optional<bool>(false));
 test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetProtocol(DnssdServiceProtocol::kDnssdProtocolTcp)
                                           .SetServiceName("_matter")
@@ -98,7 +98,7 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetProductId(Optional<uint16_t>(897))
         .SetRotatingDeviceId(Optional<const char *>("id_that_spins"))
         .SetTcpSupported(Optional<bool>(true))
-        .SetICDOperatesAsLIT(Optional<bool>(true))
+        .SetICDOperatingAsLIT(Optional<bool>(true))
         // 3600005 is over the max, so this should be adjusted by the platform
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(3600000_ms32, 3600005_ms32, 65535_ms16));
 

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -53,7 +53,8 @@ OperationalAdvertisingParameters operationalParams2 =
         .SetPort(CHIP_PORT)
         .EnableIpV4(true)
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(32_ms32, 30_ms32, 10_ms16)) // SII and SAI to match below
-        .SetTcpSupported(Optional<bool>(true));
+        .SetTcpSupported(Optional<bool>(true))
+        .SetICDOperatesAsLIT(Optional<bool>(false));
 test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetProtocol(DnssdServiceProtocol::kDnssdProtocolTcp)
                                           .SetServiceName("_matter")
@@ -63,7 +64,8 @@ test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .AddTxt("SII", "32")
                                           .AddTxt("SAI", "30")
                                           .AddTxt("SAT", "10")
-                                          .AddTxt("T", "1");
+                                          .AddTxt("T", "1")
+                                          .AddTxt("ICD", "0");
 
 CommissionAdvertisingParameters commissionableNodeParamsSmall =
     CommissionAdvertisingParameters()
@@ -87,15 +89,16 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetMac(ByteSpan(kMac, sizeof(kMac)))
         .SetLongDiscriminator(22)
         .SetShortDiscriminator(2)
-        .SetVendorId(chip::Optional<uint16_t>(555))
-        .SetDeviceType(chip::Optional<uint32_t>(70000))
+        .SetVendorId(Optional<uint16_t>(555))
+        .SetDeviceType(Optional<uint32_t>(70000))
         .SetCommissioningMode(CommissioningMode::kEnabledBasic)
-        .SetDeviceName(chip::Optional<const char *>("testy-test"))
-        .SetPairingHint(chip::Optional<uint16_t>(3))
-        .SetPairingInstruction(chip::Optional<const char *>("Pair me"))
-        .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"))
-        .SetTcpSupported(chip::Optional<bool>(true))
+        .SetDeviceName(Optional<const char *>("testy-test"))
+        .SetPairingHint(Optional<uint16_t>(3))
+        .SetPairingInstruction(Optional<const char *>("Pair me"))
+        .SetProductId(Optional<uint16_t>(897))
+        .SetRotatingDeviceId(Optional<const char *>("id_that_spins"))
+        .SetTcpSupported(Optional<bool>(true))
+        .SetICDOperatesAsLIT(Optional<bool>(true))
         // 3600005 is over the max, so this should be adjusted by the platform
         .SetLocalMRPConfig(Optional<ReliableMessageProtocolConfig>::Value(3600000_ms32, 3600005_ms32, 65535_ms16));
 
@@ -112,6 +115,7 @@ test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .AddTxt("PI", "Pair me")
                                                   .AddTxt("PH", "3")
                                                   .AddTxt("T", "1")
+                                                  .AddTxt("ICD", "1")
                                                   .AddTxt("SII", "3600000")
                                                   .AddTxt("SAI", "3600000")
                                                   .AddTxt("SAT", "65535")

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -291,7 +291,7 @@ bool NodeDataIsEmpty(const DiscoveredNodeData & node)
         node.commissionData.commissioningMode != 0 || node.commissionData.deviceType != 0 ||
         node.commissionData.rotatingIdLen != 0 || node.commissionData.pairingHint != 0 ||
         node.resolutionData.mrpRetryIntervalIdle.HasValue() || node.resolutionData.mrpRetryIntervalActive.HasValue() ||
-        node.resolutionData.mrpRetryActiveThreshold.HasValue() || node.resolutionData.ICDOperatesAsLIT.HasValue() ||
+        node.resolutionData.mrpRetryActiveThreshold.HasValue() || node.resolutionData.isICDOperatingAsLIT.HasValue() ||
         node.resolutionData.supportsTcp)
     {
         return false;
@@ -392,7 +392,7 @@ bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
     return nodeData.operationalData.peerId == PeerId{} && nodeData.resolutionData.numIPs == 0 &&
         nodeData.resolutionData.port == 0 && !nodeData.resolutionData.mrpRetryIntervalIdle.HasValue() &&
         !nodeData.resolutionData.mrpRetryIntervalActive.HasValue() && !nodeData.resolutionData.supportsTcp &&
-        !nodeData.resolutionData.ICDOperatesAsLIT.HasValue();
+        !nodeData.resolutionData.isICDOperatingAsLIT.HasValue();
 }
 
 void ResetRetryIntervalIdle(DiscoveredNodeData & nodeData)
@@ -657,27 +657,27 @@ void TxtFieldICDoperatesAsLIT(nlTestSuite * inSuite, void * inContext)
     strcpy(key, "ICD");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
-    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue());
-    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.Value());
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.isICDOperatingAsLIT.HasValue());
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.isICDOperatingAsLIT.Value());
 
     // Test no other fields were populated
-    nodeData.resolutionData.ICDOperatesAsLIT.ClearValue();
+    nodeData.resolutionData.isICDOperatingAsLIT.ClearValue();
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
     // ICD is operating as a SIT device
     strcpy(key, "ICD");
     strcpy(val, "0");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
-    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue());
-    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.Value() == false);
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.isICDOperatingAsLIT.HasValue());
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.isICDOperatingAsLIT.Value() == false);
 
-    nodeData.resolutionData.ICDOperatesAsLIT.ClearValue();
+    nodeData.resolutionData.isICDOperatingAsLIT.ClearValue();
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
     // Invalid value, No key set
     strcpy(key, "ICD");
     strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
-    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue() == false);
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.isICDOperatingAsLIT.HasValue() == false);
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRI

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -80,6 +80,9 @@ void TestGetTxtFieldKey(nlTestSuite * inSuite, void * inContext)
     strcpy(key, "T");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kTcpSupported);
 
+    strcpy(key, "ICD");
+    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kLongIdleTimeICD);
+
     strcpy(key, "XX");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kUnknown);
 }
@@ -288,6 +291,7 @@ bool NodeDataIsEmpty(const DiscoveredNodeData & node)
         node.commissionData.commissioningMode != 0 || node.commissionData.deviceType != 0 ||
         node.commissionData.rotatingIdLen != 0 || node.commissionData.pairingHint != 0 ||
         node.resolutionData.mrpRetryIntervalIdle.HasValue() || node.resolutionData.mrpRetryIntervalActive.HasValue() ||
+        node.resolutionData.mrpRetryActiveThreshold.HasValue() || node.resolutionData.ICDOperatesAsLIT.HasValue() ||
         node.resolutionData.supportsTcp)
     {
         return false;
@@ -387,7 +391,8 @@ bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
 {
     return nodeData.operationalData.peerId == PeerId{} && nodeData.resolutionData.numIPs == 0 &&
         nodeData.resolutionData.port == 0 && !nodeData.resolutionData.mrpRetryIntervalIdle.HasValue() &&
-        !nodeData.resolutionData.mrpRetryIntervalActive.HasValue() && !nodeData.resolutionData.supportsTcp;
+        !nodeData.resolutionData.mrpRetryIntervalActive.HasValue() && !nodeData.resolutionData.supportsTcp &&
+        !nodeData.resolutionData.ICDOperatesAsLIT.HasValue();
 }
 
 void ResetRetryIntervalIdle(DiscoveredNodeData & nodeData)
@@ -408,6 +413,16 @@ void ResetRetryIntervalActive(DiscoveredNodeData & nodeData)
 void ResetRetryIntervalActive(ResolvedNodeData & nodeData)
 {
     nodeData.resolutionData.mrpRetryIntervalActive.ClearValue();
+}
+
+void ResetRetryActiveThreshold(DiscoveredNodeData & nodeData)
+{
+    nodeData.resolutionData.mrpRetryActiveThreshold.ClearValue();
+}
+
+void ResetRetryActiveThreshold(ResolvedNodeData & nodeData)
+{
+    nodeData.resolutionData.mrpRetryActiveThreshold.ClearValue();
 }
 
 // Test SAI (formally CRI)
@@ -559,7 +574,7 @@ void TxtFieldSessionActiveThreshold(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryActiveThreshold().Value() == 65535_ms16);
 
     // Test no other fields were populated
-    ResetRetryIntervalActive(nodeData);
+    ResetRetryActiveThreshold(nodeData);
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
     // Invalid SAI - negative value
@@ -628,6 +643,41 @@ void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
     strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.supportsTcp == false);
+}
+
+// Test ICD (ICD operation Mode)
+template <class NodeData>
+void TxtFieldICDoperatesAsLIT(nlTestSuite * inSuite, void * inContext)
+{
+    char key[4];
+    char val[16];
+    NodeData nodeData;
+
+    // ICD operates as a LIT device
+    strcpy(key, "ICD");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue());
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.Value());
+
+    // Test no other fields were populated
+    nodeData.resolutionData.ICDOperatesAsLIT.ClearValue();
+    NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
+
+    // ICD operates as a SIT device
+    strcpy(key, "ICD");
+    strcpy(val, "0");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue());
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.Value() == false);
+
+    nodeData.resolutionData.ICDOperatesAsLIT.ClearValue();
+    NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
+    // Invalid value, No key set
+    strcpy(key, "ICD");
+    strcpy(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
+    NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ICDOperatesAsLIT.HasValue() == false);
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRI
@@ -699,12 +749,14 @@ const nlTest sTests[] = {
     NL_TEST_DEF("TxtDiscoveredFieldMrpRetryIntervalActive", TxtFieldSessionActiveInterval<DiscoveredNodeData>),
     NL_TEST_DEF("TxtDiscoveredFieldMrpRetryActiveThreshold", TxtFieldSessionActiveThreshold<DiscoveredNodeData>),
     NL_TEST_DEF("TxtDiscoveredFieldTcpSupport", (TxtFieldTcpSupport<DiscoveredNodeData>) ),
-    NL_TEST_DEF("TxtDiscoveredIsDeviceSessiondle", TestIsDeviceSessionIdle<DiscoveredNodeData>),
+    NL_TEST_DEF("TxtDiscoveredIsICDoperatingAsLIT", (TxtFieldICDoperatesAsLIT<DiscoveredNodeData>) ),
+    NL_TEST_DEF("TxtDiscoveredIsDeviceSessionIdle", TestIsDeviceSessionIdle<DiscoveredNodeData>),
     NL_TEST_DEF("TxtDiscoveredIsDeviceSessionActive", TestIsDeviceSessionActive<DiscoveredNodeData>),
     NL_TEST_DEF("TxtResolvedFieldMrpRetryIntervalIdle", TxtFieldSessionIdleInterval<ResolvedNodeData>),
     NL_TEST_DEF("TxtResolvedFieldMrpRetryIntervalActive", TxtFieldSessionActiveInterval<ResolvedNodeData>),
     NL_TEST_DEF("TxtResolvedFieldMrpRetryActiveThreshold", TxtFieldSessionActiveThreshold<ResolvedNodeData>),
     NL_TEST_DEF("TxtResolvedFieldTcpSupport", (TxtFieldTcpSupport<ResolvedNodeData>) ),
+    NL_TEST_DEF("TxtResolvedFieldICDoperatingAsLIT", (TxtFieldICDoperatesAsLIT<ResolvedNodeData>) ),
     NL_TEST_DEF("TxtResolvedIsDeviceSessionIdle", TestIsDeviceSessionIdle<ResolvedNodeData>),
     NL_TEST_DEF("TxtResolvedIsDeviceSessionActive", TestIsDeviceSessionActive<ResolvedNodeData>),
     NL_TEST_SENTINEL()

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -653,7 +653,7 @@ void TxtFieldICDoperatesAsLIT(nlTestSuite * inSuite, void * inContext)
     char val[16];
     NodeData nodeData;
 
-    // ICD operates as a LIT device
+    // ICD is operating as a LIT device
     strcpy(key, "ICD");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
@@ -664,7 +664,7 @@ void TxtFieldICDoperatesAsLIT(nlTestSuite * inSuite, void * inContext)
     nodeData.resolutionData.ICDOperatesAsLIT.ClearValue();
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
-    // ICD operates as a SIT device
+    // ICD is operating as a SIT device
     strcpy(key, "ICD");
     strcpy(val, "0");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -62,7 +62,7 @@ public:
         streamer_printf(streamer_get(), "   MRP ACTIVE Threshold time:     %u ms\r\n",
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
 
-        streamer_printf(streamer_get(), "   ICD is operating as a:         %s ms\r\n", result.isICDOperatingAsLIT ? "LIT" : "SIT");
+        streamer_printf(streamer_get(), "   ICD is operating as a:         %s\r\n", result.isICDOperatingAsLIT ? "LIT" : "SIT");
 
         // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
         DeviceLayer::SystemLayer().ScheduleLambda([this] {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -59,8 +59,10 @@ public:
                         result.mrpRemoteConfig.mIdleRetransTimeout.count());
         streamer_printf(streamer_get(), "   MRP ACTIVE retransmit timeout: %u ms\r\n",
                         result.mrpRemoteConfig.mActiveRetransTimeout.count());
-        streamer_printf(streamer_get(), "   MRP ACTIVE Threshold timet:    %u ms\r\n",
+        streamer_printf(streamer_get(), "   MRP ACTIVE Threshold time:     %u ms\r\n",
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
+
+        streamer_printf(streamer_get(), "   ICD operates as :              %s ms\r\n", result.ICDOperatesAsLIT ? "LIT" : "SIT");
 
         // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
         DeviceLayer::SystemLayer().ScheduleLambda([this] {
@@ -116,7 +118,18 @@ public:
         if (retryInterval.HasValue())
             streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\r\n", retryInterval.Value());
 
+        if (nodeData.resolutionData.GetMrpRetryActiveThreshold().HasValue())
+        {
+            streamer_printf(streamer_get(), "   MRP retry active threshold time: %" PRIu32 "ms\r\n",
+                            nodeData.resolutionData.GetMrpRetryActiveThreshold().Value());
+        }
         streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.resolutionData.supportsTcp ? "yes" : "no");
+
+        if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+        {
+            streamer_printf(streamer_get(), "   ICD operates as : %s ms\r\n",
+                            nodeData.resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+        }
         streamer_printf(streamer_get(), "   IP addresses:\r\n");
         for (uint8_t i = 0; i < nodeData.resolutionData.numIPs; i++)
         {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -62,7 +62,7 @@ public:
         streamer_printf(streamer_get(), "   MRP ACTIVE Threshold time:     %u ms\r\n",
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
 
-        streamer_printf(streamer_get(), "   ICD is operating as :          %s ms\r\n", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        streamer_printf(streamer_get(), "   ICD is operating as a:         %s ms\r\n", result.isICDOperatingAsLIT ? "LIT" : "SIT");
 
         // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
         DeviceLayer::SystemLayer().ScheduleLambda([this] {
@@ -125,10 +125,10 @@ public:
         }
         streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.resolutionData.supportsTcp ? "yes" : "no");
 
-        if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
+        if (nodeData.resolutionData.isICDOperatingAsLIT.HasValue())
         {
-            streamer_printf(streamer_get(), "   ICD is operating as : %s ms\r\n",
-                            nodeData.resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
+            streamer_printf(streamer_get(), "   ICD is operating as a: %s\r\n",
+                            nodeData.resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         streamer_printf(streamer_get(), "   IP addresses:\r\n");
         for (uint8_t i = 0; i < nodeData.resolutionData.numIPs; i++)

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -62,7 +62,7 @@ public:
         streamer_printf(streamer_get(), "   MRP ACTIVE Threshold time:     %u ms\r\n",
                         result.mrpRemoteConfig.mActiveThresholdTime.count());
 
-        streamer_printf(streamer_get(), "   ICD operates as :              %s ms\r\n", result.ICDOperatesAsLIT ? "LIT" : "SIT");
+        streamer_printf(streamer_get(), "   ICD is operating as :          %s ms\r\n", result.ICDOperatesAsLIT ? "LIT" : "SIT");
 
         // Schedule a retry. Not called directly so we do not recurse in OnNodeAddressResolved
         DeviceLayer::SystemLayer().ScheduleLambda([this] {
@@ -127,7 +127,7 @@ public:
 
         if (nodeData.resolutionData.ICDOperatesAsLIT.HasValue())
         {
-            streamer_printf(streamer_get(), "   ICD operates as : %s ms\r\n",
+            streamer_printf(streamer_get(), "   ICD is operating as : %s ms\r\n",
                             nodeData.resolutionData.ICDOperatesAsLIT.Value() ? "LIT" : "SIT");
         }
         streamer_printf(streamer_get(), "   IP addresses:\r\n");

--- a/src/platform/fake/DnssdImpl.h
+++ b/src/platform/fake/DnssdImpl.h
@@ -169,7 +169,7 @@ struct ExpectedCall
         }
     }
 
-    static constexpr size_t kMaxTxtRecords                = 12;
+    static constexpr size_t kMaxTxtRecords                = 13;
     static constexpr size_t kMaxSubtypes                  = 10;
     CallType callType                                     = CallType::kUnknown;
     DnssdServiceProtocol protocol                         = DnssdServiceProtocol::kDnssdProtocolUnknown;

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -376,6 +376,8 @@ void JsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
         result["mrp"]["active_retransmit_timeout_ms"] = info.result->mrpRemoteConfig.mActiveRetransTimeout.count();
         result["mrp"]["active_threshold_time_ms"]     = info.result->mrpRemoteConfig.mActiveThresholdTime.count();
 
+        result["ICDOperatesAsLIT"] = info.result->ICDOperatesAsLIT;
+
         value["result"] = result;
     }
 

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -376,7 +376,7 @@ void JsonBackend::LogNodeDiscovered(NodeDiscoveredInfo & info)
         result["mrp"]["active_retransmit_timeout_ms"] = info.result->mrpRemoteConfig.mActiveRetransTimeout.count();
         result["mrp"]["active_threshold_time_ms"]     = info.result->mrpRemoteConfig.mActiveThresholdTime.count();
 
-        result["ICDOperatesAsLIT"] = info.result->ICDOperatesAsLIT;
+        result["isICDOperatingAsLIT"] = info.result->isICDOperatingAsLIT;
 
         value["result"] = result;
     }


### PR DESCRIPTION
fixes #28228

Add the new optional common Key `ICD` in the DNSSD advertisement. This key informs if the ICD device is currently operating as a long idle time (LIT) device or has a short idle time device (SIT). The ICD key is not advertised for non-ICD devices, or ICD devices that do not support LIT.

Add tests for this new key.
Also, add and fix some tests for the previously added SAT key.