### PR TITLE
Disable detail logging for infineon to save some flash space

### DIFF
--- a/src/platform/Infineon/CYW30739/args.gni
+++ b/src/platform/Infineon/CYW30739/args.gni
@@ -64,3 +64,9 @@ openthread_config_ip6_slaac_enable = true
 openthread_config_joiner_enable = true
 openthread_config_log_output = "platform_defined"
 openthread_config_srp_client_enable = true
+
+# TODO: this should be removed once sufficient flash for things
+#       like:
+#
+# ./scripts/build/build_examples.py --target cyw30739-cyw930739m2evb_01-ota-requestor build
+chip_detail_logging = false


### PR DESCRIPTION
We are running out of flash, make this change for now to make CI green again.