### PR TITLE
[CI] Fix OpenIoT failure for ICDMonitoringTableTest

### DIFF
--- a/src/app/tests/TestICDMonitoringTable.cpp
+++ b/src/app/tests/TestICDMonitoringTable.cpp
@@ -91,7 +91,7 @@ void TestEntryAssignationOverload(nlTestSuite * aSuite, void * aContext)
     NL_TEST_ASSERT(aSuite, entry2.checkInNodeID == entry.checkInNodeID);
     NL_TEST_ASSERT(aSuite, entry2.monitoredSubject == entry.monitoredSubject);
 
-    NL_TEST_ASSERT(aSuite, entry.IsKeyEquivalent(ByteSpan(entry2.key.As<Crypto::Aes128KeyByteArray>())));
+    NL_TEST_ASSERT(aSuite, entry2.IsKeyEquivalent(ByteSpan(kKeyBuffer1a)));
 }
 
 void TestEntryKeyFunctions(nlTestSuite * aSuite, void * aContext)


### PR DESCRIPTION
Fix #30505 

PR #30385 introduced an error that broke OpenIoT Unit tests. This is the fix for said error.

OpenIoTSDK is the ONLY CI job that run Unit Test with the PSA Crypto implementation. With such implementation, Keys are not stored in plain text within a KeyHandle, they are stored somewhere else and only a KeyId is stored inside a KeyHandle. This why the test was succeeding for every other test but not OpenIoT...

