### PR TITLE
[Silabs]Fixes and cleanup for our window app

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -754,7 +754,7 @@ void BaseApplication::OutputQrCode(bool refreshLCD)
     }
 }
 
-bool BaseApplication::getWifiProvisionStatus()
+bool BaseApplication::GetProvisionStatus()
 {
     return BaseApplication::sIsProvisioned;
 }

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -36,6 +36,10 @@
 #include <platform/CHIPDeviceEvent.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#if defined(ENABLE_WSTK_LEDS)
+#include "LEDWidget.h"
+#endif // ENABLE_WSTK_LEDS
+
 #ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
 #include <app/clusters/identify-server/identify-server.h>
 #endif
@@ -71,7 +75,8 @@ public:
     BaseApplication() = default;
     virtual ~BaseApplication(){};
     static bool sIsProvisioned;
-    static bool mIsFactoryResetTriggered;
+    static bool sIsFactoryResetTriggered;
+    static LEDWidget * sAppActionLed;
 
     /**
      * @brief Create AppTask task and Event Queue
@@ -80,6 +85,20 @@ public:
      * @return CHIP_ERROR CHIP_NO_ERROR if no errors
      */
     CHIP_ERROR StartAppTask(TaskFunction_t taskFunction);
+
+    /**
+     * @brief Links the application specific led to the baseApplication context
+     * in order to synchronize both LED animations.
+     * Some apps may not have an application led or no animation patterns.
+     *
+     * @param appLed Pointer to the configure LEDWidget for the application defined LED
+     */
+    void LinkAppLed(LEDWidget * appLed) { sAppActionLed = appLed; }
+
+    /**
+     * @brief Remove the app Led linkage form the baseApplication context
+     */
+    void UnlinkAppLed() { sAppActionLed = nullptr; }
 
     /**
      * @brief PostEvent function that add event to AppTask queue for processing

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -71,6 +71,7 @@ public:
     BaseApplication() = default;
     virtual ~BaseApplication(){};
     static bool sIsProvisioned;
+    static bool mIsFactoryResetTriggered;
 
     /**
      * @brief Create AppTask task and Event Queue
@@ -106,6 +107,9 @@ public:
     static void StopStatusLEDTimer(void);
     static bool GetProvisionStatus(void);
 
+    static void StartFactoryResetSequence(void);
+    static void CancelFactoryResetSequence(void);
+
 #ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
     // Idenfiy server command callbacks.
     static void OnIdentifyStart(Identify * identify);
@@ -113,16 +117,6 @@ public:
     static void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState);
     static void OnTriggerIdentifyEffect(Identify * identify);
 #endif
-
-    enum Function_t
-    {
-        kFunction_NoneSelected   = 0,
-        kFunction_SoftwareUpdate = 0,
-        kFunction_StartBleAdv    = 1,
-        kFunction_FactoryReset   = 2,
-
-        kFunction_Invalid
-    } Function;
 
 protected:
     CHIP_ERROR Init();

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -104,7 +104,7 @@ public:
      *        Turns off Status LED before stopping timer
      */
     static void StopStatusLEDTimer(void);
-    static bool getWifiProvisionStatus(void);
+    static bool GetProvisionStatus(void);
 
 #ifdef EMBER_AF_PLUGIN_IDENTIFY_SERVER
     // Idenfiy server command callbacks.

--- a/examples/window-app/silabs/include/AppEvent.h
+++ b/examples/window-app/silabs/include/AppEvent.h
@@ -32,14 +32,6 @@ struct AppEvent
     {
         kEventType_Button = 0,
         kEventType_Timer,
-        kEventType_Light,
-        kEventType_Install,
-        kEventType_ButtonDown,
-        kEventType_ButtonUp,
-
-        kEventType_None,
-        kEventType_Reset,
-        kEventType_ResetPressed,
         kEventType_ResetWarning,
         kEventType_ResetCanceled,
         // Button events
@@ -54,13 +46,6 @@ struct AppEvent
 
         // Cover Attribute update events
         kEventType_AttributeChange,
-
-        // Provisioning events
-        kEventType_ProvisionedStateChanged,
-        kEventType_ConnectivityStateChanged,
-        kEventType_BLEConnectionsChanged,
-        kEventType_WinkOff,
-        kEventType_WinkOn,
     };
 
     uint16_t Type;

--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -116,7 +116,7 @@ public:
     void PostAttributeChange(chip::EndpointId endpoint, chip::AttributeId attributeId);
 
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
-    void UpdateLEDs();
+    void UpdateLED();
     void UpdateLCD();
 
     static void GeneralEventHandler(AppEvent * aEvent);
@@ -130,7 +130,6 @@ protected:
     static void OnLongPressTimeout(Timer & timer);
 
     Timer * mLongPressTimer = nullptr;
-    bool isWinking          = false;
     bool mTiltMode          = false;
     bool mUpPressed         = false;
     bool mDownPressed       = false;

--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -124,32 +124,19 @@ public:
     static void OnIconTimeout(WindowManager::Timer & timer);
 
 protected:
-    struct StateFlags
-    {
-#if CHIP_ENABLE_OPENTHREAD
-        bool isThreadProvisioned = false;
-        bool isThreadEnabled     = false;
-#else
-        bool isWiFiProvisioned = false;
-        bool isWiFiEnabled     = false;
-#endif
-        bool haveBLEConnections = false;
-        bool isWinking          = false;
-    };
-
     Cover & GetCover();
     Cover * GetCover(chip::EndpointId endpoint);
 
     static void OnLongPressTimeout(Timer & timer);
 
     Timer * mLongPressTimer = nullptr;
