### PR TITLE
[OpenThread] Fix Circular dependency OpenThreadPlatform

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -408,6 +408,16 @@ void Server::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event)
         ResumeSubscriptions();
 #endif
         break;
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+    case DeviceEventType::kThreadConnectivityChange:
+        if (event.ThreadConnectivityChange.Result == kConnectivity_Established)
+        {
+            // Refresh Multicast listening
+            ChipLogDetail(DeviceLayer, "Thread Attached updating Multicast address");
+            RejoinExistingMulticastGroups();
+        }
+        break;
+#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     default:
         break;
     }

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -65,9 +65,6 @@
 #include <app/data-model/Encode.h>
 
 #include <limits>
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
-#include <app/server/Server.h>
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 extern "C" void otSysProcessDrivers(otInstance * aInstance);
 
 #if CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
@@ -209,15 +206,6 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
                 ChipLogError(DeviceLayer, "Failed to post Thread connectivity change: %" CHIP_ERROR_FORMAT, status.Format());
             }
         }
-
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
-        if (event->ThreadStateChange.AddressChanged && isThreadAttached)
-        {
-            // Refresh Multicast listening
-            ChipLogDetail(DeviceLayer, "Thread Attached updating Multicast address");
-            Server::GetInstance().RejoinExistingMulticastGroups();
-        }
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
 #if CHIP_DETAIL_LOGGING
         LogOpenThreadStateChange(mOTInst, event->ThreadStateChange.OpenThread.Flags);

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -124,13 +124,7 @@ static_library("efr32") {
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
 
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
+    public_configs = []
   }
 
   if (chip_enable_wifi) {


### PR DESCRIPTION
Fix #30596 


Use the generated even to trigger Multicast rejoin directly in Server.cpp instead of being in the OpenThread platform layer, thus removing the circular dependency. 


Tested on Silabs MG24 and we are able to see the `Thread Attached updating Multicast address` when the device is connected to a Thread network 

