### PR TITLE
[Silabs]Bump our default sw version string

### DIFF
--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -223,7 +223,7 @@ class Efr32Builder(GnBuilder):
                 ['git', 'describe', '--always', '--dirty', '--exclude', '*']).decode('ascii').strip()
             branchName = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('ascii').strip()
             self.extra_gn_options.append(
-                'sl_matter_version_str="v1.1-%s-%s"' % (branchName, shortCommitSha))
+                'sl_matter_version_str="v1.2-%s-%s"' % (branchName, shortCommitSha))
 
         if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -291,7 +291,7 @@ else
         {
             ShortCommitSha=$(git describe --always --dirty --exclude '*')
             branchName=$(git rev-parse --abbrev-ref HEAD)
-            optArgs+="sl_matter_version_str=\"v1.1-$branchName-$ShortCommitSha\" "
+            optArgs+="sl_matter_version_str=\"v1.2-$branchName-$ShortCommitSha\" "
         } &>/dev/null
     fi
 


### PR DESCRIPTION
A default software version str is created with the build scripts in the following format v<MatterVersion>-<Branch>-<SHA>. Bump the matter version from 1.1 to 1.2