### PR TITLE
[Silabs]Change the submodule platform identifier from efr32 to silabs as they…

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -105,7 +105,7 @@ labelPRBasedOnFilePath:
         - src/darwin/*
 
     efr32:
-        - src/platform/efr32/*
+        - src/platform/silabs/*
 
     esp32:
         - src/platform/ESP32/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	path = third_party/freertos/repo
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
 	branch  = V10.3.1-kernel-only
-	platforms = ameba,cc13xx_26xx,bouffalolab,efr32,esp32,k32w,infineon,qpg,cc32xx,silabs_docker
+	platforms = ameba,cc13xx_26xx,bouffalolab,esp32,k32w,infineon,qpg,cc32xx
 [submodule "simw-top-mini"]
 	path = third_party/simw-top-mini/repo
 	url = https://github.com/NXP/plug-and-trust.git
@@ -72,7 +72,7 @@
 	path = third_party/openthread/ot-efr32
 	url = https://github.com/SiliconLabs/ot-efr32.git
 	branch  = matter_sve
-	platforms = efr32,silabs_docker
+	platforms = silabs,silabs_docker
 [submodule "third_party/openthread/ot-ifx"]
 	path = third_party/openthread/ot-ifx
 	url = https://github.com/Infineon/ot-ifx-release.git
@@ -235,22 +235,22 @@
 	path = third_party/silabs/matter_support
 	url = https://github.com/SiliconLabs/sdk_support.git
 	branch = main
-	platforms = efr32,silabs_docker
+	platforms = silabs,silabs_docker
 [submodule "third_party/silabs/gecko_sdk"]
 	path = third_party/silabs/gecko_sdk
 	url = https://github.com/SiliconLabs/gecko_sdk.git
 	branch = v4.3.2
-	platforms = efr32
+	platforms = silabs
 [submodule "third_party/silabs/wiseconnect-wifi-bt-sdk"]
 	path = third_party/silabs/wiseconnect-wifi-bt-sdk
 	url = https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git
 	branch = 2.8.2
-	platforms = efr32
+	platforms = silabs
 [submodule "third_party/silabs/wifi_sdk"]
 	path = third_party/silabs/wifi_sdk
 	url = https://github.com/SiliconLabs/wiseconnect.git
 	branch = v3.1.0
-	platforms = efr32
+	platforms = silabs
 [submodule "editline"]
 	path = third_party/editline/repo
 	url = https://github.com/troglobit/editline.git

--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -33,7 +33,7 @@ ALL_PLATFORMS = set([
     'cc13xx_26xx',
     'cc32xx',
     'darwin',
-    'efr32',
+    'silabs',
     'esp32',
     'infineon',
     'k32w',


### PR DESCRIPTION
… includes other silabs platforms


also, fix the silabs platform code labeller path that was outdated.
Keep the label name as `efr32` for now as it touches more elements.