### PR TITLE
Clean up inclusion of private BuildConfig headers

### DIFF
--- a/examples/air-quality-sensor-app/linux/main.cpp
+++ b/examples/air-quality-sensor-app/linux/main.cpp
@@ -21,7 +21,7 @@
 #include <air-quality-sensor-manager.h>
 
 #include <app/util/af.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
 #include <imgui_ui/ui.h>

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -19,8 +19,8 @@
 #include "CHIPCommand.h"
 
 #include <controller/CHIPDeviceControllerFactory.h>
-#include <core/CHIPBuildConfig.h>
 #include <credentials/attestation_verifier/FileAttestationTrustStore.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>

--- a/examples/chip-tool/commands/common/DeviceScanner.h
+++ b/examples/chip-tool/commands/common/DeviceScanner.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_LAYER_TARGET_DARWIN
 

--- a/examples/contact-sensor-app/linux/main.cpp
+++ b/examples/contact-sensor-app/linux/main.cpp
@@ -18,7 +18,7 @@
 
 #include <AppMain.h>
 #include <app/util/af.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #if defined(CHIP_IMGUI_ENABLED) && CHIP_IMGUI_ENABLED
 #include <imgui_ui/ui.h>

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -21,7 +21,7 @@
 #import "CHIPToolKeypair.h"
 #import <Matter/Matter.h>
 
-#include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 
 #include "MTRError_Utils.h"

--- a/examples/platform/bouffalolab/common/iot_sdk/platform_port.cpp
+++ b/examples/platform/bouffalolab/common/iot_sdk/platform_port.cpp
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #include <FreeRTOS.h>
 

--- a/examples/platform/tizen/OptionsProxy.cpp
+++ b/examples/platform/tizen/OptionsProxy.cpp
@@ -22,8 +22,8 @@
 
 #include <app_control.h>
 
-#include <core/CHIPBuildConfig.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 namespace {
 

--- a/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
@@ -18,7 +18,7 @@
 
 #include <commands/common/CHIPCommand.h>
 
-#include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/DataVersionFilter.h>
 #include <app/util/basic-types.h>

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -62,6 +62,8 @@ buildconfig_header("app_buildconfig") {
     "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_report_on_active_mode}",
     "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
   ]
