### PR TITLE
[ICD] Add Keep active during MDNS resolution ICD Check-In Sender

### DIFF
--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -56,9 +56,7 @@ void FailSafeContext::SetFailSafeArmed(bool armed)
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     if (IsFailSafeArmed() != armed)
     {
-        ICDListener::KeepActiveFlags activeRequest = ICDListener::KeepActiveFlags::kFailSafeArmed;
-        armed ? ICDNotifier::GetInstance().BroadcastActiveRequestNotification(activeRequest)
-              : ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(activeRequest);
+        ICDNotifier::GetInstance().BroadcastActiveRequest(ICDListener::KeepActiveFlag::kFailSafeArmed, armed);
     }
 #endif
     mFailSafeArmed = armed;

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -55,6 +55,7 @@ source_set("sender") {
 
   public_deps = [
     ":cluster",
+    ":notifier",
     "${chip_root}/src/credentials:credentials",
     "${chip_root}/src/lib/address_resolve:address_resolve",
     "${chip_root}/src/protocols/secure_channel",

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -41,7 +41,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::IcdManagement;
 
 static_assert(UINT8_MAX >= CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS,
-              "ICDManager::OpenExchangeContextCount cannot hold count for the max exchange count");
+              "ICDManager::mOpenExchangeContextCount cannot hold count for the max exchange count");
 
 void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeystore)
 {
@@ -278,14 +278,14 @@ void ICDManager::OnKeepActiveRequest(KeepActiveFlags request)
     {
         // There can be multiple open exchange contexts at the same time.
         // Keep track of the requests count.
-        this->OpenExchangeContextCount++;
+        this->mOpenExchangeContextCount++;
     }
 
     if (request.Has(KeepActiveFlag::kCheckInInProgress))
     {
         // There can be multiple check-in at the same time.
         // Keep track of the requests count.
-        this->CheckInRequestCount++;
+        this->mCheckInRequestCount++;
     }
 
     this->SetKeepActiveModeRequirements(request, true /* state */);
@@ -301,16 +301,16 @@ void ICDManager::OnActiveRequestWithdrawal(KeepActiveFlags request)
     {
         // There can be multiple open exchange contexts at the same time.
         // Keep track of the requests count.
-        if (this->OpenExchangeContextCount > 0)
+        if (this->mOpenExchangeContextCount > 0)
         {
-            this->OpenExchangeContextCount--;
+            this->mOpenExchangeContextCount--;
         }
         else
         {
             ChipLogError(DeviceLayer, "The ICD Manager did not account for ExchangeContext closure");
         }
 
-        if (this->OpenExchangeContextCount == 0)
+        if (this->mOpenExchangeContextCount == 0)
         {
             this->SetKeepActiveModeRequirements(KeepActiveFlag::kExchangeContextOpen, false /* state */);
         }
@@ -320,16 +320,16 @@ void ICDManager::OnActiveRequestWithdrawal(KeepActiveFlags request)
     {
         // There can be multiple open exchange contexts at the same time.
         // Keep track of the requests count.
-        if (this->CheckInRequestCount > 0)
+        if (this->mCheckInRequestCount > 0)
         {
-            this->CheckInRequestCount--;
+            this->mCheckInRequestCount--;
         }
         else
         {
             ChipLogError(DeviceLayer, "The ICD Manager did not account for Check-In Sender start");
         }
 
-        if (this->CheckInRequestCount == 0)
+        if (this->mCheckInRequestCount == 0)
         {
             this->SetKeepActiveModeRequirements(KeepActiveFlag::kCheckInInProgress, false /* state */);
         }

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -40,8 +40,6 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::IcdManagement;
 
-uint8_t ICDManager::OpenExchangeContextCount = 0;
-uint8_t ICDManager::CheckInRequestCount      = 0;
 static_assert(UINT8_MAX >= CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS,
               "ICDManager::OpenExchangeContextCount cannot hold count for the max exchange count");
 

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -128,8 +128,8 @@ protected:
      */
     static void OnTransitionToIdle(System::Layer * aLayer, void * appState);
 
-    static uint8_t OpenExchangeContextCount;
-    static uint8_t CheckInRequestCount;
+    uint8_t OpenExchangeContextCount;
+    uint8_t CheckInRequestCount;
 
 private:
     // SIT ICDs should have a SlowPollingThreshold shorter than or equal to 15s (spec 9.16.1.5)

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -119,6 +119,7 @@ protected:
 
     static void OnIdleModeDone(System::Layer * aLayer, void * appState);
     static void OnActiveModeDone(System::Layer * aLayer, void * appState);
+
     /**
      * @brief Callback function called shortly before the device enters idle mode to allow checks to be made. This is currently only
      * called once to prevent entering in a loop if some events re-trigger this check (for instance if a check for subscription
@@ -128,6 +129,7 @@ protected:
     static void OnTransitionToIdle(System::Layer * aLayer, void * appState);
 
     static uint8_t OpenExchangeContextCount;
+    static uint8_t CheckInRequestCount;
 
 private:
     // SIT ICDs should have a SlowPollingThreshold shorter than or equal to 15s (spec 9.16.1.5)
@@ -140,7 +142,7 @@ private:
     static constexpr uint32_t kMinActiveModeDuration  = 300;
     static constexpr uint16_t kMinActiveModeThreshold = 300;
 
-    BitFlags<KeepActiveFlags> mKeepActiveFlags{ 0 };
+    KeepActiveFlags mKeepActiveFlags{ 0 };
 
     OperationalState mOperationalState             = OperationalState::IdleMode;
     ICDMode mICDMode                               = ICDMode::SIT;

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -128,8 +128,8 @@ protected:
      */
     static void OnTransitionToIdle(System::Layer * aLayer, void * appState);
 
-    uint8_t OpenExchangeContextCount;
-    uint8_t CheckInRequestCount;
+    uint8_t mOpenExchangeContextCount = 0;
+    uint8_t mCheckInRequestCount      = 0;
 
 private:
     // SIT ICDs should have a SlowPollingThreshold shorter than or equal to 15s (spec 9.16.1.5)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -544,7 +544,7 @@ void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnu
     {
         mWindowStatus = aNewStatus;
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-        app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlags::kCommissioningWindowOpen;
+        app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
         if (mWindowStatus != CommissioningWindowStatusEnum::kWindowNotOpen)
         {
             app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(request);

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -163,7 +163,7 @@ public:
     static void TestKeepActivemodeRequests(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
-        typedef ICDListener::KeepActiveFlags ActiveFlag;
+        typedef ICDListener::KeepActiveFlag ActiveFlag;
         ICDNotifier notifier = ICDNotifier::GetInstance();
 
         // Setting a requirement will transition the ICD to active mode.

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -326,7 +326,7 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, cons
     SetAutoRequestAck(!session->IsGroupSession());
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(app::ICDListener::KeepActiveFlags::kExchangeContextOpen);
+    app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
 #endif
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
@@ -345,7 +345,7 @@ ExchangeContext::~ExchangeContext()
     VerifyOrDie(mFlags.Has(Flags::kFlagClosed));
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    app::ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(app::ICDListener::KeepActiveFlags::kExchangeContextOpen);
+    app::ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // Ideally, in this scenario, the retransmit table should

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -38,7 +38,6 @@
 #include <platform/ConnectivityManager.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-#include <app/icd/ICDManager.h>  // nogncheck
 #include <app/icd/ICDNotifier.h> // nogncheck
 #endif
 
@@ -259,7 +258,7 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
     // Implement:
     //   "An ICD sender SHOULD increase t to also account for its own sleepy interval
     //   required to receive the acknowledgment"
-    mrpBackoffTime += app::ICDManager::GetFastPollingInterval();
+    mrpBackoffTime += CHIP_DEVICE_CONFIG_ICD_FAST_POLL_INTERVAL;
 #endif
 
     mrpBackoffTime += CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;


### PR DESCRIPTION
Add Keep Active during MDNS resolution

Fix #30492

Breakout of PR #30526 to speed up review and merge.

Also remove Message layer dependency on the ICDManager.