### PR TITLE
More support for local action runner act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,27 @@
+# This file contains settings for local github action runner act:
+# https://github.com/nektos/act
+#
+# It is recommended to run specific jobs that you need, all jobs except those
+# running on should darwin work.
+# e.g. act -j build_linux
+#
+# It is recommended to set up a separate bridge network
+# and possibly define it in  ~/.actrc like so:
+# --network=bridge
+# https://docs.docker.com/network/drivers/bridge/
+
+# Remove containers after finishing a job, comment out for debugging
+--rm
+
+# Reuse the checkout from host, otherwise act will do docker cp that makes
+# running jobs a lot longer even on SSD. Clean up your .environment before
+# running it.
+--bind
+
+# Easier to have 1:1 match between triggering jobs and reading logs when they
+# use the same name
+--log-prefix-job-id
+
+# Default runner image does not include enough.
+# https://github.com/nektos/act#default-runners-are-intentionally-incomplete
+-P ubuntu-latest=catthehacker/ubuntu:full-latest

--- a/.github/actions/checkout-submodules-and-bootstrap/action.yaml
+++ b/.github/actions/checkout-submodules-and-bootstrap/action.yaml
@@ -17,6 +17,8 @@ runs:
   steps:
     - name: Dump disk info
       uses: ./.github/actions/dump-disk-info
+    - name: Set git safe directory for local act runs
+      uses: ./.github/actions/git-safe-directory
     - name: Checkout submodules
       uses: ./.github/actions/checkout-submodules
       with:

--- a/.github/actions/git-safe-directory/action.yaml
+++ b/.github/actions/git-safe-directory/action.yaml
@@ -1,0 +1,9 @@
+name: Git safe directory
+description: For running act with checkout owned by non-root user
+runs:
+  using: "composite"
+  steps:
+    - name: Set git safe.directory to "*"
+      if: ${{ env.ACT }}
+      shell: bash
+      run: git config --system --add safe.directory '*'


### PR DESCRIPTION
- add .actrc with detailed comments

   decisions for defaults:
   - use bind mount rather than docker cp for speed (requires cleaning environment and action addition)
   - remove containers and volumes after finishing - those can quickly build up to big sizes

- add action that sets git's safe directory to * for act runs git started checking if user running git and user owning repo are the same github requires containers to run as root user act doing docker cp takes long time but bind is quick, yet we get fperm issues as most people dont have root owned repo.

