### PR TITLE
Suppress output of `cd` in bootstrap script

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -66,7 +66,7 @@ _bootstrap_or_activate() {
     local _BOOTSTRAP_NAME="${_BOOTSTRAP_PATH##*/}"
     local _BOOTSTRAP_DIR="${_BOOTSTRAP_PATH%/*}"
     # Strip off the 'scripts[/setup]' directory, leaving the root of the repo.
-    _CHIP_ROOT="$(cd "${_BOOTSTRAP_DIR%/setup}/.." && pwd)"
+    _CHIP_ROOT="$(cd "${_BOOTSTRAP_DIR%/setup}/.." > /dev/null && pwd)"
 
     local _CONFIG_FILE="scripts/setup/environment.json"
 


### PR DESCRIPTION
Changes bootstrap.sh to redirect the output of a `cd` command to
/dev/null. Usually `cd` does not produce output, but if a user has
modified CDPATH it may decide to echo the path that was navigated to.
This behavior was breaking bootstrap in very difficult to debug ways.