+
+  visibility = [ ":app_config" ]
 }
 
 source_set("revision_info") {
@@ -75,7 +77,7 @@ source_set("revision_info") {
 source_set("app_config") {
   sources = [ "AppConfig.h" ]
 
-  public_deps = [ ":app_buildconfig" ]
+  deps = [ ":app_buildconfig" ]
 }
 
 static_library("app") {

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -21,7 +21,7 @@
 #include "lib/core/TLV.h"
 #include "system/SystemPacketBuffer.h"
 #include "system/TLVPacketBufferBackingStore.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/ReadClient.h>
 #include <vector>

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -21,7 +21,7 @@
 #include "lib/core/CHIPError.h"
 #include "system/SystemPacketBuffer.h"
 #include "system/TLVPacketBufferBackingStore.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ReadClient.h>

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -29,7 +29,7 @@
 
 #include "access/RequestPath.h"
 #include "access/SubjectDescriptor.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/RequiredPrivilege.h>
 #include <app/util/af-types.h>
 #include <app/util/endpoint-config-api.h>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <access/AccessControl.h>
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <lib/core/CHIPCore.h>

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -22,7 +22,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/AttributeDataIBs.h
+++ b/src/app/MessageDef/AttributeDataIBs.h
@@ -27,7 +27,7 @@
 #include "ArrayParser.h"
 #include "AttributeDataIB.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -21,7 +21,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/data-model/Nullable.h>

--- a/src/app/MessageDef/AttributePathIBs.h
+++ b/src/app/MessageDef/AttributePathIBs.h
@@ -22,7 +22,7 @@
 #include "ArrayParser.h"
 #include "AttributePathIB.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/AttributeReportIB.h
+++ b/src/app/MessageDef/AttributeReportIB.h
@@ -22,7 +22,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/AttributeReportIBs.h
+++ b/src/app/MessageDef/AttributeReportIBs.h
@@ -27,7 +27,7 @@
 #include "ArrayParser.h"
 #include "AttributeReportIB.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/util/basic-types.h>

--- a/src/app/MessageDef/AttributeStatusIB.h
+++ b/src/app/MessageDef/AttributeStatusIB.h
@@ -22,7 +22,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/AttributeStatusIBs.h
+++ b/src/app/MessageDef/AttributeStatusIBs.h
@@ -22,7 +22,7 @@
 #include "ArrayParser.h"
 #include "AttributeStatusIB.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/ClusterPathIB.h
+++ b/src/app/MessageDef/ClusterPathIB.h
@@ -20,7 +20,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/NodeId.h>

--- a/src/app/MessageDef/CommandDataIB.h
+++ b/src/app/MessageDef/CommandDataIB.h
@@ -23,7 +23,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/CommandPathIB.h
+++ b/src/app/MessageDef/CommandPathIB.h
@@ -21,7 +21,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/CommandPathParams.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/basic-types.h>

--- a/src/app/MessageDef/CommandStatusIB.h
+++ b/src/app/MessageDef/CommandStatusIB.h
@@ -23,7 +23,7 @@
 #include "StatusIB.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/DataVersionFilterIB.h
+++ b/src/app/MessageDef/DataVersionFilterIB.h
@@ -20,7 +20,7 @@
 #include "ClusterPathIB.h"
 #include "StructBuilder.h"
 #include "StructParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/DataVersionFilterIBs.h
+++ b/src/app/MessageDef/DataVersionFilterIBs.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/EventDataIB.h
+++ b/src/app/MessageDef/EventDataIB.h
@@ -26,7 +26,7 @@
 #include "EventPathIB.h"
 #include "StructBuilder.h"
 #include "StructParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/EventHeader.h>
 #include <app/EventLoggingTypes.h>
 #include <app/util/basic-types.h>

--- a/src/app/MessageDef/EventFilterIB.h
+++ b/src/app/MessageDef/EventFilterIB.h
@@ -25,7 +25,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/NodeId.h>

--- a/src/app/MessageDef/EventFilterIBs.h
+++ b/src/app/MessageDef/EventFilterIBs.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -21,7 +21,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/ConcreteEventPath.h>
 #include <app/EventPathParams.h>
 #include <app/util/basic-types.h>

--- a/src/app/MessageDef/EventPathIBs.h
+++ b/src/app/MessageDef/EventPathIBs.h
@@ -23,7 +23,7 @@
 #include "EventPathIB.h"
 #include "EventPathIBs.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/EventReportIB.h
+++ b/src/app/MessageDef/EventReportIB.h
@@ -22,7 +22,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/EventReportIBs.h
+++ b/src/app/MessageDef/EventReportIBs.h
@@ -27,7 +27,7 @@
 #include "ArrayParser.h"
 #include "EventReportIB.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/EventStatusIB.h
+++ b/src/app/MessageDef/EventStatusIB.h
@@ -22,7 +22,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/InvokeResponseIB.h
+++ b/src/app/MessageDef/InvokeResponseIB.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -28,7 +28,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 
 // We need CHIPLogging.h to get the right value for CHIP_DETAIL_LOGGING here.
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/MessageDef/MessageParser.h
+++ b/src/app/MessageDef/MessageParser.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "StructParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/InteractionModelRevision.h>
 #include <app/util/basic-types.h>
 

--- a/src/app/MessageDef/ReadRequestMessage.h
+++ b/src/app/MessageDef/ReadRequestMessage.h
@@ -23,7 +23,7 @@
 #include "EventPathIBs.h"
 #include "MessageBuilder.h"
 #include "MessageParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/ReportDataMessage.h
+++ b/src/app/MessageDef/ReportDataMessage.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -26,7 +26,7 @@
 #include "StructBuilder.h"
 #include "StructParser.h"
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/Optional.h>

--- a/src/app/MessageDef/StatusResponseMessage.h
+++ b/src/app/MessageDef/StatusResponseMessage.h
@@ -18,7 +18,7 @@
 #pragma once
 #include "MessageBuilder.h"
 #include "MessageParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/SubscribeRequestMessage.h
+++ b/src/app/MessageDef/SubscribeRequestMessage.h
@@ -23,7 +23,7 @@
 #include "EventPathIBs.h"
 #include "MessageBuilder.h"
 #include "MessageParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/SubscribeResponseMessage.h
+++ b/src/app/MessageDef/SubscribeResponseMessage.h
@@ -19,7 +19,7 @@
 #include "EventPathIBs.h"
 #include "MessageBuilder.h"
 #include "MessageParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/MessageDef/TimedRequestMessage.h
+++ b/src/app/MessageDef/TimedRequestMessage.h
@@ -18,7 +18,7 @@
 #pragma once
 #include "MessageBuilder.h"
 #include "MessageParser.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -24,7 +24,7 @@
 
 #pragma once
 #include "system/SystemClock.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/EventHeader.h>

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/ReportSchedulerImpl.h>
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 
 #include <access/AccessControl.h>
 #include <access/examples/ExampleAccessControlDelegate.h>

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -42,6 +42,8 @@ buildconfig_header("ble_buildconfig") {
     defines +=
         [ "BLE_PLATFORM_CONFIG_INCLUDE=${chip_ble_platform_config_include}" ]
   }
+
+  visibility = [ ":ble_config_header" ]
 }
 
 source_set("ble_config_header") {
@@ -49,10 +51,11 @@ source_set("ble_config_header") {
 
   public_configs = [ "${chip_root}/src:includes" ]
 
-  public_deps = [
+  public_deps = [ "${chip_root}/src/system:system_config_header" ]
+
+  deps = [
     ":ble_buildconfig",
     "${chip_root}/src/platform:platform_buildconfig",
-    "${chip_root}/src/system:system_config_header",
   ]
 }
 
@@ -65,7 +68,6 @@ if (chip_config_network_layer_ble) {
       "BLEEndPoint.h",
       "Ble.h",
       "BleApplicationDelegate.h",
-      "BleConfig.h",
       "BleConnectionDelegate.h",
       "BleError.cpp",
       "BleError.h",

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "app/ConcreteCommandPath.h"
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/DeviceProxy.h>
 #include <app/util/error-mapping.h>
 #include <controller/InvokeInteraction.h>

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/CASEClientPool.h>
 #include <app/CASESessionManager.h>
 #include <app/ClusterStateCache.h>

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadPrepareParams.h>

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/AppBuildConfig.h>
+#include <app/AppConfig.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/data-model/Decode.h>

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -270,7 +270,7 @@ if (current_os == "android" || matter_enable_java_compilation) {
 
     deps = [
       ":data_model",
-      "${chip_root}/src/platform:platform_buildconfig",
+      "${chip_root}/src/platform:platform_config_header",
     ]
 
     public_configs = [ ":java-build-config" ]

--- a/src/controller/java/DeviceAttestationDelegateBridge.h
+++ b/src/controller/java/DeviceAttestationDelegateBridge.h
@@ -17,7 +17,7 @@
 
 #include <jni.h>
 #include <lib/core/NodeId.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -16,7 +16,7 @@
  */
 
 #include <lib/core/NodeId.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #include <Matter/MTRDeviceAttestationDelegate.h>
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -51,7 +51,7 @@
 #import "MTRDeviceAttestationDelegateBridge.h"
 #import "MTRDeviceConnectionBridge.h"
 
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/List.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -19,7 +19,7 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissioningDelegate.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -26,8 +26,9 @@
 
 #include <cstdint>
 
+#include <platform/CHIPDeviceConfig.h>
+
 #if CHIP_HAVE_CONFIG_H
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
 #endif
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -27,7 +27,6 @@
 #include <app/AttributeAccessInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -25,7 +25,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <inet/InetInterface.h>
 #include <lib/core/ClusterEnums.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/GeneralFaults.h>
 
 namespace chip {

--- a/src/include/platform/KeyValueStoreManager.h
+++ b/src/include/platform/KeyValueStoreManager.h
@@ -30,7 +30,7 @@
 #include <type_traits>
 
 #include <lib/core/CHIPError.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/include/platform/LockTracker.h
+++ b/src/include/platform/LockTracker.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 /// Defines support for asserting that the chip stack is locked by the current thread via
 /// the macro:

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include <platform/AttributeList.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <system/PlatformEventSupport.h>
 #include <system/SystemLayer.h>

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -56,6 +56,8 @@ buildconfig_header("inet_buildconfig") {
 
   defines += [ "INET_TCP_END_POINT_IMPL_CONFIG_FILE=<inet/TCPEndPointImpl${chip_system_config_inet}.h>" ]
   defines += [ "INET_UDP_END_POINT_IMPL_CONFIG_FILE=<inet/UDPEndPointImpl${chip_system_config_inet}.h>" ]
+
+  visibility = [ ":inet_config_header" ]
 }
 
 source_set("inet_config_header") {
@@ -63,10 +65,9 @@ source_set("inet_config_header") {
 
   public_configs = [ "${chip_root}/src:includes" ]
 
-  public_deps = [
-    ":inet_buildconfig",
-    "${chip_root}/src/system:system_config_header",
-  ]
+  public_deps = [ "${chip_root}/src/system:system_config_header" ]
+
+  deps = [ ":inet_buildconfig" ]
 }
 
 static_library("inet") {
@@ -97,7 +98,7 @@ static_library("inet") {
   public_deps = [
     ":inet_config_header",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/platform:platform_buildconfig",
+    "${chip_root}/src/platform:platform_config_header",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -69,6 +69,8 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_CONFIG_TLV_VALIDATE_CHAR_STRING_ON_WRITE=${chip_tlv_validate_char_string_on_write}",
     "CHIP_CONFIG_TLV_VALIDATE_CHAR_STRING_ON_READ=${chip_tlv_validate_char_string_on_read}",
   ]
+
+  visibility = [ ":chip_config_header" ]
 }
 
 source_set("chip_config_header") {
@@ -77,11 +79,12 @@ source_set("chip_config_header") {
   public_configs = [ "${chip_root}/src:includes" ]
 
   public_deps = [
-    ":chip_buildconfig",
     "${chip_root}/src/ble:ble_config_header",
     "${chip_root}/src/inet:inet_config_header",
     "${chip_root}/src/system:system_config_header",
   ]
+
+  deps = [ ":chip_buildconfig" ]
 
   allow_circular_includes_from = [ "${chip_root}/src/ble:ble_config_header" ]
 }

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -251,7 +251,8 @@ static_library("support") {
     ":verifymacros_no_logging",
     "${chip_root}/src/lib/core:chip_config_header",
     "${chip_root}/src/lib/core:error",
-    "${chip_root}/src/platform:platform_buildconfig",
+    "${chip_root}/src/platform:platform_config_header",
+    "${chip_root}/src/system:system_config_header",
     "${nlassert_root}:nlassert",
     "${nlio_root}:nlio",
   ]
@@ -311,6 +312,7 @@ static_library("testing") {
   public_deps = [
     ":support",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/platform",
     "${nlassert_root}:nlassert",
     "${nlunit_test_root}:nlunit-test",
   ]

--- a/src/lib/support/UnitTestUtils.cpp
+++ b/src/lib/support/UnitTestUtils.cpp
@@ -18,7 +18,7 @@
 #include <lib/support/UnitTestUtils.h>
 
 // Platform specific includes for test_utils
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 #if CHIP_DEVICE_LAYER_TARGET_EFR32 || CHIP_DEVICE_LAYER_TARGET_AMEBA
 #include <FreeRTOS.h>
 #include <task.h>

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -371,6 +371,12 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
 
     defines += [ "CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES=${chip_max_discovered_ip_addresses}" ]
+
+    visibility = [
+      ":platform_config_header",
+      "${chip_root}/src/ble:ble_config_header",
+      "${chip_root}/src/system:system_config_header",
+    ]
   }
 } else if (chip_device_platform == "none") {
   buildconfig_header("platform_buildconfig") {
@@ -392,10 +398,16 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
   }
 }
 
+source_set("platform_config_header") {
+  sources = [ "../include/platform/CHIPDeviceConfig.h" ]
+
+  deps = [ ":platform_buildconfig" ]
+}
+
 if (chip_device_platform != "none") {
-  group("platform_base") {
+  source_set("platform_base") {
     public_deps = [
-      ":platform_buildconfig",
+      ":platform_config_header",
       "${chip_root}/src/ble",
       "${chip_root}/src/inet",
       "${chip_root}/src/lib/core",
@@ -412,7 +424,6 @@ if (chip_device_platform != "none") {
 
     sources = [
       "../include/platform/BuildTime.h",
-      "../include/platform/CHIPDeviceConfig.h",
       "../include/platform/CHIPDeviceError.h",
       "../include/platform/CHIPDeviceEvent.h",
       "../include/platform/CHIPDeviceLayer.h",

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -26,7 +26,6 @@
 #include "ConfigurationManagerImpl.h"
 
 #include <lib/support/CodeUtils.h>
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Tizen/PosixConfig.h>

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -27,10 +27,9 @@
 #include <wifi-manager.h>
 #endif
 
-#include <inet/InetBuildConfig.h>
+#include <inet/InetConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -21,9 +21,8 @@
 
 #include <cstdint>
 
-#include <inet/InetBuildConfig.h>
+#include <inet/InetConfig.h>
 #include <lib/core/CHIPError.h>
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <system/SystemClock.h>

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -32,7 +32,7 @@
 #include <lib/dnssd/platform/Dnssd.h>
 #include <net/if.h>
 
-#include <inet/InetBuildConfig.h>
+#include <inet/InetConfig.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>

--- a/src/platform/Tizen/Logging.cpp
+++ b/src/platform/Tizen/Logging.cpp
@@ -20,7 +20,7 @@
 
 #include <dlog.h>
 
-#include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -24,7 +24,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/KeyValueStoreManager.h>
 #include <platform/NetworkCommissioning.h>
 

--- a/src/platform/Tizen/SystemTimeSupport.cpp
+++ b/src/platform/Tizen/SystemTimeSupport.cpp
@@ -30,7 +30,7 @@
 #include <cstdint>
 #include <ctime>
 
-#include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <system/SystemClock.h>

--- a/src/platform/bouffalolab/common/Logging.cpp
+++ b/src/platform/bouffalolab/common/Logging.cpp
@@ -16,7 +16,7 @@
  */
 #include <stdio.h>
 
-#include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/logging/LogV.h>
 
 #include <CHIPDevicePlatformConfig.h>

--- a/src/platform/logging/BUILD.gn
+++ b/src/platform/logging/BUILD.gn
@@ -18,7 +18,7 @@ if (current_os == "android") {
       "${chip_root}/src/lib/core:chip_config_header",
       "${chip_root}/src/lib/support:attributes",
       "${chip_root}/src/lib/support:logging_constants",
-      "${chip_root}/src/platform:platform_buildconfig",
+      "${chip_root}/src/platform:platform_config_header",
       "${chip_root}/src/platform/logging:headers",
     ]
 
@@ -43,7 +43,7 @@ static_library("stdio") {
     "${chip_root}/src/lib/core:chip_config_header",
     "${chip_root}/src/lib/support:attributes",
     "${chip_root}/src/lib/support:logging_constants",
-    "${chip_root}/src/platform:platform_buildconfig",
+    "${chip_root}/src/platform:platform_config_header",
     "${chip_root}/src/platform/logging:headers",
   ]
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -166,10 +166,12 @@ source_set("system_config_header") {
     "${chip_root}/src:includes",
   ]
 
-  public_deps = [
+  deps = [
     ":system_buildconfig",
     "${chip_root}/src/platform:platform_buildconfig",
   ]
+
+  public_deps = []
 
   if (target_cpu != "esp32") {
     if (chip_system_config_use_lwip) {
@@ -220,7 +222,6 @@ static_library("system") {
     "SystemAlignSize.h",
     "SystemClock.cpp",
     "SystemClock.h",
-    "SystemConfig.h",
     "SystemError.cpp",
     "SystemError.h",
     "SystemEvent.h",
@@ -253,9 +254,10 @@ static_library("system") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    ":system_config_header",
     "${chip_root}/src/lib/core:error",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/platform:platform_buildconfig",
+    "${chip_root}/src/platform:platform_config_header",
     "${nlassert_root}:nlassert",
   ]
 

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -60,7 +60,6 @@ static_library("transport") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
-    "${chip_root}/src/lib/core:chip_buildconfig",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/Session.h>
 #include <transport/raw/MessageHeader.h>


### PR DESCRIPTION
Certain configuration headers come in pairs

CHIPConfig.h & CHIPBuildConfig.h
InetConfig.h & InetBuildConfig.h
CHIPDeviceConfig.h & CHIPDeviceBuildConfig.h
AppConfig.h & AppBuildConfig.h
BleConfig.h & BleBuildConfig.h

In these cases, the second header is only the portion of the configuration that is generated by the build system and was intended to be private; including it directly may not have expected results.

Furthermore, other build systems may not generate the BuildConfig.h headers at all, which was supported through the CHIP_HAVE_CONFIG_H define. Including them directly breaks that capability.

Standardize includes on the public headers and tell GN to enforce this.