### PR TITLE
Typo in documentation, also change example EP

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1198,10 +1198,10 @@ class ChipDeviceControllerBase():
             - read request: AsyncReadTransation.ReadResponse.attributes.
                             This is of type AttributeCache.attributeCache (Attribute.py),
                             which is a dict mapping endpoints to a list of Cluster (ClusterObjects.py) classes
-                            (dict[int], List[Cluster])
+                            (dict[int, List[Cluster]])
                             Access as ret[endpoint_id][<Cluster class>][<Attribute class>]
-                            Ex. To access the OnTime attribute from the OnOff cluster on EP 0
-                            ret[0][Clusters.OnOff][Clusters.OnOff.Attributes.OnTime]
+                            Ex. To access the OnTime attribute from the OnOff cluster on EP 1
+                            ret[1][Clusters.OnOff][Clusters.OnOff.Attributes.OnTime]
 
         Raises:
             - InteractionModelError (chip.interaction_model) on error

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -894,7 +894,7 @@ class ChipDeviceControllerBase():
             to the XYZ attribute on the test cluster to endpoint 1
 
         Returns:
-            - PyChipError
+            - [PyChipError] (list - one for each pth)
         '''
         self.CheckIsActive()
 


### PR DESCRIPTION
Typo on return type. Why I didn't just copy/paste this directly in the first place...that is a good quesiton.