### PR TITLE
new: chef samples may specify Matter ports

### DIFF
--- a/examples/chef/README.md
+++ b/examples/chef/README.md
@@ -81,20 +81,19 @@ runtime. These options are also available for many Linux samples. Do not
 conflate these with chef options available at build time.
 
 Ex.:
-  --discriminator <discriminator>
-       A 12-bit unsigned integer match the value which a device advertises during commissioning.
-  --passcode <passcode>
-       A 27-bit unsigned integer, which serves as proof of possession during commissioning.
-       If not provided to compute a verifier, the --spake2p-verifier-base64 must be provided.
-  --secured-device-port <port>
-       A 16-bit unsigned integer specifying the listen port to use for secure device messages (default is 5540).
-  --KVS <filepath>
-       A file to store Key Value Store items.
+
+-   --discriminator <discriminator>: A 12-bit unsigned integer match the value
+    which a device advertises during commissioning.
+-   --passcode <passcode>: A 27-bit unsigned integer, which serves as proof of
+    possession during commissioning. If not provided to compute a verifier, the
+    --spake2p-verifier-base64 must be provided.
+-   --secured-device-port <port>: A 16-bit unsigned integer specifying the
+    listen port to use for secure device messages (default is 5540).
+-   --KVS <filepath>: A file to store Key Value Store items.
 
 For a full list, call the generated linux binary with
 
-  -h, --help
-       Print this output and then exit.
+-   -h, --help: Print this output and then exit.
 
 ## CI
 
@@ -123,7 +122,7 @@ relevant platform image. You can simulate the workflow locally by mounting your
 CHIP repo into a container and executing the CI command:
 
 ```shell
-docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-$PLATFORM:$VERSION
+docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-$PLATFORM:1$VERSION
 ```
 
 In the container:
@@ -150,7 +149,7 @@ chef_$PLATFORM:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-        image: ghcr.io/project-chip/chip-build-$PLATFORM:$VERSION
+        image: ghcr.io/project-chip/chip-build-$PLATFORM:1$VERSION
         options: --user root
 
     steps:
@@ -205,7 +204,7 @@ command for these targets.
 To test your configuration locally, you may employ a similar strategy as in CI:
 
 ```shell
-docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-vscode:$VERSION
+docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-vscode:1$VERSION
 ```
 
 In the container:

--- a/examples/chef/README.md
+++ b/examples/chef/README.md
@@ -74,6 +74,28 @@ Follow guide in [NEW_CHEF_DEVICES.md](NEW_CHEF_DEVICES.md).
 -   `chef.py`: main script for generating samples. More info on its help
     `chef.py -h`.
 
+## General Linux Options
+
+When building chef for the Linux platform there are several options available at
+runtime. These options are also available for many Linux samples. Do not
+conflate these with chef options available at build time.
+
+Ex.:
+  --discriminator <discriminator>
+       A 12-bit unsigned integer match the value which a device advertises during commissioning.
+  --passcode <passcode>
+       A 27-bit unsigned integer, which serves as proof of possession during commissioning.
+       If not provided to compute a verifier, the --spake2p-verifier-base64 must be provided.
+  --secured-device-port <port>
+       A 16-bit unsigned integer specifying the listen port to use for secure device messages (default is 5540).
+  --KVS <filepath>
+       A file to store Key Value Store items.
+
+For a full list, call the generated linux binary with
+
+  -h, --help
+       Print this output and then exit.
+
 ## CI
 
 All CI jobs for chef can be found in `.github/workflows/chef.yaml`.

--- a/examples/chef/README.md
+++ b/examples/chef/README.md
@@ -122,7 +122,7 @@ relevant platform image. You can simulate the workflow locally by mounting your
 CHIP repo into a container and executing the CI command:
 
 ```shell
-docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-$PLATFORM:1$VERSION
+docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-$PLATFORM:$VERSION
 ```
 
 In the container:
@@ -149,7 +149,7 @@ chef_$PLATFORM:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-        image: ghcr.io/project-chip/chip-build-$PLATFORM:1$VERSION
+        image: ghcr.io/project-chip/chip-build-$PLATFORM:$VERSION
         options: --user root
 
     steps:
@@ -204,7 +204,7 @@ command for these targets.
 To test your configuration locally, you may employ a similar strategy as in CI:
 
 ```shell
-docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-vscode:1$VERSION
+docker run -it --mount source=$(pwd),target=/workspace,type=bind ghcr.io/project-chip/chip-build-vscode:$VERSION
 ```
 
 In the container:

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -802,6 +802,11 @@ def main() -> int:
                 'chip_shell_cmd_server = false',
                 'chip_build_libshell = true',
                 'chip_config_network_layer_ble = false',
+                'chip_device_project_config_include = "<CHIPProjectAppConfig.h>"',
+                'chip_project_config_include = "<CHIPProjectAppConfig.h>"',
+                'chip_system_project_config_include = "<SystemProjectConfig.h>"',
+                'chip_project_config_include_dirs = [ "${chip_root}/examples/chef/linux/include" ]',
+                'chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]',
                 (f'target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", '
                  f'"CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", '
                  f'"CONFIG_ENABLE_PW_RPC={int(options.do_rpc)}", '

--- a/examples/chef/linux/include/CHIPProjectAppConfig.h
+++ b/examples/chef/linux/include/CHIPProjectAppConfig.h
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// include the CHIPProjectConfig from config/standalone
+#include <CHIPProjectConfig.h>
+
+// Allows app options (ports) to be configured on launch of app
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1


### PR DESCRIPTION
Implements FR for adding the capability of specifying the Matter secure device port at runtime

Tested building with `./chef.py -d rootnode_windowcovering_RLCxaGi9Yx -t linux -b` and running with `linux/out/rootnode_windowcovering_RLCxaGi9Yx --secured-device-port 1234`


