### PR TITLE
Issue ##30486 Set custom rpc port

### DIFF
--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -82,6 +82,7 @@ executable("chip-lighting-app") {
       "$dir_pw_log",
       "$dir_pw_rpc:server",
       "$dir_pw_rpc/system_server:facade",
+      "$dir_pw_rpc/system_server:socket",
       "$dir_pw_stream:socket_stream",
       "$dir_pw_stream:sys_io_stream",
       "$dir_pw_sync:mutex",

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -425,7 +425,7 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     }
 
 #if defined(PW_RPC_ENABLED)
-    rpc::Init();
+    rpc::Init(LinuxDeviceOptions::GetInstance().rpcServerPort);
     ChipLogProgress(NotSpecified, "PW_RPC initialized.");
 #endif // defined(PW_RPC_ENABLED)
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -84,6 +84,9 @@ enum
     kCommissionerOption_FabricID                        = 0x1020,
     kTraceTo                                            = 0x1021,
     kOptionSimulateNoInternalTime                       = 0x1022,
+#if defined(PW_RPC_ENABLED)
+    kOptionRpcServerPort                                = 0x1023,
+#endif
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -138,6 +141,9 @@ OptionDef sDeviceOptionDefs[] = {
     { "trace-to", kArgumentRequired, kTraceTo },
 #endif
     { "simulate-no-internal-time", kNoArgument, kOptionSimulateNoInternalTime },
+#if defined(PW_RPC_ENABLED)
+    { "rpc-server-port", kArgumentRequired, kOptionRpcServerPort },
+#endif
     {}
 };
 
@@ -254,6 +260,10 @@ const char * sDeviceOptionHelp =
 #endif
     "  --simulate-no-internal-time\n"
     "       Time cluster does not use internal platform time\n"
+#if defined(PW_RPC_ENABLED)
+    "  --rpc-server-port\n"
+    "       Start RPC server on specified port\n"
+#endif
     "\n";
 
 bool Base64ArgToVector(const char * arg, size_t maxSize, std::vector<uint8_t> & outVector)
@@ -507,6 +517,11 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     case kOptionSimulateNoInternalTime:
         LinuxDeviceOptions::GetInstance().mSimulateNoInternalTime = true;
         break;
+#if defined(PW_RPC_ENABLED)
+    case kOptionRpcServerPort:
+        LinuxDeviceOptions::GetInstance().rpcServerPort = static_cast<uint16_t>(atoi(aValue));
+        break;
+#endif
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -85,7 +85,7 @@ enum
     kTraceTo                                            = 0x1021,
     kOptionSimulateNoInternalTime                       = 0x1022,
 #if defined(PW_RPC_ENABLED)
-    kOptionRpcServerPort                                = 0x1023,
+    kOptionRpcServerPort = 0x1023,
 #endif
 };
 

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -68,7 +68,9 @@ struct LinuxDeviceOptions
     chip::FabricId commissionerFabricId   = chip::kUndefinedFabricId;
     std::vector<std::string> traceTo;
     bool mSimulateNoInternalTime = false;
-
+#if defined(PW_RPC_ENABLED)
+    uint16_t rpcServerPort = 33000;
+#endif
     static LinuxDeviceOptions & GetInstance();
 };
 

--- a/examples/platform/linux/Rpc.cpp
+++ b/examples/platform/linux/Rpc.cpp
@@ -18,6 +18,7 @@
 
 #include "pw_rpc/server.h"
 #include "pw_rpc_system_server/rpc_server.h"
+#include "pw_rpc_system_server/socket.h"
 
 #include <thread>
 
@@ -116,9 +117,10 @@ void RunRpcService()
     pw::rpc::system_server::Start();
 }
 
-int Init()
+int Init(uint16_t rpcServerPort)
 {
     int err = 0;
+    pw::rpc::system_server::set_socket_port(rpcServerPort);
     std::thread rpc_service(RunRpcService);
     rpc_service.detach();
     return err;

--- a/examples/platform/linux/Rpc.h
+++ b/examples/platform/linux/Rpc.h
@@ -21,7 +21,7 @@
 namespace chip {
 namespace rpc {
 
-int Init();
+int Init(uint16_t rpcServerPort);
 
 } // namespace rpc
 } // namespace chip


### PR DESCRIPTION
Added the possibility to set a custom RPC server port when running e.g. chip lighting example.