### PR TITLE
[ICD] Add ICD build config to encapsulate ICD related defines

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -25,6 +25,8 @@
 #include "AppEvent.h"
 #include "AppTask.h"
 
+#include <app/server/Server.h>
+
 #if (defined(ENABLE_WSTK_LEDS) && (defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT) || defined(SIWX_917)))
 #include "LEDWidget.h"
 #endif // ENABLE_WSTK_LEDS
@@ -37,9 +39,10 @@
 #endif // DISPLAY_ENABLED
 
 #include "SilabsDeviceDataProvider.h"
-#include <app/icd/ICDNotifier.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER == 1
+#include <app/icd/ICDNotifier.h> // nogncheck
+#endif
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <assert.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -57,10 +57,7 @@ buildconfig_header("app_buildconfig") {
     "CHIP_CONFIG_PERSIST_SUBSCRIPTIONS=${chip_persist_subscriptions}",
     "CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION=${chip_subscription_timeout_resumption}",
     "CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE=${enable_eventlist_attribute}",
-    "CHIP_CONFIG_ENABLE_ICD_SERVER=${chip_enable_icd_server}",
     "CHIP_CONFIG_ENABLE_READ_CLIENT=${chip_enable_read_client}",
-    "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_report_on_active_mode}",
-    "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
   ]
 
   visibility = [ ":app_config" ]
