### PR TITLE
[LevelControl] Level Control Recall null level behavior

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -238,18 +238,13 @@ public:
 
         // TODO : Implement action on frequency when frequency not provisional anymore
         // if(LevelControlHasFeature(endpoint, LevelControl::Feature::kFrequency)){}
-        Status status;
+
         CommandId command = LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff) ? Commands::MoveToLevelWithOnOff::Id
                                                                                             : Commands::MoveToLevel::Id;
 
-        status = moveToLevelHandler(endpoint, command, level, app::DataModel::MakeNullable(static_cast<uint16_t>(timeMs / 100)),
-                                    chip::Optional<BitMask<OptionsBitmap>>(), chip::Optional<BitMask<OptionsBitmap>>(),
-                                    INVALID_STORED_LEVEL);
-
-        if (status != Status::Success)
-        {
-            return CHIP_ERROR_READ_FAILED;
-        }
+        moveToLevelHandler(endpoint, command, level, app::DataModel::MakeNullable(static_cast<uint16_t>(timeMs / 100)),
+                           chip::Optional<BitMask<OptionsBitmap>>(), chip::Optional<BitMask<OptionsBitmap>>(),
+                           INVALID_STORED_LEVEL);
 
         return CHIP_NO_ERROR;
     }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -239,12 +239,15 @@ public:
         // TODO : Implement action on frequency when frequency not provisional anymore
         // if(LevelControlHasFeature(endpoint, LevelControl::Feature::kFrequency)){}
 
-        CommandId command = LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff) ? Commands::MoveToLevelWithOnOff::Id
-                                                                                            : Commands::MoveToLevel::Id;
+        if (!chip::app::NumericAttributeTraits<uint8_t>::IsNullValue(level))
+        {
+            CommandId command = LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff) ? Commands::MoveToLevelWithOnOff::Id
+                                                                                                : Commands::MoveToLevel::Id;
 
-        moveToLevelHandler(endpoint, command, level, app::DataModel::MakeNullable(static_cast<uint16_t>(timeMs / 100)),
-                           chip::Optional<BitMask<OptionsBitmap>>(), chip::Optional<BitMask<OptionsBitmap>>(),
-                           INVALID_STORED_LEVEL);
+            moveToLevelHandler(endpoint, command, level, app::DataModel::MakeNullable(static_cast<uint16_t>(timeMs / 100)),
+                               chip::Optional<BitMask<OptionsBitmap>>(), chip::Optional<BitMask<OptionsBitmap>>(),
+                               INVALID_STORED_LEVEL);
+        }
 
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
Applies the spec changes from: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/7645
So that the level control cluster will ignore a null value for the current level attribute coming from a recall scene and the status of the command returns success.

Note: we should merge this after the spec PR gets merged.

Fixes: https://github.com/project-chip/connectedhomeip/issues/29033
Fixes: https://github.com/project-chip/connectedhomeip/issues/29185
