### PR TITLE
Have cloudbuild integrations pull in all required python packages

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -12,7 +12,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - source ./scripts/bootstrap.sh
+          - source ./scripts/bootstrap.sh -p all,nrfconnect
       id: Bootstrap
       waitFor:
           - Submodules


### PR DESCRIPTION
Latest [nrf roll](https://github.com/project-chip/connectedhomeip/pull/30118/) does not compile unless you pull in required nrf python packages. This is because latest NRF SDK now generates factory_data.json as were previously it did not.

