### PR TITLE
Data model XML parser: when parsing derived clusters, give derived attributes precedence

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/derivation.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/derivation.py
@@ -88,13 +88,16 @@ def merge_attribute_into(a: Attribute, cluster: Cluster):
             break
 
     if existing:
-        # Do not provide merging as it seems only conformance is changed from
-        # the base cluster
+        # Merge examples:
+        #   UserLabelCluster::LabelList changes qualities (access, mandatory)
         #
-        # This should fix the correct types
+        # TODO: add more examples and handle accordingly, sometimes just the
+        #       conformance is changed
         #
-        # LOGGER.error("TODO: Do not know how to merge attribute for %s::%s", cluster.name, existing.definition.name)
-        cluster.attributes.remove(existing)
+        # To replace we could do:
+        #    cluster.attributes.remove(existing)
+        # However then we lose any overrides
+        return
 
     cluster.attributes.append(a)
 


### PR DESCRIPTION
Found that `UserLabel Cluster` will override attribute qualities and access.

Generally it seems to make sense that if a derived cluster has a defintion of something to give that priority as the source of truth.

Added a comment explaining use case so if other cases occur, we know what handling logic needs to exist.