### PR TITLE
Fix build of `esp32-m5stack-all-clusters-rpc-ipv6only` for out of tree PW_ENVIRONMENT_ROOT

### DIFF
--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -26,7 +26,7 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 # pw_env_setup_CIPD_PIGWEED = "//../home/vscode/pigweed/env/cipd/packages/pigweed"
 #
 # Existing logic:
-#   - this file is imported from `examples/common/pigweed`
+#   - this file is imported from `examples/common/pigweed` or similar
 #   - we transform paths from "//../" into "//../../../"
 #
 # This was done after protoc path detection started failing when using
@@ -34,7 +34,8 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 #
 # https://github.com/google/pigweed/commit/ddbc9fc7f5c601ab417db37e02cbe5294f21ad6d
 #
-# TODO: need a better expansion here. This replacement logic seems very brittle.
+# TODO: need a better expansion here. This replacement logic seems very brittle and
+#       it is unclear how we know exactly 3 levels of indirections are correct
 #
 if (defined(pw_env_setup_CIPD_ARM)) {
   _split_arm = string_split(pw_env_setup_CIPD_ARM, "/")

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -38,8 +38,8 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 #       it is unclear how we know exactly 3 levels of indirections are correct
 #
 if (defined(pw_env_setup_CIPD_ARM)) {
-  _split_arm = string_split(pw_env_setup_CIPD_ARM, "/")
-  if (_split_arm[0] == "" && _split_arm[1] == "" && _split_arm[2] == "..") {
+  _split_arm = string_split(pw_env_setup_CIPD_ARM, "//../")
+  if (_split_arm[0] == "") {
     pw_env_setup_CIPD_ARM = get_path_info(
             string_replace(pw_env_setup_CIPD_ARM, "//../", "//../../../"),
             "abspath")
@@ -49,9 +49,8 @@ if (defined(pw_env_setup_CIPD_ARM)) {
   }
 }
 if (defined(pw_env_setup_CIPD_PIGWEED)) {
-  _split_pigweed = string_split(pw_env_setup_CIPD_PIGWEED, "/")
-  if (_split_pigweed[0] == "" && _split_pigweed[1] == "" &&
-      _split_pigweed[2] == "..") {
+  _split_pigweed = string_split(pw_env_setup_CIPD_PIGWEED, "//../")
+  if (_split_pigweed[0] == "") {
     pw_env_setup_CIPD_PIGWEED =
         get_path_info(
             string_replace(pw_env_setup_CIPD_PIGWEED, "//../", "//../../../"),
@@ -64,9 +63,8 @@ if (defined(pw_env_setup_CIPD_PIGWEED)) {
 }
 
 if (defined(pw_env_setup_CIPD_PYTHON)) {
-  _split_python = string_split(pw_env_setup_CIPD_PYTHON, "/")
-  if (_split_python[0] == "" && _split_python[1] == "" &&
-      _split_python[2] == "..") {
+  _split_python = string_split(pw_env_setup_CIPD_PYTHON, "//../")
+  if (_split_python[0] == "") {
     pw_env_setup_CIPD_PYTHON =
         get_path_info(
             string_replace(pw_env_setup_CIPD_PYTHON, "//../", "//../../../"),
@@ -78,8 +76,8 @@ if (defined(pw_env_setup_CIPD_PYTHON)) {
   }
 }
 if (defined(pw_env_setup_VIRTUAL_ENV)) {
-  _split_env = string_split(pw_env_setup_VIRTUAL_ENV, "/")
-  if (_split_env[0] == "" && _split_env[1] == "" && _split_env[2] == "..") {
+  _split_env = string_split(pw_env_setup_VIRTUAL_ENV, "//../")
+  if (_split_env[0] == "") {
     pw_env_setup_VIRTUAL_ENV =
         get_path_info(
             string_replace(pw_env_setup_VIRTUAL_ENV, "//../", "//../../../"),

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -37,54 +37,24 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 # TODO: need a better expansion here. This replacement logic seems very brittle and
 #       it is unclear how we know exactly 3 levels of indirections are correct
 #
+
+# Rebase paths to our root.
 if (defined(pw_env_setup_CIPD_ARM)) {
-  _split_arm = string_split(pw_env_setup_CIPD_ARM, "//../")
-  if (_split_arm[0] == "") {
-    pw_env_setup_CIPD_ARM = get_path_info(
-            string_replace(pw_env_setup_CIPD_ARM, "//../", "//../../../"),
-            "abspath")
-  } else {
-    pw_env_setup_CIPD_ARM =
-        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_ARM}", "abspath")
-  }
+  pw_env_setup_CIPD_ARM =
+      get_path_info(rebase_path(pw_env_setup_CIPD_ARM, "", _bootstrap_root), "abspath")
 }
+
 if (defined(pw_env_setup_CIPD_PIGWEED)) {
-  _split_pigweed = string_split(pw_env_setup_CIPD_PIGWEED, "//../")
-  if (_split_pigweed[0] == "") {
-    pw_env_setup_CIPD_PIGWEED =
-        get_path_info(
-            string_replace(pw_env_setup_CIPD_PIGWEED, "//../", "//../../../"),
-            "abspath")
-  } else {
-    pw_env_setup_CIPD_PIGWEED =
-        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PIGWEED}",
-                      "abspath")
-  }
+  pw_env_setup_CIPD_PIGWEED =
+      get_path_info(rebase_path(pw_env_setup_CIPD_PIGWEED, "", _bootstrap_root), "abspath")
 }
 
 if (defined(pw_env_setup_CIPD_PYTHON)) {
-  _split_python = string_split(pw_env_setup_CIPD_PYTHON, "//../")
-  if (_split_python[0] == "") {
-    pw_env_setup_CIPD_PYTHON =
-        get_path_info(
-            string_replace(pw_env_setup_CIPD_PYTHON, "//../", "//../../../"),
-            "abspath")
-  } else {
-    pw_env_setup_CIPD_PYTHON =
-        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PYTHON}",
-                      "abspath")
-  }
+  pw_env_setup_CIPD_PYTHON =
+      get_path_info(rebase_path(pw_env_setup_CIPD_PYTHON, "", _bootstrap_root), "abspath")
 }
+
 if (defined(pw_env_setup_VIRTUAL_ENV)) {
-  _split_env = string_split(pw_env_setup_VIRTUAL_ENV, "//../")
-  if (_split_env[0] == "") {
-    pw_env_setup_VIRTUAL_ENV =
-        get_path_info(
-            string_replace(pw_env_setup_VIRTUAL_ENV, "//../", "//../../../"),
-            "abspath")
-  } else {
-    pw_env_setup_VIRTUAL_ENV =
-        get_path_info("${_bootstrap_root}/${pw_env_setup_VIRTUAL_ENV}",
-                      "abspath")
-  }
+  pw_env_setup_VIRTUAL_ENV =
+      get_path_info(rebase_path(pw_env_setup_VIRTUAL_ENV, "", _bootstrap_root), "abspath")
 }

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -20,20 +20,72 @@ _bootstrap_root = "//third_party/connectedhomeip"
 import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 
 # Rebase paths to our root.
+#
+# If out of tree, the paths will look like:
+#
+# pw_env_setup_CIPD_PIGWEED = "//../home/vscode/pigweed/env/cipd/packages/pigweed"
+#
+# Existing logic:
+#   - this file is imported from `examples/common/pigweed`
+#   - we transform paths from "//../" into "//../../../"
+#
+# This was done after protoc path detection started failing when using
+# a PW_ENVIRONMENT_ROOT that is out of tree after
+#
+# https://github.com/google/pigweed/commit/ddbc9fc7f5c601ab417db37e02cbe5294f21ad6d
+#
+# TODO: need a better expansion here. This replacement logic seems very brittle.
+#
 if (defined(pw_env_setup_CIPD_ARM)) {
-  pw_env_setup_CIPD_ARM =
-      get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_ARM}", "abspath")
+  _split_arm = string_split(pw_env_setup_CIPD_ARM, "/")
+  if (_split_arm[0] == "" && _split_arm[1] == "" && _split_arm[2] == "..") {
+    pw_env_setup_CIPD_ARM = get_path_info(
+            string_replace(pw_env_setup_CIPD_ARM, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_ARM =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_ARM}", "abspath")
+  }
 }
 if (defined(pw_env_setup_CIPD_PIGWEED)) {
-  pw_env_setup_CIPD_PIGWEED =
-      get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PIGWEED}",
-                    "abspath")
+  _split_pigweed = string_split(pw_env_setup_CIPD_PIGWEED, "/")
+  if (_split_pigweed[0] == "" && _split_pigweed[1] == "" &&
+      _split_pigweed[2] == "..") {
+    pw_env_setup_CIPD_PIGWEED =
+        get_path_info(
+            string_replace(pw_env_setup_CIPD_PIGWEED, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_PIGWEED =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PIGWEED}",
+                      "abspath")
+  }
 }
+
 if (defined(pw_env_setup_CIPD_PYTHON)) {
-  pw_env_setup_CIPD_PYTHON =
-      get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PYTHON}", "abspath")
+  _split_python = string_split(pw_env_setup_CIPD_PYTHON, "/")
+  if (_split_python[0] == "" && _split_python[1] == "" &&
+      _split_python[2] == "..") {
+    pw_env_setup_CIPD_PYTHON =
+        get_path_info(
+            string_replace(pw_env_setup_CIPD_PYTHON, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_PYTHON =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PYTHON}",
+                      "abspath")
+  }
 }
 if (defined(pw_env_setup_VIRTUAL_ENV)) {
-  pw_env_setup_VIRTUAL_ENV =
-      get_path_info("${_bootstrap_root}/${pw_env_setup_VIRTUAL_ENV}", "abspath")
+  _split_env = string_split(pw_env_setup_VIRTUAL_ENV, "/")
+  if (_split_env[0] == "" && _split_env[1] == "" && _split_env[2] == "..") {
+    pw_env_setup_VIRTUAL_ENV =
+        get_path_info(
+            string_replace(pw_env_setup_VIRTUAL_ENV, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_VIRTUAL_ENV =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_VIRTUAL_ENV}",
+                      "abspath")
+  }
 }

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -37,24 +37,54 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 # TODO: need a better expansion here. This replacement logic seems very brittle and
 #       it is unclear how we know exactly 3 levels of indirections are correct
 #
-
-# Rebase paths to our root.
 if (defined(pw_env_setup_CIPD_ARM)) {
-  pw_env_setup_CIPD_ARM =
-      get_path_info(rebase_path(pw_env_setup_CIPD_ARM, "", _bootstrap_root), "abspath")
+  _split_arm = string_split(pw_env_setup_CIPD_ARM, "//../")
+  if (_split_arm[0] == "") {
+    pw_env_setup_CIPD_ARM = get_path_info(
+            string_replace(pw_env_setup_CIPD_ARM, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_ARM =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_ARM}", "abspath")
+  }
 }
-
 if (defined(pw_env_setup_CIPD_PIGWEED)) {
-  pw_env_setup_CIPD_PIGWEED =
-      get_path_info(rebase_path(pw_env_setup_CIPD_PIGWEED, "", _bootstrap_root), "abspath")
+  _split_pigweed = string_split(pw_env_setup_CIPD_PIGWEED, "//../")
+  if (_split_pigweed[0] == "") {
+    pw_env_setup_CIPD_PIGWEED =
+        get_path_info(
+            string_replace(pw_env_setup_CIPD_PIGWEED, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_PIGWEED =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PIGWEED}",
+                      "abspath")
+  }
 }
 
 if (defined(pw_env_setup_CIPD_PYTHON)) {
-  pw_env_setup_CIPD_PYTHON =
-      get_path_info(rebase_path(pw_env_setup_CIPD_PYTHON, "", _bootstrap_root), "abspath")
+  _split_python = string_split(pw_env_setup_CIPD_PYTHON, "//../")
+  if (_split_python[0] == "") {
+    pw_env_setup_CIPD_PYTHON =
+        get_path_info(
+            string_replace(pw_env_setup_CIPD_PYTHON, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_CIPD_PYTHON =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PYTHON}",
+                      "abspath")
+  }
 }
-
 if (defined(pw_env_setup_VIRTUAL_ENV)) {
-  pw_env_setup_VIRTUAL_ENV =
-      get_path_info(rebase_path(pw_env_setup_VIRTUAL_ENV, "", _bootstrap_root), "abspath")
+  _split_env = string_split(pw_env_setup_VIRTUAL_ENV, "//../")
+  if (_split_env[0] == "") {
+    pw_env_setup_VIRTUAL_ENV =
+        get_path_info(
+            string_replace(pw_env_setup_VIRTUAL_ENV, "//../", "//../../../"),
+            "abspath")
+  } else {
+    pw_env_setup_VIRTUAL_ENV =
+        get_path_info("${_bootstrap_root}/${pw_env_setup_VIRTUAL_ENV}",
+                      "abspath")
+  }
 }

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -25,14 +25,14 @@ import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 #
 # pw_env_setup_CIPD_PIGWEED = "//../home/vscode/pigweed/env/cipd/packages/pigweed"
 #
+# and these paths are used by things like protoc since
+# https://github.com/google/pigweed/commit/ddbc9fc7f5c601ab417db37e02cbe5294f21ad6d
+#
+# See https://github.com/project-chip/connectedhomeip/issues/30475
+#
 # Existing logic:
 #   - this file is imported from `examples/common/pigweed` or similar
 #   - we transform paths from "//../" into "//../../../"
-#
-# This was done after protoc path detection started failing when using
-# a PW_ENVIRONMENT_ROOT that is out of tree after
-#
-# https://github.com/google/pigweed/commit/ddbc9fc7f5c601ab417db37e02cbe5294f21ad6d
 #
 # TODO: need a better expansion here. This replacement logic seems very brittle and
 #       it is unclear how we know exactly 3 levels of indirections are correct


### PR DESCRIPTION
In https://github.com/google/pigweed/commit/ddbc9fc7f5c601ab417db37e02cbe5294f21ad6d pigweed started using `pw_env_setup_CIPD_PIGWEED` however our examples was not really setting this up correctly for out-of-tree pigweed environment root (such as the vscode one). Pigweed auto-generates `build_overrides/pigweed_environment.gni` and our examples scripts tried to rebase those paths, however the rebase is invalid when the paths are relative (like saying `//../home/vscode/pwenv` when working in `/workspace`)

Fixes #30475 

Changes:

- detect `//../` prefix as an indicator of relative paths and then work around that by adding extra relative paths (I could not find a way to find out the right path here !)
- update this for all CIPD paths

Tested:
  - compiled esp32-m5stack-all-clusters-rpc-ipv6only on a vscode image