### PR TITLE
Fix spelling error in hotfix

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -871,7 +871,7 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                                      attribute_id=GlobalAttributeIds.CLUSTER_REVISION_ID)
                     self.record_error(self.get_test_name(
-                    ), location=location, problem=f'Revision found on cluster ({cluster[GlobalAttirbuteIds.CLUSTER_REVISION_ID]}) does not match revision listed in the spec ({clusters[cluster_id].revision})')
+                    ), location=location, problem=f'Revision found on cluster ({cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]}) does not match revision listed in the spec ({clusters[cluster_id].revision})')
                     success = False
         if not success:
             # TODO: Right now, we have failures in all-cluster, so we can't fail this test and keep it in CI. For now, just log.


### PR DESCRIPTION
A hotfix just went in for a merge conflict, but the hotfix also needs a hotfix. It's turtles all the way down.

see https://github.com/project-chip/connectedhomeip/pull/30286