### PR TITLE
Add a lint for use of PRI*64 macros.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,19 @@ jobs:
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,
             # to avoid our grep regexp matching itself.
+            - name: Check for use of PRI*64, which are not supported on some libcs.
+              if: always()
+              run: |
+                  # TODO: MessageDefHelper should ideally not be excluded here.
+                  # TODO: chip_im_initiatore should ideally not be excluded here.
+                  # TODO: TLVDebug should ideally not be excluded here.
+                  # TODO: protocol_decoder.cpp should ideally not be excluded here.
+                  # TODO: PersistentStorageMacros.h should ideally not be excluded here.
+                  git grep -n "PRI.64" -- './*' ':(exclude).github/workflows/lint.yml' ':(exclude)examples/chip-tool' ':(exclude)examples/tv-casting-app' ':(exclude)src/app/MessageDef/MessageDefHelper.cpp' ':(exclude)src/app/tests/integration/chip_im_initiator.cpp' ':(exclude)src/lib/core/TLVDebug.cpp' ':(exclude)src/lib/dnssd/tests/TestTxtFields.cpp' ':(exclude)src/lib/format/protocol_decoder.cpp' ':(exclude)src/lib/support/PersistentStorageMacros.h' ':(exclude)src/messaging/tests/echo/echo_requester.cpp' ':(exclude)src/platform/Linux' ':(exclude)src/platform/Ameba' ':(exclude)src/platform/ESP32' ':(exclude)src/platform/webos' ':(exclude)zzz_generated/chip-tool' ':(exclude)src/tools/chip-cert/Cmd_PrintCert.cpp' && exit 1 || exit 0
+
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we want to exclude this file,
+            # to avoid our grep regexp matching itself.
             - name: Check for use of %zu, which are not supported on some libcs.
               if: always()
               run: |

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -119,17 +119,18 @@ static bool PrintServerSession(void * context, SessionHandle & session)
     case Session::SessionType::kSecure: {
         SecureSession * secureSession         = session->AsSecureSession();
         SecureSession::Type secureSessionType = secureSession->GetSecureSessionType();
-        streamer_printf(
-            streamer_get(), "session type=SECURE %s id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
-            secureSessionType == SecureSession::Type::kCASE ? "CASE" : "PASE", secureSession->GetLocalSessionId(),
-            secureSession->AsSecureSession()->GetPeerSessionId(), secureSession->GetPeerNodeId(), secureSession->GetFabricIndex());
+        streamer_printf(streamer_get(),
+                        "session type=SECURE %s id=0x%04x peerSessionId=0x%04x peerNodeId=0x" ChipLogFormatX64 " fabricIdx=%d\r\n",
+                        secureSessionType == SecureSession::Type::kCASE ? "CASE" : "PASE", secureSession->GetLocalSessionId(),
+                        secureSession->AsSecureSession()->GetPeerSessionId(), ChipLogValueX64(secureSession->GetPeerNodeId()),
+                        secureSession->GetFabricIndex());
         break;
     }
 
     case Session::SessionType::kUnauthenticated: {
         UnauthenticatedSession * unsecuredSession = session->AsUnauthenticatedSession();
-        streamer_printf(streamer_get(), "session type=UNSECURED id=0x0000 peerNodeId=0x%016" PRIx64 "\r\n",
-                        unsecuredSession->GetPeerNodeId());
+        streamer_printf(streamer_get(), "session type=UNSECURED id=0x0000 peerNodeId=0x" ChipLogFormatX64 "\r\n",
+                        ChipLogValueX64(unsecuredSession->GetPeerNodeId()));
         break;
     }
 

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR AttributePathIB::Parser::PrettyPrint() const
             {
                 NodeId node;
                 reader.Get(node);
-                PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
+                PRETTY_PRINT("\tNode = 0x" ChipLogFormatX64 ",", ChipLogValueX64(node));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/ClusterPathIB.cpp
+++ b/src/app/MessageDef/ClusterPathIB.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR ClusterPathIB::Parser::PrettyPrint() const
             {
                 NodeId node;
                 reader.Get(node);
-                PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
+                PRETTY_PRINT("\tNode = 0x" ChipLogFormatX64 ",", ChipLogValueX64(node));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -70,7 +70,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 EventNumber number;
                 ReturnErrorOnFailure(reader.Get(number));
-                PRETTY_PRINT("\tEventNumber = 0x%" PRIx64 ",", number);
+                PRETTY_PRINT("\tEventNumber = 0x" ChipLogFormatX64 ",", ChipLogValueX64(number));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -81,7 +81,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 uint64_t value;
                 ReturnErrorOnFailure(reader.Get(value));
-                PRETTY_PRINT("\tPriorityLevel = 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tPriorityLevel = 0x" ChipLogFormatX64 ",", ChipLogValueX64(value));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -92,7 +92,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 uint64_t value;
                 ReturnErrorOnFailure(reader.Get(value));
-                PRETTY_PRINT("\tEpochTimestamp = 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tEpochTimestamp = 0x" ChipLogFormatX64 ",", ChipLogValueX64(value));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -104,7 +104,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 uint64_t value;
                 ReturnErrorOnFailure(reader.Get(value));
-                PRETTY_PRINT("\tSystemTimestamp = 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tSystemTimestamp = 0x" ChipLogFormatX64 ",", ChipLogValueX64(value));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -115,7 +115,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 uint64_t value;
                 ReturnErrorOnFailure(reader.Get(value));
-                PRETTY_PRINT("\tDeltaEpochTimestampstamp= 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tDeltaEpochTimestampstamp= 0x" ChipLogFormatX64 ",", ChipLogValueX64(value));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -126,7 +126,7 @@ CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
             {
                 uint64_t value;
                 ReturnErrorOnFailure(reader.Get(value));
-                PRETTY_PRINT("\tDeltaSystemTimestamp = 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tDeltaSystemTimestamp = 0x" ChipLogFormatX64 ",", ChipLogValueX64(value));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR EventFilterIB::Parser::PrettyPrint() const
         {
             NodeId node;
             ReturnErrorOnFailure(reader.Get(node));
-            PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
+            PRETTY_PRINT("\tNode = 0x" ChipLogFormatX64 ",", ChipLogValueX64(node));
         }
 #endif // CHIP_DETAIL_LOGGING
         break;
@@ -66,7 +66,7 @@ CHIP_ERROR EventFilterIB::Parser::PrettyPrint() const
         {
             uint64_t eventMin;
             ReturnErrorOnFailure(reader.Get(eventMin));
-            PRETTY_PRINT("\tEventMin = 0x%" PRIx64 ",", eventMin);
+            PRETTY_PRINT("\tEventMin = 0x" ChipLogFormatX64 ",", ChipLogValueX64(eventMin));
         }
 #endif // CHIP_DETAIL_LOGGING
         break;

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR EventPathIB::Parser::PrettyPrint() const
             {
                 NodeId node;
                 reader.Get(node);
-                PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
+                PRETTY_PRINT("\tNode = 0x" ChipLogFormatX64 ",", ChipLogValueX64(node));
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -138,6 +138,8 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
 
         ReturnErrorOnFailure(aReader.Get(value_s64));
 
+        // TODO: Figure out how to not use PRId64 here, since it's not supported
+        // on all libcs.
         PRETTY_PRINT_SAMELINE("%" PRId64 ", ", value_s64);
         break;
     }
@@ -147,6 +149,8 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
 
         ReturnErrorOnFailure(aReader.Get(value_u64));
 
+        // TODO: Figure out how to not use PRIu64 here, since it's not supported
+        // on all libcs.
         PRETTY_PRINT_SAMELINE("%" PRIu64 ", ", value_u64);
         break;
     }

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3144,8 +3144,10 @@ bool DoorLockServer::sendRemoteLockUserChange(chip::EndpointId endpointId, LockD
     }
     ChipLogProgress(Zcl,
                     "[RemoteLockUserChange] Sent lock user change event "
-                    "[endpointId=%d,eventNumber=%" PRIu64 ",dataType=%u,operation=%u,nodeId=%" PRIu64 ",fabricIndex=%d]",
-                    endpointId, eventNumber, to_underlying(dataType), to_underlying(operation), nodeId, fabricIndex);
+                    "[endpointId=%d,eventNumber=0x" ChipLogFormatX64 ",dataType=%u,operation=%u,nodeId=0x" ChipLogFormatX64
+                    ",fabricIndex=%d]",
+                    endpointId, ChipLogValueX64(eventNumber), to_underlying(dataType), to_underlying(operation),
+                    ChipLogValueX64(nodeId), fabricIndex);
     return true;
 }
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -120,8 +120,10 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
         ConcreteAttributePath readPath;
 
         ChipLogDetail(DataManagement,
-                      "Building Reports for ReadHandler with LastReportGeneration = %" PRIu64 " DirtyGeneration = %" PRIu64,
-                      apReadHandler->mPreviousReportsBeginGeneration, apReadHandler->mDirtyGeneration);
+                      "Building Reports for ReadHandler with LastReportGeneration = 0x" ChipLogFormatX64
+                      " DirtyGeneration = 0x" ChipLogFormatX64,
+                      ChipLogValueX64(apReadHandler->mPreviousReportsBeginGeneration),
+                      ChipLogValueX64(apReadHandler->mDirtyGeneration));
 
         // This ReadHandler is not generating reports, so we reset the iterator for a clean start.
         if (!apReadHandler->IsReporting())

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -73,9 +73,9 @@ void ReportSchedulerImpl::OnSubscriptionEstablished(ReadHandler * aReadHandler)
     newNode = mNodesPool.CreateObject(aReadHandler, this, now);
 
     ChipLogProgress(DataManagement,
-                    "Registered a ReadHandler that will schedule a report between system Timestamp: %" PRIu64
-                    " and system Timestamp %" PRIu64 ".",
-                    newNode->GetMinTimestamp().count(), newNode->GetMaxTimestamp().count());
+                    "Registered a ReadHandler that will schedule a report between system Timestamp: 0x" ChipLogFormatX64
+                    " and system Timestamp 0x" ChipLogFormatX64 ".",
+                    ChipLogValueX64(newNode->GetMinTimestamp().count()), ChipLogValueX64(newNode->GetMaxTimestamp().count()));
 }
 
 /// @brief When a ReadHandler becomes reportable, schedule, recalculate and reschedule the report.

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -193,8 +193,8 @@ void SynchronizedReportSchedulerImpl::TimerFired()
         if (node->IsReportableNow(now))
         {
             node->SetEngineRunScheduled(true);
-            ChipLogProgress(DataManagement, "Handler: %p with min: %" PRIu64 " and max: %" PRIu64 "", (node),
-                            node->GetMinTimestamp().count(), node->GetMaxTimestamp().count());
+            ChipLogProgress(DataManagement, "Handler: %p with min: 0x" ChipLogFormatX64 " and max: 0x" ChipLogFormatX64 "", (node),
+                            ChipLogValueX64(node->GetMinTimestamp().count()), ChipLogValueX64(node->GetMaxTimestamp().count()));
         }
 
         return Loop::Continue;

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1940,7 +1940,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
 
     readPrepareParams.mMinIntervalFloorSeconds   = 1;
     readPrepareParams.mMaxIntervalCeilingSeconds = 2;
