### PR TITLE
[Silabs] Add .rps support in the build step and flasher script

### DIFF
--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -147,6 +147,12 @@ template("flashable_executable") {
       } else {
         flashing_options = []
       }
+
+      # Allows to set a different image name in flasher script
+      if (defined(invoker.flashing_image_name)) {
+        image_name = invoker.flashing_image_name
+      }
+
       flashing_options += [
         "--application",
         rebase_path(image_name, root_out_dir, root_out_dir),

--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -148,7 +148,7 @@ template("flashable_executable") {
         flashing_options = []
       }
 
-      # Allows to set a different image name in flasher script
+      # Allows to set a different image name in the flasher script
       if (defined(invoker.flashing_image_name)) {
         image_name = invoker.flashing_image_name
       }

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -338,27 +338,33 @@ else
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
-    # Generate RPS file from .s37 for 917 SoC builds
-    # if ["USE_RPS_EXTENSION" == true]; then
-    # fi
+    # Get .s37 path and name
+    binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
+
+    # set commander path
+    if [ -z "$COMMANDER_PATH" ]; then
+        commanderPath="commander"
+    else
+        commanderPath="$COMMANDER_PATH"
+    fi
+
+    # # Generate RPS file from .s37 for 917 SoC builds
+    if [ "$USE_RPS_EXTENSION" == true ]; then
+
+        # Create .rps
+        rpsName=$(sed 's/[^\.]*$/rps/' <<< "$binName")
+        "$commanderPath" rps create "$rpsName" --app "$binName"
+    fi
 
     # add bootloader to generated image
     if [ "$USE_BOOTLOADER" == true ]; then
 
-        binName=""
         InternalBootloaderBoards=("BRD4337A" "BRD2704A" "BRD2703A" "BRD4319A")
         bootloaderPath=""
-        commanderPath=""
+
         # find the matter root folder
         if [ -z "$MATTER_ROOT" ]; then
             MATTER_ROOT="$CHIP_ROOT"
-        fi
-
-        # set commander path
-        if [ -z "$COMMANDER_PATH" ]; then
-            commanderPath="commander"
-        else
-            commanderPath="$COMMANDER_PATH"
         fi
 
         # search bootloader directory for the respective bootloaders for the input board
@@ -378,7 +384,6 @@ else
             bootloaderPath="${bootloaderFiles[0]}"
         fi
         echo "$bootloaderPath"
-        binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
         echo "$binName"
         "$commanderPath" convert "$binName" "$bootloaderPath" -o "$binName"
     fi

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -352,7 +352,7 @@ else
     if [ "$USE_RPS_EXTENSION" == true ]; then
 
         # Create .rps
-        rpsName=$(sed 's/[^\.]*$/rps/' <<< "$binName")
+        rpsName=$(sed 's/[^\.]*$/rps/' <<<"$binName")
         "$commanderPath" rps create "$rpsName" --app "$binName"
     fi
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -338,27 +338,17 @@ else
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
-    # Get .s37 path and name
-    binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
-
-    # set commander path
-    if [ -z "$COMMANDER_PATH" ]; then
-        commanderPath="commander"
-    else
-        commanderPath="$COMMANDER_PATH"
-    fi
-
-    # # Generate RPS file from .s37 for 917 SoC builds
-    if [ "$USE_RPS_EXTENSION" == true ]; then
-
-        # Create .rps
-        rpsName=$(sed 's/[^\.]*$/rps/' <<<"$binName")
-        "$commanderPath" rps create "$rpsName" --app "$binName"
-    fi
-
     # add bootloader to generated image
     if [ "$USE_BOOTLOADER" == true ]; then
+        # Get .s37 path and name
+        binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
 
+        # set commander path
+        if [ -z "$COMMANDER_PATH" ]; then
+            commanderPath="commander"
+        else
+            commanderPath="$COMMANDER_PATH"
+        fi
         InternalBootloaderBoards=("BRD4337A" "BRD2704A" "BRD2703A" "BRD4319A")
         bootloaderPath=""
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -31,7 +31,6 @@ fi
 set -x
 env
 USE_WIFI=false
-USE_RPS_EXTENSION=false
 USE_DOCKER=false
 USE_GIT_SHA_FOR_VERSION=true
 USE_SLC=false
@@ -285,7 +284,6 @@ else
     if [ "$SILABS_BOARD" == "BRD4325B" ] || [ "$SILABS_BOARD" == "BRD4325C" ] || [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD4325G" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
-        USE_RPS_EXTENSION=true
         optArgs+="chip_device_platform =\"SiWx917\" "
     fi
 
@@ -340,21 +338,21 @@ else
 
     # add bootloader to generated image
     if [ "$USE_BOOTLOADER" == true ]; then
-        # Get .s37 path and name
-        binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
+
+        binName=""
+        InternalBootloaderBoards=("BRD4337A" "BRD2704A" "BRD2703A" "BRD4319A")
+        bootloaderPath=""
+        commanderPath=""
+        # find the matter root folder
+        if [ -z "$MATTER_ROOT" ]; then
+            MATTER_ROOT="$CHIP_ROOT"
+        fi
 
         # set commander path
         if [ -z "$COMMANDER_PATH" ]; then
             commanderPath="commander"
         else
             commanderPath="$COMMANDER_PATH"
-        fi
-        InternalBootloaderBoards=("BRD4337A" "BRD2704A" "BRD2703A" "BRD4319A")
-        bootloaderPath=""
-
-        # find the matter root folder
-        if [ -z "$MATTER_ROOT" ]; then
-            MATTER_ROOT="$CHIP_ROOT"
         fi
 
         # search bootloader directory for the respective bootloaders for the input board
@@ -374,6 +372,7 @@ else
             bootloaderPath="${bootloaderFiles[0]}"
         fi
         echo "$bootloaderPath"
+        binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
         echo "$binName"
         "$commanderPath" convert "$binName" "$bootloaderPath" -o "$binName"
     fi

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -31,6 +31,7 @@ fi
 set -x
 env
 USE_WIFI=false
+USE_RPS_EXTENSION=false
 USE_DOCKER=false
 USE_GIT_SHA_FOR_VERSION=true
 USE_SLC=false
@@ -281,9 +282,10 @@ else
     fi
 
     # 917 exception. TODO find a more generic way
-    if [ "$SILABS_BOARD" == "BRD4325B" ] || [ "$SILABS_BOARD" == "BRD4325C" ] || [ "$SILABS_BOARD" == "BRD4338A" ]; then
+    if [ "$SILABS_BOARD" == "BRD4325B" ] || [ "$SILABS_BOARD" == "BRD4325C" ] || [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD4325G" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
+        USE_RPS_EXTENSION=true
         optArgs+="chip_device_platform =\"SiWx917\" "
     fi
 
@@ -335,6 +337,10 @@ else
     ninja -C "$BUILD_DIR"/
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
+
+    # Generate RPS file from .s37 for 917 SoC builds
+    # if ["USE_RPS_EXTENSION" == true]; then
+    # fi
 
     # add bootloader to generated image
     if [ "$USE_BOOTLOADER" == true ]; then

--- a/scripts/flashing/silabs_firmware_utils.py
+++ b/scripts/flashing/silabs_firmware_utils.py
@@ -49,7 +49,6 @@ operations:
                         Do not reset device after flashing
 """
 
-import os
 import sys
 
 import firmware_utils
@@ -134,18 +133,9 @@ class Flasher(firmware_utils.Flasher):
 
     def flash(self, image):
         """Flash image."""
-        ext = os.path.splitext(image)[-1].lower()
-
-        if ext == ".rps":
-            # rps load command for .rps files
-            arguments = ['rps', 'load']
-        else:
-            # flash command for .s37 files
-            arguments = ['flash']
-
         return self.run_tool(
             'commander',
-            [arguments, self.DEVICE_ARGUMENTS, image],
+            ['flash', self.DEVICE_ARGUMENTS, image],
             name='Flash')
 
     def reset(self):

--- a/scripts/flashing/silabs_firmware_utils.py
+++ b/scripts/flashing/silabs_firmware_utils.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Flash an EFR32 device.
+"""Flash an SILABS device.
 
 This is layered so that a caller can perform individual operations
 through an `Flasher` instance, or operations according to a command line.
@@ -24,7 +24,7 @@ usage: silabs_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
                                [--commander FILE] [--device DEVICE]
                                [--serialno SERIAL] [--ip ADDRESS]
 
-Flash EFR32 device
+Flash SILABS device
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -56,7 +56,7 @@ import firmware_utils
 
 # Additional options that can be use to configure an `Flasher`
 # object (as dictionary keys) and/or passed as command line options.
-EFR32_OPTIONS = {
+SILABS_OPTIONS = {
     # Configuration options define properties used in flashing operations.
     'configuration': {
         # Tool configuration options.
@@ -72,7 +72,7 @@ EFR32_OPTIONS = {
                 Unable to execute {commander}.
 
                 Please ensure that this tool is installed and
-                available. See the EFR32 example README for
+                available. See the SILABS example README for
                 installation instructions.
 
                 """,
@@ -106,11 +106,11 @@ EFR32_OPTIONS = {
 
 
 class Flasher(firmware_utils.Flasher):
-    """Manage efr32 flashing."""
+    """Manage silabs flashing."""
 
     def __init__(self, **options):
-        super().__init__(platform='EFR32', module=__name__, **options)
-        self.define_options(EFR32_OPTIONS)
+        super().__init__(platform='SILABS', module=__name__, **options)
+        self.define_options(SILABS_OPTIONS)
 
     # Common command line arguments for commander device subcommands.
     DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {

--- a/scripts/flashing/silabs_firmware_utils.py
+++ b/scripts/flashing/silabs_firmware_utils.py
@@ -19,7 +19,7 @@ through an `Flasher` instance, or operations according to a command line.
 For `Flasher`, see the class documentation. For the parse_command()
 interface or standalone execution:
 
-usage: efr32_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
+usage: silabs_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
                                [--verify_application] [--reset] [--skip_reset]
                                [--commander FILE] [--device DEVICE]
                                [--serialno SERIAL] [--ip ADDRESS]
@@ -49,6 +49,7 @@ operations:
                         Do not reset device after flashing
 """
 
+import os
 import sys
 
 import firmware_utils
@@ -133,9 +134,18 @@ class Flasher(firmware_utils.Flasher):
 
     def flash(self, image):
         """Flash image."""
+        ext = os.path.splitext(image)[-1].lower()
+
+        if ext == ".rps":
+            # rps load command for .rps files
+            arguments = ['rps', 'load']
+        else:
+            # flash command for .s37 files
+            arguments = ['flash']
+
         return self.run_tool(
             'commander',
-            ['flash', self.DEVICE_ARGUMENTS, image],
+            [arguments, self.DEVICE_ARGUMENTS, image],
             name='Flash')
 
     def reset(self):

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -51,6 +51,9 @@ declare_args() {
 
   # Self-provision enabled
   use_provision_channel = false
+
+  # Board required .rps file to flash instead of .s37
+  use_rps_extension = false
 }
 
 declare_args() {
@@ -111,6 +114,7 @@ if (silabs_board == "BRD4304A") {
   show_qr_code = false
   wifi_soc = true
   silabs_board_lower = "brd4325b"
+  use_rps_extension = true
 } else if (silabs_board == "BRD4325C") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -119,6 +123,7 @@ if (silabs_board == "BRD4304A") {
   wifi_soc = true
   wifi_soc_common_flash = true
   silabs_board_lower = "brd4325c"
+  use_rps_extension = true
 } else if (silabs_board == "BRD4325G") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -127,6 +132,7 @@ if (silabs_board == "BRD4304A") {
   wifi_soc = true
   wifi_soc_common_flash = true
   silabs_board_lower = "brd4325g"
+  use_rps_extension = true
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
@@ -135,6 +141,7 @@ if (silabs_board == "BRD4304A") {
   wifi_soc = true
   wifi_soc_common_flash = true
   silabs_board_lower = "brd4338a"
+  use_rps_extension = true
 } else if (silabs_board == "BRD4180A") {
   assert(
       false,

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -17,6 +17,35 @@ import("//build_overrides/chip.gni")
 import("${build_root}/toolchain/flashable_executable.gni")
 import("silabs_board.gni")
 
+template("generate_rps_file") {
+  forward_variables_from(invoker,
+                         [
+                           "conversion_input",
+                           "conversion_output",
+                           "deps",
+                         ])
+  action(target_name) {
+    # Check if variables exist
+    commander_path = getenv("COMMANDER_PATH")
+    if (commander_path == "") {
+      commander_path = "commander"
+    }
+
+    inputs = [ conversion_input ]
+    outputs = [ conversion_output ]
+
+    args = [
+      commander_path,
+      "rps",
+      "create",
+      rebase_path(conversion_output, root_build_dir),
+      "--app",
+      rebase_path(conversion_input, root_build_dir),
+    ]
+    script = "${build_root}/gn_run_binary.py"
+  }
+}
+
 template("silabs_executable") {
   output_base_name = get_path_info(invoker.output_name, "name")
   objcopy_image_name = output_base_name + ".s37"
@@ -65,10 +94,25 @@ template("silabs_executable") {
     deps = [ ":$executable_target" ]
   }
 
+  if (use_rps_extension) {
+    rps_target_name = target_name + ".rps"
+    generate_rps_file(rps_target_name) {
+      conversion_input = "${root_out_dir}/${objcopy_image_name}"
+      conversion_output = "${root_out_dir}/${flashing_image_name}"
+      deps = [
+        ":$executable_target",
+        ":$flash_target_name.image",
+      ]
+    }
+  }
   group(target_name) {
     deps = [
       ":$flash_target_name",
       ":$hex_target_name",
     ]
+
+    if (use_rps_extension) {
+      deps += [ ":$rps_target_name" ]
+    }
   }
 }

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -19,8 +19,7 @@ import("silabs_board.gni")
 
 template("silabs_executable") {
   output_base_name = get_path_info(invoker.output_name, "name")
-  extension = ".s37"
-  objcopy_image_name = output_base_name + extension
+  objcopy_image_name = output_base_name + ".s37"
   objcopy_image_format = "srec"
   objcopy = "arm-none-eabi-objcopy"
 

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -14,13 +14,19 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-
 import("${build_root}/toolchain/flashable_executable.gni")
+import("silabs_board.gni")
 
 template("silabs_executable") {
   output_base_name = get_path_info(invoker.output_name, "name")
 
-  objcopy_image_name = output_base_name + ".s37"
+  if (use_rps_extension) {
+    extension = ".rps"
+  } else {
+    extension = ".s37"
+  }
+
+  objcopy_image_name = output_base_name + extension
   objcopy_image_format = "srec"
   objcopy = "arm-none-eabi-objcopy"
 
@@ -31,7 +37,7 @@ template("silabs_executable") {
 
   flashing_runtime_target = target_name + ".flashing_runtime"
   flashing_script_inputs = [
-    "${chip_root}/scripts/flashing/efr32_firmware_utils.py",
+    "${chip_root}/scripts/flashing/silabs_firmware_utils.py",
     "${chip_root}/scripts/flashing/firmware_utils.py",
   ]
   copy(flashing_runtime_target) {

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -19,13 +19,7 @@ import("silabs_board.gni")
 
 template("silabs_executable") {
   output_base_name = get_path_info(invoker.output_name, "name")
-
-  if (use_rps_extension) {
-    extension = ".rps"
-  } else {
-    extension = ".s37"
-  }
-
+  extension = ".s37"
   objcopy_image_name = output_base_name + extension
   objcopy_image_format = "srec"
   objcopy = "arm-none-eabi-objcopy"
@@ -34,6 +28,10 @@ template("silabs_executable") {
   # is collectively self-contained; this allows flashing to work reliably
   # even if the build and flashing steps take place on different machines
   # or in different containers.
+
+  if (use_rps_extension) {
+    flashing_image_name = output_base_name + ".rps"
+  }
 
   flashing_runtime_target = target_name + ".flashing_runtime"
   flashing_script_inputs = [
@@ -48,7 +46,7 @@ template("silabs_executable") {
   flashing_script_generator =
       "${chip_root}/scripts/flashing/gen_flashing_script.py"
   flashing_script_name = output_base_name + ".flash.py"
-  flashing_options = [ "efr32" ]
+  flashing_options = [ "silabs" ]
 
   flash_target_name = target_name + ".flash_executable"
   flashbundle_name = "${target_name}.flashbundle.txt"


### PR DESCRIPTION
#### Description
Silabs uses two different extensions for binaries. 
Add support for the `.rps` in the build script to generate the file and in the flasher to flash the .rps file.

#### Tests
Manual tests to validate that the correct extension is used based on the board being built

