### PR TITLE
Fix constraint type checks for command responses.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -491,7 +491,7 @@ class _TestStepWithPlaceholders:
                         # the the value type for the target field.
                         if is_typed_constraint(constraint):
                             value[key][constraint] = self._update_value_with_definition(
-                                constraint_value, mapping_type)
+                                constraint_value, mapping)
                 else:
                     # This key, value pair does not rely on cluster specifications.
                     pass


### PR DESCRIPTION
For a command response, the YAML parser was ending up with the wrong type definition (the one for the whole command response, not the one for the one field) when a type-dependent constraint was used on a field of the response. This led to issues when a type-dependent constraint (like "contains") was used with a list of structs: the field names for the structs were not found, since the object used for lookup had field names for the command itself, not for the field in question.

Fixes https://github.com/project-chip/connectedhomeip/issues/30204
