### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-24 : [nrfconnect] Update nRF Connect SDK version.
+25 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=5e5f3cfde3fb5070b2e6cfb8ab08bc688b5aa3d4
+ARG ZEPHYR_REVISION=e6a32f41ccec55c2233631406842b71ff270089d
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- samples: net: openthread: Add simple SED example
- boards: soc: riscv: telink_b9x: added flash size check
- soc: riscv: telink_b9x: Print heap info during fail
- west.yml: ld: soc: move BLE data to RAM DLM in deep sleep mode
- scripts: west_commands: runners: Add BDT tool support
- boards: telink: tlsr9528a: doc: Add direct BDT download links
- drivers: gpio: gpio_b9x: Added deep sleep mode gpio recovery
- boards: riscv: telink: Documentation update
- boards: drivers: led_strip: add the telink ws2812 gpio driver

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully