### PR TITLE
[platform] Simplify ConfigurationManager::RunUnitTests()

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -84,8 +84,7 @@ public:
 #else
         kPrimaryMACAddressLength = 6,
 #endif
-        kMaxMACAddressLength  = 8,
-        kMaxLanguageTagLength = 5 // ISO 639-1 standard language codes
+        kMaxMACAddressLength = 8
     };
 
     virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf)                           = 0;
@@ -123,8 +122,9 @@ public:
     virtual CHIP_ERROR SetFailSafeArmed(bool val)                                      = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
-
-    virtual CHIP_ERROR RunUnitTests() = 0;
+#if CHIP_CONFIG_TEST
+    virtual void RunUnitTests() = 0;
+#endif
 
     virtual bool IsFullyProvisioned()   = 0;
     virtual void InitiateFactoryReset() = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -103,7 +103,9 @@ public:
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;
-    CHIP_ERROR RunUnitTests(void) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override;
+#endif
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
@@ -131,7 +133,7 @@ protected:
 
     CHIP_ERROR PersistProvisioningData(ProvisioningDataSet & provData);
 
-    // Methods to read and write configuration values, as well as run the configuration unit test.
+    // Methods to read and write configuration values.
     typedef typename ConfigClass::Key Key;
     virtual CHIP_ERROR ReadConfigValue(Key key, bool & val)                                        = 0;
     virtual CHIP_ERROR ReadConfigValue(Key key, uint32_t & val)                                    = 0;
@@ -144,7 +146,6 @@ protected:
     virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str)                              = 0;
     virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen)               = 0;
     virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)          = 0;
-    virtual void RunConfigUnitTest(void)                                                           = 0;
 };
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -45,6 +45,10 @@
 #include <platform/internal/GenericConfigurationManagerImpl.h>
 #include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
+#if CHIP_CONFIG_TEST
+#include <platform/internal/testing/ConfigUnitTest.h>
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ThreadStackManager.h>
 #endif
@@ -663,15 +667,14 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSecondaryPairingInst
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_CONFIG_TEST
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::RunUnitTests()
+void GenericConfigurationManagerImpl<ConfigClass>::RunUnitTests()
 {
-#if !defined(NDEBUG)
     ChipLogProgress(DeviceLayer, "Running configuration unit test");
-    RunConfigUnitTest();
-#endif
-    return CHIP_NO_ERROR;
+    Internal::RunConfigUnitTest<ConfigClass>();
 }
+#endif
 
 template <class ConfigClass>
 void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()

--- a/src/platform/ASR/ASRConfig.cpp
+++ b/src/platform/ASR/ASRConfig.cpp
@@ -293,8 +293,6 @@ CHIP_ERROR ASRConfig::FactoryResetConfig(void)
     return CHIP_NO_ERROR;
 }
 
-void ASRConfig::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ASR/ASRConfig.h
+++ b/src/platform/ASR/ASRConfig.h
@@ -111,8 +111,6 @@ public:
     static CHIP_ERROR ReadFactoryConfigValue(asr_matter_partition_t matter_partition, uint32_t & val);
 #endif
     static CHIP_ERROR FactoryResetConfig(void);
-
-    static void RunConfigUnitTest(void);
 };
 
 struct ASRConfig::Key

--- a/src/platform/ASR/ConfigurationManagerImpl.cpp
+++ b/src/platform/ASR/ConfigurationManagerImpl.cpp
@@ -200,11 +200,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return ASRConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    ASRConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/ASR/ConfigurationManagerImpl.h
+++ b/src/platform/ASR/ConfigurationManagerImpl.h
@@ -49,7 +49,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
-
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
@@ -64,7 +66,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -414,8 +414,6 @@ exit:
     return err;
 }
 
-void AmebaConfig::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -91,8 +91,6 @@ public:
 
     static CHIP_ERROR InitNamespace(void);
     static CHIP_ERROR ClearNamespace(void);
