### PR TITLE
TempSensor2 setup reachable

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -900,7 +900,7 @@ void ApplicationInit()
     Light2.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
 
     TempSensor1.SetReachable(true);
-    TempSensor1.SetReachable(true);
+    TempSensor2.SetReachable(true);
 
     TempSensor1.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);
     TempSensor2.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);


### PR DESCRIPTION
The bridge-app example 
TempSensor1.SetReachable(true);
This piece of code has been executed twice. I believe one of them should be
TempSensor2.SetReachable(true);


> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

