### PR TITLE
[Kotlin] Make timedInvokeTimeoutMs field non-optional if mustUseTimed attribute is set

### DIFF
--- a/kotlin-detect-config.yaml
+++ b/kotlin-detect-config.yaml
@@ -46,6 +46,7 @@ style:
             - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
             - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
             - "**/src/controller/java/tests/matter/tlv/TlvWriterTest.kt"
+            - "**/src/controller/java/generated/java/**/*"
     WildcardImport:
         excludes:
             - "**/examples/android/CHIPTest/app/src/androidTest/java/com/tcl/chip/chiptest/ExampleInstrumentedTest.kt"

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/MatterClusters.jinja
@@ -58,9 +58,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 {% set typeLookup = idl | createLookupContext(cluster) %}
-class {{cluster.name}}Cluster(private val endpointId: UShort) {
+class {{cluster.name}}Cluster(private val controller: MatterController, private val endpointId: UShort) {
 
 {%- set already_handled_command = [] -%}
 {%- for command in cluster.commands | sort(attribute='code') -%}
@@ -101,19 +102,32 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
   {{field.name | lowfirst_except_acronym}}: {{encode_value(cluster, field | asEncodable(typeLookup), 0)}}
 {%- if not loop.last -%}, {% endif %}  
 {%- endfor -%}
+{%- if command.is_timed_invoke -%}
+  , timedInvokeTimeoutMs: Int)
+{%- else -%}
   , timedInvokeTimeoutMs: Int? = null)
+{%- endif -%}
+{%- else -%}
+{%- if command.is_timed_invoke -%}
+  timedInvokeTimeoutMs: Int)
 {%- else -%}
   timedInvokeTimeoutMs: Int? = null)
+{%- endif -%}
 {%- endif -%}
 {%- if command | hasResponse -%}
     : {{callbackName}} {
 {%- else %} {
-{%- endif %}  
+{%- endif %}
+    val commandId = {{command.code}}L
+{% if command.is_timed_invoke %}
+    // Implementation needs to be added here
+{%- else %}
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
       // Do the action without timedInvokeTimeoutMs
-    }
+    }    
+{%- endif %}    
   }
 {% endfor -%}
 
@@ -132,19 +146,24 @@ class {{cluster.name}}Cluster(private val endpointId: UShort) {
 {% endif -%}
 {%- if attribute.is_writable %}
 {%- set encodable = attribute.definition | asEncodable(typeLookup) -%}
-{%- set encodable2 = attribute.definition | asEncodable(typeLookup) -%}
-{%- if not attribute.requires_timed_write %}
-  suspend fun write{{ attribute.definition.name | upfirst }}Attribute(
-    value: {{ encode_value_without_optional_nullable(cluster, encodable, 0) }}
-  ) {
-    // Implementation needs to be added here
-  }
-{% endif %}
+{%- set encodable2 = attribute.definition | asEncodable(typeLookup) %}
   suspend fun write{{ attribute.definition.name | upfirst }}Attribute(
     value: {{ encode_value_without_optional_nullable(cluster, encodable2, 0) }},
+{%- if attribute.requires_timed_write -%}
     timedWriteTimeoutMs: Int
+{%- else %}
+    timedWriteTimeoutMs: Int? = null
+{%- endif %}    
   ) {
+{%- if attribute.requires_timed_write %}
     // Implementation needs to be added here
+{%- else %}
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }    
+{%- endif %}    
   }
 {% endif %}
 {%- if attribute.is_subscribable %}

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccessControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccessControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class AccessControlCluster(private val endpointId: UShort) {
+class AccessControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class AclAttribute(val value: List<AccessControlClusterAccessControlEntryStruct>)
 
   class ExtensionAttribute(val value: List<AccessControlClusterAccessControlExtensionStruct>?)
@@ -40,15 +44,15 @@ class AccessControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAclAttribute(value: List<AccessControlClusterAccessControlEntryStruct>) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeAclAttribute(
     value: List<AccessControlClusterAccessControlEntryStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAclAttribute(minInterval: Int, maxInterval: Int): AclAttribute {
@@ -66,16 +70,14 @@ class AccessControlCluster(private val endpointId: UShort) {
   }
 
   suspend fun writeExtensionAttribute(
-    value: List<AccessControlClusterAccessControlExtensionStruct>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeExtensionAttribute(
     value: List<AccessControlClusterAccessControlExtensionStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeExtensionAttribute(minInterval: Int, maxInterval: Int): ExtensionAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccountLoginCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AccountLoginCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class AccountLoginCluster(private val endpointId: UShort) {
+class AccountLoginCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GetSetupPINResponse(val setupPIN: String)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -32,33 +36,23 @@ class AccountLoginCluster(private val endpointId: UShort) {
 
   suspend fun getSetupPIN(
     tempAccountIdentifier: String,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ): GetSetupPINResponse {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 0L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun login(
-    tempAccountIdentifier: String,
-    setupPIN: String,
-    timedInvokeTimeoutMs: Int? = null
-  ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun login(tempAccountIdentifier: String, setupPIN: String, timedInvokeTimeoutMs: Int) {
+    val commandId = 2L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun logout(timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun logout(timedInvokeTimeoutMs: Int) {
+    val commandId = 3L
+
+    // Implementation needs to be added here
   }
 
   suspend fun readGeneratedCommandListAttribute(): GeneratedCommandListAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActionsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActionsCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ActionsCluster(private val endpointId: UShort) {
+class ActionsCluster(private val controller: MatterController, private val endpointId: UShort) {
   class ActionListAttribute(val value: List<ActionsClusterActionStruct>)
 
   class EndpointListsAttribute(val value: List<ActionsClusterEndpointListStruct>)
@@ -33,6 +34,8 @@ class ActionsCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun instantAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -46,6 +49,8 @@ class ActionsCluster(private val endpointId: UShort) {
     transitionTime: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -54,6 +59,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun startAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -67,6 +74,8 @@ class ActionsCluster(private val endpointId: UShort) {
     duration: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -75,6 +84,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun stopAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -83,6 +94,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun pauseAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -96,6 +109,8 @@ class ActionsCluster(private val endpointId: UShort) {
     duration: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -104,6 +119,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun resumeAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -112,6 +129,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun enableAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -125,6 +144,8 @@ class ActionsCluster(private val endpointId: UShort) {
     duration: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 9L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -133,6 +154,8 @@ class ActionsCluster(private val endpointId: UShort) {
   }
 
   suspend fun disableAction(actionID: UShort, invokeID: UInt?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 10L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -146,6 +169,8 @@ class ActionsCluster(private val endpointId: UShort) {
     duration: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 11L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActivatedCarbonFilterMonitoringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ActivatedCarbonFilterMonitoringCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ActivatedCarbonFilterMonitoringCluster(private val endpointId: UShort) {
+class ActivatedCarbonFilterMonitoringCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class LastChangedTimeAttribute(val value: UInt?)
 
   class ReplacementProductListAttribute(
@@ -35,6 +39,8 @@ class ActivatedCarbonFilterMonitoringCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetCondition(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -78,12 +84,12 @@ class ActivatedCarbonFilterMonitoringCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLastChangedTimeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLastChangedTimeAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AdministratorCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AdministratorCommissioningCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class AdministratorCommissioningCluster(private val endpointId: UShort) {
+class AdministratorCommissioningCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class AdminFabricIndexAttribute(val value: UByte?)
 
   class AdminVendorIdAttribute(val value: UShort?)
@@ -38,32 +42,26 @@ class AdministratorCommissioningCluster(private val endpointId: UShort) {
     discriminator: UShort,
     iterations: UInt,
     salt: ByteArray,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 0L
+
+    // Implementation needs to be added here
   }
 
   suspend fun openBasicCommissioningWindow(
     commissioningTimeout: UShort,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 1L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun revokeCommissioning(timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun revokeCommissioning(timedInvokeTimeoutMs: Int) {
+    val commandId = 2L
+
+    // Implementation needs to be added here
   }
 
   suspend fun readWindowStatusAttribute(): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AirQualityCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AirQualityCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class AirQualityCluster(private val endpointId: UShort) {
+class AirQualityCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationBasicCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationBasicCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ApplicationBasicCluster(private val endpointId: UShort) {
+class ApplicationBasicCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ApplicationAttribute(val value: ApplicationBasicClusterApplicationStruct)
 
   class AllowedVendorListAttribute(val value: List<UShort>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ApplicationLauncherCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ApplicationLauncherCluster(private val endpointId: UShort) {
+class ApplicationLauncherCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class LauncherResponse(val status: UInt, val data: ByteArray?)
 
   class CatalogListAttribute(val value: List<UShort>?)
@@ -39,6 +43,8 @@ class ApplicationLauncherCluster(private val endpointId: UShort) {
     data: ByteArray?,
     timedInvokeTimeoutMs: Int? = null
   ): LauncherResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -50,6 +56,8 @@ class ApplicationLauncherCluster(private val endpointId: UShort) {
     application: ApplicationLauncherClusterApplicationStruct?,
     timedInvokeTimeoutMs: Int? = null
   ): LauncherResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +69,8 @@ class ApplicationLauncherCluster(private val endpointId: UShort) {
     application: ApplicationLauncherClusterApplicationStruct?,
     timedInvokeTimeoutMs: Int? = null
   ): LauncherResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AudioOutputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/AudioOutputCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class AudioOutputCluster(private val endpointId: UShort) {
+class AudioOutputCluster(private val controller: MatterController, private val endpointId: UShort) {
   class OutputListAttribute(val value: List<AudioOutputClusterOutputInfoStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +32,8 @@ class AudioOutputCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun selectOutput(index: UByte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -39,6 +42,8 @@ class AudioOutputCluster(private val endpointId: UShort) {
   }
 
   suspend fun renameOutput(index: UByte, name: String, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BallastConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BallastConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BallastConfigurationCluster(private val endpointId: UShort) {
+class BallastConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class IntrinsicBallastFactorAttribute(val value: UByte?)
 
   class BallastFactorAdjustmentAttribute(val value: UByte?)
@@ -66,12 +70,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMinLevelAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMinLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMinLevelAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMinLevelAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -82,12 +86,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMaxLevelAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMaxLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMaxLevelAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMaxLevelAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -98,12 +102,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeIntrinsicBallastFactorAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeIntrinsicBallastFactorAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeIntrinsicBallastFactorAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeIntrinsicBallastFactorAttribute(
@@ -117,12 +121,15 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBallastFactorAdjustmentAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBallastFactorAdjustmentAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBallastFactorAdjustmentAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBallastFactorAdjustmentAttribute(
@@ -144,12 +151,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampTypeAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampTypeAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampTypeAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampTypeAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -160,12 +167,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampManufacturerAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampManufacturerAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampManufacturerAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampManufacturerAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -176,12 +183,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampRatedHoursAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampRatedHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampRatedHoursAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampRatedHoursAttribute(
@@ -195,12 +202,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampBurnHoursAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampBurnHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampBurnHoursAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampBurnHoursAttribute(
@@ -214,12 +221,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampAlarmModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampAlarmModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampAlarmModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampAlarmModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -230,12 +237,12 @@ class BallastConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLampBurnHoursTripPointAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLampBurnHoursTripPointAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLampBurnHoursTripPointAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLampBurnHoursTripPointAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BarrierControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BarrierControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BarrierControlCluster(private val endpointId: UShort) {
+class BarrierControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +33,8 @@ class BarrierControlCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun barrierControlGoToPercent(percentOpen: UByte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -37,6 +43,8 @@ class BarrierControlCluster(private val endpointId: UShort) {
   }
 
   suspend fun barrierControlStop(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -72,12 +80,12 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierOpenEventsAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierOpenEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierOpenEventsAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierOpenEventsAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -88,12 +96,12 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierCloseEventsAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierCloseEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierCloseEventsAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierCloseEventsAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -104,12 +112,15 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierCommandOpenEventsAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierCommandOpenEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierCommandOpenEventsAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierCommandOpenEventsAttribute(
@@ -123,12 +134,15 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierCommandCloseEventsAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierCommandCloseEventsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierCommandCloseEventsAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierCommandCloseEventsAttribute(
@@ -142,12 +156,12 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierOpenPeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierOpenPeriodAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -158,12 +172,12 @@ class BarrierControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBarrierClosePeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBarrierClosePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBarrierClosePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBarrierClosePeriodAttribute(minInterval: Int, maxInterval: Int): UShort {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BasicInformationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BasicInformationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BasicInformationCluster(private val endpointId: UShort) {
+class BasicInformationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class CapabilityMinimaAttribute(val value: BasicInformationClusterCapabilityMinimaStruct)
 
   class ProductAppearanceAttribute(val value: BasicInformationClusterProductAppearanceStruct?)
@@ -33,6 +37,8 @@ class BasicInformationCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun mfgSpecificPing(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -84,12 +90,12 @@ class BasicInformationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNodeLabelAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNodeLabelAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -100,12 +106,12 @@ class BasicInformationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLocationAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLocationAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLocationAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLocationAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -194,12 +200,12 @@ class BasicInformationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLocalConfigDisabledAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLocalConfigDisabledAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLocalConfigDisabledAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLocalConfigDisabledAttribute(minInterval: Int, maxInterval: Int): Boolean {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BinaryInputBasicCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BinaryInputBasicCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BinaryInputBasicCluster(private val endpointId: UShort) {
+class BinaryInputBasicCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -32,12 +36,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeActiveTextAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeActiveTextAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeActiveTextAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeActiveTextAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -48,12 +52,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeDescriptionAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeDescriptionAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeDescriptionAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeDescriptionAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -64,12 +68,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInactiveTextAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInactiveTextAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInactiveTextAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInactiveTextAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -80,12 +84,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOutOfServiceAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOutOfServiceAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOutOfServiceAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOutOfServiceAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -104,12 +108,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePresentValueAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writePresentValueAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writePresentValueAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePresentValueAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -120,12 +124,12 @@ class BinaryInputBasicCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeReliabilityAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeReliabilityAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeReliabilityAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeReliabilityAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BindingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BindingCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BindingCluster(private val endpointId: UShort) {
+class BindingCluster(private val controller: MatterController, private val endpointId: UShort) {
   class BindingAttribute(val value: List<BindingClusterTargetStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -38,15 +39,15 @@ class BindingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBindingAttribute(value: List<BindingClusterTargetStruct>) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeBindingAttribute(
     value: List<BindingClusterTargetStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBindingAttribute(minInterval: Int, maxInterval: Int): BindingAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BooleanStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BooleanStateCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BooleanStateCluster(private val endpointId: UShort) {
+class BooleanStateCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BridgedDeviceBasicInformationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/BridgedDeviceBasicInformationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class BridgedDeviceBasicInformationCluster(private val endpointId: UShort) {
+class BridgedDeviceBasicInformationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ProductAppearanceAttribute(
     val value: BridgedDeviceBasicInformationClusterProductAppearanceStruct?
   )
@@ -60,12 +64,12 @@ class BridgedDeviceBasicInformationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNodeLabelAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNodeLabelAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNodeLabelAttribute(minInterval: Int, maxInterval: Int): CharString {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonDioxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonDioxideConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class CarbonDioxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+class CarbonDioxideConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonMonoxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/CarbonMonoxideConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class CarbonMonoxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+class CarbonMonoxideConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ChannelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ChannelCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ChannelCluster(private val endpointId: UShort) {
+class ChannelCluster(private val controller: MatterController, private val endpointId: UShort) {
   class ChangeChannelResponse(val status: UInt, val data: String?)
 
   class ChannelListAttribute(val value: List<ChannelClusterChannelInfoStruct>?)
@@ -40,6 +41,8 @@ class ChannelCluster(private val endpointId: UShort) {
     match: String,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeChannelResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -52,6 +55,8 @@ class ChannelCluster(private val endpointId: UShort) {
     minorNumber: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -60,6 +65,8 @@ class ChannelCluster(private val endpointId: UShort) {
   }
 
   suspend fun skipChannel(count: Short, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ColorControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ColorControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ColorControlCluster(private val endpointId: UShort) {
+class ColorControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class NumberOfPrimariesAttribute(val value: UByte?)
 
   class Primary1IntensityAttribute(val value: UByte?)
@@ -58,6 +62,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -72,6 +78,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -87,6 +95,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -101,6 +111,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -115,6 +127,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -130,6 +144,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -145,6 +161,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -160,6 +178,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -174,6 +194,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -189,6 +211,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 9L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -203,6 +227,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 10L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -218,6 +244,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 64L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -232,6 +260,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 65L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -247,6 +277,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 66L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -262,6 +294,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 67L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -279,6 +313,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 68L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -291,6 +327,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 71L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -307,6 +345,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 75L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -324,6 +364,8 @@ class ColorControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 76L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -407,12 +449,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOptionsAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOptionsAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -596,12 +638,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeWhitePointXAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeWhitePointXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeWhitePointXAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeWhitePointXAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -612,12 +654,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeWhitePointYAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeWhitePointYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeWhitePointYAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeWhitePointYAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -628,12 +670,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointRXAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointRXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointRXAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointRXAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -644,12 +686,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointRYAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointRYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointRYAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointRYAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -660,12 +702,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointRIntensityAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointRIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointRIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointRIntensityAttribute(
@@ -679,12 +721,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointGXAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointGXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointGXAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointGXAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -695,12 +737,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointGYAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointGYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointGYAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointGYAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -711,12 +753,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointGIntensityAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointGIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointGIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointGIntensityAttribute(
@@ -730,12 +772,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointBXAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointBXAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointBXAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointBXAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -746,12 +788,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointBYAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointBYAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointBYAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointBYAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -762,12 +804,12 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeColorPointBIntensityAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeColorPointBIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeColorPointBIntensityAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeColorPointBIntensityAttribute(
@@ -884,12 +926,15 @@ class ColorControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpColorTemperatureMiredsAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpColorTemperatureMiredsAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpColorTemperatureMiredsAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpColorTemperatureMiredsAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ContentLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ContentLauncherCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ContentLauncherCluster(private val endpointId: UShort) {
+class ContentLauncherCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class LauncherResponse(val status: UInt, val data: String?)
 
   class AcceptHeaderAttribute(val value: List<String>?)
@@ -38,6 +42,8 @@ class ContentLauncherCluster(private val endpointId: UShort) {
     data: String?,
     timedInvokeTimeoutMs: Int? = null
   ): LauncherResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -51,6 +57,8 @@ class ContentLauncherCluster(private val endpointId: UShort) {
     brandingInformation: ContentLauncherClusterBrandingInformationStruct?,
     timedInvokeTimeoutMs: Int? = null
   ): LauncherResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -73,12 +81,15 @@ class ContentLauncherCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSupportedStreamingProtocolsAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSupportedStreamingProtocolsAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSupportedStreamingProtocolsAttribute(
+    value: ULong,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSupportedStreamingProtocolsAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DescriptorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DescriptorCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class DescriptorCluster(private val endpointId: UShort) {
+class DescriptorCluster(private val controller: MatterController, private val endpointId: UShort) {
   class DeviceTypeListAttribute(val value: List<DescriptorClusterDeviceTypeStruct>)
 
   class ServerListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DiagnosticLogsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DiagnosticLogsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class DiagnosticLogsCluster(private val endpointId: UShort) {
+class DiagnosticLogsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class RetrieveLogsResponse(
     val status: UInt,
     val logContent: ByteArray,
@@ -41,6 +45,8 @@ class DiagnosticLogsCluster(private val endpointId: UShort) {
     transferFileDesignator: String?,
     timedInvokeTimeoutMs: Int? = null
   ): RetrieveLogsResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherAlarmCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class DishwasherAlarmCluster(private val endpointId: UShort) {
+class DishwasherAlarmCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +33,8 @@ class DishwasherAlarmCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun reset(alarms: ULong, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -37,6 +43,8 @@ class DishwasherAlarmCluster(private val endpointId: UShort) {
   }
 
   suspend fun modifyEnabledAlarms(mask: ULong, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DishwasherModeCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class DishwasherModeCluster(private val endpointId: UShort) {
+class DishwasherModeCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ChangeToModeResponse(val status: UInt, val statusText: String?)
 
   class SupportedModesAttribute(val value: List<DishwasherModeClusterModeOptionStruct>)
@@ -40,6 +44,8 @@ class DishwasherModeCluster(private val endpointId: UShort) {
     newMode: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeToModeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -70,12 +76,12 @@ class DishwasherModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpModeAttribute(
@@ -89,12 +95,12 @@ class DishwasherModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DoorLockCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/DoorLockCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class DoorLockCluster(private val endpointId: UShort) {
+class DoorLockCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GetWeekDayScheduleResponse(
     val weekDayIndex: UByte,
     val userIndex: UShort,
@@ -86,32 +87,22 @@ class DoorLockCluster(private val endpointId: UShort) {
 
   class AttributeListAttribute(val value: List<UInt>)
 
-  suspend fun lockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun lockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+    val commandId = 0L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun unlockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun unlockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+    val commandId = 1L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun unlockWithTimeout(
-    timeout: UShort,
-    PINCode: ByteArray?,
-    timedInvokeTimeoutMs: Int? = null
-  ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun unlockWithTimeout(timeout: UShort, PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+    val commandId = 3L
+
+    // Implementation needs to be added here
   }
 
   suspend fun setWeekDaySchedule(
@@ -124,6 +115,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     endMinute: UByte,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 11L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -136,6 +129,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     userIndex: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): GetWeekDayScheduleResponse {
+    val commandId = 12L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -148,6 +143,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     userIndex: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 13L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -162,6 +159,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     localEndTime: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 14L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -174,6 +173,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     userIndex: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): GetYearDayScheduleResponse {
+    val commandId = 15L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -186,6 +187,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     userIndex: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 16L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -200,6 +203,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     operatingMode: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 17L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -211,6 +216,8 @@ class DoorLockCluster(private val endpointId: UShort) {
     holidayIndex: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): GetHolidayScheduleResponse {
+    val commandId = 18L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -219,6 +226,8 @@ class DoorLockCluster(private val endpointId: UShort) {
   }
 
   suspend fun clearHolidaySchedule(holidayIndex: UByte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 19L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -234,16 +243,16 @@ class DoorLockCluster(private val endpointId: UShort) {
     userStatus: UInt?,
     userType: UInt?,
     credentialRule: UInt?,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 26L
+
+    // Implementation needs to be added here
   }
 
   suspend fun getUser(userIndex: UShort, timedInvokeTimeoutMs: Int? = null): GetUserResponse {
+    val commandId = 27L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -251,12 +260,10 @@ class DoorLockCluster(private val endpointId: UShort) {
     }
   }
 
-  suspend fun clearUser(userIndex: UShort, timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun clearUser(userIndex: UShort, timedInvokeTimeoutMs: Int) {
+    val commandId = 29L
+
+    // Implementation needs to be added here
   }
 
   suspend fun setCredential(
@@ -266,19 +273,19 @@ class DoorLockCluster(private val endpointId: UShort) {
     userIndex: UShort?,
     userStatus: UInt?,
     userType: UInt?,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ): SetCredentialResponse {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 34L
+
+    // Implementation needs to be added here
   }
 
   suspend fun getCredentialStatus(
     credential: DoorLockClusterCredentialStruct,
     timedInvokeTimeoutMs: Int? = null
   ): GetCredentialStatusResponse {
+    val commandId = 36L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -288,21 +295,17 @@ class DoorLockCluster(private val endpointId: UShort) {
 
   suspend fun clearCredential(
     credential: DoorLockClusterCredentialStruct?,
-    timedInvokeTimeoutMs: Int? = null
+    timedInvokeTimeoutMs: Int
   ) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+    val commandId = 38L
+
+    // Implementation needs to be added here
   }
 
-  suspend fun unboltDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun unboltDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) {
+    val commandId = 39L
+
+    // Implementation needs to be added here
   }
 
   suspend fun readLockStateAttribute(): LockStateAttribute {
@@ -341,12 +344,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeDoorOpenEventsAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeDoorOpenEventsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeDoorOpenEventsAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeDoorOpenEventsAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -357,12 +360,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeDoorClosedEventsAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeDoorClosedEventsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeDoorClosedEventsAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeDoorClosedEventsAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -373,12 +376,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOpenPeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOpenPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOpenPeriodAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -506,12 +509,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLanguageAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLanguageAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLanguageAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLanguageAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -522,12 +525,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLEDSettingsAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLEDSettingsAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLEDSettingsAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLEDSettingsAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -538,12 +541,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAutoRelockTimeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeAutoRelockTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeAutoRelockTimeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAutoRelockTimeAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -554,12 +557,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSoundVolumeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSoundVolumeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSoundVolumeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSoundVolumeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -570,12 +573,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOperatingModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOperatingModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOperatingModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOperatingModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -608,12 +611,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnableLocalProgrammingAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnableLocalProgrammingAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnableLocalProgrammingAttribute(
+    value: Boolean,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnableLocalProgrammingAttribute(
@@ -627,12 +633,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnableOneTouchLockingAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnableOneTouchLockingAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnableOneTouchLockingAttribute(
+    value: Boolean,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnableOneTouchLockingAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -643,12 +652,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnableInsideStatusLEDAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnableInsideStatusLEDAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnableInsideStatusLEDAttribute(
+    value: Boolean,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnableInsideStatusLEDAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -659,12 +671,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnablePrivacyModeButtonAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnablePrivacyModeButtonAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnablePrivacyModeButtonAttribute(
+    value: Boolean,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnablePrivacyModeButtonAttribute(
@@ -678,12 +693,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLocalProgrammingFeaturesAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLocalProgrammingFeaturesAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLocalProgrammingFeaturesAttribute(
+    value: UInt,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLocalProgrammingFeaturesAttribute(
@@ -697,12 +715,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeWrongCodeEntryLimitAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeWrongCodeEntryLimitAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeWrongCodeEntryLimitAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeWrongCodeEntryLimitAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -713,12 +731,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUserCodeTemporaryDisableTimeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeUserCodeTemporaryDisableTimeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeUserCodeTemporaryDisableTimeAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUserCodeTemporaryDisableTimeAttribute(
@@ -732,12 +753,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSendPINOverTheAirAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSendPINOverTheAirAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSendPINOverTheAirAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSendPINOverTheAirAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -748,12 +769,15 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRequirePINforRemoteOperationAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRequirePINforRemoteOperationAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRequirePINforRemoteOperationAttribute(
+    value: Boolean,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRequirePINforRemoteOperationAttribute(
@@ -767,12 +791,12 @@ class DoorLockCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeExpiringUserTimeoutAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeExpiringUserTimeoutAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeExpiringUserTimeoutAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeExpiringUserTimeoutAttribute(minInterval: Int, maxInterval: Int): UShort {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ElectricalMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ElectricalMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ElectricalMeasurementCluster(private val endpointId: UShort) {
+class ElectricalMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +33,8 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun getProfileInfoCommand(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -42,6 +48,8 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     numberOfIntervals: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -568,15 +576,15 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAverageRmsVoltageMeasurementPeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeAverageRmsVoltageMeasurementPeriodAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAverageRmsVoltageMeasurementPeriodAttribute(
@@ -590,12 +598,15 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAverageRmsUnderVoltageCounterAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeAverageRmsUnderVoltageCounterAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeAverageRmsUnderVoltageCounterAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAverageRmsUnderVoltageCounterAttribute(
@@ -609,12 +620,15 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRmsExtremeOverVoltagePeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRmsExtremeOverVoltagePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRmsExtremeOverVoltagePeriodAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRmsExtremeOverVoltagePeriodAttribute(
@@ -628,12 +642,15 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRmsExtremeUnderVoltagePeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRmsExtremeUnderVoltagePeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRmsExtremeUnderVoltagePeriodAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRmsExtremeUnderVoltagePeriodAttribute(
@@ -647,12 +664,12 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRmsVoltageSagPeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRmsVoltageSagPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRmsVoltageSagPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRmsVoltageSagPeriodAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -663,12 +680,12 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRmsVoltageSwellPeriodAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRmsVoltageSwellPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRmsVoltageSwellPeriodAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRmsVoltageSwellPeriodAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -727,12 +744,12 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOverloadAlarmsMaskAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOverloadAlarmsMaskAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -759,12 +776,12 @@ class ElectricalMeasurementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAcOverloadAlarmsMaskAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeAcOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeAcOverloadAlarmsMaskAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAcOverloadAlarmsMaskAttribute(minInterval: Int, maxInterval: Int): UShort {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/EthernetNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/EthernetNetworkDiagnosticsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class EthernetNetworkDiagnosticsCluster(private val endpointId: UShort) {
+class EthernetNetworkDiagnosticsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class PHYRateAttribute(val value: UInt?)
 
   class FullDuplexAttribute(val value: Boolean?)
@@ -35,6 +39,8 @@ class EthernetNetworkDiagnosticsCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetCounts(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FanControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FanControlCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class FanControlCluster(private val endpointId: UShort) {
+class FanControlCluster(private val controller: MatterController, private val endpointId: UShort) {
   class PercentSettingAttribute(val value: UByte?)
 
   class SpeedSettingAttribute(val value: UByte?)
@@ -38,6 +39,8 @@ class FanControlCluster(private val endpointId: UShort) {
     lowestOff: Boolean?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -49,12 +52,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeFanModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeFanModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeFanModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeFanModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -65,12 +68,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeFanModeSequenceAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeFanModeSequenceAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeFanModeSequenceAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeFanModeSequenceAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -81,12 +84,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePercentSettingAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writePercentSettingAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writePercentSettingAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePercentSettingAttribute(
@@ -116,12 +119,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSpeedSettingAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSpeedSettingAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSpeedSettingAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSpeedSettingAttribute(
@@ -151,12 +154,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRockSettingAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRockSettingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRockSettingAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRockSettingAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -175,12 +178,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeWindSettingAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeWindSettingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeWindSettingAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeWindSettingAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -191,12 +194,12 @@ class FanControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeAirflowDirectionAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeAirflowDirectionAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeAirflowDirectionAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeAirflowDirectionAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FaultInjectionCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FaultInjectionCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class FaultInjectionCluster(private val endpointId: UShort) {
+class FaultInjectionCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -36,6 +40,8 @@ class FaultInjectionCluster(private val endpointId: UShort) {
     takeMutex: Boolean,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -49,6 +55,8 @@ class FaultInjectionCluster(private val endpointId: UShort) {
     percentage: UByte,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FixedLabelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FixedLabelCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class FixedLabelCluster(private val endpointId: UShort) {
+class FixedLabelCluster(private val controller: MatterController, private val endpointId: UShort) {
   class LabelListAttribute(val value: List<FixedLabelClusterLabelStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FlowMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FlowMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class FlowMeasurementCluster(private val endpointId: UShort) {
+class FlowMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: UShort?)
 
   class MinMeasuredValueAttribute(val value: UShort?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FormaldehydeConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/FormaldehydeConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class FormaldehydeConcentrationMeasurementCluster(private val endpointId: UShort) {
+class FormaldehydeConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralCommissioningCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class GeneralCommissioningCluster(private val endpointId: UShort) {
+class GeneralCommissioningCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ArmFailSafeResponse(val errorCode: UInt, val debugText: String)
 
   class SetRegulatoryConfigResponse(val errorCode: UInt, val debugText: String)
@@ -43,6 +47,8 @@ class GeneralCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong,
     timedInvokeTimeoutMs: Int? = null
   ): ArmFailSafeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -56,6 +62,8 @@ class GeneralCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong,
     timedInvokeTimeoutMs: Int? = null
   ): SetRegulatoryConfigResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -66,6 +74,8 @@ class GeneralCommissioningCluster(private val endpointId: UShort) {
   suspend fun commissioningComplete(
     timedInvokeTimeoutMs: Int? = null
   ): CommissioningCompleteResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -77,12 +87,12 @@ class GeneralCommissioningCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBreadcrumbAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBreadcrumbAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBreadcrumbAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBreadcrumbAttribute(minInterval: Int, maxInterval: Int): ULong {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GeneralDiagnosticsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class GeneralDiagnosticsCluster(private val endpointId: UShort) {
+class GeneralDiagnosticsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class TimeSnapshotResponse(val systemTimeUs: ULong, val UTCTimeUs: ULong?)
 
   class NetworkInterfacesAttribute(val value: List<GeneralDiagnosticsClusterNetworkInterface>)
@@ -43,6 +47,8 @@ class GeneralDiagnosticsCluster(private val endpointId: UShort) {
     eventTrigger: ULong,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -51,6 +57,8 @@ class GeneralDiagnosticsCluster(private val endpointId: UShort) {
   }
 
   suspend fun timeSnapshot(timedInvokeTimeoutMs: Int? = null): TimeSnapshotResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupKeyManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupKeyManagementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class GroupKeyManagementCluster(private val endpointId: UShort) {
+class GroupKeyManagementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class KeySetReadResponse(val groupKeySet: GroupKeyManagementClusterGroupKeySetStruct)
 
   class KeySetReadAllIndicesResponse(val groupKeySetIDs: List<UShort>)
@@ -40,6 +44,8 @@ class GroupKeyManagementCluster(private val endpointId: UShort) {
     groupKeySet: GroupKeyManagementClusterGroupKeySetStruct,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -51,6 +57,8 @@ class GroupKeyManagementCluster(private val endpointId: UShort) {
     groupKeySetID: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): KeySetReadResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -59,6 +67,8 @@ class GroupKeyManagementCluster(private val endpointId: UShort) {
   }
 
   suspend fun keySetRemove(groupKeySetID: UShort, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -69,6 +79,8 @@ class GroupKeyManagementCluster(private val endpointId: UShort) {
   suspend fun keySetReadAllIndices(
     timedInvokeTimeoutMs: Int? = null
   ): KeySetReadAllIndicesResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -86,15 +98,15 @@ class GroupKeyManagementCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeGroupKeyMapAttribute(value: List<GroupKeyManagementClusterGroupKeyMapStruct>) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeGroupKeyMapAttribute(
     value: List<GroupKeyManagementClusterGroupKeyMapStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeGroupKeyMapAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/GroupsCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class GroupsCluster(private val endpointId: UShort) {
+class GroupsCluster(private val controller: MatterController, private val endpointId: UShort) {
   class AddGroupResponse(val status: UInt, val groupID: UShort)
 
   class ViewGroupResponse(val status: UInt, val groupID: UShort, val groupName: String)
@@ -41,6 +42,8 @@ class GroupsCluster(private val endpointId: UShort) {
     groupName: String,
     timedInvokeTimeoutMs: Int? = null
   ): AddGroupResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -49,6 +52,8 @@ class GroupsCluster(private val endpointId: UShort) {
   }
 
   suspend fun viewGroup(groupID: UShort, timedInvokeTimeoutMs: Int? = null): ViewGroupResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -60,6 +65,8 @@ class GroupsCluster(private val endpointId: UShort) {
     groupList: List<UShort>,
     timedInvokeTimeoutMs: Int? = null
   ): GetGroupMembershipResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -68,6 +75,8 @@ class GroupsCluster(private val endpointId: UShort) {
   }
 
   suspend fun removeGroup(groupID: UShort, timedInvokeTimeoutMs: Int? = null): RemoveGroupResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -76,6 +85,8 @@ class GroupsCluster(private val endpointId: UShort) {
   }
 
   suspend fun removeAllGroups(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -88,6 +99,8 @@ class GroupsCluster(private val endpointId: UShort) {
     groupName: String,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/HepaFilterMonitoringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/HepaFilterMonitoringCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class HepaFilterMonitoringCluster(private val endpointId: UShort) {
+class HepaFilterMonitoringCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class LastChangedTimeAttribute(val value: UInt?)
 
   class ReplacementProductListAttribute(
@@ -35,6 +39,8 @@ class HepaFilterMonitoringCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetCondition(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -78,12 +84,12 @@ class HepaFilterMonitoringCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLastChangedTimeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLastChangedTimeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLastChangedTimeAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IcdManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IcdManagementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class IcdManagementCluster(private val endpointId: UShort) {
+class IcdManagementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class RegisterClientResponse(val ICDCounter: UInt)
 
   class RegisteredClientsAttribute(
@@ -41,6 +45,8 @@ class IcdManagementCluster(private val endpointId: UShort) {
     verificationKey: ByteArray?,
     timedInvokeTimeoutMs: Int? = null
   ): RegisterClientResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -53,6 +59,8 @@ class IcdManagementCluster(private val endpointId: UShort) {
     verificationKey: ByteArray?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +69,8 @@ class IcdManagementCluster(private val endpointId: UShort) {
   }
 
   suspend fun stayActiveRequest(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IdentifyCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class IdentifyCluster(private val endpointId: UShort) {
+class IdentifyCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +30,8 @@ class IdentifyCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun identify(identifyTime: UShort, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -41,6 +44,8 @@ class IdentifyCluster(private val endpointId: UShort) {
     effectVariant: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 64L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -52,12 +57,12 @@ class IdentifyCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeIdentifyTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeIdentifyTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeIdentifyTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeIdentifyTimeAttribute(minInterval: Int, maxInterval: Int): UShort {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IlluminanceMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/IlluminanceMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class IlluminanceMeasurementCluster(private val endpointId: UShort) {
+class IlluminanceMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: UShort?)
 
   class MinMeasuredValueAttribute(val value: UShort?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/KeypadInputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/KeypadInputCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class KeypadInputCluster(private val endpointId: UShort) {
+class KeypadInputCluster(private val controller: MatterController, private val endpointId: UShort) {
   class SendKeyResponse(val status: UInt)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +32,8 @@ class KeypadInputCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun sendKey(keyCode: UInt, timedInvokeTimeoutMs: Int? = null): SendKeyResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherControlsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherControlsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class LaundryWasherControlsCluster(private val endpointId: UShort) {
+class LaundryWasherControlsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SpinSpeedsAttribute(val value: List<String>?)
 
   class SpinSpeedCurrentAttribute(val value: UByte?)
@@ -49,12 +53,12 @@ class LaundryWasherControlsCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSpinSpeedCurrentAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSpinSpeedCurrentAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSpinSpeedCurrentAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSpinSpeedCurrentAttribute(
@@ -68,12 +72,12 @@ class LaundryWasherControlsCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNumberOfRinsesAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNumberOfRinsesAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNumberOfRinsesAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNumberOfRinsesAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LaundryWasherModeCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class LaundryWasherModeCluster(private val endpointId: UShort) {
+class LaundryWasherModeCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ChangeToModeResponse(val status: UInt, val statusText: String?)
 
   class SupportedModesAttribute(val value: List<LaundryWasherModeClusterModeOptionStruct>)
@@ -40,6 +44,8 @@ class LaundryWasherModeCluster(private val endpointId: UShort) {
     newMode: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeToModeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -70,12 +76,12 @@ class LaundryWasherModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpModeAttribute(
@@ -89,12 +95,12 @@ class LaundryWasherModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LevelControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LevelControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class LevelControlCluster(private val endpointId: UShort) {
+class LevelControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class CurrentLevelAttribute(val value: UByte?)
 
   class OnLevelAttribute(val value: UByte?)
@@ -47,6 +51,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +67,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -76,6 +84,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -84,6 +94,8 @@ class LevelControlCluster(private val endpointId: UShort) {
   }
 
   suspend fun stop(optionsMask: UInt, optionsOverride: UInt, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -98,6 +110,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -112,6 +126,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -127,6 +143,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -139,6 +157,8 @@ class LevelControlCluster(private val endpointId: UShort) {
     optionsOverride: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -147,6 +167,8 @@ class LevelControlCluster(private val endpointId: UShort) {
   }
 
   suspend fun moveToClosestFrequency(frequency: UShort, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -217,12 +239,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOptionsAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOptionsAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOptionsAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -233,12 +255,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnOffTransitionTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnOffTransitionTimeAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -249,12 +271,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnLevelAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnLevelAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnLevelAttribute(minInterval: Int, maxInterval: Int): OnLevelAttribute {
@@ -265,12 +287,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnTransitionTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnTransitionTimeAttribute(
@@ -284,12 +306,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOffTransitionTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOffTransitionTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOffTransitionTimeAttribute(
@@ -303,12 +325,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeDefaultMoveRateAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeDefaultMoveRateAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeDefaultMoveRateAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeDefaultMoveRateAttribute(
@@ -322,12 +344,12 @@ class LevelControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpCurrentLevelAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpCurrentLevelAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpCurrentLevelAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpCurrentLevelAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LocalizationConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LocalizationConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class LocalizationConfigurationCluster(private val endpointId: UShort) {
+class LocalizationConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SupportedLocalesAttribute(val value: List<String>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -34,12 +38,12 @@ class LocalizationConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeActiveLocaleAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeActiveLocaleAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeActiveLocaleAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeActiveLocaleAttribute(minInterval: Int, maxInterval: Int): CharString {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LowPowerCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/LowPowerCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class LowPowerCluster(private val endpointId: UShort) {
+class LowPowerCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +30,8 @@ class LowPowerCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun sleep(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaInputCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaInputCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class MediaInputCluster(private val endpointId: UShort) {
+class MediaInputCluster(private val controller: MatterController, private val endpointId: UShort) {
   class InputListAttribute(val value: List<MediaInputClusterInputInfoStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +32,8 @@ class MediaInputCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun selectInput(index: UByte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -39,6 +42,8 @@ class MediaInputCluster(private val endpointId: UShort) {
   }
 
   suspend fun showInputStatus(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -47,6 +52,8 @@ class MediaInputCluster(private val endpointId: UShort) {
   }
 
   suspend fun hideInputStatus(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -55,6 +62,8 @@ class MediaInputCluster(private val endpointId: UShort) {
   }
 
   suspend fun renameInput(index: UByte, name: String, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaPlaybackCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MediaPlaybackCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class MediaPlaybackCluster(private val endpointId: UShort) {
+class MediaPlaybackCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class PlaybackResponse(val status: UInt, val data: String?)
 
   class StartTimeAttribute(val value: ULong?)
@@ -41,6 +45,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun play(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -49,6 +55,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun pause(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -57,6 +65,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun stop(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -65,6 +75,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun startOver(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -73,6 +85,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun previous(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -81,6 +95,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun next(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -89,6 +105,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun rewind(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -97,6 +115,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun fastForward(timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -108,6 +128,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
     deltaPositionMilliseconds: ULong,
     timedInvokeTimeoutMs: Int? = null
   ): PlaybackResponse {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -119,6 +141,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
     deltaPositionMilliseconds: ULong,
     timedInvokeTimeoutMs: Int? = null
   ): PlaybackResponse {
+    val commandId = 9L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -127,6 +151,8 @@ class MediaPlaybackCluster(private val endpointId: UShort) {
   }
 
   suspend fun seek(position: ULong, timedInvokeTimeoutMs: Int? = null): PlaybackResponse {
+    val commandId = 11L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MicrowaveOvenControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MicrowaveOvenControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class MicrowaveOvenControlCluster(private val endpointId: UShort) {
+class MicrowaveOvenControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -34,6 +38,8 @@ class MicrowaveOvenControlCluster(private val endpointId: UShort) {
     powerSetting: UByte?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -42,6 +48,8 @@ class MicrowaveOvenControlCluster(private val endpointId: UShort) {
   }
 
   suspend fun addMoreTime(timeToAdd: UInt, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MicrowaveOvenModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/MicrowaveOvenModeCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class MicrowaveOvenModeCluster(private val endpointId: UShort) {
+class MicrowaveOvenModeCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SupportedModesAttribute(val value: List<MicrowaveOvenModeClusterModeOptionStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ModeSelectCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ModeSelectCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ModeSelectCluster(private val endpointId: UShort) {
+class ModeSelectCluster(private val controller: MatterController, private val endpointId: UShort) {
   class StandardNamespaceAttribute(val value: UInt?)
 
   class SupportedModesAttribute(val value: List<ModeSelectClusterModeOptionStruct>)
@@ -37,6 +38,8 @@ class ModeSelectCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun changeToMode(newMode: UByte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -86,12 +89,12 @@ class ModeSelectCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpModeAttribute(
@@ -105,12 +108,12 @@ class ModeSelectCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NetworkCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NetworkCommissioningCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class NetworkCommissioningCluster(private val endpointId: UShort) {
+class NetworkCommissioningCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ScanNetworksResponse(
     val networkingStatus: UInt,
     val debugText: String?,
@@ -62,6 +66,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): ScanNetworksResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -75,6 +81,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): NetworkConfigResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -87,6 +95,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): NetworkConfigResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -99,6 +109,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): NetworkConfigResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -111,6 +123,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): ConnectNetworkResponse {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -124,6 +138,8 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     breadcrumb: ULong?,
     timedInvokeTimeoutMs: Int? = null
   ): NetworkConfigResponse {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -167,12 +183,12 @@ class NetworkCommissioningCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInterfaceEnabledAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInterfaceEnabledAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInterfaceEnabledAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInterfaceEnabledAttribute(minInterval: Int, maxInterval: Int): Boolean {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NitrogenDioxideConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/NitrogenDioxideConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class NitrogenDioxideConcentrationMeasurementCluster(private val endpointId: UShort) {
+class NitrogenDioxideConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OccupancySensingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OccupancySensingCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OccupancySensingCluster(private val endpointId: UShort) {
+class OccupancySensingCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -59,12 +63,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePIROccupiedToUnoccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writePIROccupiedToUnoccupiedDelayAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writePIROccupiedToUnoccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePIROccupiedToUnoccupiedDelayAttribute(
@@ -78,12 +85,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePIRUnoccupiedToOccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writePIRUnoccupiedToOccupiedDelayAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writePIRUnoccupiedToOccupiedDelayAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePIRUnoccupiedToOccupiedDelayAttribute(
@@ -97,15 +107,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePIRUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writePIRUnoccupiedToOccupiedThresholdAttribute(
     value: UByte,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePIRUnoccupiedToOccupiedThresholdAttribute(
@@ -119,15 +129,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeUltrasonicOccupiedToUnoccupiedDelayAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUltrasonicOccupiedToUnoccupiedDelayAttribute(
@@ -141,15 +151,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeUltrasonicUnoccupiedToOccupiedDelayAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUltrasonicUnoccupiedToOccupiedDelayAttribute(
@@ -163,15 +173,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
     value: UByte,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUltrasonicUnoccupiedToOccupiedThresholdAttribute(
@@ -185,15 +195,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writePhysicalContactOccupiedToUnoccupiedDelayAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePhysicalContactOccupiedToUnoccupiedDelayAttribute(
@@ -207,15 +217,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writePhysicalContactUnoccupiedToOccupiedDelayAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePhysicalContactUnoccupiedToOccupiedDelayAttribute(
@@ -229,15 +239,15 @@ class OccupancySensingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writePhysicalContactUnoccupiedToOccupiedThresholdAttribute(
     value: UByte,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribePhysicalContactUnoccupiedToOccupiedThresholdAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OnOffCluster(private val endpointId: UShort) {
+class OnOffCluster(private val controller: MatterController, private val endpointId: UShort) {
   class StartUpOnOffAttribute(val value: UInt?)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +32,8 @@ class OnOffCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun off(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -39,6 +42,8 @@ class OnOffCluster(private val endpointId: UShort) {
   }
 
   suspend fun on(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -47,6 +52,8 @@ class OnOffCluster(private val endpointId: UShort) {
   }
 
   suspend fun toggle(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -59,6 +66,8 @@ class OnOffCluster(private val endpointId: UShort) {
     effectVariant: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 64L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -67,6 +76,8 @@ class OnOffCluster(private val endpointId: UShort) {
   }
 
   suspend fun onWithRecallGlobalScene(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 65L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -80,6 +91,8 @@ class OnOffCluster(private val endpointId: UShort) {
     offWaitTime: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 66L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -107,12 +120,12 @@ class OnOffCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnTimeAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -123,12 +136,12 @@ class OnOffCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOffWaitTimeAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOffWaitTimeAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOffWaitTimeAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOffWaitTimeAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -139,12 +152,12 @@ class OnOffCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpOnOffAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpOnOffAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpOnOffAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpOnOffAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffSwitchConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OnOffSwitchConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OnOffSwitchConfigurationCluster(private val endpointId: UShort) {
+class OnOffSwitchConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -40,12 +44,12 @@ class OnOffSwitchConfigurationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSwitchActionsAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSwitchActionsAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSwitchActionsAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSwitchActionsAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalCredentialsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalCredentialsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OperationalCredentialsCluster(private val endpointId: UShort) {
+class OperationalCredentialsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class AttestationResponse(
     val attestationElements: ByteArray,
     val attestationSignature: ByteArray
@@ -49,6 +53,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     attestationNonce: ByteArray,
     timedInvokeTimeoutMs: Int? = null
   ): AttestationResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -60,6 +66,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     certificateType: UInt,
     timedInvokeTimeoutMs: Int? = null
   ): CertificateChainResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -72,6 +80,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     isForUpdateNOC: Boolean?,
     timedInvokeTimeoutMs: Int? = null
   ): CSRResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -87,6 +97,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     adminVendorId: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): NOCResponse {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -99,6 +111,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     ICACValue: ByteArray?,
     timedInvokeTimeoutMs: Int? = null
   ): NOCResponse {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -107,6 +121,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
   }
 
   suspend fun updateFabricLabel(label: String, timedInvokeTimeoutMs: Int? = null): NOCResponse {
+    val commandId = 9L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -115,6 +131,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
   }
 
   suspend fun removeFabric(fabricIndex: UByte, timedInvokeTimeoutMs: Int? = null): NOCResponse {
+    val commandId = 10L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -126,6 +144,8 @@ class OperationalCredentialsCluster(private val endpointId: UShort) {
     rootCACertificate: ByteArray,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 11L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OperationalStateCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OperationalStateCluster(private val endpointId: UShort) {
+class OperationalStateCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class OperationalCommandResponse(
     val commandResponseState: OperationalStateClusterErrorStateStruct
   )
@@ -45,6 +49,8 @@ class OperationalStateCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun pause(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -53,6 +59,8 @@ class OperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun stop(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +69,8 @@ class OperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun start(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -69,6 +79,8 @@ class OperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun resume(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OtaSoftwareUpdateProviderCluster(private val endpointId: UShort) {
+class OtaSoftwareUpdateProviderCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class QueryImageResponse(
     val status: UInt,
     val delayedActionTime: UInt?,
@@ -52,6 +56,8 @@ class OtaSoftwareUpdateProviderCluster(private val endpointId: UShort) {
     metadataForProvider: ByteArray?,
     timedInvokeTimeoutMs: Int? = null
   ): QueryImageResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -64,6 +70,8 @@ class OtaSoftwareUpdateProviderCluster(private val endpointId: UShort) {
     newVersion: UInt,
     timedInvokeTimeoutMs: Int? = null
   ): ApplyUpdateResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -76,6 +84,8 @@ class OtaSoftwareUpdateProviderCluster(private val endpointId: UShort) {
     softwareVersion: UInt,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateRequestorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OtaSoftwareUpdateRequestorCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OtaSoftwareUpdateRequestorCluster(private val endpointId: UShort) {
+class OtaSoftwareUpdateRequestorCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class DefaultOTAProvidersAttribute(
     val value: List<OtaSoftwareUpdateRequestorClusterProviderLocation>
   )
@@ -42,6 +46,8 @@ class OtaSoftwareUpdateRequestorCluster(private val endpointId: UShort) {
     endpoint: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -60,16 +66,14 @@ class OtaSoftwareUpdateRequestorCluster(private val endpointId: UShort) {
   }
 
   suspend fun writeDefaultOTAProvidersAttribute(
-    value: List<OtaSoftwareUpdateRequestorClusterProviderLocation>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeDefaultOTAProvidersAttribute(
     value: List<OtaSoftwareUpdateRequestorClusterProviderLocation>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeDefaultOTAProvidersAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OzoneConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/OzoneConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class OzoneConcentrationMeasurementCluster(private val endpointId: UShort) {
+class OzoneConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm10ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm10ConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class Pm10ConcentrationMeasurementCluster(private val endpointId: UShort) {
+class Pm10ConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm1ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm1ConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class Pm1ConcentrationMeasurementCluster(private val endpointId: UShort) {
+class Pm1ConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm25ConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/Pm25ConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class Pm25ConcentrationMeasurementCluster(private val endpointId: UShort) {
+class Pm25ConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class PowerSourceCluster(private val endpointId: UShort) {
+class PowerSourceCluster(private val controller: MatterController, private val endpointId: UShort) {
   class WiredAssessedInputVoltageAttribute(val value: UInt?)
 
   class WiredAssessedInputFrequencyAttribute(val value: UShort?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PowerSourceConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class PowerSourceConfigurationCluster(private val endpointId: UShort) {
+class PowerSourceConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SourcesAttribute(val value: List<UShort>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PressureMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PressureMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class PressureMeasurementCluster(private val endpointId: UShort) {
+class PressureMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Short?)
 
   class MinMeasuredValueAttribute(val value: Short?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ProxyConfigurationCluster(private val endpointId: UShort) {
+class ProxyConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyDiscoveryCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyDiscoveryCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ProxyDiscoveryCluster(private val endpointId: UShort) {
+class ProxyDiscoveryCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyValidCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ProxyValidCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ProxyValidCluster(private val endpointId: UShort) {
+class ProxyValidCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PulseWidthModulationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PulseWidthModulationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class PulseWidthModulationCluster(private val endpointId: UShort) {
+class PulseWidthModulationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PumpConfigurationAndControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/PumpConfigurationAndControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
+class PumpConfigurationAndControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MaxPressureAttribute(val value: Short?)
 
   class MaxSpeedAttribute(val value: UShort?)
@@ -245,12 +249,12 @@ class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLifetimeRunningHoursAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLifetimeRunningHoursAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLifetimeRunningHoursAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLifetimeRunningHoursAttribute(
@@ -272,12 +276,12 @@ class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLifetimeEnergyConsumedAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLifetimeEnergyConsumedAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLifetimeEnergyConsumedAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLifetimeEnergyConsumedAttribute(
@@ -291,12 +295,12 @@ class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOperationModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOperationModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOperationModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOperationModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -307,12 +311,12 @@ class PumpConfigurationAndControlCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeControlModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeControlModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeControlModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeControlModeAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RadonConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RadonConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RadonConcentrationMeasurementCluster(private val endpointId: UShort) {
+class RadonConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAlarmCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RefrigeratorAlarmCluster(private val endpointId: UShort) {
+class RefrigeratorAlarmCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RefrigeratorAndTemperatureControlledCabinetModeCluster(private val endpointId: UShort) {
+class RefrigeratorAndTemperatureControlledCabinetModeCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ChangeToModeResponse(val status: UInt, val statusText: String?)
 
   class SupportedModesAttribute(
@@ -42,6 +46,8 @@ class RefrigeratorAndTemperatureControlledCabinetModeCluster(private val endpoin
     newMode: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeToModeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -72,12 +78,12 @@ class RefrigeratorAndTemperatureControlledCabinetModeCluster(private val endpoin
     // Implementation needs to be added here
   }
 
-  suspend fun writeStartUpModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeStartUpModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStartUpModeAttribute(
@@ -91,12 +97,12 @@ class RefrigeratorAndTemperatureControlledCabinetModeCluster(private val endpoin
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RelativeHumidityMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RelativeHumidityMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RelativeHumidityMeasurementCluster(private val endpointId: UShort) {
+class RelativeHumidityMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: UShort?)
 
   class MinMeasuredValueAttribute(val value: UShort?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcCleanModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcCleanModeCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RvcCleanModeCluster(private val endpointId: UShort) {
+class RvcCleanModeCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ChangeToModeResponse(val status: UInt, val statusText: String?)
 
   class SupportedModesAttribute(val value: List<RvcCleanModeClusterModeOptionStruct>)
@@ -38,6 +42,8 @@ class RvcCleanModeCluster(private val endpointId: UShort) {
     newMode: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeToModeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -68,12 +74,12 @@ class RvcCleanModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcOperationalStateCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcOperationalStateCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RvcOperationalStateCluster(private val endpointId: UShort) {
+class RvcOperationalStateCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class OperationalCommandResponse(
     val commandResponseState: RvcOperationalStateClusterErrorStateStruct
   )
@@ -45,6 +49,8 @@ class RvcOperationalStateCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun pause(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -53,6 +59,8 @@ class RvcOperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun stop(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +69,8 @@ class RvcOperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun start(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -69,6 +79,8 @@ class RvcOperationalStateCluster(private val endpointId: UShort) {
   }
 
   suspend fun resume(timedInvokeTimeoutMs: Int? = null): OperationalCommandResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcRunModeCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/RvcRunModeCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class RvcRunModeCluster(private val endpointId: UShort) {
+class RvcRunModeCluster(private val controller: MatterController, private val endpointId: UShort) {
   class ChangeToModeResponse(val status: UInt, val statusText: String?)
 
   class SupportedModesAttribute(val value: List<RvcRunModeClusterModeOptionStruct>)
@@ -38,6 +39,8 @@ class RvcRunModeCluster(private val endpointId: UShort) {
     newMode: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ChangeToModeResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -68,12 +71,12 @@ class RvcRunModeCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOnModeAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOnModeAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOnModeAttribute(minInterval: Int, maxInterval: Int): OnModeAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SampleMeiCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SampleMeiCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class SampleMeiCluster(private val endpointId: UShort) {
+class SampleMeiCluster(private val controller: MatterController, private val endpointId: UShort) {
   class AddArgumentsResponse(val returnValue: UByte)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +32,8 @@ class SampleMeiCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun ping(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -43,6 +46,8 @@ class SampleMeiCluster(private val endpointId: UShort) {
     arg2: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): AddArgumentsResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -54,12 +59,12 @@ class SampleMeiCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeFlipFlopAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeFlipFlopAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeFlipFlopAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeFlipFlopAttribute(minInterval: Int, maxInterval: Int): Boolean {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ScenesCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ScenesCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ScenesCluster(private val endpointId: UShort) {
+class ScenesCluster(private val controller: MatterController, private val endpointId: UShort) {
   class AddSceneResponse(val status: UShort, val groupID: UShort, val sceneID: UByte)
 
   class ViewSceneResponse(
@@ -79,6 +80,8 @@ class ScenesCluster(private val endpointId: UShort) {
     extensionFieldSets: List<ScenesClusterExtensionFieldSet>,
     timedInvokeTimeoutMs: Int? = null
   ): AddSceneResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -91,6 +94,8 @@ class ScenesCluster(private val endpointId: UShort) {
     sceneID: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): ViewSceneResponse {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -103,6 +108,8 @@ class ScenesCluster(private val endpointId: UShort) {
     sceneID: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): RemoveSceneResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -114,6 +121,8 @@ class ScenesCluster(private val endpointId: UShort) {
     groupID: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): RemoveAllScenesResponse {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -126,6 +135,8 @@ class ScenesCluster(private val endpointId: UShort) {
     sceneID: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): StoreSceneResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -139,6 +150,8 @@ class ScenesCluster(private val endpointId: UShort) {
     transitionTime: UShort?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -150,6 +163,8 @@ class ScenesCluster(private val endpointId: UShort) {
     groupID: UShort,
     timedInvokeTimeoutMs: Int? = null
   ): GetSceneMembershipResponse {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -165,6 +180,8 @@ class ScenesCluster(private val endpointId: UShort) {
     extensionFieldSets: List<ScenesClusterExtensionFieldSet>,
     timedInvokeTimeoutMs: Int? = null
   ): EnhancedAddSceneResponse {
+    val commandId = 64L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -177,6 +194,8 @@ class ScenesCluster(private val endpointId: UShort) {
     sceneID: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): EnhancedViewSceneResponse {
+    val commandId = 65L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -192,6 +211,8 @@ class ScenesCluster(private val endpointId: UShort) {
     sceneIdentifierTo: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): CopySceneResponse {
+    val commandId = 66L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SmokeCoAlarmCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SmokeCoAlarmCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class SmokeCoAlarmCluster(private val endpointId: UShort) {
+class SmokeCoAlarmCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -29,6 +33,8 @@ class SmokeCoAlarmCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun selfTestRequest(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -128,12 +134,12 @@ class SmokeCoAlarmCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSmokeSensitivityLevelAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSmokeSensitivityLevelAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSmokeSensitivityLevelAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSmokeSensitivityLevelAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SoftwareDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SoftwareDiagnosticsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class SoftwareDiagnosticsCluster(private val endpointId: UShort) {
+class SoftwareDiagnosticsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ThreadMetricsAttribute(val value: List<SoftwareDiagnosticsClusterThreadMetricsStruct>?)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -31,6 +35,8 @@ class SoftwareDiagnosticsCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetWatermarks(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SwitchCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/SwitchCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class SwitchCluster(private val endpointId: UShort) {
+class SwitchCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TargetNavigatorCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TargetNavigatorCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TargetNavigatorCluster(private val endpointId: UShort) {
+class TargetNavigatorCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class NavigateTargetResponse(val status: UInt, val data: String?)
 
   class TargetListAttribute(val value: List<TargetNavigatorClusterTargetInfoStruct>)
@@ -37,6 +41,8 @@ class TargetNavigatorCluster(private val endpointId: UShort) {
     data: String?,
     timedInvokeTimeoutMs: Int? = null
   ): NavigateTargetResponse {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureControlCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureControlCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TemperatureControlCluster(private val endpointId: UShort) {
+class TemperatureControlCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SupportedTemperatureLevelsAttribute(val value: List<String>?)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -35,6 +39,8 @@ class TemperatureControlCluster(private val endpointId: UShort) {
     targetTemperatureLevel: UByte?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TemperatureMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TemperatureMeasurementCluster(private val endpointId: UShort) {
+class TemperatureMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Short?)
 
   class MinMeasuredValueAttribute(val value: Short?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ThermostatCluster(private val endpointId: UShort) {
+class ThermostatCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GetWeeklyScheduleResponse(
     val numberOfTransitionsForSequence: UByte,
     val dayOfWeekForSequence: UInt,
@@ -58,6 +59,8 @@ class ThermostatCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun setpointRaiseLower(mode: UInt, amount: Byte, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -72,6 +75,8 @@ class ThermostatCluster(private val endpointId: UShort) {
     transitions: List<ThermostatClusterThermostatScheduleTransition>,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -84,6 +89,8 @@ class ThermostatCluster(private val endpointId: UShort) {
     modeToReturn: UInt,
     timedInvokeTimeoutMs: Int? = null
   ): GetWeeklyScheduleResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -92,6 +99,8 @@ class ThermostatCluster(private val endpointId: UShort) {
   }
 
   suspend fun clearWeeklySchedule(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -181,12 +190,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeHVACSystemTypeConfigurationAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeHVACSystemTypeConfigurationAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeHVACSystemTypeConfigurationAttribute(
+    value: UInt,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeHVACSystemTypeConfigurationAttribute(
@@ -200,12 +212,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLocalTemperatureCalibrationAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLocalTemperatureCalibrationAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLocalTemperatureCalibrationAttribute(
+    value: Byte,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLocalTemperatureCalibrationAttribute(
@@ -219,12 +234,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOccupiedCoolingSetpointAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOccupiedCoolingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOccupiedCoolingSetpointAttribute(
+    value: Short,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOccupiedCoolingSetpointAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -235,12 +253,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOccupiedHeatingSetpointAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOccupiedHeatingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOccupiedHeatingSetpointAttribute(
+    value: Short,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOccupiedHeatingSetpointAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -251,12 +272,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUnoccupiedCoolingSetpointAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeUnoccupiedCoolingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeUnoccupiedCoolingSetpointAttribute(
+    value: Short,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUnoccupiedCoolingSetpointAttribute(
@@ -270,12 +294,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUnoccupiedHeatingSetpointAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeUnoccupiedHeatingSetpointAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeUnoccupiedHeatingSetpointAttribute(
+    value: Short,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUnoccupiedHeatingSetpointAttribute(
@@ -289,12 +316,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMinHeatSetpointLimitAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMinHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMinHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMinHeatSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -305,12 +332,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMaxHeatSetpointLimitAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMaxHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMaxHeatSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMaxHeatSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -321,12 +348,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMinCoolSetpointLimitAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMinCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMinCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMinCoolSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -337,12 +364,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMaxCoolSetpointLimitAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMaxCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMaxCoolSetpointLimitAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMaxCoolSetpointLimitAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -353,12 +380,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeMinSetpointDeadBandAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeMinSetpointDeadBandAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeMinSetpointDeadBandAttribute(value: Byte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeMinSetpointDeadBandAttribute(minInterval: Int, maxInterval: Int): Byte {
@@ -369,12 +396,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRemoteSensingAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRemoteSensingAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRemoteSensingAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRemoteSensingAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -385,12 +412,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeControlSequenceOfOperationAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeControlSequenceOfOperationAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeControlSequenceOfOperationAttribute(
+    value: UInt,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeControlSequenceOfOperationAttribute(
@@ -404,12 +434,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeSystemModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeSystemModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeSystemModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeSystemModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -458,12 +488,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeTemperatureSetpointHoldAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeTemperatureSetpointHoldAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeTemperatureSetpointHoldAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeTemperatureSetpointHoldAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -475,15 +505,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeTemperatureSetpointHoldDurationAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeTemperatureSetpointHoldDurationAttribute(
     value: UShort,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeTemperatureSetpointHoldDurationAttribute(
@@ -497,15 +527,15 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeThermostatProgrammingOperationModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeThermostatProgrammingOperationModeAttribute(
     value: UInt,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeThermostatProgrammingOperationModeAttribute(
@@ -557,12 +587,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOccupiedSetbackAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOccupiedSetbackAttribute(
@@ -598,12 +628,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUnoccupiedSetbackAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeUnoccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeUnoccupiedSetbackAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUnoccupiedSetbackAttribute(
@@ -639,12 +669,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEmergencyHeatDeltaAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEmergencyHeatDeltaAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEmergencyHeatDeltaAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEmergencyHeatDeltaAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -655,12 +685,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACTypeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACTypeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACTypeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -671,12 +701,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACCapacityAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACCapacityAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACCapacityAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACCapacityAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -687,12 +717,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACRefrigerantTypeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACRefrigerantTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACRefrigerantTypeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACRefrigerantTypeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -703,12 +733,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACCompressorTypeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACCompressorTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACCompressorTypeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACCompressorTypeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -719,12 +749,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACErrorCodeAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACErrorCodeAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACErrorCodeAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACErrorCodeAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -735,12 +765,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACLouverPositionAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACLouverPositionAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACLouverPositionAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACLouverPositionAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -762,12 +792,12 @@ class ThermostatCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeACCapacityformatAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeACCapacityformatAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeACCapacityformatAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeACCapacityformatAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatUserInterfaceConfigurationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThermostatUserInterfaceConfigurationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ThermostatUserInterfaceConfigurationCluster(private val endpointId: UShort) {
+class ThermostatUserInterfaceConfigurationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -32,12 +36,12 @@ class ThermostatUserInterfaceConfigurationCluster(private val endpointId: UShort
     // Implementation needs to be added here
   }
 
-  suspend fun writeTemperatureDisplayModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeTemperatureDisplayModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeTemperatureDisplayModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeTemperatureDisplayModeAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -48,12 +52,12 @@ class ThermostatUserInterfaceConfigurationCluster(private val endpointId: UShort
     // Implementation needs to be added here
   }
 
-  suspend fun writeKeypadLockoutAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeKeypadLockoutAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeKeypadLockoutAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeKeypadLockoutAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -64,12 +68,15 @@ class ThermostatUserInterfaceConfigurationCluster(private val endpointId: UShort
     // Implementation needs to be added here
   }
 
-  suspend fun writeScheduleProgrammingVisibilityAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeScheduleProgrammingVisibilityAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeScheduleProgrammingVisibilityAttribute(
+    value: UInt,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeScheduleProgrammingVisibilityAttribute(

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThreadNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/ThreadNetworkDiagnosticsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class ThreadNetworkDiagnosticsCluster(private val endpointId: UShort) {
+class ThreadNetworkDiagnosticsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class ChannelAttribute(val value: UShort?)
 
   class RoutingRoleAttribute(val value: UInt?)
@@ -71,6 +75,8 @@ class ThreadNetworkDiagnosticsCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetCounts(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeFormatLocalizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeFormatLocalizationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TimeFormatLocalizationCluster(private val endpointId: UShort) {
+class TimeFormatLocalizationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SupportedCalendarTypesAttribute(val value: List<UInt>?)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -34,12 +38,12 @@ class TimeFormatLocalizationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeHourFormatAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeHourFormatAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeHourFormatAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeHourFormatAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -50,12 +54,12 @@ class TimeFormatLocalizationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeActiveCalendarTypeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeActiveCalendarTypeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeActiveCalendarTypeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeActiveCalendarTypeAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeSynchronizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TimeSynchronizationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TimeSynchronizationCluster(private val endpointId: UShort) {
+class TimeSynchronizationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class SetTimeZoneResponse(val DSTOffsetRequired: Boolean)
 
   class UTCTimeAttribute(val value: ULong?)
@@ -48,6 +52,8 @@ class TimeSynchronizationCluster(private val endpointId: UShort) {
     timeSource: UInt?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -59,6 +65,8 @@ class TimeSynchronizationCluster(private val endpointId: UShort) {
     trustedTimeSource: TimeSynchronizationClusterFabricScopedTrustedTimeSourceStruct?,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -70,6 +78,8 @@ class TimeSynchronizationCluster(private val endpointId: UShort) {
     timeZone: List<TimeSynchronizationClusterTimeZoneStruct>,
     timedInvokeTimeoutMs: Int? = null
   ): SetTimeZoneResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -81,6 +91,8 @@ class TimeSynchronizationCluster(private val endpointId: UShort) {
     DSTOffset: List<TimeSynchronizationClusterDSTOffsetStruct>,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -89,6 +101,8 @@ class TimeSynchronizationCluster(private val endpointId: UShort) {
   }
 
   suspend fun setDefaultNTP(defaultNTP: String?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurementCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurementCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class TotalVolatileOrganicCompoundsConcentrationMeasurementCluster(private val endpointId: UShort) {
+class TotalVolatileOrganicCompoundsConcentrationMeasurementCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class MeasuredValueAttribute(val value: Float?)
 
   class MinMeasuredValueAttribute(val value: Float?)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitLocalizationCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitLocalizationCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class UnitLocalizationCluster(private val endpointId: UShort) {
+class UnitLocalizationCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)
@@ -32,12 +36,12 @@ class UnitLocalizationCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeTemperatureUnitAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeTemperatureUnitAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeTemperatureUnitAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeTemperatureUnitAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitTestingCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UnitTestingCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class UnitTestingCluster(private val endpointId: UShort) {
+class UnitTestingCluster(private val controller: MatterController, private val endpointId: UShort) {
   class TestSpecificResponse(val returnValue: UByte)
 
   class TestAddArgumentsResponse(val returnValue: UByte)
@@ -176,6 +177,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun test(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -184,6 +187,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
   }
 
   suspend fun testNotHandled(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -192,6 +197,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
   }
 
   suspend fun testSpecific(timedInvokeTimeoutMs: Int? = null): TestSpecificResponse {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -200,6 +207,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
   }
 
   suspend fun testUnknownCommand(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 3L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -212,6 +221,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg2: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): TestAddArgumentsResponse {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -223,6 +234,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: Boolean,
     timedInvokeTimeoutMs: Int? = null
   ): TestSimpleArgumentResponse {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -239,6 +252,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg6: Boolean,
     timedInvokeTimeoutMs: Int? = null
   ): TestStructArrayArgumentResponse {
+    val commandId = 6L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -250,6 +265,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UnitTestingClusterSimpleStruct,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -261,6 +278,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UnitTestingClusterNestedStruct,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -272,6 +291,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: List<UnitTestingClusterSimpleStruct>,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 9L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -283,6 +304,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: List<UByte>,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 10L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -294,6 +317,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UnitTestingClusterNestedStructList,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 11L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -305,6 +330,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: List<UnitTestingClusterNestedStructList>,
     timedInvokeTimeoutMs: Int? = null
   ): BooleanResponse {
+    val commandId = 12L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -316,6 +343,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: List<UByte>,
     timedInvokeTimeoutMs: Int? = null
   ): TestListInt8UReverseResponse {
+    val commandId = 13L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -328,6 +357,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg2: UInt,
     timedInvokeTimeoutMs: Int? = null
   ): TestEnumsResponse {
+    val commandId = 14L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -339,6 +370,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UByte?,
     timedInvokeTimeoutMs: Int? = null
   ): TestNullableOptionalResponse {
+    val commandId = 15L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -361,6 +394,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     nullableOptionalList: List<UInt>?,
     timedInvokeTimeoutMs: Int? = null
   ): TestComplexNullableOptionalResponse {
+    val commandId = 16L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -372,6 +407,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UnitTestingClusterSimpleStruct,
     timedInvokeTimeoutMs: Int? = null
   ): SimpleStructResponse {
+    val commandId = 17L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -379,15 +416,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     }
   }
 
-  suspend fun timedInvokeRequest(timedInvokeTimeoutMs: Int? = null) {
-    if (timedInvokeTimeoutMs != null) {
-      // Do the action with timedInvokeTimeoutMs
-    } else {
-      // Do the action without timedInvokeTimeoutMs
-    }
+  suspend fun timedInvokeRequest(timedInvokeTimeoutMs: Int) {
+    val commandId = 18L
+
+    // Implementation needs to be added here
   }
 
   suspend fun testSimpleOptionalArgumentRequest(arg1: Boolean?, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 19L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -401,6 +438,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg3: Boolean,
     timedInvokeTimeoutMs: Int? = null
   ): TestEmitTestEventResponse {
+    val commandId = 20L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -412,6 +451,8 @@ class UnitTestingCluster(private val endpointId: UShort) {
     arg1: UByte,
     timedInvokeTimeoutMs: Int? = null
   ): TestEmitTestFabricScopedEventResponse {
+    val commandId = 21L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -423,12 +464,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBooleanAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -439,12 +480,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBitmap8Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBitmap8Attribute(minInterval: Int, maxInterval: Int): UByte {
@@ -455,12 +496,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBitmap16Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBitmap16Attribute(minInterval: Int, maxInterval: Int): UShort {
@@ -471,12 +512,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBitmap32Attribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBitmap32Attribute(minInterval: Int, maxInterval: Int): UInt {
@@ -487,12 +528,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeBitmap64Attribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeBitmap64Attribute(minInterval: Int, maxInterval: Int): ULong {
@@ -503,12 +544,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt8uAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt8uAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -519,12 +560,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt16uAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt16uAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -535,12 +576,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt24uAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt24uAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -551,12 +592,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt32uAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt32uAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -567,12 +608,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt40uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt40uAttribute(minInterval: Int, maxInterval: Int): ULong {
@@ -583,12 +624,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt48uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt48uAttribute(minInterval: Int, maxInterval: Int): ULong {
@@ -599,12 +640,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt56uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt56uAttribute(minInterval: Int, maxInterval: Int): ULong {
@@ -615,12 +656,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt64uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt64uAttribute(minInterval: Int, maxInterval: Int): ULong {
@@ -631,12 +672,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt8sAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt8sAttribute(minInterval: Int, maxInterval: Int): Byte {
@@ -647,12 +688,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt16sAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt16sAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt16sAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -663,12 +704,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt24sAttribute(value: Int) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt24sAttribute(value: Int, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt24sAttribute(value: Int, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt24sAttribute(minInterval: Int, maxInterval: Int): Int {
@@ -679,12 +720,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt32sAttribute(value: Int) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt32sAttribute(value: Int, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt32sAttribute(value: Int, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt32sAttribute(minInterval: Int, maxInterval: Int): Int {
@@ -695,12 +736,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt40sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt40sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt40sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt40sAttribute(minInterval: Int, maxInterval: Int): Long {
@@ -711,12 +752,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt48sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt48sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt48sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt48sAttribute(minInterval: Int, maxInterval: Int): Long {
@@ -727,12 +768,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt56sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt56sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt56sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt56sAttribute(minInterval: Int, maxInterval: Int): Long {
@@ -743,12 +784,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeInt64sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeInt64sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeInt64sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeInt64sAttribute(minInterval: Int, maxInterval: Int): Long {
@@ -759,12 +800,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnum8Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnum8Attribute(minInterval: Int, maxInterval: Int): UByte {
@@ -775,12 +816,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnum16Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnum16Attribute(minInterval: Int, maxInterval: Int): UShort {
@@ -791,12 +832,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeFloatSingleAttribute(value: Float) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeFloatSingleAttribute(minInterval: Int, maxInterval: Int): Float {
@@ -807,12 +848,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeFloatDoubleAttribute(value: Double) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeFloatDoubleAttribute(minInterval: Int, maxInterval: Int): Double {
@@ -823,12 +864,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeOctetStringAttribute(value: ByteArray) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeOctetStringAttribute(minInterval: Int, maxInterval: Int): OctetString {
@@ -839,12 +880,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeListInt8uAttribute(value: List<UByte>) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeListInt8uAttribute(value: List<UByte>, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeListInt8uAttribute(value: List<UByte>, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListInt8uAttribute(minInterval: Int, maxInterval: Int): ListInt8uAttribute {
@@ -855,12 +896,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeListOctetStringAttribute(value: List<ByteArray>) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeListOctetStringAttribute(value: List<ByteArray>, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeListOctetStringAttribute(
+    value: List<ByteArray>,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListOctetStringAttribute(
@@ -875,16 +919,14 @@ class UnitTestingCluster(private val endpointId: UShort) {
   }
 
   suspend fun writeListStructOctetStringAttribute(
-    value: List<UnitTestingClusterTestListStructOctet>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeListStructOctetStringAttribute(
     value: List<UnitTestingClusterTestListStructOctet>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListStructOctetStringAttribute(
@@ -898,12 +940,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLongOctetStringAttribute(value: ByteArray) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLongOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLongOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLongOctetStringAttribute(minInterval: Int, maxInterval: Int): OctetString {
@@ -914,12 +956,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeCharStringAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeCharStringAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeCharStringAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -930,12 +972,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLongCharStringAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeLongCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeLongCharStringAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLongCharStringAttribute(minInterval: Int, maxInterval: Int): CharString {
@@ -946,12 +988,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEpochUsAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEpochUsAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEpochUsAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEpochUsAttribute(minInterval: Int, maxInterval: Int): ULong {
@@ -962,12 +1004,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEpochSAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEpochSAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEpochSAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEpochSAttribute(minInterval: Int, maxInterval: Int): UInt {
@@ -978,12 +1020,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeVendorIdAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeVendorIdAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeVendorIdAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeVendorIdAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -996,16 +1038,14 @@ class UnitTestingCluster(private val endpointId: UShort) {
   }
 
   suspend fun writeListNullablesAndOptionalsStructAttribute(
-    value: List<UnitTestingClusterNullablesAndOptionalsStruct>
-  ) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeListNullablesAndOptionalsStructAttribute(
     value: List<UnitTestingClusterNullablesAndOptionalsStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListNullablesAndOptionalsStructAttribute(
@@ -1019,12 +1059,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeEnumAttrAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeEnumAttrAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -1035,15 +1075,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeStructAttrAttribute(value: UnitTestingClusterSimpleStruct) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeStructAttrAttribute(
     value: UnitTestingClusterSimpleStruct,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeStructAttrAttribute(
@@ -1057,12 +1097,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRangeRestrictedInt8uAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRangeRestrictedInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRangeRestrictedInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRangeRestrictedInt8uAttribute(minInterval: Int, maxInterval: Int): UByte {
@@ -1073,12 +1113,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRangeRestrictedInt8sAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRangeRestrictedInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRangeRestrictedInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRangeRestrictedInt8sAttribute(minInterval: Int, maxInterval: Int): Byte {
@@ -1089,12 +1129,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRangeRestrictedInt16uAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRangeRestrictedInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRangeRestrictedInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRangeRestrictedInt16uAttribute(minInterval: Int, maxInterval: Int): UShort {
@@ -1105,12 +1145,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeRangeRestrictedInt16sAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeRangeRestrictedInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeRangeRestrictedInt16sAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeRangeRestrictedInt16sAttribute(minInterval: Int, maxInterval: Int): Short {
@@ -1121,12 +1161,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeListLongOctetStringAttribute(value: List<ByteArray>) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeListLongOctetStringAttribute(value: List<ByteArray>, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeListLongOctetStringAttribute(
+    value: List<ByteArray>,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListLongOctetStringAttribute(
@@ -1146,15 +1189,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeListFabricScopedAttribute(value: List<UnitTestingClusterTestFabricScoped>) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeListFabricScopedAttribute(
     value: List<UnitTestingClusterTestFabricScoped>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeListFabricScopedAttribute(
@@ -1180,12 +1223,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeGeneralErrorBooleanAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeGeneralErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeGeneralErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeGeneralErrorBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -1196,12 +1239,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeClusterErrorBooleanAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeClusterErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeClusterErrorBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeClusterErrorBooleanAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -1212,12 +1255,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeUnsupportedAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeUnsupportedAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeUnsupportedAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeUnsupportedAttribute(minInterval: Int, maxInterval: Int): Boolean {
@@ -1228,12 +1271,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableBooleanAttribute(value: Boolean) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableBooleanAttribute(value: Boolean, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableBooleanAttribute(
@@ -1247,12 +1290,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableBitmap8Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableBitmap8Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableBitmap8Attribute(
@@ -1266,12 +1309,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableBitmap16Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableBitmap16Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableBitmap16Attribute(
@@ -1285,12 +1328,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableBitmap32Attribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableBitmap32Attribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableBitmap32Attribute(
@@ -1304,12 +1347,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableBitmap64Attribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableBitmap64Attribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableBitmap64Attribute(
@@ -1323,12 +1366,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt8uAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt8uAttribute(
@@ -1342,12 +1385,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt16uAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt16uAttribute(
@@ -1361,12 +1404,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt24uAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt24uAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt24uAttribute(
@@ -1380,12 +1423,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt32uAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt32uAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt32uAttribute(
@@ -1399,12 +1442,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt40uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt40uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt40uAttribute(
@@ -1418,12 +1461,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt48uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt48uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt48uAttribute(
@@ -1437,12 +1480,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt56uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt56uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt56uAttribute(
@@ -1456,12 +1499,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt64uAttribute(value: ULong) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt64uAttribute(value: ULong, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt64uAttribute(
@@ -1475,12 +1518,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt8sAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt8sAttribute(
@@ -1494,12 +1537,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt16sAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt16sAttribute(value: Short, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt16sAttribute(
@@ -1513,12 +1556,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt24sAttribute(value: Int) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt24sAttribute(value: Int, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt24sAttribute(value: Int, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt24sAttribute(
@@ -1532,12 +1575,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt32sAttribute(value: Int) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt32sAttribute(value: Int, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt32sAttribute(value: Int, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt32sAttribute(
@@ -1551,12 +1594,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt40sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt40sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt40sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt40sAttribute(
@@ -1570,12 +1613,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt48sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt48sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt48sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt48sAttribute(
@@ -1589,12 +1632,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt56sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt56sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt56sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt56sAttribute(
@@ -1608,12 +1651,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableInt64sAttribute(value: Long) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableInt64sAttribute(value: Long, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableInt64sAttribute(value: Long, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableInt64sAttribute(
@@ -1627,12 +1670,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableEnum8Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableEnum8Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableEnum8Attribute(
@@ -1646,12 +1689,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableEnum16Attribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableEnum16Attribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableEnum16Attribute(
@@ -1665,12 +1708,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableFloatSingleAttribute(value: Float) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableFloatSingleAttribute(value: Float, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableFloatSingleAttribute(
@@ -1684,12 +1727,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableFloatDoubleAttribute(value: Double) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableFloatDoubleAttribute(value: Double, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableFloatDoubleAttribute(
@@ -1703,12 +1746,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableOctetStringAttribute(value: ByteArray) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableOctetStringAttribute(value: ByteArray, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableOctetStringAttribute(
+    value: ByteArray,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableOctetStringAttribute(
@@ -1722,12 +1768,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableCharStringAttribute(value: String) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableCharStringAttribute(value: String, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableCharStringAttribute(value: String, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableCharStringAttribute(
@@ -1741,12 +1787,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableEnumAttrAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableEnumAttrAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableEnumAttrAttribute(
@@ -1760,15 +1806,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableStructAttribute(value: UnitTestingClusterSimpleStruct) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeNullableStructAttribute(
     value: UnitTestingClusterSimpleStruct,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableStructAttribute(
@@ -1782,12 +1828,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableRangeRestrictedInt8uAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableRangeRestrictedInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableRangeRestrictedInt8uAttribute(
+    value: UByte,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableRangeRestrictedInt8uAttribute(
@@ -1801,12 +1850,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableRangeRestrictedInt8sAttribute(value: Byte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableRangeRestrictedInt8sAttribute(value: Byte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableRangeRestrictedInt8sAttribute(
+    value: Byte,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableRangeRestrictedInt8sAttribute(
@@ -1820,12 +1872,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableRangeRestrictedInt16uAttribute(value: UShort) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableRangeRestrictedInt16uAttribute(value: UShort, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableRangeRestrictedInt16uAttribute(
+    value: UShort,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableRangeRestrictedInt16uAttribute(
@@ -1839,12 +1894,15 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeNullableRangeRestrictedInt16sAttribute(value: Short) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeNullableRangeRestrictedInt16sAttribute(value: Short, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeNullableRangeRestrictedInt16sAttribute(
+    value: Short,
+    timedWriteTimeoutMs: Int? = null
+  ) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeNullableRangeRestrictedInt16sAttribute(
@@ -1858,12 +1916,12 @@ class UnitTestingCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeWriteOnlyInt8uAttribute(value: UByte) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeWriteOnlyInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeWriteOnlyInt8uAttribute(value: UByte, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeWriteOnlyInt8uAttribute(minInterval: Int, maxInterval: Int): UByte {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UserLabelCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/UserLabelCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class UserLabelCluster(private val endpointId: UShort) {
+class UserLabelCluster(private val controller: MatterController, private val endpointId: UShort) {
   class LabelListAttribute(val value: List<UserLabelClusterLabelStruct>)
 
   class GeneratedCommandListAttribute(val value: List<UInt>)
@@ -34,15 +35,15 @@ class UserLabelCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeLabelListAttribute(value: List<UserLabelClusterLabelStruct>) {
-    // Implementation needs to be added here
-  }
-
   suspend fun writeLabelListAttribute(
     value: List<UserLabelClusterLabelStruct>,
-    timedWriteTimeoutMs: Int
+    timedWriteTimeoutMs: Int? = null
   ) {
-    // Implementation needs to be added here
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeLabelListAttribute(minInterval: Int, maxInterval: Int): LabelListAttribute {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WakeOnLanCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WakeOnLanCluster.kt
@@ -17,9 +17,10 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class WakeOnLanCluster(private val endpointId: UShort) {
+class WakeOnLanCluster(private val controller: MatterController, private val endpointId: UShort) {
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   class AcceptedCommandListAttribute(val value: List<UInt>)

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WiFiNetworkDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WiFiNetworkDiagnosticsCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class WiFiNetworkDiagnosticsCluster(private val endpointId: UShort) {
+class WiFiNetworkDiagnosticsCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class BssidAttribute(val value: ByteArray?)
 
   class SecurityTypeAttribute(val value: UInt?)
@@ -55,6 +59,8 @@ class WiFiNetworkDiagnosticsCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun resetCounts(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {

--- a/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WindowCoveringCluster.kt
+++ b/src/controller/java/generated/java/matter/devicecontroller/cluster/clusters/WindowCoveringCluster.kt
@@ -17,9 +17,13 @@
 
 package matter.devicecontroller.cluster.clusters
 
+import matter.controller.MatterController
 import matter.devicecontroller.cluster.structs.*
 
-class WindowCoveringCluster(private val endpointId: UShort) {
+class WindowCoveringCluster(
+  private val controller: MatterController,
+  private val endpointId: UShort
+) {
   class CurrentPositionLiftAttribute(val value: UShort?)
 
   class CurrentPositionTiltAttribute(val value: UShort?)
@@ -45,6 +49,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
   class AttributeListAttribute(val value: List<UInt>)
 
   suspend fun upOrOpen(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 0L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -53,6 +59,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
   }
 
   suspend fun downOrClose(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 1L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -61,6 +69,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
   }
 
   suspend fun stopMotion(timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 2L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -69,6 +79,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
   }
 
   suspend fun goToLiftValue(liftValue: UShort, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 4L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -80,6 +92,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
     liftPercent100thsValue: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 5L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -88,6 +102,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
   }
 
   suspend fun goToTiltValue(tiltValue: UShort, timedInvokeTimeoutMs: Int? = null) {
+    val commandId = 7L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -99,6 +115,8 @@ class WindowCoveringCluster(private val endpointId: UShort) {
     tiltPercent100thsValue: UShort,
     timedInvokeTimeoutMs: Int? = null
   ) {
+    val commandId = 8L
+
     if (timedInvokeTimeoutMs != null) {
       // Do the action with timedInvokeTimeoutMs
     } else {
@@ -310,12 +328,12 @@ class WindowCoveringCluster(private val endpointId: UShort) {
     // Implementation needs to be added here
   }
 
-  suspend fun writeModeAttribute(value: UInt) {
-    // Implementation needs to be added here
-  }
-
-  suspend fun writeModeAttribute(value: UInt, timedWriteTimeoutMs: Int) {
-    // Implementation needs to be added here
+  suspend fun writeModeAttribute(value: UInt, timedWriteTimeoutMs: Int? = null) {
+    if (timedWriteTimeoutMs != null) {
+      // Do the action with timedWriteTimeoutMs
+    } else {
+      // Do the action without timedWriteTimeoutMs
+    }
   }
 
   suspend fun subscribeModeAttribute(minInterval: Int, maxInterval: Int): UByte {


### PR DESCRIPTION
If the mustUseTimedInvoke attribute is set for a command, it indicates that the timedInvokeTimeoutMs parameter is mandatory and should not have a default value. The template should then be adjusted to check for the mustUseTimedInvoke attribute and generate the appropriate function signature.
 
 Instead of 
`  suspend fun lockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int? = null) `
  
  We should have:
`  suspend fun lockDoor(PINCode: ByteArray?, timedInvokeTimeoutMs: Int) `

Similar adjustment apply to write attribute.