-
-    static void RunConfigUnitTest(void);
 };
 
 struct AmebaConfig::Key

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -263,11 +263,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return AmebaConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    AmebaConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -56,6 +56,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
@@ -70,7 +73,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Beken/BekenConfig.cpp
+++ b/src/platform/Beken/BekenConfig.cpp
@@ -317,8 +317,6 @@ CHIP_ERROR BekenConfig::ClearNamespace(const char * ns)
     return CHIP_NO_ERROR;
 }
 
-void BekenConfig::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Beken/BekenConfig.h
+++ b/src/platform/Beken/BekenConfig.h
@@ -93,8 +93,6 @@ public:
 
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
-
-    static void RunConfigUnitTest(void);
 };
 
 struct BekenConfig::Key

--- a/src/platform/Beken/ConfigurationManagerImpl.cpp
+++ b/src/platform/Beken/ConfigurationManagerImpl.cpp
@@ -214,11 +214,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return BekenConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    BekenConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/Beken/ConfigurationManagerImpl.h
+++ b/src/platform/Beken/ConfigurationManagerImpl.h
@@ -53,7 +53,9 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
     CHIP_ERROR GetBootReason(uint32_t & bootReason);
     CHIP_ERROR StoreBootReason(uint32_t bootReason);
-
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
@@ -68,7 +70,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str);
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen);
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
-    void RunConfigUnitTest(void);
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -488,15 +488,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
 #endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest()
