### PR TITLE
[Scenes] .zap .matter attributes RAM fix

### DIFF
--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -4429,9 +4429,9 @@ endpoint 1 {
   }
 
   server cluster Scenes {
-    callback attribute nameSupport default = 0x80;
-    callback attribute lastConfiguredBy;
-    callback attribute sceneTableSize default = 16;
+    ram      attribute nameSupport default = 0x80;
+    ram      attribute lastConfiguredBy;
+    ram      attribute sceneTableSize default = 16;
     callback attribute fabricSceneInfo;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
@@ -4989,8 +4989,8 @@ endpoint 2 {
   }
 
   server cluster Scenes {
-    callback attribute nameSupport default = 0x80;
-    callback attribute sceneTableSize default = 16;
+    ram      attribute nameSupport default = 0x80;
+    ram      attribute sceneTableSize default = 16;
     callback attribute fabricSceneInfo;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
@@ -4672,7 +4672,7 @@
               "side": "server",
               "type": "NameSupportBitmap",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x80",
@@ -4688,7 +4688,7 @@
               "side": "server",
               "type": "node_id",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -4704,7 +4704,7 @@
               "side": "server",
               "type": "int16u",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "16",
@@ -10908,7 +10908,7 @@
               "side": "server",
               "type": "NameSupportBitmap",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x80",
@@ -10924,7 +10924,7 @@
               "side": "server",
               "type": "int16u",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "16",
@@ -11004,7 +11004,7 @@
               "side": "server",
               "type": "array",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -12254,5 +12254,3 @@
     }
   ]
 }
-
-

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -2531,15 +2531,15 @@ endpoint 1 {
   }
 
   server cluster Scenes {
-    callback attribute nameSupport default = 0x80;
-    callback attribute lastConfiguredBy;
-    callback attribute sceneTableSize default = 16;
+    ram      attribute nameSupport default = 0x80;
+    ram      attribute lastConfiguredBy;
+    ram      attribute sceneTableSize default = 16;
     callback attribute fabricSceneInfo;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute eventList;
     callback attribute attributeList;
-    callback attribute featureMap default = 15;
+    ram      attribute featureMap default = 15;
     ram      attribute clusterRevision default = 5;
 
     handle command AddScene;

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.zap
@@ -4111,7 +4111,7 @@
               "side": "server",
               "type": "NameSupportBitmap",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x80",
@@ -4127,7 +4127,7 @@
               "side": "server",
               "type": "node_id",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
@@ -4143,7 +4143,7 @@
               "side": "server",
               "type": "int16u",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "16",
@@ -4239,7 +4239,7 @@
               "side": "server",
               "type": "bitmap32",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "15",
@@ -5902,5 +5902,3 @@
     }
   ]
 }
-
-


### PR DESCRIPTION
Converted attributes wrongfully Identified as external or having callback in both .zap and .matter files.