### PR TITLE
While setting up a subscription, read requests read through, causing more traffic and slowing subscriptions times

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -96,11 +96,15 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 - (void)setDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue;
 
 /**
- * Read attribute in a designated attribute path
+ * Read attribute in a designated attribute path.  If there is no value available
+ * for the attribute, whether because the device does not implement it or
+ * because the subscription priming read has not yet gotten to this attribute,
+ * nil will be returned.
  *
- * TODO: Need to document that this returns "the system's best guess" of attribute values.
+ * TODO: Need to fully document that this returns "the system's best guess" of attribute values.
  *
- * @return a data-value dictionary of the attribute as described in MTRDeviceResponseHandler
+ * @return a data-value dictionary of the attribute as described in MTRDeviceResponseHandler,
+ *         or nil if there is no value.
  */
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeWithEndpointID:(NSNumber *)endpointID
                                                               clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -910,9 +910,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     // 1. The attribute is not in the specification (so we don't know whether hasChangesOmittedQuality can be trusted).
     // 2. Subscription not in a state we can expect reports
     // 3. There is subscription but attribute has Changes Omitted quality
-    // 4. Cache has no entry
     // TODO: add option for BaseSubscriptionCallback to report during priming, to reduce when case 4 is hit
-    if (!attributeIsSpecified || ![self _subscriptionAbleToReport] || hasChangesOmittedQuality || !attributeValueToReturn) {
+    if (!attributeIsSpecified || ![self _subscriptionAbleToReport] || hasChangesOmittedQuality) {
         // Read requests container will be a mutable array of items, each being an array containing:
         //   [attribute request path, params]
         // Batching handler should only coalesce when params are equal.


### PR DESCRIPTION
Testing has shown that this generating more data on the wire, we should just return nil for Darwin while subscriptions are being set up.