### PR TITLE
Cooktop device

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2278,7 +2278,7 @@ limitations under the License.
     <deviceType>
         <name>Cooktop</name>
         <domain>CHIP</domain>
-        <typeName>Matter Cooktop Device Type</typeName>
+        <typeName>Matter Cooktop</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0078</deviceId>
         <clusters lockOthers="true">

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2279,13 +2279,12 @@ limitations under the License.
         <name>Cooktop</name>
         <domain>CHIP</domain>
         <typeName>Matter Cooktop</typeName>
+        <class>Simple</class>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0078</deviceId>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="true" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>ON_OFF</requireAttribute>
-                <requireCommand>Off</requireCommand>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
             </include>
         </clusters>
     </deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2275,4 +2275,18 @@ limitations under the License.
             </include>
         </clusters>
     </deviceType>
+    <deviceType>
+        <name>Cooktop</name>
+        <domain>CHIP</domain>
+        <typeName>Matter Cooktop Device Type</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0078</deviceId>
+        <clusters lockOthers="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="On/Off" client="true" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>ON_OFF</requireAttribute>
+                <requireCommand>Off</requireCommand>
+            </include>
+        </clusters>
+    </deviceType>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2283,7 +2283,13 @@ limitations under the License.
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0078</deviceId>
         <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
+                <requireAttribute>SERVER_LIST</requireAttribute>
+                <requireAttribute>CLIENT_LIST</requireAttribute>
+                <requireAttribute>PARTS_LIST</requireAttribute>
+            </include>
+            <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
             </include>
         </clusters>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2284,10 +2284,6 @@ limitations under the License.
         <deviceId editable="false">0x0078</deviceId>
         <clusters lockOthers="true">
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
-                <requireAttribute>SERVER_LIST</requireAttribute>
-                <requireAttribute>CLIENT_LIST</requireAttribute>
-                <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -90,6 +90,7 @@ constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x00000850, DeviceTypeClass::Simple, "Matter On/Off Sensor" },
 };
 
+static_assert(ExtractVendorFromMEI(0x00000078) != 0, "Must have class defined for \"Matter Cooktop Device Type\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10001) != 0, "Must have class defined for \"Matter Orphan Clusters\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10002) != 0, "Must have class defined for \"Matter Secondary Network Commissioning Device Type\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10003) != 0, "Must have class defined for \"Matter All-clusters-app Server Example\" if it's a standard device type");

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -64,6 +64,7 @@ constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x00000074, DeviceTypeClass::Simple, "Matter Robotic Vacuum Cleaner" },
     { 0x00000075, DeviceTypeClass::Simple, "Matter Dishwasher" },
     { 0x00000076, DeviceTypeClass::Simple, "Matter Smoke CO Alarm" },
+    { 0x00000078, DeviceTypeClass::Simple, "Matter Cooktop" },
     { 0x0000007C, DeviceTypeClass::Simple, "Matter Laundry Dryer" },
     { 0x00000100, DeviceTypeClass::Simple, "Matter On/Off Light" },
     { 0x00000101, DeviceTypeClass::Simple, "Matter Dimmable Light" },
@@ -90,7 +91,6 @@ constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x00000850, DeviceTypeClass::Simple, "Matter On/Off Sensor" },
 };
 
-static_assert(ExtractVendorFromMEI(0x00000078) != 0, "Must have class defined for \"Matter Cooktop Device Type\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10001) != 0, "Must have class defined for \"Matter Orphan Clusters\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10002) != 0, "Must have class defined for \"Matter Secondary Network Commissioning Device Type\" if it's a standard device type");
 static_assert(ExtractVendorFromMEI(0xFFF10003) != 0, "Must have class defined for \"Matter All-clusters-app Server Example\" if it's a standard device type");


### PR DESCRIPTION
Add a new cooktop device to the matters devices xml file.

The new Cooktop Spec has the timer cluster removed. Here is the PR for the updated spec for this cooktop device:
https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/8593


