### PR TITLE
Implement PDC support in Network Commissioning cluster

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -118,28 +118,9 @@ private:
     void HandleReorderNetwork(HandlerContext & ctx, const Commands::ReorderNetwork::DecodableType & req);
 
 public:
-    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * apDelegate) :
-        CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mFeatureFlags(Feature::kWiFiNetworkInterface),
-        mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
-    {
-        mpDriver.Set<DeviceLayer::NetworkCommissioning::WiFiDriver *>(apDelegate);
-    }
-
-    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * apDelegate) :
-        CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mFeatureFlags(Feature::kThreadNetworkInterface),
-        mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
-    {
-        mpDriver.Set<DeviceLayer::NetworkCommissioning::ThreadDriver *>(apDelegate);
-    }
-
-    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * apDelegate) :
-        CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mFeatureFlags(Feature::kEthernetNetworkInterface),
-        mpWirelessDriver(nullptr), mpBaseDriver(apDelegate)
-    {}
-
+    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * apDelegate);
+    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * apDelegate);
+    Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * apDelegate);
     virtual ~Instance() = default;
 };
 

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -112,10 +112,12 @@ private:
     // Actual handlers of the commands
     void HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetworks::DecodableType & req);
     void HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands::AddOrUpdateWiFiNetwork::DecodableType & req);
+    void HandleAddOrUpdateWiFiNetworkWithPDC(HandlerContext & ctx, const Commands::AddOrUpdateWiFiNetwork::DecodableType & req);
     void HandleAddOrUpdateThreadNetwork(HandlerContext & ctx, const Commands::AddOrUpdateThreadNetwork::DecodableType & req);
     void HandleRemoveNetwork(HandlerContext & ctx, const Commands::RemoveNetwork::DecodableType & req);
     void HandleConnectNetwork(HandlerContext & ctx, const Commands::ConnectNetwork::DecodableType & req);
     void HandleReorderNetwork(HandlerContext & ctx, const Commands::ReorderNetwork::DecodableType & req);
+    void HandleQueryIdentity(HandlerContext & ctx, const Commands::QueryIdentity::DecodableType & req);
 
 public:
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * apDelegate);

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -347,6 +347,15 @@
 #endif
 
 /**
+ * CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+ *
+ * Enable support for WiFi Per-Device Credentials
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC 0
+#endif
+
+/**
  * CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL
  *
  * The interval at which the chip platform will attempt to reconnect to the configured WiFi

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -23,10 +23,14 @@
 
 #pragma once
 
+#include <credentials/CHIPCert.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/Optional.h>
 #include <lib/support/ThreadOperationalDataset.h>
+#include <lib/support/Variant.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
 #include <app-common/zap-generated/cluster-enums.h>
@@ -79,8 +83,12 @@ protected:
 struct Network
 {
     uint8_t networkID[kMaxNetworkIDLen];
-    uint8_t networkIDLen;
-    bool connected;
+    uint8_t networkIDLen = 0;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+    Optional<Credentials::CertificateKeyIdStorage> networkIdentifier;
+    Optional<Credentials::CertificateKeyIdStorage> clientIdentifier;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+    bool connected = false;
 };
 
 static_assert(sizeof(Network::networkID) <= std::numeric_limits<decltype(Network::networkIDLen)>::max(),
@@ -275,6 +283,72 @@ public:
      * @param callback    Callback that will be invoked upon finishing the scan
      */
     virtual void ScanNetworks(ByteSpan ssid, ScanCallback * callback) = 0;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+    virtual bool SupportsPerDeviceCredentials() { return false; };
+
+    /**
+     * @brief Adds or updates a WiFi network with Per-Device Credentials on the device.
+     *
+     * @param ssid                          The SSID of the network to be added / updated.
+     * @param networkIdentity               The Network Identity of the network, in compact-pdc-identity format.
+     * @param clientIdentityNetworkIndex    If present, the index of the existing network configuration of which the Client
+     *                                      Identity is to be re-used. Otherwise a new Client Identity shall be generated.
+     * @param outStatus                     The application-level status code (Status::kSuccess on success).
+     * @param outDebugText                  A debug text buffer that may be populated by the driver when a Status is returned.
+     *                                      The size of the span must be reduced to the length of text emitted (or 0, if none).
+     * @param outClientIdentity             On success, the Client Identity that was generated or copied, depending on the
+     *                                      presence of `clientIdentityNetworkIndex`.
+     * @param outNextworkIndex              On success, the index of the network entry that was added or updated.
+     *
+     * @retval CHIP_NO_ERROR and outStatus == kSuccess on success.
+     * @retval CHIP_NO_ERROR and outStatus != kSuccess for application-level errors. outDebugText should be populated.
+     * @retval CHIP_ERROR_* on internal errors. None of the output parameters will be examined in this case.
+     */
+    virtual CHIP_ERROR AddOrUpdateNetworkWithPDC(ByteSpan ssid, ByteSpan networkIdentity,
+                                                 Optional<uint8_t> clientIdentityNetworkIndex, Status & outStatus,
+                                                 MutableCharSpan & outDebugText, MutableByteSpan & outClientIdentity,
+                                                 uint8_t & outNetworkIndex)
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    /**
+     * @brief Retrieves the Network Identity associated with a network.
+     *
+     * @param networkIndex          The 0-based index of the network.
+     * @param outNetworkIdentity    The output buffer to be populated with the Network
+     *                              Identity in compact-pdc-identity TLV format.
+     *
+     * @return CHIP_NO_ERROR on success or a CHIP_ERROR on failure.
+     */
+    virtual CHIP_ERROR GetNetworkIdentity(uint8_t networkIndex, MutableByteSpan & outNetworkIdentity)
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    /**
+     * @brief Retrieves the Network Client Identity associated with a network.
+     *
+     * @param networkIndex          The 0-based index of the network.
+     * @param outNetworkIdentity    The output buffer to be populated with the Network
+     *                              Client Identity in compact-pdc-identity TLV format.
+     *
+     * @return CHIP_NO_ERROR on success or a CHIP_ERROR on failure.
+     */
+    virtual CHIP_ERROR GetClientIdentity(uint8_t networkIndex, MutableByteSpan & outClientIdentity)
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    /**
+     * @brief Signs the specified message with the private key of a Network Client Identity.
+     */
+    virtual CHIP_ERROR SignWithClientIdentity(uint8_t networkIndex, ByteSpan & message, Crypto::P256ECDSASignature & outSignature)
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 
     ~WiFiDriver() override = default;
 };

--- a/src/platform/Darwin/CHIPDevicePlatformConfig.h
+++ b/src/platform/Darwin/CHIPDevicePlatformConfig.h
@@ -25,6 +25,7 @@
 
 // ==================== Platform Adaptations ====================
 
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC 1
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION 0
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP 0
 

--- a/src/platform/Linux/CHIPDevicePlatformConfig.h
+++ b/src/platform/Linux/CHIPDevicePlatformConfig.h
@@ -26,6 +26,7 @@
 // ==================== Platform Adaptations ====================
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC 1
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION 1
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP 0
 #else


### PR DESCRIPTION
The two commits are best viewed separately:

1. Small refactorings of network-commissioning.cpp
    - Tidy up EnumerateAcceptedCommands
    - Move constructors out of header
    - Simplify debug text logic
    - Simplify enumeration of Iterator
    - Use CHIP_ERROR_FORMAT for logging errors
    - Refer to Status type name consistently

2. Implement PDC support in Network Commissioning cluster and add the relevant APIs to NetworkCommissioning::WiFiDriver.

