### PR TITLE
ESP32: Use GetPartitionLabelByNamespace in ESP32Config::ConfigValueExists()

### DIFF
--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -371,10 +371,10 @@ bool ESP32Config::ConfigValueExists(Key key)
 {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     nvs_iterator_t iterator = NULL;
-    esp_err_t err           = nvs_entry_find(NVS_DEFAULT_PART_NAME, key.Namespace, NVS_TYPE_ANY, &iterator);
+    esp_err_t err           = nvs_entry_find(GetPartitionLabelByNamespace(key.Namespace), key.Namespace, NVS_TYPE_ANY, &iterator);
     for (; iterator && err == ESP_OK; err = nvs_entry_next(&iterator))
 #else
-    nvs_iterator_t iterator = nvs_entry_find(NVS_DEFAULT_PART_NAME, key.Namespace, NVS_TYPE_ANY);
+    nvs_iterator_t iterator = nvs_entry_find(GetPartitionLabelByNamespace(key.Namespace), key.Namespace, NVS_TYPE_ANY);
     for (; iterator; iterator = nvs_entry_next(iterator))
 #endif
     {


### PR DESCRIPTION
We should use GetPartitionLabelByNamespace() instead of NVS_DEFAULT_PART_NAME in function ESP32Config::ConfigValueExists() so that the entry could be found in the correct partition.

