### PR TITLE
[Scenes] SceneHandler helpers

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -163,6 +163,7 @@ template("chip_data_model") {
       "${_app_root}/clusters/on-off-server/on-off-server.h",
       "${_app_root}/clusters/scenes-server/ExtensionFieldSets.h",
       "${_app_root}/clusters/scenes-server/ExtensionFieldSetsImpl.h",
+      "${_app_root}/clusters/scenes-server/SceneHandlerImpl.h",
       "${_app_root}/clusters/scenes-server/SceneTable.h",
       "${_app_root}/clusters/scenes-server/SceneTableImpl.h",
       "${_app_root}/clusters/scenes-server/scenes-server.h",
@@ -278,6 +279,7 @@ template("chip_data_model") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",
           "${_app_root}/clusters/scenes-server/ExtensionFieldSetsImpl.cpp",
+          "${_app_root}/clusters/scenes-server/SceneHandlerImpl.cpp",
           "${_app_root}/clusters/scenes-server/SceneTableImpl.cpp",
         ]
       } else if (cluster == "operational-state-server") {

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -104,101 +104,14 @@ static constexpr size_t kOnOffMaxEnpointCount =
     EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 #ifdef EMBER_AF_PLUGIN_SCENES
-static EmberEventControl sceneHandlerEventControls[kOnOffMaxEnpointCount];
 static void sceneOnOffCallback(EndpointId endpoint);
+using OnOffEndPointPair        = chip::scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
+using sTransitionTimeInterface = chip::scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEnpointCount>;
 
 class DefaultOnOffSceneHandler : public scenes::DefaultSceneHandlerImpl
 {
 public:
-    /// @brief Struct to keep track of the desired state of the OnOff attribute between ApplyScene and
-    /// transition time expiration
-    struct EndpointStatePair
-    {
-        EndpointStatePair(EndpointId endpoint = kInvalidEndpointId, bool status = false) : mEndpoint(endpoint), mState(status) {}
-        EndpointId mEndpoint;
-        bool mState;
-    };
-
-    /// @brief Struct holding an array of EndpointStatePair. Handles insertion, get and removal by EndpointID.
-    /// TODO: Implement generic object to handle this boilerplate array manipulation
-    struct StatePairBuffer
-    {
-        bool IsEmpty() const { return (mPairCount == 0); }
-
-        CHIP_ERROR FindPair(const EndpointId endpoint, uint16_t & found_index) const
-        {
-            VerifyOrReturnError(!IsEmpty(), CHIP_ERROR_NOT_FOUND);
-            for (found_index = 0; found_index < mPairCount; found_index++)
-            {
-                if (endpoint == mStatePairBuffer[found_index].mEndpoint)
-                {
-                    return CHIP_NO_ERROR;
-                }
-            }
-
-            return CHIP_ERROR_NOT_FOUND;
-        }
-
-        CHIP_ERROR InsertPair(const EndpointStatePair & status)
-        {
-            uint16_t idx;
-            CHIP_ERROR err = FindPair(status.mEndpoint, idx);
-
-            if (CHIP_NO_ERROR == err)
-            {
-                mStatePairBuffer[idx] = status;
-            }
-            else if (mPairCount < MAX_ENDPOINT_COUNT)
-            {
-                // if not found, insert at the end
-                mStatePairBuffer[mPairCount] = status;
-                mPairCount++;
-            }
-            else
-            {
-                return CHIP_ERROR_NO_MEMORY;
-            }
-
-            return CHIP_NO_ERROR;
-        }
-
-        CHIP_ERROR GetPair(const EndpointId endpoint, EndpointStatePair & status) const
-        {
-            uint16_t idx;
-            ReturnErrorOnFailure(FindPair(endpoint, idx));
-
-            status = mStatePairBuffer[idx];
-            return CHIP_NO_ERROR;
-        }
-
-        /// @brief Removes Pair and decrements Pair count if the endpoint existed in the array
-        /// @param endpoint : endpoint id of the pair
-        CHIP_ERROR RemovePair(const EndpointId endpoint)
-        {
-            uint16_t position;
-            VerifyOrReturnValue(CHIP_NO_ERROR == FindPair(endpoint, position), CHIP_NO_ERROR);
-
-            uint16_t nextPos = static_cast<uint16_t>(position + 1);
-            uint16_t moveNum = static_cast<uint16_t>(mPairCount - nextPos);
-
-            // Compress array after removal, if the removed position is not the last
-            if (moveNum)
-            {
-                memmove(&mStatePairBuffer[position], &mStatePairBuffer[nextPos], sizeof(EndpointStatePair) * moveNum);
-            }
-
-            mPairCount--;
-            // Clear last occupied position
-            mStatePairBuffer[mPairCount].mEndpoint = kInvalidEndpointId;
-
-            return CHIP_NO_ERROR;
-        }
-
-        uint16_t mPairCount;
-        EndpointStatePair mStatePairBuffer[kOnOffMaxEnpointCount];
-    };
-
-    StatePairBuffer mSceneEndpointStatePairs;
+    DefaultSceneHandlerImpl::StatePairBuffer<bool, kOnOffMaxEnpointCount> mSceneEndpointStatePairs;
     // As per spec, 1 attribute is scenable in the on off cluster
     static constexpr uint8_t scenableAttributeCount = 1;
 
@@ -279,7 +192,7 @@ public:
             auto & decodePair = pair_iterator.GetValue();
             VerifyOrReturnError(decodePair.attributeID == Attributes::OnOff::Id, CHIP_ERROR_INVALID_ARGUMENT);
             ReturnErrorOnFailure(
-                mSceneEndpointStatePairs.InsertPair(EndpointStatePair(endpoint, static_cast<bool>(decodePair.attributeValue))));
+                mSceneEndpointStatePairs.InsertPair(OnOffEndPointPair(endpoint, static_cast<bool>(decodePair.attributeValue))));
         }
         // Verify that the EFS was completely read
         CHIP_ERROR err = pair_iterator.GetStatus();
