### PR TITLE
Add comment regarding why platforms depend on address resolve config

### DIFF
--- a/src/platform/Infineon/CYW30739/BUILD.gn
+++ b/src/platform/Infineon/CYW30739/BUILD.gn
@@ -82,6 +82,11 @@ static_library("CYW30739") {
       "ThreadStackManagerImpl.cpp",
       "ThreadStackManagerImpl.h",
     ]
+
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
     public_configs = [
       "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
     ]

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -106,8 +106,9 @@ static_library("BL702") {
     #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
     #
     #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs =
-        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
+    public_configs = [
+      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
+    ]
   }
 
   if (chip_enable_ethernet) {

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -101,6 +101,13 @@ static_library("BL702") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
+
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
+    public_configs =
+        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
   }
 
   if (chip_enable_ethernet) {
@@ -115,7 +122,4 @@ static_library("BL702") {
 
   deps += [ "${chip_root}/src/credentials:credentials_header" ]
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
-
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 }

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -93,8 +93,9 @@ static_library("BL702L") {
     #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
     #
     #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs =
-        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
+    public_configs = [
+      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
+    ]
   }
 
   deps += [ "${chip_root}/src/credentials:credentials_header" ]

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -88,11 +88,15 @@ static_library("BL702L") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
+
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
+    public_configs =
+        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
   }
 
   deps += [ "${chip_root}/src/credentials:credentials_header" ]
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
-
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 }

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
@@ -52,6 +52,11 @@ static_library("cc13x2_26x2") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/platform:platform_base",
   ]
+
+  # TODO: platform should NOT depend on default_address_resolve_config. This should
+  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+  #
+  #       Currently this exists because OpenThread platform includes src/app/Server.h
   public_configs =
       [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
@@ -52,6 +52,11 @@ static_library("cc13x4_26x4") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/platform:platform_base",
   ]
+
+  # TODO: platform should NOT depend on default_address_resolve_config. This should
+  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+  #
+  #       Currently this exists because OpenThread platform includes src/app/Server.h
   public_configs =
       [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 

--- a/src/platform/nxp/k32w/k32w0/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w0/BUILD.gn
@@ -145,8 +145,9 @@ static_library("k32w0") {
     #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
     #
     #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs =
-        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
+    public_configs = [
+      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
+    ]
   }
 
   public_deps += [ "${chip_root}/src/crypto" ]

--- a/src/platform/nxp/k32w/k32w0/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w0/BUILD.gn
@@ -140,10 +140,14 @@ static_library("k32w0") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
+
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
+    public_configs =
+        [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
   }
 
   public_deps += [ "${chip_root}/src/crypto" ]
-
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 }

--- a/src/platform/nxp/k32w/k32w1/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w1/BUILD.gn
@@ -107,6 +107,10 @@ static_library("k32w1") {
 
   public_deps += [ "${chip_root}/src/crypto" ]
 
+  # TODO: platform should NOT depend on default_address_resolve_config. This should
+  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+  #
+  #       Currently this exists because OpenThread platform includes src/app/Server.h
   public_configs =
       [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 }

--- a/src/platform/nxp/rt/rw61x/BUILD.gn
+++ b/src/platform/nxp/rt/rw61x/BUILD.gn
@@ -147,7 +147,10 @@ static_library("nxp_platform") {
   public_configs = [
     ":nxp_platform_config",
 
-    # address_resolve config needed by the include of server.h in ConfigurationManagerImpl.cpp
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
     "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
   ]
 }

--- a/src/platform/qpg/BUILD.gn
+++ b/src/platform/qpg/BUILD.gn
@@ -70,6 +70,10 @@ static_library("qpg") {
       public_deps += [ "${openthread_root}:libopenthread-mtd" ]
     }
 
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
     public_configs += [
       "${chip_root}/third_party/openthread/platforms/qpg:openthread_qpg_config",
       "${chip_root}/src/lib/address_resolve:default_address_resolve_config",

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -124,6 +124,10 @@ static_library("efr32") {
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
 
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
     public_configs = [
       "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
     ]

--- a/src/platform/stm32/BUILD.gn
+++ b/src/platform/stm32/BUILD.gn
@@ -90,6 +90,10 @@ static_library("stm32") {
 
     deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
 
+    # TODO: platform should NOT depend on default_address_resolve_config. This should
+    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
+    #
+    #       Currently this exists because OpenThread platform includes src/app/Server.h
     public_configs = [
       "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
     ]


### PR DESCRIPTION
We should not have a platform dependency on address_resolve, yet here we are.

Added a comment so that this is not copy & pasted and also so that it is removed in time (I hope) when #30596 is fixed.