### PR TITLE
Remove `BarrierControlBarrierPosition` and `BarrierControlMovingState`

### DIFF
--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -247,9 +247,8 @@ static uint8_t getCurrentPosition(EndpointId endpoint)
     // way of knowing the position of the barrier. Let's guess that the barrier is
     // open so that we don't leave the barrier open when it should be closed.
     uint8_t currentPositionFromAttribute = emAfPluginBarrierControlServerGetBarrierPosition(endpoint);
-    return ((currentPositionFromAttribute == BarrierControl::Position::kUnknown)
-                ? static_cast<uint8_t>(BarrierControl::Position::kOpen)
-                : currentPositionFromAttribute);
+    return ((currentPositionFromAttribute == BarrierControl::Position::kUnknown) ? BarrierControl::Position::kOpen
+                                                                                 : currentPositionFromAttribute);
 }
 
 static uint32_t calculateDelayMs(EndpointId endpoint, uint8_t targetPosition, bool * opening)
@@ -300,7 +299,7 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
         emAfPluginBarrierControlServerSetBarrierPosition(endpoint,
                                                          (emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint)
                                                               ? state.currentPosition
-                                                              : static_cast<uint8_t>(BarrierControl::Position::kUnknown)));
+                                                              : BarrierControl::Position::kUnknown));
         setMovingState(endpoint,
                        (state.increasing ? BarrierControl::MovingState::kOpening : BarrierControl::MovingState::kClosing));
 

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -38,6 +38,29 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BarrierControl;
 using chip::Protocols::InteractionModel::Status;
 
+// this is NOT in any spec (CHIP spec does not currently have BarrierControl)
+// and XMLs do not attach these enums to clusters. SO set some constants here
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace BarrierControl {
+namespace Position {
+static constexpr uint8_t kClosed  = 0;
+static constexpr uint8_t kOpen    = 100;
+static constexpr uint8_t kUnknown = 255;
+} // namespace Position
+
+namespace MovingState {
+static constexpr uint8_t kStopped = 0;
+static constexpr uint8_t kClosing = 1;
+static constexpr uint8_t kOpening = 2;
+} // namespace MovingState
+
+} // namespace BarrierControl
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
 typedef struct
 {
     uint8_t currentPosition;
@@ -220,8 +243,8 @@ static uint8_t getCurrentPosition(EndpointId endpoint)
     // way of knowing the position of the barrier. Let's guess that the barrier is
     // open so that we don't leave the barrier open when it should be closed.
     uint8_t currentPositionFromAttribute = emAfPluginBarrierControlServerGetBarrierPosition(endpoint);
-    return ((currentPositionFromAttribute == EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_UNKNOWN)
-                ? static_cast<uint8_t>(EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_OPEN)
+    return ((currentPositionFromAttribute == BarrierControl::Position::kUnknown)
+                ? static_cast<uint8_t>(BarrierControl::Position::kOpen)
                 : currentPositionFromAttribute);
 }
 
@@ -249,7 +272,7 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
     if (state.currentPosition == state.targetPosition)
     {
         emAfPluginBarrierControlServerSetBarrierPosition(endpoint, state.currentPosition);
-        setMovingState(endpoint, EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_STOPPED);
+        setMovingState(endpoint, BarrierControl::MovingState::kStopped);
         cancelEndpointTimerCallback(endpoint);
     }
     else
@@ -274,10 +297,11 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
             endpoint,
             (emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint)
                  ? state.currentPosition
-                 : static_cast<uint8_t>(EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_UNKNOWN)));
+                 : static_cast<uint8_t>(BarrierControl::Position::kUnknown)));
         setMovingState(
             endpoint,
-            (state.increasing ? EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_OPENING : EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_CLOSING));
+            (state.increasing ? BarrierControl::MovingState::kOpening : BarrierControl::MovingState::kClosing));
+        
         scheduleTimerCallbackMs(endpoint, state.delayMs);
     }
 }
@@ -307,8 +331,8 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(
     }
     else if (percentOpen > 100 // "100" means "100%", so greater than that is invalid
              || (!emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint) &&
-                 percentOpen != EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_CLOSED &&
-                 percentOpen != EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_OPEN))
+                 percentOpen != BarrierControl::Position::kClosed &&
+                 percentOpen != BarrierControl::Position::kOpen))
     {
         status = Status::ConstraintError;
     }
