### PR TITLE
Add fatal lock tracking support to unlock diagnostic

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -107,7 +107,10 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_UnlockChipStack()
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     if (!mChipStackIsLocked)
     {
-        ChipLogError(DeviceLayer, "_UnlockChipStack may error status");
+        ChipLogError(DeviceLayer, "_UnlockChipStack while unlocked");
+#if CHIP_STACK_LOCK_TRACKING_ERROR_FATAL
+        chipDie();
+#endif
     }
     mChipStackIsLocked = false;
 #endif


### PR DESCRIPTION
It's an error to try to unlock a lock without holding it. Currently we don't have "fatal" lock diagnostics for this error; add this case.