### PR TITLE
[ICD] Start the ICD in idle

### DIFF
--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -73,7 +73,7 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
     // VerifyOrDie(kFastPollingInterval.count() < activeModeDuration);
 
     UpdateICDMode();
-    UpdateOperationState(OperationalState::ActiveMode);
+    UpdateOperationState(OperationalState::IdleMode);
 }
 
 void ICDManager::Shutdown()
@@ -84,7 +84,7 @@ void ICDManager::Shutdown()
     DeviceLayer::SystemLayer().CancelTimer(OnActiveModeDone, this);
     DeviceLayer::SystemLayer().CancelTimer(OnTransitionToIdle, this);
     mICDMode          = ICDMode::SIT;
-    mOperationalState = OperationalState::IdleMode;
+    mOperationalState = OperationalState::ActiveMode;
     mStorage          = nullptr;
     mFabricTable      = nullptr;
     mStateObserverPool.ReleaseAll();

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -141,7 +141,8 @@ private:
 
     BitFlags<KeepActiveFlags> mKeepActiveFlags{ 0 };
 
-    OperationalState mOperationalState             = OperationalState::IdleMode;
+    // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
+    OperationalState mOperationalState             = OperationalState::ActiveMode;
     ICDMode mICDMode                               = ICDMode::SIT;
     PersistentStorageDelegate * mStorage           = nullptr;
     FabricTable * mFabricTable                     = nullptr;

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -141,13 +141,15 @@ public:
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
 
-        // After the init we should be in active mode
+        // After the init we should be in Idle mode
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+        AdvanceClockAndRunEventLoop(ctx, secondsToMilliseconds(ICDManagementServer::GetInstance().GetIdleModeDurationSec()) + 1);
+        // Idle mode interval expired, ICDManager transitioned to the ActiveMode.
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         AdvanceClockAndRunEventLoop(ctx, ICDManagementServer::GetInstance().GetActiveModeDurationMs() + 1);
         // Active mode interval expired, ICDManager transitioned to the IdleMode.
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
         AdvanceClockAndRunEventLoop(ctx, secondsToMilliseconds(ICDManagementServer::GetInstance().GetIdleModeDurationSec()) + 1);
-        // Idle mode interval expired, ICDManager transitioned to the ActiveMode.
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Events updating the Operation to Active mode can extend the current active mode time by 1 Active mode threshold.


### PR DESCRIPTION
fixes #30280
Change the initial value of mOperationalState so the init sequence of the ICDManager triggers the Idle mode behaviour first.

The ICD will toggle in active mode if there is a requirement to do so.


