### PR TITLE
Remove dependency on src/lib/address_resolve from platform

### DIFF
--- a/src/platform/Infineon/CYW30739/BUILD.gn
+++ b/src/platform/Infineon/CYW30739/BUILD.gn
@@ -83,14 +83,6 @@ static_library("CYW30739") {
       "ThreadStackManagerImpl.h",
     ]
 
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
-
     deps += [
       "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     ]

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -101,14 +101,6 @@ static_library("BL702") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
-
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
   }
 
   if (chip_enable_ethernet) {

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -88,14 +88,6 @@ static_library("BL702L") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
-
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
   }
 
   deps += [ "${chip_root}/src/credentials:credentials_header" ]

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/BUILD.gn
@@ -53,13 +53,6 @@ static_library("cc13x2_26x2") {
     "${chip_root}/src/platform:platform_base",
   ]
 
-  # TODO: platform should NOT depend on default_address_resolve_config. This should
-  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-  #
-  #       Currently this exists because OpenThread platform includes src/app/Server.h
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
-
   if (chip_enable_ble) {
     sources += [
       "../BLEManagerImpl.cpp",

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/BUILD.gn
@@ -53,13 +53,6 @@ static_library("cc13x4_26x4") {
     "${chip_root}/src/platform:platform_base",
   ]
 
-  # TODO: platform should NOT depend on default_address_resolve_config. This should
-  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-  #
-  #       Currently this exists because OpenThread platform includes src/app/Server.h
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
-
   if (chip_enable_ble) {
     sources += [
       "../BLEManagerImpl.cpp",

--- a/src/platform/nxp/k32w/k32w0/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w0/BUILD.gn
@@ -140,14 +140,6 @@ static_library("k32w0") {
       ]
       deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
     }
-
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
   }
 
   public_deps += [ "${chip_root}/src/crypto" ]

--- a/src/platform/nxp/k32w/k32w1/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w1/BUILD.gn
@@ -106,11 +106,4 @@ static_library("k32w1") {
   }
 
   public_deps += [ "${chip_root}/src/crypto" ]
-
-  # TODO: platform should NOT depend on default_address_resolve_config. This should
-  #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-  #
-  #       Currently this exists because OpenThread platform includes src/app/Server.h
-  public_configs =
-      [ "${chip_root}/src/lib/address_resolve:default_address_resolve_config" ]
 }

--- a/src/platform/nxp/rt/rw61x/BUILD.gn
+++ b/src/platform/nxp/rt/rw61x/BUILD.gn
@@ -144,7 +144,5 @@ static_library("nxp_platform") {
     "${chip_root}/src/platform:syscalls_stub",
   ]
 
-  public_configs = [
-    ":nxp_platform_config",
-  ]
+  public_configs = [ ":nxp_platform_config" ]
 }

--- a/src/platform/nxp/rt/rw61x/BUILD.gn
+++ b/src/platform/nxp/rt/rw61x/BUILD.gn
@@ -146,11 +146,5 @@ static_library("nxp_platform") {
 
   public_configs = [
     ":nxp_platform_config",
-
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
   ]
 }

--- a/src/platform/qpg/BUILD.gn
+++ b/src/platform/qpg/BUILD.gn
@@ -70,15 +70,6 @@ static_library("qpg") {
       public_deps += [ "${openthread_root}:libopenthread-mtd" ]
     }
 
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs += [
-      "${chip_root}/third_party/openthread/platforms/qpg:openthread_qpg_config",
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
-
     sources += [
       "../OpenThread/OpenThreadUtils.cpp",
       "ThreadStackManagerImpl.cpp",

--- a/src/platform/qpg/BUILD.gn
+++ b/src/platform/qpg/BUILD.gn
@@ -70,6 +70,10 @@ static_library("qpg") {
       public_deps += [ "${openthread_root}:libopenthread-mtd" ]
     }
 
+    public_configs += [
+      "${chip_root}/third_party/openthread/platforms/qpg:openthread_qpg_config",
+    ]
+
     sources += [
       "../OpenThread/OpenThreadUtils.cpp",
       "ThreadStackManagerImpl.cpp",

--- a/src/platform/stm32/BUILD.gn
+++ b/src/platform/stm32/BUILD.gn
@@ -89,14 +89,6 @@ static_library("stm32") {
     public_deps += [ "${stm32_sdk_build_root}:stm32_sdk" ]
 
     deps += [ "${chip_root}/src/lib/dnssd:platform_header" ]
-
-    # TODO: platform should NOT depend on default_address_resolve_config. This should
-    #       be removed. See https://github.com/project-chip/connectedhomeip/issues/30596
-    #
-    #       Currently this exists because OpenThread platform includes src/app/Server.h
-    public_configs = [
-      "${chip_root}/src/lib/address_resolve:default_address_resolve_config",
-    ]
   }
 
   # Set the compiler flags


### PR DESCRIPTION
Now that #30596 is fixed, we expect to need this less.

There are a few more open bugs for sliabs and nxp, I will check how CI behaves and add those back with an approriate comment if needed.

