### PR TITLE
[ReportScheduler] Fixed chunked reporting for Synchronized Report Scheduler

### DIFF
--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -154,7 +154,10 @@ public:
     }
 
     /// @brief Check if a ReadHandler is reportable without considering the timing
-    bool IsReadHandlerReportable(ReadHandler * aReadHandler) const { return aReadHandler->ShouldStartReporting(); }
+    bool IsReadHandlerReportable(ReadHandler * aReadHandler) const
+    {
+        return (nullptr != aReadHandler) ? aReadHandler->ShouldStartReporting() : false;
+    }
     /// @brief Sets the ForceDirty flag of a ReadHandler
     void HandlerForceDirtyState(ReadHandler * aReadHandler) { aReadHandler->ForceDirtyState(); }
 

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -96,6 +96,7 @@ public:
                      IsEngineRunScheduled()));
         }
 
+        bool IsChunkedReport() const { return mReadHandler->IsChunkedReport(); }
         bool IsEngineRunScheduled() const { return mFlags.Has(ReadHandlerNodeFlags::EngineRunScheduled); }
         void SetEngineRunScheduled(bool aEngineRunScheduled)
         {

--- a/src/app/reporting/ReportSchedulerImpl.h
+++ b/src/app/reporting/ReportSchedulerImpl.h
@@ -44,7 +44,7 @@ public:
     void OnSubscriptionReportSent(ReadHandler * aReadHandler) final;
     void OnReadHandlerDestroyed(ReadHandler * aReadHandler) override;
 
-    bool IsReportScheduled(ReadHandler * aReadHandler);
+    virtual bool IsReportScheduled(ReadHandler * aReadHandler);
 
     void ReportTimerCallback() override;
 

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -191,7 +191,8 @@ void SynchronizedReportSchedulerImpl::TimerFired()
 
         if (node->IsReportableNow(now))
         {
-            // We assume we fired the timer early if no handler is reportable at the moment
+            // We set firedEarly false here because we assume we fired the timer early if no handler is reportable at the moment,
+            // which becomes false if we find a handler that is reportable
             firedEarly = false;
             node->SetEngineRunScheduled(true);
             ChipLogProgress(DataManagement, "Handler: %p with min: 0x" ChipLogFormatX64 " and max: 0x" ChipLogFormatX64 "", (node),

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -133,7 +133,6 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::FindNextMinInterval(const Timestamp 
 CHIP_ERROR SynchronizedReportSchedulerImpl::CalculateNextReportTimeout(Timeout & timeout, ReadHandlerNode * aNode,
                                                                        const Timestamp & now)
 {
-    VerifyOrReturnError(nullptr != FindReadHandlerNode(aNode->GetReadHandler()), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(FindNextMaxInterval(now));
     ReturnErrorOnFailure(FindNextMinInterval(now));
     bool reportableNow   = false;
@@ -205,18 +204,8 @@ void SynchronizedReportSchedulerImpl::TimerFired()
     // If there are no handlers registers, no need to schedule the next report
     if (mNodesPool.Allocated() && firedEarly)
     {
-        ReadHandlerNode * firstNode = nullptr;
-
-        // If we fired the timer early, we need to restart the timer
-        mNodesPool.ForEachActiveObject([&firstNode](ReadHandlerNode * node) {
-            firstNode = node;
-            return Loop::Break;
-        });
-
-        VerifyOrReturn(firstNode); // Verify we have a valid node
-
         Timeout timeout = Milliseconds32(0);
-        ReturnOnFailure(CalculateNextReportTimeout(timeout, firstNode, now));
+        ReturnOnFailure(CalculateNextReportTimeout(timeout, nullptr, now));
         ScheduleReport(timeout, nullptr, now);
     }
     else

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -212,8 +212,7 @@ void SynchronizedReportSchedulerImpl::TimerFired()
             return Loop::Break;
         });
 
-        bool firstNodeFound = (nullptr != firstNode);
-        VerifyOrReturn(firstNodeFound);
+        VerifyOrReturn(firstNode); // Verify we have a valid node
 
         Timeout timeout = Milliseconds32(0);
         ReturnOnFailure(CalculateNextReportTimeout(timeout, firstNode, now));

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -40,7 +40,7 @@ public:
 
     void OnTransitionToIdle() override;
 
-    bool IsReportScheduled();
+    bool IsReportScheduled(ReadHandler * ReadHandler) override;
 
     void TimerFired() override;
 

--- a/src/app/reporting/tests/MockReportScheduler.cpp
+++ b/src/app/reporting/tests/MockReportScheduler.cpp
@@ -29,7 +29,7 @@ namespace reporting {
 
 static chip::app::DefaultTimerDelegate sTimerDelegate;
 static ReportSchedulerImpl sTestDefaultReportScheduler(&sTimerDelegate);
-static SynchronizedReportSchedulerImpl sTestReportScheduler(&sTimerDelegate);
+static SynchronizedReportSchedulerImpl sTestSyncReportScheduler(&sTimerDelegate);
 
 ReportSchedulerImpl * GetDefaultReportScheduler()
 {
@@ -38,7 +38,7 @@ ReportSchedulerImpl * GetDefaultReportScheduler()
 
 SynchronizedReportSchedulerImpl * GetSynchronizedReportScheduler()
 {
-    return &sTestReportScheduler;
+    return &sTestSyncReportScheduler;
 }
 
 } // namespace reporting

--- a/src/app/tests/TestReportScheduler.cpp
+++ b/src/app/tests/TestReportScheduler.cpp
@@ -517,7 +517,7 @@ public:
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 2);
 
         // Confirm that a report emission is scheduled
-        NL_TEST_ASSERT(aSuite, syncScheduler.IsReportScheduled());
+        NL_TEST_ASSERT(aSuite, syncScheduler.IsReportScheduled(readHandler1));
 
         // Validates that the lowest max is selected as the common max timestamp
         NL_TEST_ASSERT(aSuite, syncScheduler.mNextMaxTimestamp == node1->GetMaxTimestamp());


### PR DESCRIPTION
Fix bug where chunked report would not be properly handled by synchronised report scheduler and added a version of TestReadInteraction unit test that would perform all the read interaction tests while using the synchronized report scheduler. 

The Report Synchronisation logic has also been changed so it gets rescheduled if a timer somehow fired too early for its handler's min interval.

Fixes: https://github.com/project-chip/connectedhomeip/issues/30518
