### PR TITLE
[dns-sd] Untangle dependencies between Resolver and ResolverProxy

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -28,8 +28,6 @@
 #include <transport/SessionDelegate.h>
 #include <transport/SessionUpdateDelegate.h>
 
-#include <lib/dnssd/ResolverProxy.h>
-
 namespace chip {
 
 class OperationalSessionSetupPoolDelegate;

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -117,7 +117,6 @@ CHIP_ERROR DiscoveryCommands::SetupDiscoveryCommands()
         ReturnErrorOnFailure(mDNSResolver.Init(chip::DeviceLayer::UDPEndPointManager()));
         mReady = true;
     }
-    mDNSResolver.SetOperationalDelegate(this);
     mDNSResolver.SetCommissioningDelegate(this);
     return CHIP_NO_ERROR;
 }
@@ -125,7 +124,6 @@ CHIP_ERROR DiscoveryCommands::SetupDiscoveryCommands()
 CHIP_ERROR DiscoveryCommands::TearDownDiscoveryCommands()
 {
     mDNSResolver.StopDiscovery();
-    mDNSResolver.SetOperationalDelegate(nullptr);
     mDNSResolver.SetCommissioningDelegate(nullptr);
     return CHIP_NO_ERROR;
 }

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -24,7 +24,7 @@
 
 #include <app-common/zap-generated/tests/simulated-cluster-objects.h>
 
