### PR TITLE
[Kotlin] Fix timeout error im interaction tests

### DIFF
--- a/src/controller/java/src/matter/controller/MatterControllerImpl.kt
+++ b/src/controller/java/src/matter/controller/MatterControllerImpl.kt
@@ -604,7 +604,7 @@ class MatterControllerImpl(params: ControllerParams) : MatterController {
 
     // im interaction time out value, it would override the default value in c++ im
     // layer if this value is non-zero.
-    private const val CHIP_IM_TIMEOUT_MS = 0
+    private const val CHIP_IM_TIMEOUT_MS = 3000
 
     // CHIP error values, lift from ChipError.h in the Matter SDK.
     private const val CHIP_ERROR_UNEXPECTED_EVENT: UInt = 0xc0u


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/actions/runs/6792149565/job/18464946480?pr=30293

```
[2023-11-08 01:01:38.518519][JAVA ][STDOUT][18420:18441] CHIP:EM: Retransmitting MessageCounter:1377510 on exchange 2113i Send Cnt 1
[2023-11-08 01:01:38.862107][JAVA ][STDOUT][18420:18441] CHIP:EM: Retransmitting MessageCounter:1377510 on exchange 2113i Send Cnt 2
[2023-11-08 01:01:39.492974][JAVA ][STDOUT][18420:18441] CHIP:EM: Retransmitting MessageCounter:1377510 on exchange 2113i Send Cnt 3
[2023-11-08 01:01:40.398111][JAVA ][STDOUT][18420:18441] CHIP:EM: Retransmitting MessageCounter:1377510 on exchange 2113i Send Cnt 4
[2023-11-08 01:01:41.178398][JAVA ][STDOUT]Run command failed with exception: Timeout!
[2023-11-08 01:01:41.194851][JAVA ][STDERR]Nov 08, 2023 1:01:41 AM matter.controller.MatterControllerImpl close
[2023-11-08 01:01:41.194883][JAVA ][STDERR]INFO: MatterController is closed
```

Currently, the default timeout for IM operations in C++ is set to 2 seconds. However, this duration appears to be insufficient for Kotlin tests, likely due to additional delays introduced by the JVM. To address this, we should extend the timeout to 3 seconds to determine if this resolves the issue.

If the same problem is observed in Java IM tests, a similar adjustment to the timeout value may be necessary to ensure consistent test performance.