-{
-#if CHIP_DISABLE_PLATFORM_KVS
-    return;
-#else  // CHIP_DISABLE_PLATFORM_KVS
-    PosixConfig::RunConfigUnitTest();
-#endif // CHIP_DISABLE_PLATFORM_KVS
-}
-
 ConfigurationManager & ConfigurationMgrImpl()
 {
     return ConfigurationManagerImpl::GetDefaultInstance();

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -72,6 +72,9 @@ private:
     CHIP_ERROR GetLocationCapability(uint8_t & location) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
@@ -89,7 +92,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 };
 
 /**

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
@@ -193,9 +192,7 @@ exit:
     return err;
 }
 
-void PosixConfig::RunConfigUnitTest() {}
-
-#endif // CHIP_DISABLE_PLATFORM_KVS
+#endif // !CHIP_DISABLE_PLATFORM_KVS
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -93,8 +93,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
 protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -404,11 +404,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return ESP32Config::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    ESP32Config::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -76,6 +76,9 @@ private:
     CHIP_ERROR MapConfigError(esp_err_t error);
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -91,7 +94,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -417,8 +417,6 @@ CHIP_ERROR ESP32Config::ClearNamespace(const char * ns)
     return CHIP_NO_ERROR;
 }
 
-void ESP32Config::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -126,8 +126,6 @@ public:
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
 
-    static void RunConfigUnitTest(void);
-
 private:
     static const char * GetPartitionLabelByNamespace(const char * ns);
 };

--- a/src/platform/Infineon/CYW30739/CYW30739Config.cpp
+++ b/src/platform/Infineon/CYW30739/CYW30739Config.cpp
@@ -159,8 +159,6 @@ CHIP_ERROR CYW30739Config::FactoryResetConfig(void)
     return CHIP_NO_ERROR;
 }
 
-void CYW30739Config::RunConfigUnitTest(void) {}
-
 bool CYW30739Config::IsDataFromFlash(const void * data)
 {
     return reinterpret_cast<void *>(FLASH_BASE_ADDRESS) <= data && data < reinterpret_cast<void *>(FLASH_BASE_ADDRESS + FLASH_SIZE);

--- a/src/platform/Infineon/CYW30739/CYW30739Config.h
+++ b/src/platform/Infineon/CYW30739/CYW30739Config.h
@@ -115,7 +115,6 @@ public:
     static CHIP_ERROR ClearConfigValue(Key key);
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
-    static void RunConfigUnitTest(void);
 
 private:
     static bool IsDataFromFlash(const void * data);

--- a/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.cpp
@@ -177,11 +177,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return CYW30739Config::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    CYW30739Config::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
@@ -52,6 +52,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -67,7 +70,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.cpp
@@ -216,11 +216,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return P6Config::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    P6Config::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
@@ -56,6 +56,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -71,7 +74,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Infineon/PSOC6/P6Config.cpp
+++ b/src/platform/Infineon/PSOC6/P6Config.cpp
@@ -249,8 +249,6 @@ CHIP_ERROR P6Config::FactoryResetConfig(void)
     return CHIP_NO_ERROR;
 }
 
-void P6Config::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Infineon/PSOC6/P6Config.h
+++ b/src/platform/Infineon/PSOC6/P6Config.h
@@ -110,8 +110,6 @@ public:
     static bool ConfigValueExists(Key key);
 
     static CHIP_ERROR FactoryResetConfig(void);
-
-    static void RunConfigUnitTest(void);
 };
 
 struct P6Config::Key

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -265,11 +265,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest()
-{
-    PosixConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -76,7 +76,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
@@ -575,12 +574,6 @@ CHIP_ERROR PosixConfig::FactoryResetCounters()
 
 exit:
     return err;
-}
-
-void PosixConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<PosixConfig>();
 }
 
 } // namespace Internal

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -103,7 +103,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig();
     static CHIP_ERROR FactoryResetCounters();
-    static void RunConfigUnitTest();
 
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -174,11 +174,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return Internal::PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest()
-{
-    Internal::PosixConfig::RunConfigUnitTest();
-}
-
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
     return ReadConfigValue(PosixConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -63,6 +63,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
     CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
@@ -80,7 +83,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 };
 
 /**

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -183,8 +183,6 @@ CHIP_ERROR PosixConfig::FactoryResetConfig()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-void PosixConfig::RunConfigUnitTest() {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/PosixConfig.h
+++ b/src/platform/Tizen/PosixConfig.h
@@ -98,8 +98,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
 protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -168,11 +168,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return ZephyrConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    ZephyrConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -67,7 +67,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -28,7 +28,6 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <zephyr/settings/settings.h>
 
@@ -280,12 +279,6 @@ CHIP_ERROR ZephyrConfig::FactoryResetConfig(void)
             return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
 
     return CHIP_NO_ERROR;
-}
-
-void ZephyrConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<ZephyrConfig>();
 }
 
 bool ZephyrConfig::BuildCounterConfigKey(::chip::Platform::PersistedStorage::Key counterId, char key[SETTINGS_MAX_NAME_LEN])

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -90,8 +90,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
 private:
     static bool BuildCounterConfigKey(::chip::Platform::PersistedStorage::Key counterId, char key[]);
 };

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -27,7 +27,6 @@
 #include <cstdint>
 #include <cstring>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CHIPJNIError.h>
@@ -458,12 +457,6 @@ CHIP_ERROR AndroidConfig::FactoryResetConfig()
 {
     const AndroidConfig::Key key = { AndroidConfig::kConfigNamespace_ChipConfig, nullptr };
     return AndroidConfig::ClearConfigValue(key);
-}
-
-void AndroidConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<AndroidConfig>();
 }
 
 } // namespace Internal

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -102,8 +102,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig();
 
-    static void RunConfigUnitTest();
-
     static void InitializeWithObject(jobject managerObject);
 
 protected:

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -136,11 +136,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return AndroidConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    AndroidConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     return;

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -68,7 +68,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/bouffalolab/common/BLConfig.cpp
+++ b/src/platform/bouffalolab/common/BLConfig.cpp
@@ -211,8 +211,6 @@ CHIP_ERROR BLConfig::FactoryResetConfig(void)
     return CHIP_NO_ERROR;
 }
 
-void BLConfig::RunConfigUnitTest() {}
-
 bool BLConfig::ConfigValueExists(const char * key)
 {
     env_node_obj node;

--- a/src/platform/bouffalolab/common/BLConfig.h
+++ b/src/platform/bouffalolab/common/BLConfig.h
@@ -99,8 +99,6 @@ public:
     static bool ConfigValueExists(const char * key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
     // internal to the platform for KeyValueStoreManagerImpl.cpp
     static CHIP_ERROR ReadKVS(const char * key, void * value, size_t value_size, size_t * read_bytes_size, size_t offset_bytes);
     static CHIP_ERROR WriteKVS(const char * key, const void * value, size_t value_size);

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
@@ -179,11 +179,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return BLConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    BLConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
@@ -37,6 +37,9 @@ public:
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
     bool IsFullyProvisioned();
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
 private:
     // ===== Members that implement the ConfigurationManager private interface.
@@ -59,7 +62,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;

--- a/src/platform/cc13xx_26xx/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13xx_26xx/ConfigurationManagerImpl.cpp
@@ -197,10 +197,13 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return CC13XX_26XXConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+#if CHIP_CONFIG_TEST
+void ConfigurationManagerImpl::RunUnitTests(void)
 {
+    ChipLogProgress(DeviceLayer, "Running configuration unit test");
     CC13XX_26XXConfig::RunConfigUnitTest();
 }
+#endif
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -53,6 +53,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override;
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -68,7 +71,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
@@ -52,7 +52,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
-
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override;
+#endif
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
@@ -67,7 +69,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/cc32xx/CC32XXConfig.h
+++ b/src/platform/cc32xx/CC32XXConfig.h
@@ -79,8 +79,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
     // internal to the platform for KeyValueStoreManagerImpl.cpp
     static CHIP_ERROR ReadKVS(const char * key, void * value, size_t value_size, size_t * read_bytes_size, size_t offset_bytes);
     static CHIP_ERROR WriteKVS(const char * key, const void * value, size_t value_size);

--- a/src/platform/cc32xx/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.cpp
@@ -167,10 +167,13 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return CC32XXConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+#if CHIP_CONFIG_TEST
+void ConfigurationManagerImpl::RunUnitTests(void)
 {
+    ChipLogProgress(DeviceLayer, "Running configuration unit test");
     CC32XXConfig::RunConfigUnitTest();
 }
+#endif
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {

--- a/src/platform/cc32xx/ConfigurationManagerImpl.h
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.h
@@ -47,7 +47,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
-
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override;
+#endif
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
@@ -62,7 +64,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -85,8 +85,8 @@ private:
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#if !defined(NDEBUG)
-    CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif
     bool IsFullyProvisioned() override { return false; }
     void LogDeviceConfig() override {}

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -216,11 +216,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return MbedConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    MbedConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -68,7 +68,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -337,12 +337,6 @@ CHIP_ERROR MbedConfig::ClearNamespace(const char * ns)
     return err == MBED_SUCCESS ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
 }
 
-void MbedConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<MbedConfig>();
-}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <string.h>
 
@@ -98,8 +97,6 @@ public:
     static CHIP_ERROR ReadCounter(Key counterId, uint32_t & value);
     static CHIP_ERROR WriteCounter(Key counterId, uint32_t value);
     static CHIP_ERROR ClearNamespace(const char * ns);
-
-    static void RunConfigUnitTest(void);
 };
 
 } // namespace Internal

--- a/src/platform/mt793x/ConfigurationManagerImpl.cpp
+++ b/src/platform/mt793x/ConfigurationManagerImpl.cpp
@@ -214,11 +214,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return MT793XConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    MT793XConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/mt793x/ConfigurationManagerImpl.h
+++ b/src/platform/mt793x/ConfigurationManagerImpl.h
@@ -70,7 +70,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
     uint32_t rebootCause;

--- a/src/platform/mt793x/MT793XConfig.cpp
+++ b/src/platform/mt793x/MT793XConfig.cpp
@@ -30,7 +30,6 @@
 #include <platform/mt793x/MT793XConfig.h>
 
 #include <lib/core/CHIPEncoding.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include "FreeRTOS.h"
 #include "nvdm.h"
@@ -463,12 +462,6 @@ CHIP_ERROR MT793XConfig::MapNvdmStatus(nvdm_status_t nvdm_status)
     }
 
     return err;
-}
-
-void MT793XConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<MT793XConfig>();
 }
 
 void MT793XConfig::OnExit()

--- a/src/platform/mt793x/MT793XConfig.h
+++ b/src/platform/mt793x/MT793XConfig.h
@@ -125,8 +125,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
 private:
     static CHIP_ERROR MapNvdmStatus(nvdm_status_t nvdm_status);
     static void OnExit(void);

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -245,11 +245,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return NXPConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    NXPConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/nxp/common/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.h
@@ -58,6 +58,9 @@ private:
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -73,7 +76,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/nxp/common/NXPConfig.cpp
+++ b/src/platform/nxp/common/NXPConfig.cpp
@@ -30,7 +30,6 @@
 #include "FunctionLib.h"
 #include "board.h"
 #include <lib/core/CHIPEncoding.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 /* FS Writes in Idle task only - LittleFS only , already enabled by default on NVM */
 #ifndef CHIP_PLAT_SAVE_NVM_DATA_ON_IDLE
