### PR TITLE
Move `Identify Cluster` to spec

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_dishwasher_cc105034fe.matter
+++ b/examples/chef/devices/rootnode_dishwasher_cc105034fe.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_genericswitch_9866e35d0b.matter
+++ b/examples/chef/devices/rootnode_genericswitch_9866e35d0b.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_onofflight_samplemei.matter
+++ b/examples/chef/devices/rootnode_onofflight_samplemei.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_pump_5f904818cc.matter
+++ b/examples/chef/devices/rootnode_pump_5f904818cc.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_pump_a811bb33a0.matter
+++ b/examples/chef/devices/rootnode_pump_a811bb33a0.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.matter
+++ b/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
+++ b/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
+++ b/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/nxp/zap/lighting-on-off.matter
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/qpg/zap/light.matter
+++ b/examples/lighting-app/qpg/zap/light.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lock-app/nxp/zap/lock-app.matter
+++ b/examples/lock-app/nxp/zap/lock-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
+++ b/examples/resource-monitoring-app/resource-monitoring-common/resource-monitoring-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/rvc-app/rvc-common/rvc-app.matter
+++ b/examples/rvc-app/rvc-common/rvc-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
@@ -71,6 +77,10 @@ server cluster Identify = 3 {
     kAudibleBeep = 3;
     kDisplay = 4;
     kActuator = 5;
+  }
+
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
   }
 
   attribute int16u identifyTime = 0;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -25,6 +25,10 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;

--- a/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
@@ -62,6 +62,12 @@ limitations under the License.
       <arg name="IdentifyTime" type="int16u"/>
       <access op="invoke" privilege="manage"/>
     </command>
+    <command source="client" code="0x01" name="IdentifyQuery" optional="false">
+      <description>
+        This command allows the sending device to request the target or targets to respond if they are currently identifying themselves.
+      </description>
+      <access op="invoke" privilege="manage"/>
+    </command>
     <command source="client" code="0x40" name="TriggerEffect" optional="true">
       <description>
         Command description for TriggerEffect
@@ -71,4 +77,9 @@ limitations under the License.
       <access op="invoke" privilege="manage"/>
     </command>
   </cluster>
+
+  <bitmap name="Feature" type="bitmap32">
+    <cluster code="0x0003"/>
+    <field name="Query" mask="0x1"/>
+  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
@@ -62,11 +62,17 @@ limitations under the License.
       <arg name="IdentifyTime" type="int16u"/>
       <access op="invoke" privilege="manage"/>
     </command>
-    <command source="client" code="0x01" name="IdentifyQuery" optional="false">
-      <description>
+    <command source="client" code="0x01" name="IdentifyQuery" optional="true" response="IdentifyQueryResponse">
+    <description>
         This command allows the sending device to request the target or targets to respond if they are currently identifying themselves.
-      </description>
-      <access op="invoke" privilege="manage"/>
+    </description>
+    <access op="invoke" privilege="manage"/>
+    </command>
+    <command source="server" code="0x00" name="IdentifyQueryResponse" optional="true">
+    <description>
+        This command is generated in response to receiving an IdentifyQuery Command, in the case that the device is currently identifying itself
+    </description>
+    <arg name="Timeout" type="int16u"/>
     </command>
     <command source="client" code="0x40" name="TriggerEffect" optional="true">
       <description>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -42,6 +42,10 @@ client cluster Identify = 3 {
     int16u identifyTime = 0;
   }
 
+  response struct IdentifyQueryResponse = 0 {
+    int16u timeout = 0;
+  }
+
   request struct TriggerEffectRequest {
     EffectIdentifierEnum effectIdentifier = 0;
     EffectVariantEnum effectVariant = 1;
@@ -50,7 +54,7 @@ client cluster Identify = 3 {
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
   /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
-  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
+  command access(invoke: manage) IdentifyQuery(): IdentifyQueryResponse = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -25,6 +25,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
+  bitmap Feature : bitmap32 {
+    kQuery = 0x1;
+  }
+
   attribute int16u identifyTime = 0;
   readonly attribute IdentifyTypeEnum identifyType = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -45,6 +49,8 @@ client cluster Identify = 3 {
 
   /** Command description for Identify */
   command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
+  /** This command allows the sending device to request the target or targets to respond if they are currently identifying themselves. */
+  command access(invoke: manage) IdentifyQuery(): DefaultSuccess = 1;
   /** Command description for TriggerEffect */
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -133,6 +133,14 @@ public class ChipClusters {
       identify(chipClusterPtr, callback, identifyTime, timedInvokeTimeoutMs);
     }
 
+    public void identifyQuery(DefaultClusterCallback callback) {
+      identifyQuery(chipClusterPtr, callback, null);
+    }
+
+    public void identifyQuery(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      identifyQuery(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
     public void triggerEffect(DefaultClusterCallback callback, Integer effectIdentifier, Integer effectVariant) {
       triggerEffect(chipClusterPtr, callback, effectIdentifier, effectVariant, null);
     }
@@ -142,6 +150,8 @@ public class ChipClusters {
     }
 
     private native void identify(long chipClusterPtr, DefaultClusterCallback callback, Integer identifyTime, @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void identifyQuery(long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer timedInvokeTimeoutMs);
 
     private native void triggerEffect(long chipClusterPtr, DefaultClusterCallback callback, Integer effectIdentifier, Integer effectVariant, @Nullable Integer timedInvokeTimeoutMs);
 

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -133,11 +133,11 @@ public class ChipClusters {
       identify(chipClusterPtr, callback, identifyTime, timedInvokeTimeoutMs);
     }
 
-    public void identifyQuery(DefaultClusterCallback callback) {
+    public void identifyQuery(IdentifyQueryResponseCallback callback) {
       identifyQuery(chipClusterPtr, callback, null);
     }
 
-    public void identifyQuery(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+    public void identifyQuery(IdentifyQueryResponseCallback callback, int timedInvokeTimeoutMs) {
       identifyQuery(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
@@ -151,9 +151,14 @@ public class ChipClusters {
 
     private native void identify(long chipClusterPtr, DefaultClusterCallback callback, Integer identifyTime, @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void identifyQuery(long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer timedInvokeTimeoutMs);
+    private native void identifyQuery(long chipClusterPtr, IdentifyQueryResponseCallback callback, @Nullable Integer timedInvokeTimeoutMs);
 
     private native void triggerEffect(long chipClusterPtr, DefaultClusterCallback callback, Integer effectIdentifier, Integer effectVariant, @Nullable Integer timedInvokeTimeoutMs);
+
+    public interface IdentifyQueryResponseCallback {
+      void onSuccess(Integer timeout);
+      void onError(Exception error);
+    }
 
     public interface GeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> value);

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
@@ -385,6 +385,7 @@ public class ClusterIDMapping {
 
         public enum Command {
             Identify(0L),
+            IdentifyQuery(1L),
             TriggerEffect(64L),;
             private final long id;
             Command(long id) {

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
@@ -213,6 +213,28 @@ public class ClusterInfoMapping {
     }
   }
 
+
+  public static class DelegatedIdentifyClusterIdentifyQueryResponseCallback implements ChipClusters.IdentifyCluster.IdentifyQueryResponseCallback, DelegatedClusterCallback {
+    private ClusterCommandCallback callback;
+    @Override
+    public void setCallbackDelegate(ClusterCommandCallback callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void onSuccess(Integer timeout) {
+      Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
+
+      CommandResponseInfo timeoutResponseValue = new CommandResponseInfo("timeout", "Integer");
+      responseValues.put(timeoutResponseValue, timeout);
+      callback.onSuccess(responseValues);
+    }
+
+    @Override
+    public void onError(Exception error) {
+      callback.onFailure(error);
+    }
+  }
   public static class DelegatedIdentifyClusterGeneratedCommandListAttributeCallback implements ChipClusters.IdentifyCluster.GeneratedCommandListAttributeCallback, DelegatedClusterCallback {
     private ClusterCommandCallback callback;
     @Override
@@ -17575,12 +17597,12 @@ public class ClusterInfoMapping {
     InteractionInfo identifyidentifyQueryInteractionInfo = new InteractionInfo(
       (cluster, callback, commandArguments) -> {
         ((ChipClusters.IdentifyCluster) cluster)
-        .identifyQuery((DefaultClusterCallback) callback
-        );
-      },
-      () -> new DelegatedDefaultClusterCallback(),
+          .identifyQuery((ChipClusters.IdentifyCluster.IdentifyQueryResponseCallback) callback
+            );
+        },
+        () -> new DelegatedIdentifyClusterIdentifyQueryResponseCallback(),
         identifyidentifyQueryCommandParams
-    );
+      );
     identifyClusterInteractionInfoMap.put("identifyQuery", identifyidentifyQueryInteractionInfo);
 
     Map<String, CommandParameterInfo> identifytriggerEffectCommandParams = new LinkedHashMap<String, CommandParameterInfo>();

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
@@ -17571,6 +17571,18 @@ public class ClusterInfoMapping {
     );
     identifyClusterInteractionInfoMap.put("identify", identifyidentifyInteractionInfo);
 
+    Map<String, CommandParameterInfo> identifyidentifyQueryCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+    InteractionInfo identifyidentifyQueryInteractionInfo = new InteractionInfo(
+      (cluster, callback, commandArguments) -> {
+        ((ChipClusters.IdentifyCluster) cluster)
+        .identifyQuery((DefaultClusterCallback) callback
+        );
+      },
+      () -> new DelegatedDefaultClusterCallback(),
+        identifyidentifyQueryCommandParams
+    );
+    identifyClusterInteractionInfoMap.put("identifyQuery", identifyidentifyQueryInteractionInfo);
+
     Map<String, CommandParameterInfo> identifytriggerEffectCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
 
     CommandParameterInfo identifytriggerEffecteffectIdentifierCommandParameterInfo = new CommandParameterInfo("effectIdentifier", Integer.class, Integer.class);

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
@@ -20,6 +20,8 @@ package matter.devicecontroller.cluster.clusters
 import matter.devicecontroller.cluster.structs.*
 
 class IdentifyCluster(private val endpointId: UShort) {
+  class IdentifyQueryResponse(val timeout: UShort)
+
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -36,7 +38,7 @@ class IdentifyCluster(private val endpointId: UShort) {
     }
   }
 
-  suspend fun identifyQuery(timedInvokeTimeoutMs: Int? = null) {
+  suspend fun identifyQuery(timedInvokeTimeoutMs: Int? = null): IdentifyQueryResponse {
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
@@ -36,6 +36,14 @@ class IdentifyCluster(private val endpointId: UShort) {
     }
   }
 
+  suspend fun identifyQuery(timedInvokeTimeoutMs: Int? = null) {
+    if (timedInvokeTimeoutMs != null) {
+      // Do the action with timedInvokeTimeoutMs
+    } else {
+      // Do the action without timedInvokeTimeoutMs
+    }
+  }
+
   suspend fun triggerEffect(
     effectIdentifier: UInt,
     effectVariant: UInt,

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -29,6 +29,66 @@
 
 namespace chip {
 
+CHIPIdentifyClusterIdentifyQueryResponseCallback::CHIPIdentifyClusterIdentifyQueryResponseCallback(jobject javaCallback) :
+    Callback::Callback<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>(CallbackFn, this)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        return;
+    }
+
+    javaCallbackRef = env->NewGlobalRef(javaCallback);
+    if (javaCallbackRef == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+    }
+}
+
+CHIPIdentifyClusterIdentifyQueryResponseCallback::~CHIPIdentifyClusterIdentifyQueryResponseCallback()
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+};
+
+void CHIPIdentifyClusterIdentifyQueryResponseCallback::CallbackFn(
+    void * context, const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & dataResponse)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
+    jobject javaCallbackRef;
+    jmethodID javaMethod;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Error invoking Java callback: no JNIEnv"));
+
+    std::unique_ptr<CHIPIdentifyClusterIdentifyQueryResponseCallback, void (*)(CHIPIdentifyClusterIdentifyQueryResponseCallback *)>
+        cppCallback(reinterpret_cast<CHIPIdentifyClusterIdentifyQueryResponseCallback *>(context),
+                    chip::Platform::Delete<CHIPIdentifyClusterIdentifyQueryResponseCallback>);
+    VerifyOrReturn(cppCallback != nullptr, ChipLogError(Zcl, "Error invoking Java callback: failed to cast native callback"));
+
+    javaCallbackRef = cppCallback->javaCallbackRef;
+    // Java callback is allowed to be null, exit early if this is the case.
+    VerifyOrReturn(javaCallbackRef != nullptr);
+
+    err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Integer;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
+
+    jobject Timeout;
+    std::string TimeoutClassName     = "java/lang/Integer";
+    std::string TimeoutCtorSignature = "(I)V";
+    jint jniTimeout                  = static_cast<jint>(dataResponse.timeout);
+    chip::JniReferences::GetInstance().CreateBoxedObject<jint>(TimeoutClassName.c_str(), TimeoutCtorSignature.c_str(), jniTimeout,
+                                                               Timeout);
+
+    env->CallVoidMethod(javaCallbackRef, javaMethod, Timeout);
+}
 CHIPGroupsClusterAddGroupResponseCallback::CHIPGroupsClusterAddGroupResponseCallback(jobject javaCallback) :
     Callback::Callback<CHIPGroupsClusterAddGroupResponseCallbackType>(CallbackFn, this)
 {

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.h
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.h
@@ -24,6 +24,21 @@
 
 namespace chip {
 
+class CHIPIdentifyClusterIdentifyQueryResponseCallback
+    : public Callback::Callback<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>
+{
+public:
+    CHIPIdentifyClusterIdentifyQueryResponseCallback(jobject javaCallback);
+
+    ~CHIPIdentifyClusterIdentifyQueryResponseCallback();
+
+    static void CallbackFn(void * context,
+                           const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & data);
+
+private:
+    jobject javaCallbackRef;
+};
+
 class CHIPGroupsClusterAddGroupResponseCallback : public Callback::Callback<CHIPGroupsClusterAddGroupResponseCallbackType>
 {
 public:

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -41,6 +41,12 @@ class ChipClusters:
                     "identifyTime": "int",
                 },
             },
+            0x00000001: {
+                "commandId": 0x00000001,
+                "commandName": "IdentifyQuery",
+                "args": {
+                },
+            },
             0x00000040: {
                 "commandId": 0x00000040,
                 "commandName": "TriggerEffect",

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -99,6 +99,10 @@ class Identify(Cluster):
             # enum value. This specific should never be transmitted.
             kUnknownEnumValue = 6,
 
+    class Bitmaps:
+        class Feature(IntFlag):
+            kQuery = 0x1
+
     class Commands:
         @dataclass
         class Identify(ClusterCommand):
@@ -115,6 +119,19 @@ class Identify(Cluster):
                     ])
 
             identifyTime: 'uint' = 0
+
+        @dataclass
+        class IdentifyQuery(ClusterCommand):
+            cluster_id: typing.ClassVar[int] = 0x00000003
+            command_id: typing.ClassVar[int] = 0x00000001
+            is_client: typing.ClassVar[bool] = True
+            response_type: typing.ClassVar[str] = None
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields=[
+                    ])
 
         @dataclass
         class TriggerEffect(ClusterCommand):

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -121,11 +121,27 @@ class Identify(Cluster):
             identifyTime: 'uint' = 0
 
         @dataclass
+        class IdentifyQueryResponse(ClusterCommand):
+            cluster_id: typing.ClassVar[int] = 0x00000003
+            command_id: typing.ClassVar[int] = 0x00000000
+            is_client: typing.ClassVar[bool] = False
+            response_type: typing.ClassVar[str] = None
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields=[
+                        ClusterObjectFieldDescriptor(Label="timeout", Tag=0, Type=uint),
+                    ])
+
+            timeout: 'uint' = 0
+
+        @dataclass
         class IdentifyQuery(ClusterCommand):
             cluster_id: typing.ClassVar[int] = 0x00000003
             command_id: typing.ClassVar[int] = 0x00000001
             is_client: typing.ClassVar[bool] = True
-            response_type: typing.ClassVar[str] = None
+            response_type: typing.ClassVar[str] = 'IdentifyQueryResponse'
 
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -45,6 +45,14 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params completion:(MTRStatusCompletion)completion MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 /**
+ * Command IdentifyQuery
+ *
+ * This command allows the sending device to request the target or targets to respond if they are currently identifying themselves.
+ */
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_PROVISIONALLY_AVAILABLE;
+- (void)identifyQueryWithCompletion:(MTRStatusCompletion)completion
+    MTR_PROVISIONALLY_AVAILABLE;
+/**
  * Command TriggerEffect
  *
  * Command description for TriggerEffect
@@ -13438,6 +13446,10 @@ typedef NS_ENUM(uint8_t, MTRIdentifyType) {
     MTRIdentifyTypeDisplay MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x04,
     MTRIdentifyTypeActuator MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x05,
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+
+typedef NS_OPTIONS(uint32_t, MTRIdentifyFeature) {
+    MTRIdentifyFeatureQuery MTR_PROVISIONALLY_AVAILABLE = 0x1,
+} MTR_PROVISIONALLY_AVAILABLE;
 
 typedef NS_OPTIONS(uint32_t, MTRGroupsFeature) {
     MTRGroupsFeatureGroupNames MTR_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0)) = 0x1,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -49,8 +49,8 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  * This command allows the sending device to request the target or targets to respond if they are currently identifying themselves.
  */
-- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params completion:(MTRStatusCompletion)completion MTR_PROVISIONALLY_AVAILABLE;
-- (void)identifyQueryWithCompletion:(MTRStatusCompletion)completion
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params completion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
+- (void)identifyQueryWithCompletion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion
     MTR_PROVISIONALLY_AVAILABLE;
 /**
  * Command TriggerEffect

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -5444,6 +5444,7 @@ typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 
     // Cluster Identify commands
     MTRCommandIDTypeClusterIdentifyCommandIdentifyID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x00000000,
+    MTRCommandIDTypeClusterIdentifyCommandIdentifyQueryID MTR_PROVISIONALLY_AVAILABLE = 0x00000001,
     MTRCommandIDTypeClusterIdentifyCommandTriggerEffectID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x00000040,
 
     // Cluster Groups deprecated command id names

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -5444,6 +5444,7 @@ typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 
     // Cluster Identify commands
     MTRCommandIDTypeClusterIdentifyCommandIdentifyID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x00000000,
+    MTRCommandIDTypeClusterIdentifyCommandIdentifyQueryResponseID MTR_PROVISIONALLY_AVAILABLE = 0x00000000,
     MTRCommandIDTypeClusterIdentifyCommandIdentifyQueryID MTR_PROVISIONALLY_AVAILABLE = 0x00000001,
     MTRCommandIDTypeClusterIdentifyCommandTriggerEffectID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x00000040,
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -44,6 +44,9 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, readonly) MTRDevice * device MTR_NEWLY_AVAILABLE;
 
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_PROVISIONALLY_AVAILABLE;
+- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+    MTR_PROVISIONALLY_AVAILABLE;
 - (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeIdentifyTimeWithParams:(MTRReadParams * _Nullable)params MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -44,8 +44,8 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, readonly) MTRDevice * device MTR_NEWLY_AVAILABLE;
 
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
-- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_PROVISIONALLY_AVAILABLE;
-- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
+- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion
     MTR_PROVISIONALLY_AVAILABLE;
 - (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -83,11 +83,11 @@ using chip::System::Clock::Timeout;
                                         completion:responseHandler];
 }
 
-- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion
 {
     [self identifyQueryWithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completion];
 }
-- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(void (^)(MTRIdentifyClusterIdentifyQueryResponseParams * _Nullable data, NSError * _Nullable error))completion
 {
     if (params == nil) {
         params = [[MTRIdentifyClusterIdentifyQueryParams
@@ -95,7 +95,7 @@ using chip::System::Clock::Timeout;
     }
 
     auto responseHandler = ^(id _Nullable response, NSError * _Nullable error) {
-        completion(error);
+        completion(response, error);
     };
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
@@ -109,7 +109,7 @@ using chip::System::Clock::Timeout;
                              expectedValueInterval:expectedValueIntervalMs
                                 timedInvokeTimeout:timedInvokeTimeoutMs
                        serverSideProcessingTimeout:params.serverSideProcessingTimeout
-                                     responseClass:nil
+                                     responseClass:MTRIdentifyClusterIdentifyQueryResponseParams.class
                                              queue:self.callbackQueue
                                         completion:responseHandler];
 }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -83,6 +83,37 @@ using chip::System::Clock::Timeout;
                                         completion:responseHandler];
 }
 
+- (void)identifyQueryWithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+{
+    [self identifyQueryWithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completion];
+}
+- (void)identifyQueryWithParams:(MTRIdentifyClusterIdentifyQueryParams * _Nullable)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
+{
+    if (params == nil) {
+        params = [[MTRIdentifyClusterIdentifyQueryParams
+            alloc] init];
+    }
+
+    auto responseHandler = ^(id _Nullable response, NSError * _Nullable error) {
+        completion(error);
+    };
+
+    auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
+
+    using RequestType = Identify::Commands::IdentifyQuery::Type;
+    [self.device _invokeKnownCommandWithEndpointID:@(self.endpoint)
+                                         clusterID:@(RequestType::GetClusterId())
+                                         commandID:@(RequestType::GetCommandId())
+                                    commandPayload:params
+                                    expectedValues:expectedValues
+                             expectedValueInterval:expectedValueIntervalMs
+                                timedInvokeTimeout:timedInvokeTimeoutMs
+                       serverSideProcessingTimeout:params.serverSideProcessingTimeout
+                                     responseClass:nil
+                                             queue:self.callbackQueue
+                                        completion:responseHandler];
+}
+
 - (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedValues expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:(MTRStatusCompletion)completion
 {
     if (params == nil) {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -50,6 +50,34 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
 @end
 
+MTR_PROVISIONALLY_AVAILABLE
+@interface MTRIdentifyClusterIdentifyQueryParams : NSObject <NSCopying>
+/**
+ * Controls whether the command is a timed command (using Timed Invoke).
+ *
+ * If nil (the default value), a regular invoke is done for commands that do
+ * not require a timed invoke and a timed invoke with some default timed request
+ * timeout is done for commands that require a timed invoke.
+ *
+ * If not nil, a timed invoke is done, with the provided value used as the timed
+ * request timeout.  The value should be chosen small enough to provide the
+ * desired security properties but large enough that it will allow a round-trip
+ * from the sever to the client (for the status response and actual invoke
+ * request) within the timeout window.
+ *
+ */
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+/**
+ * Controls how much time, in seconds, we will allow for the server to process the command.
+ *
+ * The command will then time out if that much time, plus an allowance for retransmits due to network failures, passes.
+ *
+ * If nil, the framework will try to select an appropriate timeout value itself.
+ */
+@property (nonatomic, copy, nullable) NSNumber * serverSideProcessingTimeout;
+@end
+
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRIdentifyClusterTriggerEffectParams : NSObject <NSCopying>
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -51,6 +51,25 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @end
 
 MTR_PROVISIONALLY_AVAILABLE
+@interface MTRIdentifyClusterIdentifyQueryResponseParams : NSObject <NSCopying>
+
+@property (nonatomic, copy) NSNumber * _Nonnull timeout MTR_PROVISIONALLY_AVAILABLE;
+
+/**
+ * Initialize an MTRIdentifyClusterIdentifyQueryResponseParams with a response-value dictionary
+ * of the sort that MTRDeviceResponseHandler would receive.
+ *
+ * Will return nil and hand out an error if the response-value dictionary is not
+ * a command data response or is not the right command response.
+ *
+ * Will return nil and hand out an error if the data response does not match the known
+ * schema for this command.
+ */
+- (nullable instancetype)initWithResponseValue:(NSDictionary<NSString *, id> *)responseValue
+                                         error:(NSError * __autoreleasing *)error MTR_PROVISIONALLY_AVAILABLE;
+@end
+
+MTR_PROVISIONALLY_AVAILABLE
 @interface MTRIdentifyClusterIdentifyQueryParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -112,6 +112,85 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
+@implementation MTRIdentifyClusterIdentifyQueryResponseParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeout = @(0);
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MTRIdentifyClusterIdentifyQueryResponseParams alloc] init];
+
+    other.timeout = self.timeout;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: timeout:%@; >", NSStringFromClass([self class]), _timeout];
+    return descriptionString;
+}
+
+- (nullable instancetype)initWithResponseValue:(NSDictionary<NSString *, id> *)responseValue
+                                         error:(NSError * __autoreleasing *)error
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    using DecodableType = chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType;
+    chip::System::PacketBufferHandle buffer = [MTRBaseDevice _responseDataForCommand:responseValue
+                                                                           clusterID:DecodableType::GetClusterId()
+                                                                           commandID:DecodableType::GetCommandId()
+                                                                               error:error];
+    if (buffer.IsNull()) {
+        return nil;
+    }
+
+    chip::TLV::TLVReader reader;
+    reader.Init(buffer->Start(), buffer->DataLength());
+
+    CHIP_ERROR err = reader.Next(chip::TLV::AnonymousTag());
+    if (err == CHIP_NO_ERROR) {
+        DecodableType decodedStruct;
+        err = chip::app::DataModel::Decode(reader, decodedStruct);
+        if (err == CHIP_NO_ERROR) {
+            err = [self _setFieldsFromDecodableStruct:decodedStruct];
+            if (err == CHIP_NO_ERROR) {
+                return self;
+            }
+        }
+    }
+
+    NSString * errorStr = [NSString stringWithFormat:@"Command payload decoding failed: %s", err.AsString()];
+    MTR_LOG_ERROR("%s", errorStr.UTF8String);
+    if (error != nil) {
+        NSDictionary * userInfo = @{ NSLocalizedFailureReasonErrorKey : NSLocalizedString(errorStr, nil) };
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeSchemaMismatch userInfo:userInfo];
+    }
+    return nil;
+}
+
+@end
+
+@implementation MTRIdentifyClusterIdentifyQueryResponseParams (InternalMethods)
+
+- (CHIP_ERROR)_setFieldsFromDecodableStruct:(const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType &)decodableStruct
+{
+    {
+        self.timeout = [NSNumber numberWithUnsignedShort:decodableStruct.timeout];
+    }
+    return CHIP_NO_ERROR;
+}
+
+@end
+
 @implementation MTRIdentifyClusterIdentifyQueryParams
 - (instancetype)init
 {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -112,6 +112,79 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
+@implementation MTRIdentifyClusterIdentifyQueryParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _timedInvokeTimeoutMs = nil;
+        _serverSideProcessingTimeout = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone;
+{
+    auto other = [[MTRIdentifyClusterIdentifyQueryParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+    other.serverSideProcessingTimeout = self.serverSideProcessingTimeout;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
+@end
+
+@implementation MTRIdentifyClusterIdentifyQueryParams (InternalMethods)
+
+- (CHIP_ERROR)_encodeToTLVReader:(chip::System::PacketBufferTLVReader &)reader
+{
+    chip::app::Clusters::Identify::Commands::IdentifyQuery::Type encodableStruct;
+    ListFreer listFreer;
+
+    auto buffer = chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSizeWithoutReserve, 0);
+    if (buffer.IsNull()) {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    chip::System::PacketBufferTLVWriter writer;
+    // Commands never need chained buffers, since they cannot be chunked.
+    writer.Init(std::move(buffer), /* useChainedBuffers = */ false);
+
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::AnonymousTag(), encodableStruct));
+
+    ReturnErrorOnFailure(writer.Finalize(&buffer));
+
+    reader.Init(std::move(buffer));
+    return reader.Next(chip::TLV::kTLVType_Structure, chip::TLV::AnonymousTag());
+}
+
+- (NSDictionary<NSString *, id> * _Nullable)_encodeAsDataValue:(NSError * __autoreleasing *)error
+{
+    chip::System::PacketBufferTLVReader reader;
+    CHIP_ERROR err = [self _encodeToTLVReader:reader];
+    if (err != CHIP_NO_ERROR) {
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:err];
+        }
+        return nil;
+    }
+
+    auto decodedObj = MTRDecodeDataValueDictionaryFromCHIPTLV(&reader);
+    if (decodedObj == nil) {
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+    }
+    return decodedObj;
+}
+@end
+
 @implementation MTRIdentifyClusterTriggerEffectParams
 - (instancetype)init
 {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
@@ -28,6 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface MTRIdentifyClusterIdentifyQueryParams (InternalMethods)
+
+- (NSDictionary<NSString *, id> * _Nullable)_encodeAsDataValue:(NSError * __autoreleasing *)error;
+
+@end
+
 @interface MTRIdentifyClusterTriggerEffectParams (InternalMethods)
 
 - (NSDictionary<NSString *, id> * _Nullable)_encodeAsDataValue:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloads_Internal.h
@@ -28,6 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface MTRIdentifyClusterIdentifyQueryResponseParams (InternalMethods)
+
+- (CHIP_ERROR)_setFieldsFromDecodableStruct:(const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType &)decodableStruct;
+
+@end
+
 @interface MTRIdentifyClusterIdentifyQueryParams (InternalMethods)
 
 - (NSDictionary<NSString *, id> * _Nullable)_encodeAsDataValue:(NSError * __autoreleasing *)error;

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -8569,6 +8569,12 @@ bool emberAfIdentifyClusterIdentifyCallback(chip::app::CommandHandler * commandO
                                             const chip::app::ConcreteCommandPath & commandPath,
                                             const chip::app::Clusters::Identify::Commands::Identify::DecodableType & commandData);
 /**
+ * @brief Identify Cluster IdentifyQuery Command callback (from client)
+ */
+bool emberAfIdentifyClusterIdentifyQueryCallback(
+    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+    const chip::app::Clusters::Identify::Commands::IdentifyQuery::DecodableType & commandData);
+/**
  * @brief Identify Cluster TriggerEffect Command callback (from client)
  */
 bool emberAfIdentifyClusterTriggerEffectCallback(

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -71,6 +71,12 @@ enum class IdentifyTypeEnum : uint8_t
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 6,
 };
+
+// Bitmap for Feature
+enum class Feature : uint32_t
+{
+    kQuery = 0x1,
+};
 } // namespace Identify
 
 namespace Groups {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -375,6 +375,40 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
     }
 }
 } // namespace Identify.
+namespace IdentifyQueryResponse {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
+{
+    DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
+    encoder.Encode(to_underlying(Fields::kTimeout), timeout);
+    return encoder.Finalize();
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    detail::StructDecodeIterator __iterator(reader);
+    while (true)
+    {
+        auto __element = __iterator.Next();
+        if (std::holds_alternative<CHIP_ERROR>(__element))
+        {
+            return std::get<CHIP_ERROR>(__element);
+        }
+
+        CHIP_ERROR err              = CHIP_NO_ERROR;
+        const uint8_t __context_tag = std::get<uint8_t>(__element);
+
+        if (__context_tag == to_underlying(Fields::kTimeout))
+        {
+            err = DataModel::Decode(reader, timeout);
+        }
+        else
+        {
+        }
+
+        ReturnErrorOnFailure(err);
+    }
+}
+} // namespace IdentifyQueryResponse.
 namespace IdentifyQuery {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -375,6 +375,26 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
     }
 }
 } // namespace Identify.
+namespace IdentifyQuery {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
+{
+    DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
+    return encoder.Finalize();
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    detail::StructDecodeIterator __iterator(reader);
+    while (true)
+    {
+        auto __element = __iterator.Next();
+        if (std::holds_alternative<CHIP_ERROR>(__element))
+        {
+            return std::get<CHIP_ERROR>(__element);
+        }
+    }
+}
+} // namespace IdentifyQuery.
 namespace TriggerEffect {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -283,6 +283,11 @@ struct Type;
 struct DecodableType;
 } // namespace Identify
 
+namespace IdentifyQueryResponse {
+struct Type;
+struct DecodableType;
+} // namespace IdentifyQueryResponse
+
 namespace IdentifyQuery {
 struct Type;
 struct DecodableType;
@@ -328,6 +333,38 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Identify
+namespace IdentifyQueryResponse {
+enum class Fields : uint8_t
+{
+    kTimeout = 0,
+};
+
+struct Type
+{
+public:
+    // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
+
+    uint16_t timeout = static_cast<uint16_t>(0);
+
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+
+    using ResponseType = DataModel::NullObjectType;
+
+    static constexpr bool MustUseTimedInvoke() { return false; }
+};
+
+struct DecodableType
+{
+public:
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
+
+    uint16_t timeout = static_cast<uint16_t>(0);
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+}; // namespace IdentifyQueryResponse
 namespace IdentifyQuery {
 enum class Fields : uint8_t
 {
@@ -342,7 +379,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
 
-    using ResponseType = DataModel::NullObjectType;
+    using ResponseType = Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -283,6 +283,11 @@ struct Type;
 struct DecodableType;
 } // namespace Identify
 
+namespace IdentifyQuery {
+struct Type;
+struct DecodableType;
+} // namespace IdentifyQuery
+
 namespace TriggerEffect {
 struct Type;
 struct DecodableType;
@@ -323,6 +328,34 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Identify
+namespace IdentifyQuery {
+enum class Fields : uint8_t
+{
+};
+
+struct Type
+{
+public:
+    // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQuery::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
+
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+
+    using ResponseType = DataModel::NullObjectType;
+
+    static constexpr bool MustUseTimedInvoke() { return false; }
+};
+
+struct DecodableType
+{
+public:
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQuery::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+}; // namespace IdentifyQuery
 namespace TriggerEffect {
 enum class Fields : uint8_t
 {

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
@@ -34,6 +34,10 @@ namespace Identify {
 static constexpr CommandId Id = 0x00000000;
 } // namespace Identify
 
+namespace IdentifyQueryResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace IdentifyQueryResponse
+
 namespace IdentifyQuery {
 static constexpr CommandId Id = 0x00000001;
 } // namespace IdentifyQuery

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
@@ -34,6 +34,10 @@ namespace Identify {
 static constexpr CommandId Id = 0x00000000;
 } // namespace Identify
 
+namespace IdentifyQuery {
+static constexpr CommandId Id = 0x00000001;
+} // namespace IdentifyQuery
+
 namespace TriggerEffect {
 static constexpr CommandId Id = 0x00000040;
 } // namespace TriggerEffect

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -141,6 +141,7 @@
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Identify                                                          |   0x00 |
+| * IdentifyQuery                                                     |   0x01 |
 | * TriggerEffect                                                     |   0x40 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
@@ -191,6 +192,42 @@ public:
 
 private:
     chip::app::Clusters::Identify::Commands::Identify::Type mRequest;
+};
+
+/*
+ * Command IdentifyQuery
+ */
+class IdentifyIdentifyQuery : public ClusterCommand
+{
+public:
+    IdentifyIdentifyQuery(CredentialIssuerCommands * credsIssuerConfig) : ClusterCommand("identify-query", credsIssuerConfig)
+    {
+        ClusterCommand::AddArguments();
+    }
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        constexpr chip::ClusterId clusterId = chip::app::Clusters::Identify::Id;
+        constexpr chip::CommandId commandId = chip::app::Clusters::Identify::Commands::IdentifyQuery::Id;
+
+        ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") command (0x%08" PRIX32 ") on endpoint %u", clusterId,
+                        commandId, endpointIds.at(0));
+        return ClusterCommand::SendCommand(device, endpointIds.at(0), clusterId, commandId, mRequest);
+    }
+
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
+    {
+        constexpr chip::ClusterId clusterId = chip::app::Clusters::Identify::Id;
+        constexpr chip::CommandId commandId = chip::app::Clusters::Identify::Commands::IdentifyQuery::Id;
+
+        ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") command (0x%08" PRIX32 ") on Group %u", clusterId, commandId,
+                        groupId);
+
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, clusterId, commandId, mRequest);
+    }
+
+private:
+    chip::app::Clusters::Identify::Commands::IdentifyQuery::Type mRequest;
 };
 
 /*
@@ -11654,6 +11691,7 @@ void registerClusterIdentify(Commands & commands, CredentialIssuerCommands * cre
         //
         make_unique<ClusterCommand>(Id, credsIssuerConfig),    //
         make_unique<IdentifyIdentify>(credsIssuerConfig),      //
+        make_unique<IdentifyIdentifyQuery>(credsIssuerConfig), //
         make_unique<IdentifyTriggerEffect>(credsIssuerConfig), //
         //
         // Attributes

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -4400,6 +4400,14 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 }
 
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const Identify::Commands::IdentifyQueryResponse::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    ReturnErrorOnFailure(DataModelLogger::LogValue("timeout", indent + 1, value.timeout));
+    DataModelLogger::LogString(indent, "}");
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
                                      const Groups::Commands::AddGroupResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
@@ -13677,6 +13685,17 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
 
     switch (path.mClusterId)
     {
+    case Identify::Id: {
+        switch (path.mCommandId)
+        {
+        case Identify::Commands::IdentifyQueryResponse::Id: {
+            Identify::Commands::IdentifyQueryResponse::DecodableType value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("IdentifyQueryResponse", 1, value);
+        }
+        }
+        break;
+    }
     case Groups::Id: {
         switch (path.mCommandId)
         {

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
@@ -412,6 +412,8 @@ static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::UnitTesting::Events::TestFabricScopedEvent::DecodableType & value);
 
 static CHIP_ERROR LogValue(const char * label, size_t indent,
+                           const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & value);
+static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType & value);
 static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType & value);


### PR DESCRIPTION
Moved to revision 4 according to the 1.2 spec:

- added new Query feature
- Added IdentifyQuery and IdentifyQueryResponse