@@ -342,7 +366,7 @@ bool emberAfBarrierControlClusterBarrierControlStopCallback(app::CommandHandler 
 {
     EndpointId endpoint = commandPath.mEndpointId;
     cancelEndpointTimerCallback(endpoint);
-    setMovingState(endpoint, EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_STOPPED);
+    setMovingState(endpoint, BarrierControl::MovingState::kStopped);
     sendDefaultResponse(commandObj, commandPath, Status::Success);
     return true;
 }

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -293,15 +293,13 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
                 emAfPluginBarrierControlServerIncrementEvents(endpoint, false, false);
             }
         }
-        emAfPluginBarrierControlServerSetBarrierPosition(
-            endpoint,
-            (emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint)
-                 ? state.currentPosition
-                 : static_cast<uint8_t>(BarrierControl::Position::kUnknown)));
-        setMovingState(
-            endpoint,
-            (state.increasing ? BarrierControl::MovingState::kOpening : BarrierControl::MovingState::kClosing));
-        
+        emAfPluginBarrierControlServerSetBarrierPosition(endpoint,
+                                                         (emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint)
+                                                              ? state.currentPosition
+                                                              : static_cast<uint8_t>(BarrierControl::Position::kUnknown)));
+        setMovingState(endpoint,
+                       (state.increasing ? BarrierControl::MovingState::kOpening : BarrierControl::MovingState::kClosing));
+
         scheduleTimerCallbackMs(endpoint, state.delayMs);
     }
 }
@@ -331,8 +329,7 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(
     }
     else if (percentOpen > 100 // "100" means "100%", so greater than that is invalid
              || (!emAfPluginBarrierControlServerIsPartialBarrierSupported(endpoint) &&
-                 percentOpen != BarrierControl::Position::kClosed &&
-                 percentOpen != BarrierControl::Position::kOpen))
+                 percentOpen != BarrierControl::Position::kClosed && percentOpen != BarrierControl::Position::kOpen))
     {
         status = Status::ConstraintError;
     }

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -39,11 +39,15 @@ using namespace chip::app::Clusters::BarrierControl;
 using chip::Protocols::InteractionModel::Status;
 
 // this is NOT in any spec (CHIP spec does not currently have BarrierControl)
-// and XMLs do not attach these enums to clusters. SO set some constants here
+// and XMLs do not attach these enums to clusters.
+//
+// This directly defines some constants. These could be replaced with real
+// constants if we ever have some BarrierControl in the matter specification.
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace BarrierControl {
+
 namespace Position {
 static constexpr uint8_t kClosed  = 0;
 static constexpr uint8_t kOpen    = 100;

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -8,8 +8,6 @@ DarwinForceWritable:
 WeakEnums:
     # Allow-list of enums that we generate as enums, not enum classes.
     # The goal is to drive this down to 0.
-    - BarrierControlBarrierPosition
-    - BarrierControlMovingState
     - ColorControlOptions
     - ColorMode
     - EnhancedColorMode

--- a/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
@@ -30,18 +30,6 @@ limitations under the License.
     <field name="positionFailure" mask="0x08"/>
   </bitmap>
 
-  <enum name="BarrierControlBarrierPosition" type="int8u">
-    <item name="Closed" value="0"/>
-    <item name="Open" value="100"/>
-    <item name="Unknown" value="0xFF"/>
-  </enum>
-
-  <enum name="BarrierControlMovingState" type="enum8">
-    <item name="Stopped" value="0x00"/>
-    <item name="Closing" value="0x01"/>
-    <item name="Opening" value="0x02"/>
-  </enum>
-
   <cluster>
     <name>Barrier Control</name>
     <domain>Closures</domain>

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -24,22 +24,6 @@
 
 // ZCL enums
 
-// Enum for BarrierControlBarrierPosition
-enum EmberAfBarrierControlBarrierPosition : uint8_t
-{
-    EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_CLOSED  = 0,
-    EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_OPEN    = 100,
-    EMBER_ZCL_BARRIER_CONTROL_BARRIER_POSITION_UNKNOWN = 255,
-};
-
-// Enum for BarrierControlMovingState
-enum EmberAfBarrierControlMovingState : uint8_t
-{
-    EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_STOPPED = 0,
-    EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_CLOSING = 1,
-    EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_OPENING = 2,
-};
-
 // Enum for ColorControlOptions
 enum EmberAfColorControlOptions : uint8_t
 {


### PR DESCRIPTION
This is super awkward because this cluster is NOT a spec cluster, yet we have shipped API for it and I was told I cannot remove it because of that ...

Changes:
  - remove weak enum entries
  - define these enums directly inside the CPP implementation
  - remove the unused (and not tied to a cluster) XML definitions
  
### Tested

- compile all clusters app.