### PR TITLE
Minor fix and increase heap for EFR test runner

### DIFF
--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -312,10 +312,8 @@ void PtrSrvTxtMultipleRespondersToInstance(nlTestSuite * inSuite, void * inConte
 
 void PtrSrvTxtMultipleRespondersToServiceListing(nlTestSuite * inSuite, void * inContext)
 {
-    // CommonTestElements common1(inSuite, "test1");
-    // CommonTestElements common2(inSuite, "test2");
-    auto common1 = new CommonTestElements(inSuite, "test1");
-    auto common2 = new CommonTestElements(inSuite, "test2");
+    auto common1 = std::make_unique<CommonTestElements>(inSuite, "test1");
+    auto common2 = std::make_unique<CommonTestElements>(inSuite, "test2");
     // Just use the server from common1.
     ResponseSender responseSender(&common1->server);
 
@@ -342,10 +340,8 @@ void PtrSrvTxtMultipleRespondersToServiceListing(nlTestSuite * inSuite, void * i
     responseSender.Respond(1, queryData, &common1->packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common1->server.GetSendCalled());
-    NL_TEST_ASSERT(inSuite, common1->server.GetHeaderFound());
 
-    delete common1;
-    delete common2;
+    NL_TEST_ASSERT(inSuite, common1->server.GetHeaderFound());
 }
 
 const nlTest sTests[] = {

--- a/src/test_driver/efr32/include/FreeRTOSConfig.h
+++ b/src/test_driver/efr32/include/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)
-#define configTOTAL_HEAP_SIZE ((size_t) (20 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t) (32 * 1024))
 
 /* Optional functions - most linkers will remove unused functions anyway. */
 #define INCLUDE_vTaskPrioritySet (1)


### PR DESCRIPTION
EFR32 tests were hanging, it seems due to insufficient HEAP.

## Changes:
  - Bump up HEAP available for EFR test runner
  - switch heap usage to unique_ptr to use RAII instead of new/delete