### PR TITLE
[QPG] Fix build failure due to OpenThread flag

### DIFF
--- a/examples/platform/qpg/project_include/OpenThreadConfig.h
+++ b/examples/platform/qpg/project_include/OpenThreadConfig.h
@@ -76,6 +76,7 @@
 
 #define OPENTHREAD_ENABLE_VENDOR_EXTENSION 0
 #define OPENTHREAD_EXAMPLES_SIMULATION 0
+#define OPENTHREAD_CONFIG_PLATFORM_BOOTLOADER_MODE_ENABLE 0
 
 // Use the Qorvo-supplied default platform configuration for remainder
 // of OpenThread config options.


### PR DESCRIPTION
OPENTHREAD_CONFIG_PLATFORM_BOOTLOADER_MODE_ENABLE was added to openthread. 
No default exists in the OT stack, which caused a build error.

Required to bump openthread by dependabot in #30284 
