### PR TITLE
Ensure is active exists in chipdevicectrl.py

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -376,16 +376,18 @@ class ChipDeviceControllerBase():
         ''' Shuts down this controller and reclaims any used resources, including the bound
             C++ constructor instance in the SDK.
         '''
-        if self._isActive:
-            if self.devCtrl is not None:
-                self._ChipStack.Call(
-                    lambda: self._dmLib.pychip_DeviceController_DeleteDeviceController(
-                        self.devCtrl)
-                ).raise_on_error()
-                self.devCtrl = None
+        if not self._isActive:
+            return
 
-            ChipDeviceController.activeList.remove(self)
-            self._isActive = False
+        if self.devCtrl is not None:
+            self._ChipStack.Call(
+                lambda: self._dmLib.pychip_DeviceController_DeleteDeviceController(
+                    self.devCtrl)
+            ).raise_on_error()
+            self.devCtrl = None
+
+        ChipDeviceController.activeList.remove(self)
+        self._isActive = False
 
     def ShutdownAll():
         ''' Shut down all active controllers and reclaim any used resources.

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -251,6 +251,7 @@ class ChipDeviceControllerBase():
         self.devCtrl = devCtrl
         self.name = name
         self.fabricCheckNodeId = -1
+        self._isActive = False
 
         self._Cluster = ChipClusters(builtins.chipStack)
         self._Cluster.InitLib(self._dmLib)
@@ -375,7 +376,7 @@ class ChipDeviceControllerBase():
         ''' Shuts down this controller and reclaims any used resources, including the bound
             C++ constructor instance in the SDK.
         '''
-        if (self._isActive):
+        if self._isActive:
             if self.devCtrl is not None:
                 self._ChipStack.Call(
                     lambda: self._dmLib.pychip_DeviceController_DeleteDeviceController(


### PR DESCRIPTION
The propertly of isActive was never set in the constructor, so if code fails early given that shutdown is called on finalize, I got odd errors like:

```
...
[1699641297.730103][956550:956550] CHIP:DL: BLE shutdown
[1699641297.730115][956550:956550] CHIP:DL: System Layer shutdown
ERROR:root:Final result: FAIL !
Exception ignored in: <function ChipDeviceControllerBase.__del__ at 0x7f278d98ee80>
Traceback (most recent call last):
  File "/usr/local/google/home/andreilitvin/devel/connectedhomeip/out/venv/lib/python3.11/site-packages/chip/ChipDeviceCtrl.py", line 414, in __del__
    self.Shutdown()
  File "/usr/local/google/home/andreilitvin/devel/connectedhomeip/out/venv/lib/python3.11/site-packages/chip/ChipDeviceCtrl.py", line 378, in Shutdown
    if (self._isActive):
        ^^^^^^^^^^^^^^
AttributeError: 'ChipDeviceController' object has no attribute '_isActive'
```

Set isactive in the constructor and a minor cleanup while I am at it.