### PR TITLE
Add invoke command test for invoke boundary conditions on `reply too large`

### DIFF
--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -71,6 +71,9 @@ namespace {
 
 /// allows a value to only be changed within a scope,
 /// this is to force determinism in test execution
+///
+/// When a variable of this type is used, it should
+/// only be changed via `ScopedChange`.
 template <typename T>
 class ScopedChangeOnly
 {
@@ -85,6 +88,28 @@ private:
     T mValue;
 };
 
+/// Allows a scoped mutation to occur on a variable.
+///
+/// When an instance of this class goes out of scope, the variable
+/// will be reset to the default.
+///
+/// Example usage
+///
+/// int              a = 123;
+/// ScopedChangeOnly b(234);
+///
+/// /* a == 123, b == 234 */
+/// {
+///    ScopedChange changeA(a, 321);
+///    /* a == 321, b == 234 */
+///    {
+///       ScopedChange changeB(b, 10);
+///       /* a == 321, b == 10 */
+///    }
+///    /* a == 321, b == 234 */
+/// }
+/// /* a == 123, b == 234 */
+///
 template <typename T>
 class ScopedChange
 {
@@ -122,6 +147,21 @@ namespace app {
 
 CommandHandler::Handle asyncCommandHandle;
 
+/// This is a struct that can be passed into `AddResponseData` and can have
+/// a controllable size buffer that will be encoded
+///
+/// Actual encoding is:
+///
+///    TAG: STRUCT BEGIN
+///       <ContextTag: 1> <ByteSpan>
+///    STRUCT_END
+///
+/// Which is a few more bytes than just the given size.
+///
+/// Usage example:
+///
+/// CHIP_ERROR err = commandObj.AddResponseData(path, ForcedSizeBuffer(123));
+///
 struct ForcedSizeBuffer
 {
     chip::Platform::ScopedMemoryBufferWithSize<uint8_t> mBuffer;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1171,11 +1171,11 @@ void TestCommandInteraction::TestCommandReplyLimits(nlTestSuite * apSuite, void 
 
     for (uint32_t replySize = kMinSize; replySize <= kMaxSize; replySize++)
     {
-        if ((replySize >= 1145) && (replySize <= 1161)) {
-            continue; // Unclear why these fail
+        if ((replySize >= 1145) && (replySize <= 1160)) {
+            continue; // Unclear why these fail - onFinalCalledTimes is not 1
         }
 
-        if ((replySize >= 1162) && (replySize <= 1165)) {
+        if ((replySize >= 1161) && (replySize <= 1165)) {
             // Crash due to MessageBuilder::EncodeInteractionModelRevision() encoding failure
             // these return CHIP_ERROR_INVALID_TLV_TAG because of a context tag not being inside a struct/list
             continue;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1171,11 +1171,13 @@ void TestCommandInteraction::TestCommandReplyLimits(nlTestSuite * apSuite, void 
 
     for (uint32_t replySize = kMinSize; replySize <= kMaxSize; replySize++)
     {
-        if ((replySize >= 1145) && (replySize <= 1160)) {
+        if ((replySize >= 1145) && (replySize <= 1160))
+        {
             continue; // Unclear why these fail - onFinalCalledTimes is not 1
         }
 
-        if ((replySize >= 1161) && (replySize <= 1165)) {
+        if ((replySize >= 1161) && (replySize <= 1165))
+        {
             // Crash due to MessageBuilder::EncodeInteractionModelRevision() encoding failure
             // these return CHIP_ERROR_INVALID_TLV_TAG because of a context tag not being inside a struct/list
             continue;
@@ -1199,11 +1201,11 @@ void TestCommandInteraction::TestCommandReplyLimits(nlTestSuite * apSuite, void 
         NL_TEST_ASSERT(
             apSuite,
             (mockCommandSenderDelegate.onResponseCalledTimes == 1 && mockCommandSenderDelegate.onErrorCalledTimes == 0) //
-            || (mockCommandSenderDelegate.onResponseCalledTimes == 0 && mockCommandSenderDelegate.onErrorCalledTimes == 1)
-        );
+                || (mockCommandSenderDelegate.onResponseCalledTimes == 0 && mockCommandSenderDelegate.onErrorCalledTimes == 1));
 
-        if (mockCommandSenderDelegate.onErrorCalledTimes == 1) {
-           NL_TEST_ASSERT(apSuite, mockCommandSenderDelegate.mError == CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
+        if (mockCommandSenderDelegate.onErrorCalledTimes == 1)
+        {
+            NL_TEST_ASSERT(apSuite, mockCommandSenderDelegate.mError == CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
         }
     }
 }

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -585,7 +585,8 @@ CHIP_ERROR TestCommandInteraction::AddInvokeRequestForSize(CommandSender * apCom
     return apCommandSender->FinishCommand();
 }
 
-CHIP_ERROR TestCommandInteraction::AddInvokeRequestWithSize(CommandSender * apCommandSender, uint32_t requestSize) {
+CHIP_ERROR TestCommandInteraction::AddInvokeRequestWithSize(CommandSender * apCommandSender, uint32_t requestSize)
+{
     auto commandPathParams = MakeTestCommandPath(kTestCommandLargeRequest);
     ReturnErrorOnFailure(apCommandSender->PrepareCommand(commandPathParams));
 
@@ -1297,16 +1298,17 @@ void TestCommandInteraction::TestCommandRequestLimits(nlTestSuite * apSuite, voi
     /// As buffer sizes increase, we expect to fail earlier and earlier.
     /// what we do NOT expect is for larger buffers to behave better than smaller ones
     /// because that may indicate some logic error somewhere
-    enum class ErrorState {
+    enum class ErrorState
+    {
         kSucceeding,
         kFailingToSend,
         kFailingToPrepare,
     };
     ErrorState errorState = ErrorState::kSucceeding;
 
-    unsigned requestsSent = 0;
+    unsigned requestsSent         = 0;
     unsigned invokeCreateFailures = 0;
-    unsigned sendFailures = 0;
+    unsigned sendFailures         = 0;
 
     for (uint32_t requestSize = kMinSize; requestSize <= kMaxSize; requestSize++)
     {
@@ -1315,14 +1317,16 @@ void TestCommandInteraction::TestCommandRequestLimits(nlTestSuite * apSuite, voi
 
         CHIP_ERROR err = AddInvokeRequestWithSize(&commandSender, requestSize);
 
-        if (err != CHIP_NO_ERROR) {
+        if (err != CHIP_NO_ERROR)
+        {
             invokeCreateFailures++;
             errorState = ErrorState::kFailingToPrepare;
             continue;
         }
 
         err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
-        if (err != CHIP_NO_ERROR) {
+        if (err != CHIP_NO_ERROR)
+        {
             NL_TEST_ASSERT(apSuite, (errorState == ErrorState::kSucceeding) || (errorState == ErrorState::kFailingToSend));
             errorState = ErrorState::kFailingToSend;
             sendFailures++;


### PR DESCRIPTION
Expectation for the codebase is that replies either go through or we manage to send an error reply (so that exchanges are not stuck). 

This creates a draft test that is intended to go over all boundery conditions and validate our rollback capabilities.

Also fixes test sequencing issues where global state variables are not resetted properly. I switched for them to be scoped/changed within each test only.

## NOTE - this shows bugs

This test is supposed to pass always, but it does NOT. See ranges and commends of reply sizes:

  - for buffers 1145 to 1161 we fail with no data being received at all
  - for buffers 1162 to 1165 we seem to enter in an invalid mode where we fail to setup some enclosing struct for replies

For even larger buffers, our error handling is ok. We should have followup changes to fix this logic.