### PR TITLE
[Telink] Fixed hanging on BLE Shutdown (TC-SC-4.1)

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -180,7 +180,8 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
 
 void BLEManagerImpl::_Shutdown()
 {
-    if (mBLERadioInitialized) {
+    if (mBLERadioInitialized)
+    {
         bt_disable();
         mBLERadioInitialized = false;
     }

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -180,8 +180,10 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
 
 void BLEManagerImpl::_Shutdown()
 {
-    bt_disable();
-    mBLERadioInitialized = false;
+    if (mBLERadioInitialized) {
+        bt_disable();
+        mBLERadioInitialized = false;
+    }
 }
 
 void BLEManagerImpl::DriveBLEState(intptr_t arg)


### PR DESCRIPTION
Refactored BLE shutdown condition to pass test TC-SC-4.1. 
Device would become stuck at scheduler routines after open-basic-commissioning-window time expires.

