### PR TITLE
[Scenes] Use of "contains" in Yaml S 2.2

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
@@ -449,76 +449,31 @@ tests:
               - name: "TransitionTime"
                 value: 0x0000
               - name: "ExtensionFieldSets"
-                value:
-                    [
-                        {
-                            ClusterID: 0x0006,
-                            AttributeValueList:
-                                [{ AttributeID: 0x0000, AttributeValue: 0x01 }],
-                        },
-                        {
-                            ClusterID: 0x0008,
-                            AttributeValueList:
-                                [{ AttributeID: 0x0000, AttributeValue: 0x64 }],
-                        },
-                        {
-                            ClusterID: 0x0300,
-                            AttributeValueList:
-                                [
-                                    {
-                                        AttributeID: 0x0003,
-                                        AttributeValue: 0x616b,
-                                    },
-                                    {
-                                        AttributeID: 0x0004,
-                                        AttributeValue: 0x607d,
-                                    },
-                                    {
-                                        AttributeID: 0x4000,
-                                        AttributeValue: 0x0000,
-                                    },
-                                    {
-                                        AttributeID: 0x0001,
-                                        AttributeValue: 0x00,
-                                    },
-                                    {
-                                        AttributeID: 0x4002,
-                                        AttributeValue: 0x00,
-                                    },
-                                    {
-                                        AttributeID: 0x4003,
-                                        AttributeValue: 0x00,
-                                    },
-                                    {
-                                        AttributeID: 0x4004,
-                                        AttributeValue: 0x0019,
-                                    },
-                                    {
-                                        AttributeID: 0x0007,
-                                        AttributeValue: 0x00,
-                                    },
-                                    {
-                                        AttributeID: 0x4001,
-                                        AttributeValue: 0x02,
-                                    },
-                                ],
-                        },
-                    ]
-                #TODO : Need to change the check for a check like below if possible
-                # constraints:
-                #     type: list
-                #     contains: [
-                #         {
-                #             ClusterID: 0x0006,
-                #             AttributeValueList:
-                #                 [{ AttributeID: 0x0000, AttributeValue: 0x01 }],
-                #         },
-                #         {
-                #             ClusterID: 0x0008,
-                #             AttributeValueList:
-                #                 [{ AttributeID: 0x0000, AttributeValue: 0x64 }],
-                #         },
-                #     ]
+                constraints:
+                    type: list
+                    contains:
+                        [
+                            {
+                                ClusterID: 0x0006,
+                                AttributeValueList:
+                                    [
+                                        {
+                                            AttributeID: 0x0000,
+                                            AttributeValue: 0x01,
+                                        },
+                                    ],
+                            },
+                            {
+                                ClusterID: 0x0008,
+                                AttributeValueList:
+                                    [
+                                        {
+                                            AttributeID: 0x0000,
+                                            AttributeValue: 0x64,
+                                        },
+                                    ],
+                            },
+                        ]
 
     - label:
           "Step 5: TH sends a ViewScene command to DUT with the GroupID field


### PR DESCRIPTION
Now that https://github.com/project-chip/connectedhomeip/pull/30218 is merged, we can use the "contains" method when checking EFS in ViewScene command's Response.

Removed the explicit value check.
