### PR TITLE
Undo linux platform forced address  config

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -109,6 +109,8 @@ static_library("Linux") {
     "${chip_root}/third_party/inipp",
   ]
 
+  public_configs = []
+
   if (chip_mdns == "platform") {
     sources += [
       "DnssdImpl.cpp",

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -109,9 +109,6 @@ static_library("Linux") {
     "${chip_root}/third_party/inipp",
   ]
 
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
-
   if (chip_mdns == "platform") {
     sources += [
       "DnssdImpl.cpp",


### PR DESCRIPTION
Address config should be configured based on dependencies on lib/address_resolve.

I see it included in thread devices (which maybe we should figure out generally), however overall we should not add more forced dependencies on platform level.

Undoes part of #30527 