### PR TITLE
Disable -Wdocumentation for libwebsocket.

### DIFF
--- a/examples/common/websocket-server/BUILD.gn
+++ b/examples/common/websocket-server/BUILD.gn
@@ -16,8 +16,12 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 config("websocket_server_config_disable_warnings") {
-  # Unfortunately, some of the libwebsockets headers include -Wshadow failures.
-  cflags = [ "-Wno-shadow" ]
+  # Unfortunately, some of the libwebsockets headers include -Wshadow failures,
+  # and have tons of -Wdocumentation issues.
+  cflags = [
+    "-Wno-shadow",
+    "-Wno-documentation",
+  ]
 }
 
 static_library("websocket-server") {

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -1901,6 +1901,13 @@
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
 				USER_HEADER_SEARCH_PATHS = "";
+				WARNING_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+					"-Wconversion",
+					"-Wno-documentation",
+				);
 			};
 			name = Debug;
 		};
@@ -1970,6 +1977,13 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = "";
+				WARNING_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+					"-Wconversion",
+					"-Wno-documentation",
+				);
 			};
 			name = Release;
 		};


### PR DESCRIPTION
It triggers tens of thousands of those warnings.

For the Xcode build of darwin-framework-tool, this just disables -Wdocumentation across the board, since I don't see a way to do it for particular files.
