### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-25 : [Telink] Update Docker image (Zephyr update)
+26 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=e6a32f41ccec55c2233631406842b71ff270089d
+ARG ZEPHYR_REVISION=e0800ce0375563dfeea8ffc32ebc78d5aaf4f091
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- drivers: gpio_b9x: Added delayed interrupts by gpio level wakeup
- drivers: gpio_b9x: Fixed port F pu/pd support. Not supported
- dts: telink_b92: fixed typos in power definitions
- drivers: gpio_b9x: Removed unnecessary delay in wakeup action
- soc: riscv: telink_b9x: Reduce ramcode usage for Matter
- drivers: i2c: update B9X i2c driver for PM

**Testing**
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully