### PR TITLE
Set a python log redirect for python testing, so all logs are available

### DIFF
--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -443,6 +443,8 @@ class MatterStackState:
             self._chip_stack = ChipStack(**kwargs)
             builtins.chipStack = self._chip_stack
 
+        chip.logging.RedirectToPythonLogging()
+
         self._storage = self._chip_stack.GetStorageManager()
         self._certificate_authority_manager = chip.CertificateAuthority.CertificateAuthorityManager(chipStack=self._chip_stack)
         self._certificate_authority_manager.LoadAuthoritiesFromStorage()


### PR DESCRIPTION
Logging redirect was never done in tests.

It looks like linux defaults to "send logs to console" while as darwin does not send anything. Make it consistent across systems.