### PR TITLE
Fix Endpoint Definitions for Air-Purifier CC32XX Example-App

### DIFF
--- a/examples/air-purifier-app/cc32xx/main/AppTask.cpp
+++ b/examples/air-purifier-app/cc32xx/main/AppTask.cpp
@@ -62,8 +62,8 @@ extern void DisplayBanner();
 
 #define AIR_PURIFIER_ENDPOINT 1
 #define AIR_QUALITY_SENSOR_ENDPOINT 2
-#define RELATIVE_HUMIDITY_SENSOR_ENDPOINT 3
-#define TEMPERATURE_SENSOR_ENDPOINT 4
+#define TEMPERATURE_SENSOR_ENDPOINT 3
+#define RELATIVE_HUMIDITY_SENSOR_ENDPOINT 4
 
 // Added the below three for DNS Server Initialization
 using namespace ::chip;


### PR DESCRIPTION
# 📖 Description
The endpoint definitions for temperature and relative humidity got mixed up in the cc32xx example and didn't match the definition in the .zap file.

This PR fixes this.