-    StateFlags mState;
-    bool mTiltMode       = false;
-    bool mUpPressed      = false;
-    bool mDownPressed    = false;
-    bool mUpSuppressed   = false;
-    bool mDownSuppressed = false;
-    bool mResetWarning   = false;
+    bool isWinking          = false;
+    bool mTiltMode          = false;
+    bool mUpPressed         = false;
+    bool mDownPressed       = false;
+    bool mUpSuppressed      = false;
+    bool mDownSuppressed    = false;
+    bool mResetWarning      = false;
 
 private:
     void HandleLongPress();
@@ -158,7 +145,6 @@ private:
     Cover mCoverList[WINDOW_COVER_COUNT];
     uint8_t mCurrentCover = 0;
 
-    LEDWidget mStatusLED;
     LEDWidget mActionLED;
 #ifdef DISPLAY_ENABLED
     Timer mIconTimer;

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -126,7 +126,7 @@ void AppTask::AppTaskMain(void * pvParameter)
 
     SILABS_LOG("App Task started");
 
-    WindowManager::sWindow.UpdateLEDs();
+    WindowManager::sWindow.UpdateLED();
     WindowManager::sWindow.UpdateLCD();
 
     while (true)

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -23,8 +23,6 @@
 
 #include "WindowManager.h"
 
-#include "LEDWidget.h"
-
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -39,19 +37,9 @@
 
 #include <lib/support/CodeUtils.h>
 
-#if !defined(BRD2704A)
-#define LIGHT_LED 1
-#else
-#define LIGHT_LED 0
-#endif
-
 using namespace chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
-
-namespace {
-LEDWidget sLightLED;
-}
 
 using namespace chip::TLV;
 using namespace ::chip::DeviceLayer;
@@ -81,23 +69,6 @@ CHIP_ERROR AppTask::Init()
         SILABS_LOG("WindowMgr::Init() failed");
         appError(err);
     }
-
-    sLightLED.Init(LIGHT_LED);
-
-// Update the LCD with the Stored value. Show QR Code if not provisioned
-#ifdef DISPLAY_ENABLED
-
-#ifdef QR_CODE_ENABLED
-#ifdef SL_WIFI
-    if (!ConnectivityMgr().IsWiFiStationProvisioned())
-#else
-    if (!ConnectivityMgr().IsThreadProvisioned())
-#endif /* !SL_WIFI */
-    {
-        GetLCD().ShowQRCode(true);
-    }
-#endif // QR_CODE_ENABLED
-#endif
 
     return err;
 }

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -42,7 +42,6 @@
 
 #ifdef DISPLAY_ENABLED
 #include <LcdPainter.h>
-SilabsLCD slLCD;
 #endif
 
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
@@ -602,8 +601,6 @@ CHIP_ERROR WindowManager::Init()
 {
     chip::DeviceLayer::PlatformMgr().LockChipStack();
 
-    ConfigurationMgr().LogDeviceConfig();
-
     // Timers
     mLongPressTimer = new Timer(LONG_PRESS_TIMEOUT, OnLongPressTimeout, this);
 
@@ -614,10 +611,7 @@ CHIP_ERROR WindowManager::Init()
     // Initialize LEDs
     LEDWidget::InitGpio();
     mActionLED.Init(APP_ACTION_LED);
-
-#ifdef DISPLAY_ENABLED
-    slLCD.Init();
-#endif
+    AppTask::GetAppTask().LinkAppLed(&mActionLED);
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
@@ -637,13 +631,11 @@ void WindowManager::UpdateLED()
     Cover & cover = GetCover();
     if (mResetWarning)
     {
-        SILABS_LOG("---- UPDATE ACTION LED mResetWarning")
         mActionLED.Set(false);
         mActionLED.Blink(500);
     }
     else
     {
-        SILABS_LOG("******* UPDATE ACTION LED NORMAL")
         // Action LED
         NPercent100ths current;
         LimitStatus liftLimit = LimitStatus::Intermediate;
@@ -664,12 +656,10 @@ void WindowManager::UpdateLED()
         }
         else if (LimitStatus::IsUpOrOpen == liftLimit)
         {
-            SILABS_LOG("---- UPDATE ACTION LED IsUpOrOpen")
             mActionLED.Set(true);
         }
         else if (LimitStatus::IsDownOrClose == liftLimit)
         {
-            SILABS_LOG("---- UPDATE ACTION LED IsDownOrClose")
             mActionLED.Set(false);
         }
         else
@@ -698,7 +688,7 @@ void WindowManager::UpdateLCD()
 
         if (!tilt.IsNull() && !lift.IsNull())
         {
-            LcdPainter::Paint(slLCD, type, lift.Value(), tilt.Value(), mIcon);
+            LcdPainter::Paint(AppTask::GetAppTask().GetLCD(), type, lift.Value(), tilt.Value(), mIcon);
         }
     }
 #endif // DISPLAY_ENABLED


### PR DESCRIPTION
Problem:
Our window app was not fully updated to leverage our BaseApplication class shared by all our apps which caused some issues:
- LEDs behaviours were not working properly.
- LCD was always stuck on QRcode.
 
Changes:
- Clean up some old unused code, duplicated code, or behaviours that are already implemented by the base application.
- Clean up Factory Reset sequence and button handler logic in BaseApplication.
- Re-use the factory Reset sequence in the WindowApp manager.
- Option to link The application controlled led to the BaseApplication to sync animations with the status led.
