### PR TITLE
Followup on post-merge comments on #30393

### DIFF
--- a/examples/placeholder/linux/static-supported-temperature-levels.cpp
+++ b/examples/placeholder/linux/static-supported-temperature-levels.cpp
@@ -27,9 +27,7 @@ using namespace chip::app::Clusters::TemperatureControl;
 using chip::Protocols::InteractionModel::Status;
 
 // TODO: Configure your options for each endpoint
-CharSpan AppSupportedTemperatureLevelsDelegate::temperatureLevelOptions[] = { CharSpan::fromCharString("Hot"),
-                                                                              CharSpan::fromCharString("Warm"),
-                                                                              CharSpan::fromCharString("Cold") };
+CharSpan AppSupportedTemperatureLevelsDelegate::temperatureLevelOptions[] = { "Hot"_span, "Warm"_span, "Cold"_span };
 
 const AppSupportedTemperatureLevelsDelegate::EndpointPair AppSupportedTemperatureLevelsDelegate::supportedOptionsByEndpoints
     [EMBER_AF_TEMPERATURE_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT] = {

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -209,7 +209,6 @@ struct SceneTableData : public SceneTableEntry, PersistentData<kPersistentSceneB
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
-        // TODO: if we have mNameLength, should this bin ByteSpan instead?
         CharSpan nameSpan(mStorageData.mName, mStorageData.mNameLength);
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -551,7 +551,7 @@ void TimeSynchronizationServer::InitTimeZone()
     for (auto & tzStore : mTimeZoneObj.timeZoneList)
     {
         memset(tzStore.name, 0, sizeof(tzStore.name));
-        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = MakeOptional(CharSpan(tzStore.name, 0)) };
+        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = NullOptional()) };
     }
 }
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -551,7 +551,7 @@ void TimeSynchronizationServer::InitTimeZone()
     for (auto & tzStore : mTimeZoneObj.timeZoneList)
     {
         memset(tzStore.name, 0, sizeof(tzStore.name));
-        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = NullOptional()) };
+        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = NullOptional() };
     }
 }
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -551,7 +551,7 @@ void TimeSynchronizationServer::InitTimeZone()
     for (auto & tzStore : mTimeZoneObj.timeZoneList)
     {
         memset(tzStore.name, 0, sizeof(tzStore.name));
-        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = NullOptional() };
+        tzStore.timeZone = { .offset = 0, .validAt = 0, .name = chip::NullOptional };
     }
 }
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -588,7 +588,7 @@ using CHIP_ERROR = ::chip::ChipError;
  *    Invalid UTF8 string (contains some characters that are invalid)
  *
  */
-#define CHIP_ERROR_INVALID_UTF8                       CHIP_CORE_ERROR(0x12)
+#define CHIP_ERROR_INVALID_UTF8                                CHIP_CORE_ERROR(0x12)
 
 /**
  *  @def CHIP_ERROR_INTEGRITY_CHECK_FAILED


### PR DESCRIPTION
Changes:
  - some alignment
  - use `_span` instead of `CharSpan::fromCharString`
  - removed a comment that made little sense (it was for when I thought embedded 0s in a string are bad ... I still think they are, however spec says they are valid)
  - set an uninitialized timezone string to nulloptional instead of empty string.