### PR TITLE
ReadHandler: Delete the subscription information storage when ReadHandler fails to establish the session for subsription resumption

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -99,6 +99,11 @@ void ReadHandler::ResumeSubscription(CASESessionManager & caseSessionManager,
     mSubscriptionId          = subscriptionInfo.mSubscriptionId;
     mMinIntervalFloorSeconds = subscriptionInfo.mMinInterval;
     mMaxInterval             = subscriptionInfo.mMaxInterval;
+
+    mResumingSubscriptionNodeId = subscriptionInfo.mNodeId;
+    mResumingSubscriptionFabricIndex = subscriptionInfo.mFabricIndex;
+    mIsResumingSubscription = true;
+
     SetStateFlag(ReadHandlerFlags::FabricFiltered, subscriptionInfo.mFabricFiltered);
 
     // Move dynamically allocated attributes and events from the SubscriptionInfo struct into
@@ -908,6 +913,11 @@ void ReadHandler::HandleDeviceConnected(void * context, Messaging::ExchangeManag
     }
     // Notify the observer that a subscription has been resumed
     _this->mObserver->OnSubscriptionEstablished(_this);
+
+    // Reset the subsription resumption parameters
+    _this->mIsResumingSubscription = false;
+    _this->mResumingSubscriptionNodeId = kUndefinedNodeId;
+    _this->mResumingSubscriptionFabricIndex = kUndefinedFabricIndex;
 
     _this->MoveToState(HandlerState::CanStartReporting);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -100,9 +100,9 @@ void ReadHandler::ResumeSubscription(CASESessionManager & caseSessionManager,
     mMinIntervalFloorSeconds = subscriptionInfo.mMinInterval;
     mMaxInterval             = subscriptionInfo.mMaxInterval;
 
-    mResumingSubscriptionNodeId = subscriptionInfo.mNodeId;
+    mResumingSubscriptionNodeId      = subscriptionInfo.mNodeId;
     mResumingSubscriptionFabricIndex = subscriptionInfo.mFabricIndex;
-    mIsResumingSubscription = true;
+    mIsResumingSubscription          = true;
 
     SetStateFlag(ReadHandlerFlags::FabricFiltered, subscriptionInfo.mFabricFiltered);
 
@@ -915,8 +915,8 @@ void ReadHandler::HandleDeviceConnected(void * context, Messaging::ExchangeManag
     _this->mObserver->OnSubscriptionEstablished(_this);
 
     // Reset the subsription resumption parameters
-    _this->mIsResumingSubscription = false;
-    _this->mResumingSubscriptionNodeId = kUndefinedNodeId;
+    _this->mIsResumingSubscription          = false;
+    _this->mResumingSubscriptionNodeId      = kUndefinedNodeId;
     _this->mResumingSubscriptionFabricIndex = kUndefinedFabricIndex;
 
     _this->MoveToState(HandlerState::CanStartReporting);

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -388,13 +388,21 @@ private:
     NodeId GetInitiatorNodeId() const
     {
         auto session = GetSession();
-        return session == nullptr ? kUndefinedNodeId : session->GetPeerNodeId();
+        if (session)
+        {
+            return session->GetPeerNodeId();
+        }
+        return IsType(InteractionType::Subscribe) && mIsResumingSubscription ? mResumingSubscriptionNodeId : kUndefinedNodeId;
     }
 
     FabricIndex GetAccessingFabricIndex() const
     {
         auto session = GetSession();
-        return session == nullptr ? kUndefinedFabricIndex : session->GetFabricIndex();
+        if (session)
+        {
+            return session->GetFabricIndex();
+        }
+        return IsType(InteractionType::Subscribe) && mIsResumingSubscription ? mResumingSubscriptionFabricIndex : kUndefinedFabricIndex;
     }
 
     Transport::SecureSession * GetSession() const;
@@ -535,6 +543,12 @@ private:
     SubscriptionId mSubscriptionId    = 0;
     uint16_t mMinIntervalFloorSeconds = 0;
     uint16_t mMaxInterval             = 0;
+
+    // When we close the read handler after it fails to resume subscription beacuse the session is not established,
+    // we should use these values to delete the subscription storage.
+    FabricIndex mResumingSubscriptionFabricIndex = kUndefinedFabricIndex;
+    NodeId mResumingSubscriptionNodeId = kUndefinedNodeId;
+    bool mIsResumingSubscription = false;
 
     EventNumber mEventMin = 0;
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -402,7 +402,8 @@ private:
         {
             return session->GetFabricIndex();
         }
-        return IsType(InteractionType::Subscribe) && mIsResumingSubscription ? mResumingSubscriptionFabricIndex : kUndefinedFabricIndex;
+        return IsType(InteractionType::Subscribe) && mIsResumingSubscription ? mResumingSubscriptionFabricIndex
+                                                                             : kUndefinedFabricIndex;
     }
 
     Transport::SecureSession * GetSession() const;
@@ -547,8 +548,8 @@ private:
     // When we close the read handler after it fails to resume subscription beacuse the session is not established,
     // we should use these values to delete the subscription storage.
     FabricIndex mResumingSubscriptionFabricIndex = kUndefinedFabricIndex;
-    NodeId mResumingSubscriptionNodeId = kUndefinedNodeId;
-    bool mIsResumingSubscription = false;
+    NodeId mResumingSubscriptionNodeId           = kUndefinedNodeId;
+    bool mIsResumingSubscription                 = false;
 
     EventNumber mEventMin = 0;
 


### PR DESCRIPTION
We should delete the persistent subscription information when a ReadHandler fails to establish the session for subscription resumption and then closes. But now we cannot delete it because `GetInitiatorNodeId()` and `GetAccessingFabricIndex()` will return `kUndefinedNodeId` and `kUndefinedFabricIndex` if session is not established. 