@@ -248,7 +245,7 @@ static_library("app") {
     ":app_config",
     ":revision_info",
     "${chip_root}/src/access",
-    "${chip_root}/src/app/icd:notifier",
+    "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/app/icd:observer",
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/support",
@@ -259,7 +256,10 @@ static_library("app") {
   ]
 
   if (chip_enable_icd_server) {
-    public_deps += [ "${chip_root}/src/app/icd:manager" ]
+    public_deps += [
+      "${chip_root}/src/app/icd:manager",
+      "${chip_root}/src/app/icd:notifier",
+    ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -19,14 +19,15 @@
  *    @file
  *          Provides the implementation of the FailSafeContext object.
  */
-
-#include <app/icd/ICDNotifier.h>
+#include "FailSafeContext.h"
+#include <app/icd/ICDConfig.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/ICDNotifier.h> // nogncheck
+#endif
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-
-#include "FailSafeContext.h"
 
 using namespace chip::DeviceLayer;
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -28,6 +28,7 @@
 #include <app/MessageDef/StatusResponseMessage.h>
 #include <app/MessageDef/SubscribeRequestMessage.h>
 #include <app/MessageDef/SubscribeResponseMessage.h>
+#include <app/icd/ICDConfig.h>
 #include <lib/core/TLVUtilities.h>
 #include <messaging/ExchangeContext.h>
 

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -140,6 +140,7 @@ function(chip_configure_data_model APP_TARGET)
         ${CHIP_APP_BASE_DIR}/util/binding-table.cpp
         ${CHIP_APP_BASE_DIR}/icd/ICDMonitoringTable.cpp
         ${CHIP_APP_BASE_DIR}/icd/ICDManagementServer.cpp
+        ${CHIP_APP_BASE_DIR}/icd/ICDNotifier.cpp
         ${CHIP_APP_BASE_DIR}/util/DataModelHandler.cpp
         ${CHIP_APP_BASE_DIR}/util/ember-compatibility-functions.cpp
         ${CHIP_APP_BASE_DIR}/util/generic-callback-stubs.cpp

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -295,7 +295,10 @@ template("chip_data_model") {
         ]
       } else if (cluster == "icd-management-server") {
         sources += [ "${_app_root}/clusters/${cluster}/${cluster}.cpp" ]
-        deps += [ "${chip_root}/src/app/icd:cluster" ]
+        deps += [
+          "${chip_root}/src/app/icd:cluster",
+          "${chip_root}/src/app/icd:icd_config",
+        ]
       } else if (cluster == "resource-monitoring-server") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -13,9 +13,30 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/buildconfig_header.gni")
 import("icd.gni")
 
 # ICD Server sources and configurations
+
+buildconfig_header("icd_buildconfig") {
+  header = "ICDBuildConfig.h"
+  header_dir = "app/icd"
+
+  defines = [
+    "CHIP_CONFIG_ENABLE_ICD_SERVER=${chip_enable_icd_server}",
+    "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_report_on_active_mode}",
+    "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
+  ]
+
+  visibility = [ ":icd_config" ]
+}
+
+source_set("icd_config") {
+  sources = [ "ICDConfig.h" ]
+
+  deps = [ ":icd_buildconfig" ]
+}
+
 source_set("observer") {
   sources = [ "ICDStateObserver.h" ]
 }
@@ -26,8 +47,10 @@ source_set("notifier") {
     "ICDNotifier.h",
   ]
 
-  deps = [ "${chip_root}/src/lib/core" ]
-  public_deps = [ "${chip_root}/src/app:app_config" ]
+  deps = [
+    ":icd_config",
+    "${chip_root}/src/lib/core",
+  ]
 }
 
 # ICD Manager source-set is broken out of the main source-set to enable unit tests
@@ -37,6 +60,8 @@ source_set("manager") {
     "ICDManager.cpp",
     "ICDManager.h",
   ]
+
+  deps = [ ":icd_config" ]
 
   public_deps = [
     ":cluster",

--- a/src/app/icd/ICDConfig.h
+++ b/src/app/icd/ICDConfig.h
@@ -1,0 +1,22 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#if CHIP_HAVE_CONFIG_H
+#include <app/icd/ICDBuildConfig.h>
+#endif

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -18,6 +18,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/icd/ICDConfig.h>
 #include <app/icd/ICDManagementServer.h>
 #include <app/icd/ICDManager.h>
 #include <app/icd/ICDMonitoringTable.h>

--- a/src/app/icd/ICDNotifier.h
+++ b/src/app/icd/ICDNotifier.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include <app/AppConfig.h>
+#include <app/icd/ICDConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
 

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("${chip_root}/src/app/common_flags.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 
 config("server_config") {
   defines = []
@@ -50,7 +51,7 @@ static_library("server") {
 
   public_deps = [
     "${chip_root}/src/app",
-    "${chip_root}/src/app/icd:notifier",
+    "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/app/icd:observer",
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/dnssd",
@@ -60,4 +61,8 @@ static_library("server") {
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport",
   ]
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd:notifier" ]
+  }
 }

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -15,9 +15,12 @@
  *    limitations under the License.
  */
 
-#include <app/icd/ICDNotifier.h>
-#include <app/reporting/reporting.h>
+#include <app/icd/ICDConfig.h>
 #include <app/server/CommissioningWindowManager.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/ICDNotifier.h> // nogncheck
+#endif
+#include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <lib/dnssd/Advertiser.h>

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/AppConfig.h>
+#include <app/icd/ICDConfig.h>
 
 #include <access/AccessControl.h>
 #include <access/examples/ExampleAccessControlDelegate.h>

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/icd/ICDConfig.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -23,7 +23,7 @@
 #include "MinimalMdnsServer.h"
 #include "ServiceNaming.h"
 
-#include <app/AppConfig.h>
+#include <app/icd/ICDConfig.h>
 #include <crypto/RandUtils.h>
 #include <lib/dnssd/Advertiser_ImplMinimalMdnsAllocator.h>
 #include <lib/dnssd/minimal_mdns/AddressPolicy.h>

--- a/src/lib/dnssd/BUILD.gn
+++ b/src/lib/dnssd/BUILD.gn
@@ -23,6 +23,7 @@ source_set("platform_header") {
 static_library("dnssd") {
   public_deps = [
     ":platform_header",
+    "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -19,6 +19,7 @@
 
 #include <inttypes.h>
 
+#include <app/icd/ICDConfig.h>
 #include <crypto/RandUtils.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPSafeCasts.h>

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -14,7 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <app/AppConfig.h>
+#include <app/icd/ICDConfig.h>
 #include <lib/dnssd/Advertiser.h>
 
 #include <string>

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -67,7 +67,7 @@ static_library("messaging") {
 
   public_deps = [
     ":messaging_mrp_config",
-    "${chip_root}/src/app/icd:notifier",
+    "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/crypto",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
@@ -77,4 +77,8 @@ static_library("messaging") {
     "${chip_root}/src/transport",
     "${chip_root}/src/transport/raw",
   ]
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd:notifier" ]
+  }
 }

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -32,7 +32,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <app/icd/ICDNotifier.h>
+#include <app/icd/ICDConfig.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/ICDNotifier.h> // nogncheck
+#endif
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/CHIPKeyIds.h>

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -500,6 +500,7 @@ if (chip_device_platform != "none") {
       ":platform_base",
       "${chip_root}/src/app:app_config",
       "${chip_root}/src/app/common:cluster-objects",
+      "${chip_root}/src/app/icd:icd_config",
       "${chip_root}/src/credentials:build_time_header",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite_using_nltest("tests") {
   ]
 
   public_deps = [
+    "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/crypto/tests:tests.lib",
     "${chip_root}/src/lib/core",


### PR DESCRIPTION
#### Description
ICD defines were managed by the `AppConfig.h` header. This forced us to include that header in layers where it is not ideal to have this header.

PR creates an `ICDConfig.h` that can be added as dependencies for necessary layers without creating unwanted layer crossing.

fixes #30630

#### Tests
CI to validate nothing broke