@@ -544,8 +543,6 @@ CHIP_ERROR NXPConfig::MapRamStorageStatus(rsError rsStatus)
 
     return err;
 }
-
-void NXPConfig::RunConfigUnitTest(void) {}
 
 void NXPConfig::RunSystemIdleTask(void)
 {

--- a/src/platform/nxp/common/NXPConfig.h
+++ b/src/platform/nxp/common/NXPConfig.h
@@ -183,7 +183,6 @@ public:
     static CHIP_ERROR FactoryResetConfig(void);
     static bool ValidConfigKey(Key key);
 
-    static void RunConfigUnitTest(void);
     static void RunSystemIdleTask(void);
 
 private:

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -238,8 +238,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return K32WConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void) {}
-
 CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint8_t rebootCause)
 {
     BootReasonType bootReason = BootReasonType::kUnspecified;

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -57,6 +57,9 @@ public:
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
 private:
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
@@ -72,7 +75,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
     CHIP_ERROR DetermineBootReason(uint8_t rebootCause);

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
@@ -28,7 +28,6 @@
 #include <platform/nxp/k32w/k32w0/K32W0Config.h>
 
 #include <lib/core/CHIPEncoding.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include "FreeRTOS.h"
 

--- a/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.cpp
@@ -249,11 +249,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return K32WConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    K32WConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
@@ -56,6 +56,9 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
     CHIP_ERROR GetBootReason(uint32_t & bootReasons) override;
     CHIP_ERROR StoreBootReason(uint32_t bootReasons) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -71,7 +74,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/nxp/k32w/k32w1/K32W1Config.cpp
+++ b/src/platform/nxp/k32w/k32w1/K32W1Config.cpp
@@ -29,7 +29,6 @@
 
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPEncoding.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <openthread-system.h>
@@ -427,8 +426,6 @@ bool K32WConfig::ValidConfigKey(Key key)
 
     return false;
 }
-
-void K32WConfig::RunConfigUnitTest() {}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/nxp/k32w/k32w1/K32W1Config.h
+++ b/src/platform/nxp/k32w/k32w1/K32W1Config.h
@@ -132,8 +132,6 @@ public:
     static CHIP_ERROR FactoryResetConfig(void);
     static bool ValidConfigKey(Key key);
 
-    static void RunConfigUnitTest(void);
-
 private:
     static CHIP_ERROR MapRamStorageStatus(rsError rsStatus);
     static void FactoryResetConfigInternal(Key firstKey, Key lastKey);

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.cpp
@@ -207,11 +207,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return MW320Config::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    MW320Config::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.h
@@ -78,6 +78,9 @@ private:
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetBootReason(uint32_t & bootReasons) override;
     CHIP_ERROR StoreBootReason(uint32_t bootReasons) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -93,7 +96,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nxp/mw320/MW320Config.cpp
+++ b/src/platform/nxp/mw320/MW320Config.cpp
@@ -28,7 +28,6 @@
 #include <platform/nxp/mw320/MW320Config.h>
 
 #include <lib/core/CHIPEncoding.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include "FreeRTOS.h"
 
@@ -231,8 +230,6 @@ CHIP_ERROR MW320Config::ForEachRecord(Key firstKey, Key lastKey, bool addNewReco
 exit:
     return err;
 }
-
-void MW320Config::RunConfigUnitTest() {}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/nxp/mw320/MW320Config.h
+++ b/src/platform/nxp/mw320/MW320Config.h
@@ -157,8 +157,6 @@ public:
     static CHIP_ERROR FactoryResetConfig(void);
     static bool ValidConfigKey(Key key);
 
