### PR TITLE
run_zaptool and configure tweaks

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -93,6 +93,10 @@ function main() { # ...
         [[ -n "$PROJECT_PATH" && -r "${PROJECT_PATH}/.gn" ]] || fail "Invalid project '${PROJECT}' - missing .gn at '${PROJECT_PATH}'"
     fi
 
+    if [[ -n "$PW_ROOT" ]]; then
+        info "WARNING: A Pigweed environment appears to be active, this is usually a misconfiguration."
+    fi
+
     check_binary gn GN
     check_binary ninja NINJA
 
@@ -149,7 +153,7 @@ function create_empty_pw_env() {
             info "Creating empty $gni in source tree"
             echo "# ${CONFIGURE_MARKER}" >"${CHIP_ROOT}/${gni}"
         else
-            info "Warning: Leaving existing $gni in place, this might affect the build configuration."
+            info "WARNING: Leaving existing $gni in place, this might affect the build configuration."
         fi
     fi
 }

--- a/scripts/tools/zap/run_zaptool.sh
+++ b/scripts/tools/zap/run_zaptool.sh
@@ -31,6 +31,10 @@ SCRIPT_PATH="$(_get_fullpath "$0")"
 CHIP_ROOT="${SCRIPT_PATH%/scripts/tools/zap/run_zaptool.sh}"
 [[ -n "$1" ]] && ZAP_ARGS="-i \"$(_get_fullpath "$1")\"" || ZAP_ARGS=""
 
+if [[ -z "$ZAP_INSTALL_PATH" && -n "$PW_ZAP_CIPD_INSTALL_DIR" ]]; then
+    ZAP_INSTALL_PATH="$PW_ZAP_CIPD_INSTALL_DIR"
+fi
+
 if [ ! -z "$ZAP_DEVELOPMENT_PATH" ]; then
     WORKING_DIR=$ZAP_DEVELOPMENT_PATH
     ZAP_CMD="node src-script/zap-start.js"


### PR DESCRIPTION
configure: warn if running with an active PW environment
run_zaptool: default ZAP_INSTALL_PATH to PW_ZAP_CIPD_INSTALL_DIR
