### PR TITLE
RVC: Fix conformance

### DIFF
--- a/examples/rvc-app/rvc-common/rvc-app.matter
+++ b/examples/rvc-app/rvc-common/rvc-app.matter
@@ -646,12 +646,7 @@ server cluster AdministratorCommissioning = 60 {
     octet_string<32> salt = 4;
   }
 
-  request struct OpenBasicCommissioningWindowRequest {
-    int16u commissioningTimeout = 0;
-  }
-
   timed command access(invoke: administer) OpenCommissioningWindow(OpenCommissioningWindowRequest): DefaultSuccess = 0;
-  timed command access(invoke: administer) OpenBasicCommissioningWindow(OpenBasicCommissioningWindowRequest): DefaultSuccess = 1;
   timed command access(invoke: administer) RevokeCommissioning(): DefaultSuccess = 2;
 }
 
@@ -1134,7 +1129,6 @@ endpoint 0 {
     ram      attribute clusterRevision default = 0x0001;
 
     handle command OpenCommissioningWindow;
-    handle command OpenBasicCommissioningWindow;
     handle command RevokeCommissioning;
   }
 
@@ -1190,7 +1184,7 @@ endpoint 1 {
     callback attribute eventList;
     callback attribute attributeList default = 0;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 2;
+    ram      attribute clusterRevision default = 4;
 
     handle command Identify;
     handle command TriggerEffect;

--- a/examples/rvc-app/rvc-common/rvc-app.zap
+++ b/examples/rvc-app/rvc-common/rvc-app.zap
@@ -1427,14 +1427,6 @@
               "isEnabled": 1
             },
             {
-              "name": "OpenBasicCommissioningWindow",
-              "code": 1,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
               "name": "RevokeCommissioning",
               "code": 2,
               "mfgCode": null,
@@ -2095,7 +2087,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "4",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
- admin commissioning doesn't have the BCW feature, but had the command on - turned off command
- Identify cluster revision is now 4. It already included the v4 attribute, it was just the revision that was incorrect.