@@ -299,38 +212,22 @@ public:
               Scenes::ScenesServer::Instance().IsHandlerRegistered(endpoint, LevelControlServer::GetSceneHandler())))
 #endif
         {
-            OnOffServer::Instance().scheduleTimerCallbackMs(sceneEventControl(endpoint), timeMs);
+            OnOffServer::Instance().scheduleTimerCallbackMs(mTransitionTimeInterface.sceneEventControl(endpoint), timeMs);
         }
 
         return CHIP_NO_ERROR;
     }
 
 private:
-    /**
-     * @brief Configures EventControl callback when setting On Off through scenes callback
-     *
-     * @param[in] endpoint endpoint to start timer for
-     * @return EmberEventControl* configured event control
-     */
-    EmberEventControl * sceneEventControl(EndpointId endpoint)
-    {
-        EmberEventControl * controller =
-            OnOffServer::Instance().getEventControl(endpoint, Span<EmberEventControl>(sceneHandlerEventControls));
-        VerifyOrReturnValue(controller != nullptr, nullptr);
-
-        controller->endpoint = endpoint;
-        controller->callback = &sceneOnOffCallback;
-
-        return controller;
-    }
+    sTransitionTimeInterface mTransitionTimeInterface = sTransitionTimeInterface(Attributes::OnOff::Id, sceneOnOffCallback);
 };
 static DefaultOnOffSceneHandler sOnOffSceneHandler;
 
 static void sceneOnOffCallback(EndpointId endpoint)
 {
-    DefaultOnOffSceneHandler::EndpointStatePair savedState;
+    OnOffEndPointPair savedState;
     ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.GetPair(endpoint, savedState));
-    chip::CommandId command = (savedState.mState) ? Commands::On::Id : Commands::Off::Id;
+    chip::CommandId command = (savedState.mValue) ? Commands::On::Id : Commands::Off::Id;
     OnOffServer::Instance().setOnOffValue(endpoint, command, false);
     ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.RemovePair(endpoint));
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -105,8 +105,9 @@ static constexpr size_t kOnOffMaxEnpointCount =
 
 #ifdef EMBER_AF_PLUGIN_SCENES
 static void sceneOnOffCallback(EndpointId endpoint);
-using OnOffEndPointPair        = chip::scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
-using sTransitionTimeInterface = chip::scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEnpointCount>;
+using OnOffEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
+using OnOffTransitionTimeInterface =
+    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEnpointCount, EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
 
 class DefaultOnOffSceneHandler : public scenes::DefaultSceneHandlerImpl
 {
@@ -219,7 +220,7 @@ public:
     }
 
 private:
-    sTransitionTimeInterface mTransitionTimeInterface = sTransitionTimeInterface(Attributes::OnOff::Id, sceneOnOffCallback);
+    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(Attributes::OnOff::Id, sceneOnOffCallback);
 };
 static DefaultOnOffSceneHandler sOnOffSceneHandler;
 
@@ -227,7 +228,7 @@ static void sceneOnOffCallback(EndpointId endpoint)
 {
     OnOffEndPointPair savedState;
     ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.GetPair(endpoint, savedState));
-    chip::CommandId command = (savedState.mValue) ? Commands::On::Id : Commands::Off::Id;
+    CommandId command = (savedState.mValue) ? Commands::On::Id : Commands::Off::Id;
     OnOffServer::Instance().setOnOffValue(endpoint, command, false);
     ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.RemovePair(endpoint));
 }

--- a/src/app/clusters/scenes-server/BUILD.gn
+++ b/src/app/clusters/scenes-server/BUILD.gn
@@ -20,6 +20,8 @@ static_library("scenes") {
     "ExtensionFieldSets.h",
     "ExtensionFieldSetsImpl.cpp",
     "ExtensionFieldSetsImpl.h",
+    "SceneHandlerImpl.cpp",
+    "SceneHandlerImpl.h",
     "SceneTable.h",
     "SceneTableImpl.cpp",
     "SceneTableImpl.h",

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/scenes-server/SceneHandlerImpl.h>
+
+namespace chip {
+namespace scenes {
+
+CHIP_ERROR
+DefaultSceneHandlerImpl::EncodeAttributeValueList(const List<AttributeValuePairType> & aVlist, MutableByteSpan & serializedBytes)
+{
+    TLV::TLVWriter writer;
+    writer.Init(serializedBytes);
+    ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), aVlist));
+    serializedBytes.reduce_size(writer.GetLengthWritten());
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DefaultSceneHandlerImpl::DecodeAttributeValueList(const ByteSpan & serializedBytes,
+                                                             DecodableList<AttributeValuePairDecodableType> & aVlist)
+{
+    TLV::TLVReader reader;
+
+    reader.Init(serializedBytes);
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Array, TLV::AnonymousTag()));
+    ReturnErrorOnFailure(aVlist.Decode(reader));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+DefaultSceneHandlerImpl::SerializeAdd(EndpointId endpoint, const ExtensionFieldSetDecodableType & extensionFieldSet,
+                                      MutableByteSpan & serializedBytes)
+{
+    AttributeValuePairType aVPairs[kMaxAvPair];
+
+    size_t pairTotal = 0;
+    // Verify size of list
+    ReturnErrorOnFailure(extensionFieldSet.attributeValueList.ComputeSize(&pairTotal));
+    VerifyOrReturnError(pairTotal <= ArraySize(aVPairs), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    uint8_t pairCount  = 0;
+    auto pair_iterator = extensionFieldSet.attributeValueList.begin();
+    while (pair_iterator.Next())
+    {
+        aVPairs[pairCount] = pair_iterator.GetValue();
+        pairCount++;
+    }
+    ReturnErrorOnFailure(pair_iterator.GetStatus());
+    List<AttributeValuePairType> attributeValueList(aVPairs, pairCount);
+
+    return EncodeAttributeValueList(attributeValueList, serializedBytes);
+}
+
+CHIP_ERROR DefaultSceneHandlerImpl::Deserialize(EndpointId endpoint, ClusterId cluster, const ByteSpan & serializedBytes,
+                                                ExtensionFieldSetType & extensionFieldSet)
+{
+    DecodableList<AttributeValuePairDecodableType> attributeValueList;
+
+    ReturnErrorOnFailure(DecodeAttributeValueList(serializedBytes, attributeValueList));
+
+    // Verify size of list
+    size_t pairTotal = 0;
+    ReturnErrorOnFailure(attributeValueList.ComputeSize(&pairTotal));
+    VerifyOrReturnError(pairTotal <= ArraySize(mAVPairs), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    uint8_t pairCount  = 0;
+    auto pair_iterator = attributeValueList.begin();
+    while (pair_iterator.Next())
+    {
+        mAVPairs[pairCount] = pair_iterator.GetValue();
+        pairCount++;
+    };
+    ReturnErrorOnFailure(pair_iterator.GetStatus());
+
+    extensionFieldSet.clusterID          = cluster;
+    extensionFieldSet.attributeValueList = mAVPairs;
+    extensionFieldSet.attributeValueList.reduce_size(pairCount);
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace scenes
+} // namespace chip

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.h
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.h
@@ -135,8 +135,8 @@ public:
         EndpointStatePair<ValueType> mStatePairBuffer[MaxEndpointCount];
     };
 
-    /// @brief Struct meant to allow to save context for a cluster that needs to apply a scene after a transition time but does not
-    /// own a time property in its commands
+    /// @brief Helper struct that allows clusters that do not have an existing mechanism for doing
+    //         asynchronous work to perform scene transitions over some period of time.
     /// @tparam MaxEndpointCount
     template <size_t MaxEndpointCount, size_t FixedEndpointCount>
     struct TransitionTimeInterface

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.h
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.h
@@ -1,0 +1,228 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/scenes-server/SceneTable.h>
+#include <app/util/attribute-storage.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace scenes {
+
+using ClusterId = chip::ClusterId;
+
+/// @brief Default implementation of handler, handle EFS from add scene and view scene commands for any cluster
+///        The implementation of SerializeSave and ApplyScene were omitted and must be implemented in a way that
+///        is compatible with the SerializeAdd output in order to function with the Default Scene Handler.
+///        It is worth noting that this implementation is very memory consuming. In the current worst case,
+///        (Color control cluster), the Extension Field Set's value pair list TLV occupies 99 bytes of memory
+class DefaultSceneHandlerImpl : public scenes::SceneHandler
+{
+    template <typename T>
+    using List = chip::app::DataModel::List<T>;
+
+    template <typename T>
+    using DecodableList = chip::app::DataModel::DecodableList<T>;
+
+    using AttributeValuePairType          = chip::app::Clusters::Scenes::Structs::AttributeValuePair::Type;
+    using AttributeValuePairDecodableType = chip::app::Clusters::Scenes::Structs::AttributeValuePair::DecodableType;
+    using ExtensionFieldSetDecodableType  = chip::app::Clusters::Scenes::Structs::ExtensionFieldSet::DecodableType;
+    using ExtensionFieldSetType           = chip::app::Clusters::Scenes::Structs::ExtensionFieldSet::Type;
+
+public:
+    /// @brief Struct meant to map the state of a cluster to a specific endpoint. Meant to be used to apply scenes using a timer for
+    /// transitionning
+    /// @tparam ValueType type of the value to map to the endpoint, must implement operator= and operator== for complex types
+    template <typename ValueType>
+    struct EndpointStatePair
+    {
+        EndpointStatePair(EndpointId endpoint = kInvalidEndpointId, ValueType value = ValueType{}) :
+            mEndpoint(endpoint), mValue(value)
+        {}
+        EndpointId mEndpoint;
+        ValueType mValue;
+    };
+
+    template <typename ValueType, size_t MaxEndpointCount>
+    struct StatePairBuffer
+    {
+        bool IsEmpty() const { return (mPairCount == 0); }
+
+        CHIP_ERROR FindPair(const EndpointId endpoint, uint16_t & found_index) const
+        {
+            VerifyOrReturnError(!IsEmpty(), CHIP_ERROR_NOT_FOUND);
+            for (found_index = 0; found_index < mPairCount; found_index++)
+            {
+                if (endpoint == mStatePairBuffer[found_index].mEndpoint)
+                {
+                    return CHIP_NO_ERROR;
+                }
+            }
+
+            return CHIP_ERROR_NOT_FOUND;
+        }
+
+        CHIP_ERROR InsertPair(const EndpointStatePair<ValueType> & status)
+        {
+            uint16_t idx;
+            CHIP_ERROR err = FindPair(status.mEndpoint, idx);
+
+            if (CHIP_NO_ERROR == err)
+            {
+                mStatePairBuffer[idx] = status;
+            }
+            else if (mPairCount < MaxEndpointCount)
+            {
+                // If not found, insert at the end
+                mStatePairBuffer[mPairCount] = status;
+                mPairCount++;
+            }
+            else
+            {
+                return CHIP_ERROR_NO_MEMORY;
+            }
+
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR GetPair(const EndpointId endpoint, EndpointStatePair<ValueType> & status) const
+        {
+            uint16_t idx;
+            ReturnErrorOnFailure(FindPair(endpoint, idx));
+
+            status = mStatePairBuffer[idx];
+            return CHIP_NO_ERROR;
+        }
+
+        /// @brief Removes Pair and decrements Pair count if the endpoint existed in the array
+        /// @param endpoint : endpoint id of the pair
+        CHIP_ERROR RemovePair(const EndpointId endpoint)
+        {
+            uint16_t position;
+            VerifyOrReturnValue(CHIP_NO_ERROR == FindPair(endpoint, position), CHIP_NO_ERROR);
+
+            uint16_t nextPos = static_cast<uint16_t>(position + 1);
+            uint16_t moveNum = static_cast<uint16_t>(mPairCount - nextPos);
+
+            // Compress array after removal, if the removed position is not the last
+            if (moveNum)
+            {
+                memmove(&mStatePairBuffer[position], &mStatePairBuffer[nextPos], sizeof(EndpointStatePair<ValueType>) * moveNum);
+            }
+
+            mPairCount--;
+            // Clear the last occupied position
+            mStatePairBuffer[mPairCount].mEndpoint = kInvalidEndpointId;
+
+            return CHIP_NO_ERROR;
+        }
+
+        uint16_t mPairCount = 0;
+        EndpointStatePair<ValueType> mStatePairBuffer[MaxEndpointCount];
+    };
+
+    /// @brief Struct meant to allow to save context for a cluster that needs to apply a scene after a transition time but does not
+    /// own a time property in its commands
+    /// @tparam MaxEndpointCount
+    template <size_t MaxEndpointCount>
+    struct TransitionTimeInterface
+    {
+        EmberEventControl sceneHandlerEventControls[MaxEndpointCount];
+
+        TransitionTimeInterface(ClusterId clusterId, void (*callback)(EndpointId)) : mClusterId(clusterId), mCallback(callback) {}
+
+        /**
+         * @brief event control object for an endpoint
+         *
+         * @param[in] endpoint target endpoint
+         * @param[in] eventControlArray Array where to find the event control
+         * @return EmberEventControl* configured event control
+         */
+        EmberEventControl * getEventControl(EndpointId endpoint, const Span<EmberEventControl> & eventControlArray)
+        {
+            uint16_t index = emberAfGetClusterServerEndpointIndex(endpoint, mClusterId, MaxEndpointCount);
+            if (index >= eventControlArray.size())
+            {
+                return nullptr;
+            }
+
+            return &eventControlArray[index];
+        }
+
+        /**
+         * @brief Configures EventControl callback
+         *
+         * @param[in] endpoint endpoint to start timer for
+         * @return EmberEventControl* configured event control
+         */
+        EmberEventControl * sceneEventControl(EndpointId endpoint)
+        {
+            EmberEventControl * controller = getEventControl(endpoint, Span<EmberEventControl>(sceneHandlerEventControls));
+            VerifyOrReturnValue(controller != nullptr, nullptr);
+
+            controller->endpoint = endpoint;
+            controller->callback = mCallback;
+
+            return controller;
+        }
+
+        ClusterId mClusterId;
+        void (*mCallback)(EndpointId);
+    };
+
+    static constexpr uint8_t kMaxAvPair = CHIP_CONFIG_SCENES_MAX_AV_PAIRS_EFS;
+
+    DefaultSceneHandlerImpl() = default;
+    ~DefaultSceneHandlerImpl() override{};
+
+    /// @brief Encodes an attribute value list into a TLV structure and resizes the buffer to the size of the encoded data
+    /// @param aVlist[in] Attribute value list to encode
+    /// @param serializedBytes[out] Buffer to fill from the Attribute value list in a TLV format
+    /// @return CHIP_ERROR
+    virtual CHIP_ERROR EncodeAttributeValueList(const List<AttributeValuePairType> & aVlist, MutableByteSpan & serializedBytes);
+
+    /// @brief Decodes an attribute value list from a TLV structure and ensure it fits the member pair buffer
+    /// @param serializedBytes [in] Buffer to read from
+    /// @param aVlist [out] Attribute value list to fill from the TLV structure.  Only valid while the buffer backing
+    /// serializedBytes exists and its contents are not modified.
+    /// @return CHIP_ERROR
+    virtual CHIP_ERROR DecodeAttributeValueList(const ByteSpan & serializedBytes,
+                                                DecodableList<AttributeValuePairDecodableType> & aVlist);
+
+    /// @brief From command AddScene, allows handler to filter through clusters in command to serialize only the supported ones.
+    /// @param endpoint[in] Endpoint ID
+    /// @param extensionFieldSet[in] ExtensionFieldSets provided by the AddScene Command, pre initialized
+    /// @param serializedBytes[out] Buffer to fill from the ExtensionFieldSet in command
+    /// @return CHIP_NO_ERROR if successful, CHIP_ERROR_INVALID_ARGUMENT if the cluster is not supported, CHIP_ERROR value
+    /// otherwise
+    virtual CHIP_ERROR SerializeAdd(EndpointId endpoint, const ExtensionFieldSetDecodableType & extensionFieldSet,
+                                    MutableByteSpan & serializedBytes) override;
+
+    /// @brief Simulates taking data from nvm and loading it in a command object if the cluster is supported by the endpoint
+    /// @param endpoint target endpoint
+    /// @param cluster  target cluster
+    /// @param serializedBytes data to deserialize into EFS
+    /// @return CHIP_NO_ERROR if Extension Field Set was successfully populated, CHIP_ERROR_INVALID_ARGUMENT if the cluster is not
+    /// supported, specific CHIP_ERROR otherwise
+    virtual CHIP_ERROR Deserialize(EndpointId endpoint, ClusterId cluster, const ByteSpan & serializedBytes,
+                                   ExtensionFieldSetType & extensionFieldSet) override;
+
+private:
+    AttributeValuePairType mAVPairs[kMaxAvPair];
+};
+
+} // namespace scenes
+} // namespace chip

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -17,6 +17,7 @@
 
 #pragma once
 #include <app/clusters/scenes-server/ExtensionFieldSetsImpl.h>
