### PR TITLE
[Telink] Redefined ping timeout for WebSocketServer

### DIFF
--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -166,10 +166,15 @@ CHIP_ERROR WebSocketServer::Run(chip::Optional<uint16_t> port, WebSocketServerDe
 
     lws_context_creation_info info;
     memset(&info, 0, sizeof(info));
-    info.port             = port.ValueOr(kDefaultWebSocketServerPort);
-    info.iface            = nullptr;
-    info.pt_serv_buf_size = kMaxMessageBufferLen;
-    info.protocols        = protocols;
+    info.port                         = port.ValueOr(kDefaultWebSocketServerPort);
+    info.iface                        = nullptr;
+    info.pt_serv_buf_size             = kMaxMessageBufferLen;
+    info.protocols                    = protocols;
+    static const lws_retry_bo_t retry = {
+        .secs_since_valid_ping   = 400,
+        .secs_since_valid_hangup = 400,
+    };
+    info.retry_and_idle_policy = &retry;
 
     auto context = lws_create_context(&info);
     VerifyOrReturnError(nullptr != context, CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
As Test_TC_OO_2_3 has been failing on Telink platform because of WS closing on server side, added redefinition of `secs_since_valid_ping` and `secs_since_valid_hangup` so the connection would not be closed during the test.

**Fixes [#29951](https://github.com/project-chip/connectedhomeip/issues/29951)**

Tested on Telink Lighting-App Thread commissioned, as described in issue mentioned above

