### PR TITLE
Fix operational advertising in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -460,6 +460,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(CommissionerIdentity & identity, 
         commissionerParams.controllerICAC               = icacSpan;
         commissionerParams.controllerNOC                = nocSpan;
         commissionerParams.permitMultiControllerFabrics = true;
+        commissionerParams.enableServerInteractions     = NeedsOperationalAdvertising();
     }
 
     // TODO: Initialize IPK epoch key in ExampleOperationalCredentials issuer rather than relying on DefaultIpkValue

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -142,7 +142,7 @@ protected:
     // If true, the controller will be created with server capabilities enabled,
     // such as advertising operational nodes over DNS-SD and accepting incoming
     // CASE sessions.
-    virtual bool NeedsOperationalAdvertising() { return false; }
+    virtual bool NeedsOperationalAdvertising() { return mAdvertiseOperational; }
 
     // Execute any deferred cleanups.  Used when exiting interactive mode.
     static void ExecuteDeferredCleanups(intptr_t ignored);

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -267,10 +267,11 @@ public:
 
     bool IsInteractive() { return mIsInteractive; }
 
-    CHIP_ERROR RunAsInteractive(const chip::Optional<char *> & interactiveStorageDirectory)
+    CHIP_ERROR RunAsInteractive(const chip::Optional<char *> & interactiveStorageDirectory, bool advertiseOperational)
     {
-        mStorageDirectory = interactiveStorageDirectory;
-        mIsInteractive    = true;
+        mStorageDirectory     = interactiveStorageDirectory;
+        mIsInteractive        = true;
+        mAdvertiseOperational = advertiseOperational;
         return Run();
     }
 
@@ -279,6 +280,10 @@ public:
 protected:
     // mStorageDirectory lives here so we can just set it in RunAsInteractive.
     chip::Optional<char *> mStorageDirectory;
+
+    // mAdvertiseOperational lives here so we can just set it in
+    // RunAsInteractive; it's only used by CHIPCommand.
+    bool mAdvertiseOperational = false;
 
 private:
     bool InitArgument(size_t argIndex, char * argValue);

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -182,7 +182,7 @@ exit:
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-int Commands::RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory)
+int Commands::RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory, bool advertiseOperational)
 {
     std::vector<std::string> arguments;
     VerifyOrReturnValue(DecodeArgumentsFromInteractiveMode(command, arguments), EXIT_FAILURE);
@@ -207,7 +207,7 @@ int Commands::RunInteractive(const char * command, const chip::Optional<char *> 
     }
 
     ChipLogProgress(chipTool, "Command: %s", commandStr.c_str());
-    auto err = RunCommand(argc, argv, true, storageDirectory);
+    auto err = RunCommand(argc, argv, true, storageDirectory, advertiseOperational);
 
     // Do not delete arg[0]
     for (auto i = 1; i < argc; i++)
@@ -219,7 +219,7 @@ int Commands::RunInteractive(const char * command, const chip::Optional<char *> 
 }
 
 CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive,
-                                const chip::Optional<char *> & interactiveStorageDirectory)
+                                const chip::Optional<char *> & interactiveStorageDirectory, bool interactiveAdvertiseOperational)
 {
     Command * command = nullptr;
 
@@ -307,7 +307,7 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv, bool interactive,
 
     if (interactive)
     {
-        return command->RunAsInteractive(interactiveStorageDirectory);
+        return command->RunAsInteractive(interactiveStorageDirectory, interactiveAdvertiseOperational);
     }
 
     // Now that the command is initialized, get our storage from it as needed

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -42,7 +42,7 @@ public:
         Register(commandSetName, commandsList, helpText, false);
     }
     int Run(int argc, char ** argv);
-    int RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory = chip::NullOptional);
+    int RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory, bool advertiseOperational);
 
 private:
     struct CommandSet
@@ -56,7 +56,8 @@ private:
     using CommandSetMap = std::map<std::string, CommandSet>;
 
     CHIP_ERROR RunCommand(int argc, char ** argv, bool interactive = false,
-                          const chip::Optional<char *> & interactiveStorageDirectory = chip::NullOptional);
+                          const chip::Optional<char *> & interactiveStorageDirectory = chip::NullOptional,
+                          bool interactiveAdvertiseOperational                       = false);
 
     CommandSetMap::iterator GetCommandSet(std::string commandSetName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -369,7 +369,7 @@ bool InteractiveCommand::ParseCommand(char * command, int * status)
 
     ClearLine();
 
-    *status = mHandler->RunInteractive(command, GetStorageDirectory());
+    *status = mHandler->RunInteractive(command, GetStorageDirectory(), NeedsOperationalAdvertising());
 
     return true;
 }

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -380,7 +380,7 @@ bool InteractiveCommand::ParseCommand(char * command, int * status)
 
     ClearLine();
 
-    *status = mHandler->RunInteractive(command, GetStorageDirectory());
+    *status = mHandler->RunInteractive(command, GetStorageDirectory(), true);
 
     return YES;
 }


### PR DESCRIPTION
chip-tool was never setting enableServerInteractions on the commissioner params, and it happened to work as long as we unconditionally advertised everything as long as server interactions were enabled on the factory, even if specific commissioners did not want to enable server interactions.

Now that this is properly controller per-commissioner, we need to actually set the boolean we should have been setting all along.
