### PR TITLE
Match `Keypad Input Cluster` to spec

### DIFF
--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -3420,7 +3420,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -3444,7 +3444,7 @@ server cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;

--- a/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
+++ b/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
@@ -1391,7 +1391,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1415,7 +1415,7 @@ server cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -5866,7 +5866,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -5890,7 +5890,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   /** Upon receipt, this SHALL process a keycode as input to the media device. */
@@ -5988,7 +5988,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -5825,7 +5825,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -5849,7 +5849,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   /** Upon receipt, this SHALL process a keycode as input to the media device. */
@@ -5947,7 +5947,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -61,11 +61,11 @@ void KeypadInputManager::HandleSendKey(CommandResponseHelper<SendKeyResponseType
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kInvalidKeyInCurrentState;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kInvalidKeyInCurrentState;
     }
     else
     {
-        response.status = static_cast<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum>(ret);
+        response.status = static_cast<chip::app::Clusters::KeypadInput::StatusEnum>(ret);
     }
     helper.Success(response);
 }

--- a/examples/tv-app/tv-common/clusters/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/keypad-input/KeypadInputManager.cpp
@@ -31,67 +31,67 @@ void KeypadInputManager::HandleSendKey(CommandResponseHelper<SendKeyResponseType
     switch (keycCode)
     {
     case CecKeyCodeType::kUp:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kDown:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kLeft:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kRight:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kSelect:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kBackward:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kExit:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kRootMenu:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kSetupMenu:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kEnter:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumber0OrNumber10:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers1:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers2:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers3:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers4:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers5:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers6:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers7:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers8:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kNumbers9:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
         break;
     default:
-        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kUnsupportedKey;
+        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kUnsupportedKey;
     }
 
     helper.Success(response);

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2164,7 +2164,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -2188,7 +2188,7 @@ server cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1704,7 +1704,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1728,7 +1728,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   /** Upon receipt, this SHALL process a keycode as input to the media device. */

--- a/src/app/CompatEnumNames.h
+++ b/src/app/CompatEnumNames.h
@@ -58,6 +58,11 @@ namespace ApplicationLauncher {
 using ApplicationLauncherStatusEnum = StatusEnum;
 } // namespace ApplicationLauncher
 
+namespace TargetNavigator {
+// https://github.com/project-chip/connectedhomeip/pull/30316 renamed this
+using KeypadInputStatusEnum = StatusEnum;
+} // namespace TargetNavigator
+
 namespace Channel {
 using ChannelStatusEnum = StatusEnum;
 } // namespace Channel

--- a/src/app/CompatEnumNames.h
+++ b/src/app/CompatEnumNames.h
@@ -58,10 +58,10 @@ namespace ApplicationLauncher {
 using ApplicationLauncherStatusEnum = StatusEnum;
 } // namespace ApplicationLauncher
 
-namespace TargetNavigator {
+namespace KeypadInput {
 // https://github.com/project-chip/connectedhomeip/pull/30316 renamed this
 using KeypadInputStatusEnum = StatusEnum;
-} // namespace TargetNavigator
+} // namespace KeypadInput
 
 namespace Channel {
 using ChannelStatusEnum = StatusEnum;

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -32,12 +32,12 @@ limitations under the License.
 
     <command source="server" code="0x01" name="SendKeyResponse" optional="false">
       <description>This command SHALL be generated in response to a SendKey Request command.</description>
-      <arg name="Status" type="KeypadInputStatusEnum"/>
+      <arg name="Status" type="StatusEnum"/>
     </command>
 
   </cluster>
 
-  <enum name="KeypadInputStatusEnum" type="enum8">
+  <enum name="StatusEnum" type="enum8">
     <cluster code="0x0509"/>
     <item name="Success" value="0x00"/>
     <item name="UnsupportedKey" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -25,6 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
 
     <description>This cluster provides an interface for controlling the Input Selector on a media device such as a TV.</description>
+
     <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST"          type="ARRAY" entryType="InputInfoStruct" length="254"           writable="false" optional="false">InputList</attribute>
     <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="int8u" default="0x00"              min="0x00" max="0xFF"  writable="false" optional="false">CurrentInput</attribute>
 

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -6216,7 +6216,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum KeypadInputStatusEnum : enum8 {
+  enum StatusEnum : enum8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -6240,7 +6240,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    KeypadInputStatusEnum status = 0;
+    StatusEnum status = 0;
   }
 
   /** Upon receipt, this SHALL process a keycode as input to the media device. */

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -34566,7 +34566,7 @@ class KeypadInput(Cluster):
             # enum value. This specific should never be transmitted.
             kUnknownEnumValue = 14,
 
-        class KeypadInputStatusEnum(MatterIntEnum):
+        class StatusEnum(MatterIntEnum):
             kSuccess = 0x00
             kUnsupportedKey = 0x01
             kInvalidKeyInCurrentState = 0x02
@@ -34610,10 +34610,10 @@ class KeypadInput(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields=[
-                        ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=KeypadInput.Enums.KeypadInputStatusEnum),
+                        ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=KeypadInput.Enums.StatusEnum),
                     ])
 
