### PR TITLE
[zephyr] Do not build ConfigurationManager::RunUnitTests() without tests

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -124,7 +124,9 @@ public:
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 
-    virtual CHIP_ERROR RunUnitTests() = 0;
+#if CHIP_CONFIG_TEST
+    virtual void RunUnitTests() = 0;
+#endif
 
     virtual bool IsFullyProvisioned()   = 0;
     virtual void InitiateFactoryReset() = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -103,7 +103,9 @@ public:
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;
-    CHIP_ERROR RunUnitTests(void) override;
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override;
+#endif
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -663,15 +663,14 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSecondaryPairingInst
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_CONFIG_TEST
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::RunUnitTests()
+void GenericConfigurationManagerImpl<ConfigClass>::RunUnitTests()
 {
-#if !defined(NDEBUG)
     ChipLogProgress(DeviceLayer, "Running configuration unit test");
     RunConfigUnitTest();
-#endif
-    return CHIP_NO_ERROR;
 }
+#endif
 
 template <class ConfigClass>
 void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -168,9 +168,11 @@ CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t 
     return ZephyrConfig::WriteConfigValueBin(key, data, dataLen);
 }
 
-void ConfigurationManagerImpl::RunConfigUnitTest(void)
+void ConfigurationManagerImpl::RunConfigUnitTest()
 {
+#if CHIP_CONFIG_TEST
     ZephyrConfig::RunConfigUnitTest();
+#endif
 }
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -67,7 +67,7 @@ private:
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str) override;
     CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen) override;
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
-    void RunConfigUnitTest(void) override;
+    void RunConfigUnitTest() override;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -86,7 +86,7 @@ private:
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if CHIP_CONFIG_TEST
-    void RunUnitTests() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    void RunUnitTests() override {}
 #endif
     bool IsFullyProvisioned() override { return false; }
     void LogDeviceConfig() override {}

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -85,8 +85,8 @@ private:
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#if !defined(NDEBUG)
-    CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_CONFIG_TEST
+    void RunUnitTests() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif
     bool IsFullyProvisioned() override { return false; }
     void LogDeviceConfig() override {}

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -57,6 +57,13 @@ static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
 
 static void TestPlatformMgr_RunUnitTest(nlTestSuite * inSuite, void * inContext)
 {
+#if CHIP_DEVICE_LAYER_TARGET_OPEN_IOT_SDK
+    // TODO: Fix RunUnitTests() for Open IOT SDK.
+    // Previously, TestPlatformMgr_RunUnitTest was only run if !NDEBUG while the Open IOT SDK
+    // test runner was built with NDEBUG set.
+    return;
+#endif
+
     ConfigurationMgr().RunUnitTests();
 }
 

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -55,15 +55,10 @@ static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-#if !defined(NDEBUG)
 static void TestPlatformMgr_RunUnitTest(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    err = ConfigurationMgr().RunUnitTests();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    ConfigurationMgr().RunUnitTests();
 }
-#endif
 
 static void TestConfigurationMgr_SerialNumber(nlTestSuite * inSuite, void * inContext)
 {
@@ -450,9 +445,7 @@ static void TestConfigurationMgr_GetProductId(nlTestSuite * inSuite, void * inCo
  */
 static const nlTest sTests[] = {
     NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
-#if !defined(NDEBUG)
     NL_TEST_DEF("Test PlatformMgr::RunUnitTest", TestPlatformMgr_RunUnitTest),
-#endif
     NL_TEST_DEF("Test ConfigurationMgr::SerialNumber", TestConfigurationMgr_SerialNumber),
     NL_TEST_DEF("Test ConfigurationMgr::UniqueId", TestConfigurationMgr_UniqueId),
     NL_TEST_DEF("Test ConfigurationMgr::ManufacturingDate", TestConfigurationMgr_ManufacturingDate),


### PR DESCRIPTION
Do not build ConfigurationManager::RunUnitTests() nor ConfigurationManagerImpl::RunConfigUnitTest() when building a Zephyr application without unit test support.

This saves almost 1kB of flash.