-    printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2283,7 +2283,8 @@ void TestReadInteraction::TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite
 
     readPrepareParams.mMinIntervalFloorSeconds   = 1;
     readPrepareParams.mMaxIntervalCeilingSeconds = 3600;
-    printf("\nSend first subscribe request message with wildcard urgent event to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend first subscribe request message with wildcard urgent event to Node: 0x" ChipLogFormatX64 "\n",
+           ChipLogValueX64(chip::kTestDeviceNodeId));
 
     readPrepareParams.mKeepSubscriptions = true;
 
@@ -2463,7 +2464,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 1;
-    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2615,7 +2616,7 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 1;
-    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2692,7 +2693,7 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 1;
-    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2765,7 +2766,7 @@ void TestReadInteraction::TestSubscribeEarlyShutdown(nlTestSuite * apSuite, void
     readPrepareParams.mMaxIntervalCeilingSeconds   = 5;
     readPrepareParams.mKeepSubscriptions           = false;
 
-    printf("Send subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("Send subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2821,7 +2822,7 @@ void TestReadInteraction::TestSubscribeInvalidAttributePathRoundtrip(nlTestSuite
     readPrepareParams.mSessionHolder.Grab(ctx.GetSessionBobToAlice());
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 1;
-    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+    printf("\nSend subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
@@ -2933,7 +2934,7 @@ void TestReadInteraction::TestSubscribeInvalidInterval(nlTestSuite * apSuite, vo
 
         NL_TEST_ASSERT(apSuite, readClient.SendRequest(readPrepareParams) == CHIP_ERROR_INVALID_ARGUMENT);
 
-        printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend subscribe request message to Node: 0x" ChipLogFormatX64 "\n", ChipLogValueX64(chip::kTestDeviceNodeId));
 
         ctx.DrainAndServiceIO();
     }
@@ -2994,7 +2995,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripStatusReportTimeout(nlTestSu
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -3116,7 +3118,8 @@ void TestReadInteraction::TestSubscribeRoundtripStatusReportTimeout(nlTestSuite 
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -3293,7 +3296,8 @@ void TestReadInteraction::TestSubscribeRoundtripChunkStatusReportTimeout(nlTestS
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -3365,7 +3369,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkStatusReportTimeout(nlT
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -3469,7 +3474,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReportTimeout(nlTestSui
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -3571,7 +3577,8 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReport(nlTestSuite * ap
     {
         app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
                                    chip::app::ReadClient::InteractionType::Subscribe);
-        printf("\nSend first subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+        printf("\nSend first subscribe request message to Node: 0x" ChipLogFormatX64 "\n",
+               ChipLogValueX64(chip::kTestDeviceNodeId));
         delegate.mGotReport = false;
         err                 = readClient.SendRequest(readPrepareParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -126,7 +126,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
 CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Messaging::ExchangeManager & exchangeMgr,
                                                                       const SessionHandle & sessionHandle)
 {
-    ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, mNodeId);
+    ChipLogProgress(Controller, "OpenCommissioningWindow for device ID 0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -119,7 +119,8 @@ bool Cmd_Node(int argc, const char ** argv)
         return false;
     }
 
-    ChipLogProgress(NotSpecified, "Will search for node %" PRIx64 " on fabric %" PRIx64, node, fabric);
+    ChipLogProgress(NotSpecified, "Will search for node 0x" ChipLogFormatX64 " on fabric 0x" ChipLogFormatX64,
+                    ChipLogValueX64(node), ChipLogValueX64(fabric));
 
     AddressResolve::NodeLookupRequest request(PeerId().SetNodeId(node).SetCompressedFabricId(fabric));
 

--- a/src/lib/core/TLVTags.cpp
+++ b/src/lib/core/TLVTags.cpp
@@ -38,7 +38,7 @@ StringBuilderBase & Tag::AppendTo(StringBuilderBase & out)
     }
     else
     {
-        out.AddFormat("UnknownTag(0x%" PRIX64 ")", mVal);
+        out.AddFormat("UnknownTag(0x" ChipLogFormatX64 ")", ChipLogValueX64(mVal));
     }
 
     return out;

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -95,7 +95,8 @@ public:
         // Compiler should optimize these branches.
         if (is_same_v<decltype(T), uint64_t>)
         {
-            ChipLogDetail(EventLogging, "PersistedCounter::Init() aEpoch 0x%" PRIx64 " startValue 0x%" PRIx64, aEpoch, startValue);
+            ChipLogDetail(EventLogging, "PersistedCounter::Init() aEpoch 0x" ChipLogFormatX64 " startValue 0x" ChipLogFormatX64,
+                          ChipLogValueX64(aEpoch), ChipLogValueX64(startValue));
         }
         else if (is_same_v<decltype(T), uint32_t>)
         {
@@ -153,7 +154,8 @@ private:
         // Compiler should optimize these branches.
         if (is_same_v<decltype(T), uint64_t>)
         {
-            ChipLogDetail(EventLogging, "PersistedCounter::WriteStartValue() aStartValue 0x%" PRIx64, aStartValue);
+            ChipLogDetail(EventLogging, "PersistedCounter::WriteStartValue() aStartValue 0x" ChipLogFormatX64,
+                          ChipLogValueX64(aStartValue));
         }
         else
         {

--- a/src/lib/support/PersistentStorageMacros.h
+++ b/src/lib/support/PersistentStorageMacros.h
@@ -37,6 +37,7 @@ namespace chip {
         /* 2 * sizeof(chip::NodeId) to accommodate 2 character for each byte in Node Id */                                         \
         char key[len + 2 * sizeof(chip::NodeId) + 1];                                                                              \
         nlSTATIC_ASSERT_PRINT(sizeof(node) <= sizeof(uint64_t), "Node ID size is greater than expected");                          \
+        /* Be careful about switching to ChipLogFormatX64: it would change the storage keys! */                                    \
         snprintf(key, sizeof(key), "%s%" PRIx64, keyPrefix, node);                                                                 \
         action;                                                                                                                    \
     } while (0)

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -89,9 +89,10 @@ void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
 
     mRetransTable.ForEachActiveObject([&](auto * entry) {
         ChipLogDetail(ExchangeManager,
-                      "EC:" ChipLogFormatExchange " MessageCounter:" ChipLogFormatMessageCounter " NextRetransTimeCtr:%" PRIu64,
+                      "EC:" ChipLogFormatExchange " MessageCounter:" ChipLogFormatMessageCounter
+                      " NextRetransTimeCtr: 0x" ChipLogFormatX64,
                       ChipLogValueExchange(&entry->ec.Get()), entry->retainedBuf.GetMessageCounter(),
-                      entry->nextRetransTime.count());
+                      ChipLogValueX64(entry->nextRetransTime.count()));
         return Loop::Continue;
     });
 #endif
@@ -102,7 +103,7 @@ void ReliableMessageMgr::ExecuteActions()
     System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
 #if defined(RMP_TICKLESS_DEBUG)
-    ChipLogDetail(ExchangeManager, "ReliableMessageMgr::ExecuteActions at %" PRIu64 "ms", now.count());
+    ChipLogDetail(ExchangeManager, "ReliableMessageMgr::ExecuteActions at 0x" ChipLogFormatX64 "ms", ChipLogValueX64(now.count()));
 #endif
 
     ExecuteForAllContext([&](ReliableMessageContext * rc) {
@@ -397,8 +398,10 @@ void ReliableMessageMgr::StartTimer()
         const auto nextWakeDelay           = (nextWakeTime > now) ? nextWakeTime - now : 0_ms;
 
 #if defined(RMP_TICKLESS_DEBUG)
-        ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer at %" PRIu64 "ms wake at %" PRIu64 "ms (in %" PRIu64 "ms)",
-                      now.count(), nextWakeTime.count(), nextWakeDelay.count());
+        ChipLogDetail(ExchangeManager,
+                      "ReliableMessageMgr::StartTimer at 0x" ChipLogFormatX64 "ms wake at 0x" ChipLogFormatX64
+                      "ms (in 0x" ChipLogFormatX64 "ms)",
+                      ChipLogValueX64(now.count()), ChipLogValueX64(nextWakeTime.count()), ChipLogValueX64(nextWakeDelay.count()));
 #endif
         VerifyOrDie(mSystemLayer->StartTimer(nextWakeDelay, Timeout, this) == CHIP_NO_ERROR);
     }

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -663,9 +663,9 @@ void ThreadStackManagerImpl::_OnNetworkScanFinished(GAsyncResult * res)
                                    &joiner_udp_port, &channel, &rssi, &lqi, &version, &is_native, &is_joinable))
         {
             ChipLogProgress(DeviceLayer,
-                            "Thread Network: %s (%016" PRIx64 ") ExtPanId(%016" PRIx64 ") RSSI %d LQI %u"
+                            "Thread Network: %s (" ChipLogFormatX64 ") ExtPanId(" ChipLogFormatX64 ") RSSI %d LQI %u"
                             " Version %u",
-                            network_name, ext_address, ext_panid, rssi, lqi, version);
+                            network_name, ChipLogValueX64(ext_address), ChipLogValueX64(ext_panid), rssi, lqi, version);
             NetworkCommissioning::ThreadScanResponse networkScanned;
             networkScanned.panId         = panid;
             networkScanned.extendedPanId = ext_panid;

--- a/src/platform/mbed/OTAImageProcessorImpl.cpp
+++ b/src/platform/mbed/OTAImageProcessorImpl.cpp
@@ -543,8 +543,8 @@ int OTAImageProcessorImpl::ProgramMemory()
     }
     ChipLogProgress(SoftwareUpdate,
                     "Secondary slot program with offset: "
-                    "0x%" PRIx64,
-                    mParams.downloadedBytes);
+                    "0x" ChipLogFormatX64,
+                    ChipLogValueX64(mParams.downloadedBytes));
     mParams.downloadedBytes += mBlock.size();
 
     return ret;

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -67,8 +67,11 @@ static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * in
         const Clock::Microseconds64 Tend   = System::SystemClock().GetMonotonicMicroseconds64();
         const Clock::Microseconds64 Tdelta = Tend - Tstart;
 
-        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart.count(),
-                        Tend.count(), Tdelta.count(), Tdelay.count());
+        ChipLogProgress(DeviceLayer,
+                        "Start=0x" ChipLogFormatX64 " End=0x" ChipLogFormatX64 " Delta=0x" ChipLogFormatX64
+                        " Expected=0x" ChipLogFormatX64,
+                        ChipLogValueX64(Tstart.count()), ChipLogValueX64(Tend.count()), ChipLogValueX64(Tdelta.count()),
+                        ChipLogValueX64(Tdelay.count()));
 
         // verify that timers don't fire early
         NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
@@ -98,8 +101,11 @@ static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * in
         const Clock::Milliseconds64 Tend   = System::SystemClock().GetMonotonicMilliseconds64();
         const Clock::Milliseconds64 Tdelta = Tend - Tstart;
 
-        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart.count(),
-                        Tend.count(), Tdelta.count(), Tdelay.count());
+        ChipLogProgress(DeviceLayer,
+                        "Start=0x" ChipLogFormatX64 " End=0x" ChipLogFormatX64 " Delta=0x" ChipLogFormatX64
+                        " Expected=0x" ChipLogFormatX64,
+                        ChipLogValueX64(Tstart.count()), ChipLogValueX64(Tend.count()), ChipLogValueX64(Tdelta.count()),
+                        ChipLogValueX64(Tdelay.count()));
 
         // verify that timers don't fire early
         NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));

--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -585,6 +585,6 @@ void BlockQueryWithSkip::LogMessage(bdx::MessageType messageType) const
 {
     ChipLogAutomation("BlockQueryWithSkip");
     ChipLogAutomation("  Block Counter: %" PRIu32, BlockCounter);
-    ChipLogAutomation("  Bytes To Skip: %" PRIu64, BytesToSkip);
+    ChipLogAutomation("  Bytes To Skip: 0x" ChipLogFormatX64, ChipLogValueX64(BytesToSkip));
 }
 #endif // CHIP_AUTOMATION_LOGGING


### PR DESCRIPTION
These are not supported on all libcs.
