### PR TITLE
Update Darwin availability annotations.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -3258,7 +3258,10 @@
           AudioOutput:
               - OutputTypeEnum
           ApplicationLauncher:
-              - ApplicationLauncherStatusEnum
+              # StatusEnum was originally named ApplicationLauncherStatusEnum, but we
+              # generate the same API for the names with/without the cluster name at the
+              # beginning, so the name can just change here.
+              - StatusEnum
           ApplicationBasic:
               - ApplicationStatusEnum
           TestCluster:
@@ -4137,7 +4140,10 @@
                   - Internal
                   - Other
           ApplicationLauncher:
-              ApplicationLauncherStatusEnum:
+              # StatusEnum was originally named ApplicationLauncherStatusEnum, but we
+              # generate the same API for the names with/without the cluster name at the
+              # beginning, so the name can just change here.
+              StatusEnum:
                   - Success
                   - AppNotAvailable
                   - SystemBusy
@@ -7762,6 +7768,10 @@
               Feature:
                   - WaterMarks
   provisional:
+      clusters:
+          # Targeting Spring 2024 Matter release
+          - MicrowaveOvenControl
+          - MicrowaveOvenMode
       attributes:
           NetworkCommissioning:
               # Targeting Spring 2024 Matter release
@@ -7777,6 +7787,11 @@
           NetworkCommissioning:
               # Targeting Spring 2024 Matter release
               - ThreadCapabilitiesBitmap
+      bitmap values:
+          OnOff:
+              Feature:
+                  # Targeting Spring 2024 Matter release
+                  - OffOnly
   renames:
       bitmaps:
           Scenes:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -16173,10 +16173,10 @@ typedef NS_OPTIONS(uint32_t, MTRAudioOutputFeature) {
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRApplicationLauncherStatus) {
-    MTRApplicationLauncherStatusSuccess MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRApplicationLauncherStatusAppNotAvailable MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRApplicationLauncherStatusSystemBusy MTR_PROVISIONALLY_AVAILABLE = 0x02,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRApplicationLauncherStatusSuccess MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
+    MTRApplicationLauncherStatusAppNotAvailable MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
+    MTRApplicationLauncherStatusSystemBusy MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_OPTIONS(uint32_t, MTRApplicationLauncherFeature) {
     MTRApplicationLauncherFeatureApplicationPlatform MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,


### PR DESCRIPTION
* Mark new things as provisional.
* Fix incorrect availability for ApplicationLauncher's StatusEnum introduced by https://github.com/project-chip/connectedhomeip/pull/30134
