### PR TITLE
[Chef] Fix AirQualitySensor Conformance Test error

### DIFF
--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
@@ -1785,7 +1785,7 @@ endpoint 0 {
     callback attribute regulatoryConfig default = 0;
     callback attribute locationCapability default = 0;
     callback attribute supportsConcurrentConnection default = 1;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.zap
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.zap
@@ -1208,7 +1208,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
Test  `examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.*` conformance failed due to having invalid value 6 in `FeatureMap` attribute in  `GeneralCommissioning` Cluster

```
$ python ./src/python_testing/TC_DeviceBasicComposition.py  --storage-path admin_storage.json --manual-code 10054912339 --bool-arg ignore_in_progress:True allow_provisional:True --PICS src/app/tests/suites/certification/ci-pics-values

[MatterTest] 11-10 19:32:50.020 INFO ***** Test Step 11 : Validate that standard cluster FeatureMap attributes contains only known feature flags
[MatterTest] 11-10 19:32:50.020 ERROR Exception occurred in test_IDM_10_1.
Traceback (most recent call last):
  File "/home/erwinpan/matter/erwinpan1/master_1110_airquality_sensor/py/lib/python3.11/site-packages/mobly/base_test.py", line 783, in exec_one_test
    test_method()
  File "/home/erwinpan/matter/erwinpan1/master_1110_airquality_sensor/./src/python_testing/TC_DeviceBasicComposition.py", line 467, in test_IDM_10_1
    self.fail_current_test(
  File "/home/erwinpan/matter/erwinpan1/master_1110_airquality_sensor/src/python_testing/basic_composition_support.py", line 163, in fail_current_test
    asserts.fail(msg)
  File "/home/erwinpan/matter/erwinpan1/master_1110_airquality_sensor/py/lib/python3.11/site-packages/mobly/asserts.py", line 475, in fail
    raise signals.TestFailure(msg, extras)
mobly.signals.TestFailure: Details=At least one cluster has failed the range and support checks for its listed attributes, commands or features, Extras=None
[MatterTest] 11-10 19:32:50.022 INFO [Test] test_IDM_10_1 FAIL
...
Problem: ProblemSeverity.ERROR
    test_name: test_IDM_10_1
    location: 
       Endpoint: 0,
       Cluster:  48 (0x30) GeneralCommissioning
    problem: Standard cluster 48 with unkonwn feature 06
    spec_location: 
...
```