### PR TITLE
DNS this is a test to confirm something in CI, and will be closed after CI is run. No need to review

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+# no-op change
 _install_additional_pip_requirements() {
     _SETUP_PLATFORM=$1
     shift


### PR DESCRIPTION
For some reason I hitting [this failure](https://github.com/project-chip/connectedhomeip/actions/runs/6804637319/job/18502599734?pr=30288) for another PR.

I was able to reproduce this locally with the openiot image, which was great. But I slowly backed out all my changes and was on 50d07fd774925e6af9df7ad2e392c668107ee342. After cleaning everything up I still was able to reproduce the issue. Yet for some crazy reason this is not failing for any other CI jobs running on ToT.

Really this is just a sanity check that a no-op change is able to pass in CI