-    static void RunConfigUnitTest(void);
-
 protected:
     using ForEachRecordFunct = std::function<CHIP_ERROR(const Key & key, const size_t & length)>;
     static CHIP_ERROR ForEachRecord(Key firstKey, Key lastKey, bool addNewRecord, ForEachRecordFunct funct);

--- a/src/platform/openiotsdk/ConfigurationManagerImpl.cpp
+++ b/src/platform/openiotsdk/ConfigurationManagerImpl.cpp
@@ -135,11 +135,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return KVStoreConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    KVStoreConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");

--- a/src/platform/openiotsdk/ConfigurationManagerImpl.h
+++ b/src/platform/openiotsdk/ConfigurationManagerImpl.h
@@ -63,7 +63,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/openiotsdk/KVPsaPsStore.cpp
+++ b/src/platform/openiotsdk/KVPsaPsStore.cpp
@@ -413,12 +413,6 @@ CHIP_ERROR KVPsaPsStore::FactoryResetConfig()
     return err;
 }
 
-void KVPsaPsStore::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<KVPsaPsStore>();
-}
-
 bool KVPsaPsStore::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the Matter reserved key range.

--- a/src/platform/openiotsdk/KVPsaPsStore.h
+++ b/src/platform/openiotsdk/KVPsaPsStore.h
@@ -28,7 +28,6 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <platform/PersistedStorage.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <psa/protected_storage.h>
 
@@ -145,7 +144,6 @@ public:
 
     // Additional functions
     static CHIP_ERROR FactoryResetConfig(void);
-    static void RunConfigUnitTest(void);
     static bool ConfigValueExists(Key key);
     static bool ValidKvsKey(Key key);
     static void KVSKeyMapUpdate(void);

--- a/src/platform/openiotsdk/PlatformManagerImpl.cpp
+++ b/src/platform/openiotsdk/PlatformManagerImpl.cpp
@@ -24,7 +24,6 @@
 
 #include "OpenIoTSDKArchUtils.h"
 #include "platform/internal/CHIPDeviceLayerInternal.h"
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -246,11 +246,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return QPGConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    QPGConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -68,7 +68,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/qpg/qpgConfig.cpp
+++ b/src/platform/qpg/qpgConfig.cpp
@@ -29,7 +29,6 @@
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include "FreeRTOS.h"
 #include "qvCHIP.h"
@@ -266,12 +265,6 @@ CHIP_ERROR QPGConfig::MapNVMError(qvStatus_t aStatus)
         break;
     }
     return CHIP_ERROR_INTERNAL;
-}
-
-void QPGConfig::RunConfigUnitTest()
-{
-    // Run common unit test
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<QPGConfig>();
 }
 
 } // namespace Internal

--- a/src/platform/qpg/qpgConfig.h
+++ b/src/platform/qpg/qpgConfig.h
@@ -124,8 +124,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
 
-    static void RunConfigUnitTest(void);
-
 protected:
     using ForEachRecordFunct = std::function<CHIP_ERROR(const Key & key, const size_t & length)>;
     static CHIP_ERROR ForEachRecord(uint16_t fileId, uint16_t recordKey, bool addNewRecord, ForEachRecordFunct funct);

--- a/src/platform/silabs/ConfigurationManagerImpl.h
+++ b/src/platform/silabs/ConfigurationManagerImpl.h
@@ -70,7 +70,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
     uint32_t rebootCause;

--- a/src/platform/silabs/SiWx917/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/SiWx917/ConfigurationManagerImpl.cpp
@@ -259,11 +259,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return SilabsConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    SilabsConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -25,7 +25,6 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 #include <platform/silabs/CHIPDevicePlatformConfig.h>
 
 #include <nvm3.h>
@@ -550,12 +549,6 @@ bool SilabsConfig::ValidConfigKey(Key key)
     }
 
     return false;
-}
-
-void SilabsConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<SilabsConfig>();
 }
 
 void SilabsConfig::RepackNvm3Flash(void)

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -198,7 +198,6 @@ public:
     static CHIP_ERROR FactoryResetConfig(void);
     static bool ValidConfigKey(Key key);
 
