### PR TITLE
Fix darwin-tests workflow file syntax.

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -147,8 +147,8 @@ jobs:
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}
               with:
-                  name: framework-build-log-darwin-${{BUILD_VARIANT_FRAMEWORK_TOOL}}
-                  path: out/darwin-x64-darwin-framework-tool-${{BUILD_VARIANT_FRAMEWORK_TOOL}}/darwin_framework_build.log
+                  name: framework-build-log-darwin-${BUILD_VARIANT_FRAMEWORK_TOOL}
+                  path: out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin_framework_build.log
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v3
               if: ${{ failure() && !env.ACT }}

--- a/src/app/tests/suites/certification/Test_TC_APBSC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APBSC_9_1.yaml
@@ -54,7 +54,7 @@ tests:
       attribute: "ApplicationName"
       response:
           constraints:
-              type: char_string
+              type: long_char_string
               maxLength: 256
 
     - label: "Step 4: Reads the ProductID attribute"


### PR DESCRIPTION
There were extra curly braces that failed on some (but not all?) CI runs.
