### PR TITLE
[platform] Allow to disable GenericDeviceInstanceInfoProvider

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -136,12 +136,11 @@ matter_add_gn_arg_bool  ("chip_malloc_sys_heap"                   CONFIG_CHIP_MA
 matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_WIFI_NRF700X)
 matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
+matter_add_gn_arg_bool  ("chip_enable_factory_data"               CONFIG_CHIP_FACTORY_DATA)
 
-if (CONFIG_CHIP_FACTORY_DATA)
-    matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider" FALSE)
-    matter_add_gn_arg_bool("chip_enable_factory_data"                           TRUE)
-elseif (CONFIG_CHIP_FACTORY_DATA_CUSTOM_BACKEND)
-    matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider" FALSE)
+if (CONFIG_CHIP_FACTORY_DATA OR CONFIG_CHIP_FACTORY_DATA_CUSTOM_BACKEND)
+    matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider"  FALSE)
+    matter_add_gn_arg_bool("chip_use_transitional_device_instance_info_provider" FALSE)
 endif()
 
 if (CONFIG_CHIP_ROTATING_DEVICE_ID)

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -244,9 +244,11 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
 #endif
 
+#if CHIP_USE_TRANSITIONAL_DEVICE_INSTANCE_INFO_PROVIDER
     static GenericDeviceInstanceInfoProvider<ConfigClass> sGenericDeviceInstanceInfoProvider(*this);
 
     SetDeviceInstanceInfoProvider(&sGenericDeviceInstanceInfoProvider);
+#endif
 
 #if CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER
     // Using a temporary singleton here because the overall GenericConfigurationManagerImpl is

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -53,6 +53,10 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     chip_use_transitional_commissionable_data_provider =
         chip_device_platform != "linux" && chip_device_platform != "android"
 
+    # Enable default/generic test-mode DeviceInstanceInfoProvider in GenericConfigurationManagerImpl
+    # === FOR TRANSITION UNTIL ALL EXAMPLES PROVIDE THEIR OWN ===
+    chip_use_transitional_device_instance_info_provider = true
+
     # lock tracking: none/log/fatal or auto for a platform-dependent choice
     chip_stack_lock_tracking = "auto"
 
@@ -117,6 +121,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING=${chip_enable_additional_data_advertising}",
       "CHIP_DEVICE_CONFIG_RUN_AS_ROOT=${chip_device_config_run_as_root}",
       "CHIP_DISABLE_PLATFORM_KVS=${chip_disable_platform_kvs}",
+      "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=${chip_use_transitional_commissionable_data_provider}",
+      "CHIP_USE_TRANSITIONAL_DEVICE_INSTANCE_INFO_PROVIDER=${chip_use_transitional_device_instance_info_provider}",
     ]
 
     if (chip_device_platform == "linux" || chip_device_platform == "darwin" ||
@@ -150,12 +156,6 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
     if (chip_device_config_firmware_build_time != "") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firmware_build_time}\"" ]
-    }
-
-    if (chip_use_transitional_commissionable_data_provider) {
-      defines += [ "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=1" ]
-    } else {
-      defines += [ "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=0" ]
     }
 
     if (chip_device_platform == "cc13x2_26x2") {


### PR DESCRIPTION
Add `chip_use_transitional_device_instance_info_provider` GN switch to disable instantiating and configuring `GenericDeviceInstanceInfoProvider` to save a bit of RAM and flash. Set that switch to false on nrfconnect platform with factory data provider.