-class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate, public chip::Dnssd::OperationalResolveDelegate
+class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate
 {
 public:
     DiscoveryCommands(){};
@@ -63,10 +63,6 @@ public:
 
     /////////// CommissioningDelegate Interface /////////
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
-
-    /////////// OperationalDelegate Interface /////////
-    void OnOperationalNodeResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override{};
-    void OnOperationalNodeResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override{};
 
 private:
     bool mReady = false;

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -39,8 +39,7 @@ namespace Controller {
 class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::CommissioningResolveDelegate
 {
 public:
-    AbstractDnssdDiscoveryController() {}
-    ~AbstractDnssdDiscoveryController() override { mDNSResolver.Shutdown(); }
+    explicit AbstractDnssdDiscoveryController(Dnssd::Resolver * resolver = nullptr) : mDNSResolver(resolver) {}
 
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
     CHIP_ERROR StopDiscovery() { return mDNSResolver.StopDiscovery(); };

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -32,30 +32,12 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
 {
     ReturnErrorOnFailure(SetUpNodeDiscovery());
 
-    if (mResolver == nullptr)
-    {
 #if CONFIG_DEVICE_LAYER
-        mDNSResolver.Shutdown(); // reset if already inited
-        ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
+    mDNSResolver.Shutdown(); // reset if already inited
+    ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
 #endif
-        mDNSResolver.SetCommissioningDelegate(this);
-        return mDNSResolver.DiscoverCommissioners(discoveryFilter);
-    }
-
-#if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
-#endif
-    return mResolver->DiscoverCommissioners(discoveryFilter);
-}
-
-CHIP_ERROR CommissionableNodeController::StopDiscovery()
-{
-    if (mResolver == nullptr)
-    {
-        return AbstractDnssdDiscoveryController::StopDiscovery();
-    }
-
-    return mResolver->StopDiscovery();
+    mDNSResolver.SetCommissioningDelegate(this);
+    return mDNSResolver.DiscoverCommissioners(discoveryFilter);
 }
 
 CommissionableNodeController::~CommissionableNodeController()

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -36,13 +36,11 @@ namespace Controller {
 class DLL_EXPORT CommissionableNodeController : public AbstractDnssdDiscoveryController
 {
 public:
-    CommissionableNodeController(chip::Dnssd::Resolver * resolver = nullptr) : mResolver(resolver) {}
+    CommissionableNodeController(chip::Dnssd::Resolver * resolver = nullptr) : AbstractDnssdDiscoveryController(resolver) {}
     ~CommissionableNodeController() override;
 
     void RegisterDeviceDiscoveryDelegate(DeviceDiscoveryDelegate * delegate) { mDeviceDiscoveryDelegate = delegate; }
     CHIP_ERROR DiscoverCommissioners(Dnssd::DiscoveryFilter discoveryFilter = Dnssd::DiscoveryFilter());
-
-    CHIP_ERROR StopDiscovery();
 
     /**
      * @return
@@ -57,7 +55,6 @@ protected:
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mDiscoveredCommissioners); }
 
 private:
-    Dnssd::Resolver * mResolver = nullptr;
     Dnssd::DiscoveredNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];
 };
 

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -36,15 +36,14 @@ public:
     bool IsInitialized() override { return true; }
     void Shutdown() override {}
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
-    void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return ResolveNodeIdStatus; }
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return DiscoverCommissionersStatus; }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate &) override { return DiscoverCommissionersStatus; }
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate &) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StopDiscovery(DiscoveryDelegate &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -38,12 +38,12 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return ResolveNodeIdStatus; }
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate &) override { return DiscoverCommissionersStatus; }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate &) override
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext &) override { return DiscoverCommissionersStatus; }
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext &) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR StopDiscovery(DiscoveryDelegate &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StopDiscovery(DiscoveryContext &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/dnssd/BUILD.gn
+++ b/src/lib/dnssd/BUILD.gn
@@ -34,6 +34,8 @@ static_library("dnssd") {
     "IPAddressSorter.cpp",
     "IPAddressSorter.h",
     "Resolver.h",
+    "ResolverProxy.cpp",
+    "ResolverProxy.h",
     "ServiceNaming.cpp",
     "ServiceNaming.h",
     "TxtFields.cpp",

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -53,9 +53,9 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate & delegate) override;
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate & delegate) override;
-    CHIP_ERROR StopDiscovery(DiscoveryDelegate & delegate) override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) override;
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override;
+    CHIP_ERROR StopDiscovery(DiscoveryContext & context) override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
     static DiscoveryImplPlatform & GetInstance();

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -23,7 +23,6 @@
 #include <lib/core/Global.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/Resolver.h>
-#include <lib/dnssd/ResolverProxy.h>
 #include <lib/dnssd/platform/Dnssd.h>
 #include <platform/CHIPDeviceConfig.h>
 
@@ -52,15 +51,11 @@ public:
 
     // Members that implement Resolver interface.
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
-    void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override
-    {
-        mResolverProxy.SetCommissioningDelegate(delegate);
-    }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
-    CHIP_ERROR StopDiscovery() override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate & delegate) override;
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate & delegate) override;
+    CHIP_ERROR StopDiscovery(DiscoveryDelegate & delegate) override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
     static DiscoveryImplPlatform & GetInstance();
@@ -97,7 +92,6 @@ private:
 
     State mState = State::kUninitialized;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
-    ResolverProxy mResolverProxy;
     OperationalResolveDelegate * mOperationalDelegate = nullptr;
 
     friend class Global<DiscoveryImplPlatform>;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -353,6 +353,18 @@ public:
     virtual void OnNodeDiscovered(const DiscoveredNodeData & nodeData) = 0;
 };
 
+/**
+ * Node discovery context class.
+ *
+ * This class enables multiple clients of the global DNS-SD resolver to start simultaneous
+ * discovery operations.
+ *
+ * An object of this class is shared between a resolver client and the concrete resolver
+ * implementation. The client is responsible for allocating the context and passing it to
+ * the resolver when initiating a discovery operation. The resolver, in turn, is supposed to retain
+ * the context until the operation is finished. This allows the client to release the ownership of
+ * the context at any time without putting the resolver at risk of using a deleted object.
+ */
 class DiscoveryContext : public ReferenceCounted<DiscoveryContext>
 {
 public:

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -1,0 +1,71 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ResolverProxy.h"
+
+#include <lib/support/CHIPMem.h>
+
+namespace chip {
+namespace Dnssd {
+
+ResolverProxy::~ResolverProxy()
+{
+    Shutdown();
+}
+
+CHIP_ERROR ResolverProxy::Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPoint)
+{
+    VerifyOrReturnError(mDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    ReturnErrorOnFailure(mResolver.Init(udpEndPoint));
+    mDelegate = Platform::New<DiscoveryDelegate>();
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return CHIP_NO_ERROR;
+}
+
+void ResolverProxy::Shutdown()
+{
+    VerifyOrReturn(mDelegate != nullptr);
+    mDelegate->SetCommissioningDelegate(nullptr);
+    mDelegate->Release();
+    mDelegate = nullptr;
+}
+
+CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mResolver.DiscoverCommissionableNodes(filter, *mDelegate);
+}
+
+CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mResolver.DiscoverCommissioners(filter, *mDelegate);
+}
+
+CHIP_ERROR ResolverProxy::StopDiscovery()
+{
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mResolver.StopDiscovery(*mDelegate);
+}
+
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -22,11 +22,6 @@
 namespace chip {
 namespace Dnssd {
 
-ResolverProxy::~ResolverProxy()
-{
-    Shutdown();
-}
-
 CHIP_ERROR ResolverProxy::Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPoint)
 {
     VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -29,42 +29,42 @@ ResolverProxy::~ResolverProxy()
 
 CHIP_ERROR ResolverProxy::Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPoint)
 {
-    VerifyOrReturnError(mDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     ReturnErrorOnFailure(mResolver.Init(udpEndPoint));
-    mDelegate = Platform::New<DiscoveryDelegate>();
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_NO_MEMORY);
+    mContext = Platform::New<DiscoveryContext>();
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_NO_MEMORY);
 
     return CHIP_NO_ERROR;
 }
 
 void ResolverProxy::Shutdown()
 {
-    VerifyOrReturn(mDelegate != nullptr);
-    mDelegate->SetCommissioningDelegate(nullptr);
-    mDelegate->Release();
-    mDelegate = nullptr;
+    VerifyOrReturn(mContext != nullptr);
+    mContext->SetCommissioningDelegate(nullptr);
+    mContext->Release();
+    mContext = nullptr;
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    return mResolver.DiscoverCommissionableNodes(filter, *mDelegate);
+    return mResolver.DiscoverCommissionableNodes(filter, *mContext);
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 {
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    return mResolver.DiscoverCommissioners(filter, *mDelegate);
+    return mResolver.DiscoverCommissioners(filter, *mContext);
 }
 
 CHIP_ERROR ResolverProxy::StopDiscovery()
 {
-    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    return mResolver.StopDiscovery(*mDelegate);
+    return mResolver.StopDiscovery(*mContext);
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -33,9 +33,9 @@ public:
 
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate)
     {
-        if (mDelegate != nullptr)
+        if (mContext != nullptr)
         {
-            mDelegate->SetCommissioningDelegate(delegate);
+            mContext->SetCommissioningDelegate(delegate);
         }
     }
 
@@ -45,7 +45,7 @@ public:
 
 private:
     Resolver & mResolver;
-    DiscoveryDelegate * mDelegate = nullptr;
+    DiscoveryContext * mContext = nullptr;
 };
 
 } // namespace Dnssd

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -22,11 +22,24 @@
 namespace chip {
 namespace Dnssd {
 
+/**
+ * Convenience class for discovering Matter commissioners and commissionable nodes.
+ *
+ * The class simplifies the usage of the global DNS-SD resolver to discover Matter nodes by managing
+ * the lifetime of the discovery context object.
+ *
+ * The proxy provides a method to register an external commissioning delegate whose
+ * `OnNodeDiscovered` method is called whenever a new node is discovered. The delegate is
+ * automatically unregistered when the proxy is shut down or destroyed.
+ *
+ * The proxy can be safely shut down or destroyed even if the last discovery operation has not
+ * finished yet.
+ */
 class ResolverProxy
 {
 public:
     explicit ResolverProxy(Resolver * resolver = nullptr) : mResolver(resolver != nullptr ? *resolver : Resolver::Instance()) {}
-    ~ResolverProxy();
+    ~ResolverProxy() { Shutdown(); }
 
     CHIP_ERROR Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPoint = nullptr);
     void Shutdown();

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -687,6 +687,7 @@ void MinMdnsResolver::ExpireIncrementalResolvers()
 
 CHIP_ERROR MinMdnsResolver::DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context)
 {
+    // minmdns currently supports only one discovery context at a time so override the previous context
     SetDiscoveryContext(&context);
 
     return BrowseNodes(DiscoveryType::kCommissionableNode, filter);
@@ -694,6 +695,7 @@ CHIP_ERROR MinMdnsResolver::DiscoverCommissionableNodes(DiscoveryFilter filter, 
 
 CHIP_ERROR MinMdnsResolver::DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context)
 {
+    // minmdns currently supports only one discovery context at a time so override the previous context
     SetDiscoveryContext(&context);
 
     return BrowseNodes(DiscoveryType::kCommissionerNode, filter);

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -40,15 +40,15 @@ public:
     {
         ChipLogError(Discovery, "Failed to stop resolving node ID: dnssd resolving not available");
     }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate & delegate) override
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate & delegate) override
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR StopDiscovery(DiscoveryDelegate & delegate) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StopDiscovery(DiscoveryContext & context) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -17,7 +17,6 @@
 
 #include "Resolver.h"
 
-#include <lib/dnssd/ResolverProxy.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -31,7 +30,6 @@ public:
     bool IsInitialized() override { return true; }
     void Shutdown() override {}
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
-    void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override
     {
@@ -42,12 +40,15 @@ public:
     {
         ChipLogError(Discovery, "Failed to stop resolving node ID: dnssd resolving not available");
     }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryDelegate & delegate) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryDelegate & delegate) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR StopDiscovery(DiscoveryDelegate & delegate) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
@@ -61,31 +62,6 @@ NoneResolver gResolver;
 Resolver & chip::Dnssd::Resolver::Instance()
 {
     return gResolver;
-}
-
-ResolverProxy::~ResolverProxy()
-{
-    Shutdown();
-}
-
-CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
-{
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
-{
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ResolverProxy::StopDiscovery()
-{
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-}
-
-CHIP_ERROR ResolverProxy::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
-{
-    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 } // namespace Dnssd

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -38,7 +38,6 @@ namespace {
 
 Shell::Engine sShellDnsBrowseSubcommands;
 Shell::Engine sShellDnsSubcommands;
-Dnssd::ResolverProxy sResolverProxy;
 
 class DnsShellResolverDelegate : public Dnssd::CommissioningResolveDelegate, public AddressResolve::NodeListener
 {
@@ -211,31 +210,29 @@ bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)
 CHIP_ERROR BrowseCommissionableHandler(int argc, char ** argv)
 {
     Dnssd::DiscoveryFilter filter;
+    VerifyOrReturnError(ParseSubType(argc, argv, filter), CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (!ParseSubType(argc, argv, filter))
-    {
-        streamer_printf(streamer_get(), "Invalid argument\r\n");
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
+    Dnssd::ResolverProxy resolverProxy;
+    ReturnErrorOnFailure(resolverProxy.Init(DeviceLayer::UDPEndPointManager()));
+    resolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
 
     streamer_printf(streamer_get(), "Browsing commissionable nodes...\r\n");
 
-    return sResolverProxy.DiscoverCommissionableNodes(filter);
+    return resolverProxy.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
 {
     Dnssd::DiscoveryFilter filter;
+    VerifyOrReturnError(ParseSubType(argc, argv, filter), CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (!ParseSubType(argc, argv, filter))
-    {
-        streamer_printf(streamer_get(), "Invalid argument\r\n");
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
+    Dnssd::ResolverProxy resolverProxy;
+    ReturnErrorOnFailure(resolverProxy.Init(DeviceLayer::UDPEndPointManager()));
+    resolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
 
     streamer_printf(streamer_get(), "Browsing commissioners...\r\n");
 
-    return sResolverProxy.DiscoverCommissioners(filter);
+    return resolverProxy.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR BrowseHandler(int argc, char ** argv)
@@ -256,9 +253,6 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
         sShellDnsSubcommands.ForEachCommand(PrintCommandHelp, nullptr);
         return CHIP_NO_ERROR;
     }
-
-    sResolverProxy.Init(DeviceLayer::UDPEndPointManager());
-    sResolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);
 }

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -38,6 +38,7 @@ namespace {
 
 Shell::Engine sShellDnsBrowseSubcommands;
 Shell::Engine sShellDnsSubcommands;
+Dnssd::ResolverProxy sResolverProxy;
 
 class DnsShellResolverDelegate : public Dnssd::CommissioningResolveDelegate, public AddressResolve::NodeListener
 {
@@ -212,13 +213,9 @@ CHIP_ERROR BrowseCommissionableHandler(int argc, char ** argv)
     Dnssd::DiscoveryFilter filter;
     VerifyOrReturnError(ParseSubType(argc, argv, filter), CHIP_ERROR_INVALID_ARGUMENT);
 
-    Dnssd::ResolverProxy resolverProxy;
-    ReturnErrorOnFailure(resolverProxy.Init(DeviceLayer::UDPEndPointManager()));
-    resolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
-
     streamer_printf(streamer_get(), "Browsing commissionable nodes...\r\n");
 
-    return resolverProxy.DiscoverCommissionableNodes(filter);
+    return sResolverProxy.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
@@ -226,13 +223,9 @@ CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
     Dnssd::DiscoveryFilter filter;
     VerifyOrReturnError(ParseSubType(argc, argv, filter), CHIP_ERROR_INVALID_ARGUMENT);
 
-    Dnssd::ResolverProxy resolverProxy;
-    ReturnErrorOnFailure(resolverProxy.Init(DeviceLayer::UDPEndPointManager()));
-    resolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
-
     streamer_printf(streamer_get(), "Browsing commissioners...\r\n");
 
-    return resolverProxy.DiscoverCommissioners(filter);
+    return sResolverProxy.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR BrowseHandler(int argc, char ** argv)
@@ -242,6 +235,9 @@ CHIP_ERROR BrowseHandler(int argc, char ** argv)
         sShellDnsBrowseSubcommands.ForEachCommand(PrintCommandHelp, nullptr);
         return CHIP_NO_ERROR;
     }
+
+    sResolverProxy.Init(DeviceLayer::UDPEndPointManager());
+    sResolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsBrowseSubcommands.ExecCommand(argc, argv);
 }


### PR DESCRIPTION
The relationship between Resolver and Resolver Proxy is unclear as both classes depend on each other and Resolver Proxy is implemented in a source file of concrete Resolver implementation. This makes it impossible to build Matter library with several Resolver implementations and select one to be used at runtime.

The main reason for introducing Resolver Proxy was the need for running multiple parallel DNS-SD queries. Address this by adding Discovery Delegate parameter to the Resolver interface methods for starting and stopping the discovery.

Then implement Resolver Proxy as a convenience class on top of the Resolver interface. Additionally, simplify the Commissionable Node Controller class by injecting a test Resolver into Resolver Proxy.

This change is sort of aligned with https://github.com/project-chip/connectedhomeip/pull/29264 that removed the usage of `ResolverProxy` from the operational discovery path.