-            status: 'KeypadInput.Enums.KeypadInputStatusEnum' = 0
+            status: 'KeypadInput.Enums.StatusEnum' = 0
 
     class Attributes:
         @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -16504,10 +16504,10 @@ typedef NS_ENUM(uint8_t, MTRKeypadInputCecKeyCode) {
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRKeypadInputStatus) {
-    MTRKeypadInputStatusSuccess MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
-    MTRKeypadInputStatusUnsupportedKey MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
-    MTRKeypadInputStatusInvalidKeyInCurrentState MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
-} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+    MTRKeypadInputStatusSuccess MTR_PROVISIONALLY_AVAILABLE = 0x00,
+    MTRKeypadInputStatusUnsupportedKey MTR_PROVISIONALLY_AVAILABLE = 0x01,
+    MTRKeypadInputStatusInvalidKeyInCurrentState MTR_PROVISIONALLY_AVAILABLE = 0x02,
+} MTR_PROVISIONALLY_AVAILABLE;
 
 typedef NS_OPTIONS(uint32_t, MTRKeypadInputFeature) {
     MTRKeypadInputFeatureNavigationKeyCodes MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,

--- a/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
@@ -408,13 +408,13 @@ def test_tv_ctrl(device, controller):
         err, res = send_zcl_command(devCtrl, "KeypadInput", "SendKey", nodeId, endpoint,
                                     dict(keyCode=keyCode), requestTimeoutMs=1000)
         assert err == 0
-        assert res.status == KeypadInput.Enums.KeypadInputStatusEnum.kSuccess
+        assert res.status == KeypadInput.Enums.StatusEnum.kSuccess
 
     err, res = send_zcl_command(devCtrl, "KeypadInput", "SendKey", nodeId, endpoint,
                                 dict(keyCode=TV_CTRL_TEST_KEY_PAD_UNSUPPORTED_KEY),
                                 requestTimeoutMs=1000)
     assert err == 0
-    assert res.status == KeypadInput.Enums.KeypadInputStatusEnum.kUnsupportedKey
+    assert res.status == KeypadInput.Enums.StatusEnum.kUnsupportedKey
 
     # TargetNavigator
     err, res = read_zcl_attribute(devCtrl, "TargetNavigator", "TargetList", nodeId, endpoint)

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -2799,9 +2799,9 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::CecKeyCode
         return static_cast<EnumType>(14);
     }
 }
-static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::KeypadInputStatusEnum val)
+static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::StatusEnum val)
 {
-    using EnumType = KeypadInput::KeypadInputStatusEnum;
+    using EnumType = KeypadInput::StatusEnum;
     switch (val)
     {
     case EnumType::kSuccess:

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -3970,8 +3970,8 @@ enum class CecKeyCode : uint8_t
     kUnknownEnumValue = 14,
 };
 
-// Enum for KeypadInputStatusEnum
-enum class KeypadInputStatusEnum : uint8_t
+// Enum for StatusEnum
+enum class StatusEnum : uint8_t
 {
     kSuccess                  = 0x00,
     kUnsupportedKey           = 0x01,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -29737,7 +29737,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    KeypadInputStatusEnum status = static_cast<KeypadInputStatusEnum>(0);
+    StatusEnum status = static_cast<StatusEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
 
@@ -29752,7 +29752,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    KeypadInputStatusEnum status = static_cast<KeypadInputStatusEnum>(0);
+    StatusEnum status = static_cast<StatusEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SendKeyResponse


### PR DESCRIPTION
Changes:
  - rename `KeypadInputStatusEnum` to `StatusEnum`


Changes NOT made (will have a spec PR instead):
  - KeyCode is defined as uint8 currently in the spec, however the SDK defines some constants specifically for it. Removing
    existing enums sounds painful compatibility wise, so we will update the specification to contain the codes.


https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/7959 is the spec change