### PR TITLE
Make sure timezone store sizes are correct when getting the timezone span

### DIFF
--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -775,7 +775,7 @@ Span<TimeSyncDataProvider::TimeZoneStore> & TimeSynchronizationServer::GetTimeZo
     // Make sure the sizes of the entries is correct
     for (auto & tzStore : mTimeZoneObj.timeZoneList)
     {
-        tzStore.timeZone.name = MakeOptional(CharSpan(tzStore.name, strlen(tzStore.name)));
+        tzStore.timeZone.name = MakeOptional(CharSpan(tzStore.name, strnlen(tzStore.name, sizeof(tzStore.name))));
     }
 
     return mTimeZoneObj.timeZoneList;

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -771,6 +771,13 @@ CHIP_ERROR TimeSynchronizationServer::GetDefaultNtp(MutableCharSpan & dntp)
 Span<TimeSyncDataProvider::TimeZoneStore> & TimeSynchronizationServer::GetTimeZone()
 {
     mTimeZoneObj.timeZoneList = mTimeZoneObj.timeZoneList.SubSpan(0, mTimeZoneObj.validSize);
+
+    // Make sure the sizes of the entries is correct
+    for (auto & tzStore : mTimeZoneObj.timeZoneList)
+    {
+        tzStore.timeZone.name = MakeOptional(CharSpan(tzStore.name, strlen(tzStore.name)));
+    }
+
     return mTimeZoneObj.timeZoneList;
 }
 


### PR DESCRIPTION
Without it, we would always encode 64-byte worth of 0-s inside a UTF8 string (which is actually forbidden by the spec). See #30342 .

The 1300+ line of code in timesync server is somewhat hard to follow, I did not try to audit the whole code just made sure the string lengths are adjusted when reporting timezones (in particular this is done before reading the attribute).