-    static void RunConfigUnitTest(void);
     static void RepackNvm3Flash(void);
 
 protected:

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -259,11 +259,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return SilabsConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    SilabsConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/stm32/ConfigurationManagerImpl.cpp
+++ b/src/platform/stm32/ConfigurationManagerImpl.cpp
@@ -152,11 +152,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return STM32Config::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
-{
-    STM32Config::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg) {}
 
 ConfigurationManager & ConfigurationMgrImpl()

--- a/src/platform/stm32/ConfigurationManagerImpl.h
+++ b/src/platform/stm32/ConfigurationManagerImpl.h
@@ -50,6 +50,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override {}
+#endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -65,7 +68,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/stm32/STM32Config.cpp
+++ b/src/platform/stm32/STM32Config.cpp
@@ -98,8 +98,6 @@ CHIP_ERROR STM32Config::FactoryResetConfig(void)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-void STM32Config::RunConfigUnitTest(void) {}
-
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/stm32/STM32Config.h
+++ b/src/platform/stm32/STM32Config.h
@@ -85,7 +85,6 @@ public:
     static CHIP_ERROR ClearConfigValue(Key key);
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
-    static void RunConfigUnitTest(void);
 };
 
 } // namespace Internal

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -55,15 +55,10 @@ static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-#if !defined(NDEBUG)
 static void TestPlatformMgr_RunUnitTest(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    err = ConfigurationMgr().RunUnitTests();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    ConfigurationMgr().RunUnitTests();
 }
-#endif
 
 static void TestConfigurationMgr_SerialNumber(nlTestSuite * inSuite, void * inContext)
 {
@@ -450,9 +445,7 @@ static void TestConfigurationMgr_GetProductId(nlTestSuite * inSuite, void * inCo
  */
 static const nlTest sTests[] = {
     NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
-#if !defined(NDEBUG)
     NL_TEST_DEF("Test PlatformMgr::RunUnitTest", TestPlatformMgr_RunUnitTest),
-#endif
     NL_TEST_DEF("Test ConfigurationMgr::SerialNumber", TestConfigurationMgr_SerialNumber),
     NL_TEST_DEF("Test ConfigurationMgr::UniqueId", TestConfigurationMgr_UniqueId),
     NL_TEST_DEF("Test ConfigurationMgr::ManufacturingDate", TestConfigurationMgr_ManufacturingDate),

--- a/src/platform/webos/ConfigurationManagerImpl.cpp
+++ b/src/platform/webos/ConfigurationManagerImpl.cpp
@@ -245,11 +245,6 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest()
-{
-    PosixConfig::RunConfigUnitTest();
-}
-
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/webos/ConfigurationManagerImpl.h
+++ b/src/platform/webos/ConfigurationManagerImpl.h
@@ -76,7 +76,6 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/webos/PosixConfig.cpp
+++ b/src/platform/webos/PosixConfig.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <platform/internal/testing/ConfigUnitTest.h>
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
@@ -582,12 +581,6 @@ CHIP_ERROR PosixConfig::FactoryResetCounters()
 
 exit:
     return err;
-}
-
-void PosixConfig::RunConfigUnitTest()
-{
-    // Run common unit test.
-    ::chip::DeviceLayer::Internal::RunConfigUnitTest<PosixConfig>();
 }
 
 } // namespace Internal

--- a/src/platform/webos/PosixConfig.h
+++ b/src/platform/webos/PosixConfig.h
@@ -109,7 +109,6 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig();
     static CHIP_ERROR FactoryResetCounters();
-    static void RunConfigUnitTest();
 
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);


### PR DESCRIPTION
Currently, on most platforms RunUnitTests() is implemented by GenericConfigurationManagerImpl by forwarding the call to another virtual method RunConfigUnitTest() that calls ConfigClass::RunConfigUnitTest() that in turn either runs the unit test or not, depending on the platform.

Simplify this to remove boilerplate code by running the unit tests directly in GenericConfigurationManagerImpl:: RunUnitTests() and let platforms override this method if needed.

Also, include RunUnitTests() in ConfigurationManager interface only if CHIP_CONFIG_TEST is enabled. That helps save even ~1kB flash on Zephyr platforms.