+#include <app/clusters/scenes-server/SceneHandlerImpl.h>
 #include <app/clusters/scenes-server/SceneTable.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/DataModelTypes.h>
@@ -39,69 +40,6 @@ static_assert(kMaxScenesPerEndpoint <= CHIP_CONFIG_MAX_SCENES_TABLE_SIZE,
               "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE in CHIPConfig.h if you really need more scenes");
 static_assert(kMaxScenesPerEndpoint >= 16, "Per spec, kMaxScenesPerEndpoint must be at least 16");
 static constexpr uint16_t kMaxScenesPerFabric = (kMaxScenesPerEndpoint - 1) / 2;
-
-using clusterId = chip::ClusterId;
-
-/// @brief Default implementation of handler, handle EFS from add scene and view scene commands for any cluster
-///        The implementation of SerializeSave and ApplyScene were omitted and must be implemented in a way that
-///        is compatible with the SerializeAdd output in order to function with the Default Scene Handler.
-///        It is worth noting that this implementation is very memory consuming. In the current worst case,
-///        (Color control cluster), the Extension Field Set's value pair list TLV occupies 99 bytes of memory
-class DefaultSceneHandlerImpl : public scenes::SceneHandler
-{
-
-    template <typename T>
-    using List = chip::app::DataModel::List<T>;
-
-    template <typename T>
-    using DecodableList = chip::app::DataModel::DecodableList<T>;
-
-    using AttributeValuePairType          = chip::app::Clusters::Scenes::Structs::AttributeValuePair::Type;
-    using AttributeValuePairDecodableType = chip::app::Clusters::Scenes::Structs::AttributeValuePair::DecodableType;
-    using ExtensionFieldSetDecodableType  = chip::app::Clusters::Scenes::Structs::ExtensionFieldSet::DecodableType;
-    using ExtensionFieldSetType           = chip::app::Clusters::Scenes::Structs::ExtensionFieldSet::Type;
-
-public:
-    static constexpr uint8_t kMaxAvPair = CHIP_CONFIG_SCENES_MAX_AV_PAIRS_EFS;
-
-    DefaultSceneHandlerImpl() = default;
-    ~DefaultSceneHandlerImpl() override{};
-
-    /// @brief Encodes an attribute value list into a TLV structure and resizes the buffer to the size of the encoded data
-    /// @param aVlist[in] Attribute value list to encode
-    /// @param serializedBytes[out] Buffer to fill from the Attribute value list in a TLV format
-    /// @return CHIP_ERROR
-    virtual CHIP_ERROR EncodeAttributeValueList(const List<AttributeValuePairType> & aVlist, MutableByteSpan & serializedBytes);
-
-    /// @brief Decodes an attribute value list from a TLV structure and ensure it fits the member pair buffer
-    /// @param serializedBytes [in] Buffer to read from
-    /// @param aVlist [out] Attribute value list to fill from the TLV structure.  Only valid while the buffer backing
-    /// serializedBytes exists and its contents are not modified.
-    /// @return CHIP_ERROR
-    virtual CHIP_ERROR DecodeAttributeValueList(const ByteSpan & serializedBytes,
-                                                DecodableList<AttributeValuePairDecodableType> & aVlist);
-
-    /// @brief From command AddScene, allows handler to filter through clusters in command to serialize only the supported ones.
-    /// @param endpoint[in] Endpoint ID
-    /// @param extensionFieldSet[in] ExtensionFieldSets provided by the AddScene Command, pre initialized
-    /// @param serializedBytes[out] Buffer to fill from the ExtensionFieldSet in command
-    /// @return CHIP_NO_ERROR if successful, CHIP_ERROR_INVALID_ARGUMENT if the cluster is not supported, CHIP_ERROR value
-    /// otherwise
-    virtual CHIP_ERROR SerializeAdd(EndpointId endpoint, const ExtensionFieldSetDecodableType & extensionFieldSet,
-                                    MutableByteSpan & serializedBytes) override;
-
-    /// @brief Simulates taking data from nvm and loading it in a command object if the cluster is supported by the endpoint
-    /// @param endpoint target endpoint
-    /// @param cluster  target cluster
-    /// @param serializedBytes data to deserialize into EFS
-    /// @return CHIP_NO_ERROR if Extension Field Set was successfully populated, CHIP_ERROR_INVALID_ARGUMENT if the cluster is not
-    /// supported, specific CHIP_ERROR otherwise
-    virtual CHIP_ERROR Deserialize(EndpointId endpoint, ClusterId cluster, const ByteSpan & serializedBytes,
-                                   ExtensionFieldSetType & extensionFieldSet) override;
-
-private:
-    AttributeValuePairType mAVPairs[kMaxAvPair];
-};
 
 /**
  * @brief Implementation of a storage in nonvolatile storage of the scene table.

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -95,6 +95,8 @@ source_set("scenes-table-test-srcs") {
     "${chip_root}/src/app/clusters/scenes-server/ExtensionFieldSets.h",
     "${chip_root}/src/app/clusters/scenes-server/ExtensionFieldSetsImpl.cpp",
     "${chip_root}/src/app/clusters/scenes-server/ExtensionFieldSetsImpl.h",
+    "${chip_root}/src/app/clusters/scenes-server/SceneHandlerImpl.cpp",
+    "${chip_root}/src/app/clusters/scenes-server/SceneHandlerImpl.h",
     "${chip_root}/src/app/clusters/scenes-server/SceneTable.h",
     "${chip_root}/src/app/clusters/scenes-server/SceneTableImpl.cpp",
     "${chip_root}/src/app/clusters/scenes-server/SceneTableImpl.h",

--- a/src/app/tests/TestSceneTable.cpp
+++ b/src/app/tests/TestSceneTable.cpp
@@ -683,6 +683,8 @@ void TestHandlerFunctions(nlTestSuite * aSuite, void * aContext)
     memset(buffer, 0, buff_span.size());
 };
 
+void TestHandlerHelpers(nlTestSuite * aSuite, void * aContext) {}
+
 void TestStoreScenes(nlTestSuite * aSuite, void * aContext)
 {
     SceneTable * sceneTable = scenes::GetSceneTableImpl(kTestEndpoint1, defaultTestTableSize);


### PR DESCRIPTION
Added helpers to reduce code copied over when created scene new scene handlers and moved the SceneHandler class to its own file.

Those helper are meant to be used in sceneable clusters where the concept of transition time is not currently available (e.g. ModeSelect).

