### PR TITLE
[Silabs] Add missing OT source in the efr32 platform abstraction

### DIFF
--- a/third_party/openthread/platforms/efr32/BUILD.gn
+++ b/third_party/openthread/platforms/efr32/BUILD.gn
@@ -62,6 +62,7 @@ source_set("libopenthread-efr32") {
     "${sl_ot_efr32_root}/misc.c",
     "${sl_ot_efr32_root}/radio.c",
     "${sl_ot_efr32_root}/sleep.c",
+    "${sl_ot_efr32_root}/soft_source_match_table.c",
     "${sl_ot_efr32_root}/system.c",
   ]
 


### PR DESCRIPTION
#### Description
Silabs has a custom `soft_source_match_table.c`. Add it to the list of sources for the platform abstraction.
Signatures are the not the same as the default which was causing runtimes failures when the default fonction were being called.

#### Tests
Manual tests to validate crash was not happening