### PR TITLE
Fix -Wundef error in SystemLayerImplSelect.h

### DIFF
--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "system/SystemConfig.h"
+
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_SOCKETS
 #include <sys/select.h>
 #endif


### PR DESCRIPTION
src/system/SystemLayerImplSelect.h:29:5: error: 'CHIP_SYSTEM_CONFIG_USE_POSIX_SOCKETS' is not defined, evaluates to 0 [-Werror,-Wundef]

Include the header that defines this macro.