### PR TITLE
[ICD] Implement ICD Check-In Counter

### DIFF
--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -61,10 +61,7 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
     MutableByteSpan output{ buffer->Start(), buffer->MaxDataLength() };
 
-    // TODO retrieve Check-in counter
-    CounterType counter = 0;
-
-    ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mKey, counter, ByteSpan(), output));
+    ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mKey, mICDCounter, ByteSpan(), output));
     buffer->SetDataLength(static_cast<uint16_t>(output.size()));
 
     VerifyOrReturnError(mExchangeManager->GetSessionManager() != nullptr, CHIP_ERROR_INTERNAL);
@@ -81,12 +78,14 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     return exchangeContext->SendMessage(MsgType::ICD_CheckIn, std::move(buffer), Messaging::SendMessageFlags::kNoAutoRequestAck);
 }
 
-CHIP_ERROR ICDCheckInSender::RequestResolve(ICDMonitoringEntry & entry, FabricTable * fabricTable)
+CHIP_ERROR ICDCheckInSender::RequestResolve(ICDMonitoringEntry & entry, FabricTable * fabricTable, uint32_t counter)
 {
     VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(fabricTable != nullptr, CHIP_ERROR_INTERNAL);
     const FabricInfo * fabricInfo = fabricTable->FindFabricWithIndex(entry.fabricIndex);
     PeerId peerId(fabricInfo->GetCompressedFabricId(), entry.checkInNodeID);
+
+    mICDCounter = counter;
 
     AddressResolve::NodeLookupRequest request(peerId);
 

--- a/src/app/icd/ICDCheckInSender.h
+++ b/src/app/icd/ICDCheckInSender.h
@@ -34,7 +34,7 @@ public:
     ICDCheckInSender(Messaging::ExchangeManager * exchangeManager);
     ~ICDCheckInSender(){};
 
-    CHIP_ERROR RequestResolve(ICDMonitoringEntry & entry, FabricTable * fabricTable);
+    CHIP_ERROR RequestResolve(ICDMonitoringEntry & entry, FabricTable * fabricTable, uint32_t counter);
 
     // AddressResolve::NodeListener - notifications when dnssd finds a node IP address
     void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override;
@@ -51,6 +51,8 @@ private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 
     Crypto::Aes128KeyHandle mKey = Crypto::Aes128KeyHandle();
+
+    uint32_t mICDCounter = 0;
 };
 
 } // namespace app

--- a/src/app/icd/ICDConfigurationData.h
+++ b/src/app/icd/ICDConfigurationData.h
@@ -42,6 +42,8 @@ class ICDManager;
 class ICDConfigurationData
 {
 public:
+    static constexpr uint32_t ICD_CHECK_IN_COUNTER_MIN_INCREMENT = 100;
+
     enum class ICDMode : uint8_t
     {
         SIT, // Short Interval Time ICD
@@ -108,8 +110,6 @@ private:
 
     uint16_t mActiveThreshold_ms = CHIP_CONFIG_ICD_ACTIVE_MODE_THRESHOLD_MS;
 
-    // TODO : Implement ICD counter
-    // https://github.com/project-chip/connectedhomeip/issues/29184
     uint32_t mICDCounter = 0;
 
     static_assert((CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC) >= 1,

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -64,6 +64,8 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
     mSymmetricKeystore = symmetricKeystore;
     mExchangeManager   = exchangeManager;
 
+    VerifyOrDie(InitCounter() == CHIP_NO_ERROR);
+
     // Removing the check for now since it is possible for the Fast polling
     // to be larger than the ActiveModeDuration for now
     // uint32_t activeModeDuration = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
@@ -105,6 +107,9 @@ void ICDManager::SendCheckInMsgs()
 #if !CONFIG_BUILD_FOR_HOST_UNIT_TEST
     VerifyOrDie(mStorage != nullptr);
     VerifyOrDie(mFabricTable != nullptr);
+    uint32_t counter        = ICDConfigurationData::GetInstance().GetICDCounter();
+    bool counterIncremented = false;
+
     for (const auto & fabricInfo : *mFabricTable)
     {
         uint16_t supported_clients = ICDConfigurationData::GetInstance().GetClientsSupportedPerFabric();
@@ -139,18 +144,77 @@ void ICDManager::SendCheckInMsgs()
                 continue;
             }
 
+            // Increment counter only once to prevent depletion of the available range.
+            if (!counterIncremented)
+            {
+                counterIncremented = true;
+
+                if (CHIP_NO_ERROR != IncrementCounter())
+                {
+                    ChipLogError(AppServer, "Incremented ICDCounter but failed to access/save to Persistent storage");
+                }
+            }
+
             // SenderPool will be released upon transition from active to idle state
             // This will happen when all ICD Check-In messages are sent on the network
             ICDCheckInSender * sender = mICDSenderPool.CreateObject(mExchangeManager);
             VerifyOrReturn(sender != nullptr, ChipLogError(AppServer, "Failed to allocate ICDCheckinSender"));
 
-            if (CHIP_NO_ERROR != sender->RequestResolve(entry, mFabricTable))
+            if (CHIP_NO_ERROR != sender->RequestResolve(entry, mFabricTable, counter))
             {
                 ChipLogError(AppServer, "Failed to send ICD Check-In");
             }
         }
     }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+}
+
+CHIP_ERROR ICDManager::InitCounter()
+{
+    CHIP_ERROR err;
+    uint32_t temp;
+    uint16_t size = static_cast<uint16_t>(sizeof(uint32_t));
+
+    err = mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::ICDCheckInCounter().KeyName(), &temp, size);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        // First time retrieving the counter
+        temp = chip::Crypto::GetRandU32();
+    }
+    else if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+
+    ICDConfigurationData::GetInstance().SetICDCounter(temp);
+    temp += ICDConfigurationData::ICD_CHECK_IN_COUNTER_MIN_INCREMENT;
+
+    // Increment the count directly to minimize flash write.
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::ICDCheckInCounter().KeyName(), &temp, size);
+}
+
+CHIP_ERROR ICDManager::IncrementCounter()
+{
+    uint32_t temp      = 0;
+    StorageKeyName key = DefaultStorageKeyAllocator::ICDCheckInCounter();
+    uint16_t size      = static_cast<uint16_t>(sizeof(uint32_t));
+
+    ICDConfigurationData::GetInstance().mICDCounter++;
+
+    if (mStorage == nullptr)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key.KeyName(), &temp, size));
+
+    if (temp == ICDConfigurationData::GetInstance().mICDCounter)
+    {
+        temp = ICDConfigurationData::GetInstance().mICDCounter + ICDConfigurationData::ICD_CHECK_IN_COUNTER_MIN_INCREMENT;
+        return mStorage->SyncSetKeyValue(key.KeyName(), &temp, size);
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 void ICDManager::UpdateICDMode()

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -120,6 +120,10 @@ protected:
      */
     static void OnTransitionToIdle(System::Layer * aLayer, void * appState);
 
+    // ICD Counter
+    CHIP_ERROR IncrementCounter();
+    CHIP_ERROR InitCounter();
+
     uint8_t mOpenExchangeContextCount = 0;
     uint8_t mCheckInRequestCount      = 0;
 

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -314,6 +314,15 @@ public:
         // Check ICDManager is still in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
     }
+
+    static void TestICDCounter(nlTestSuite * aSuite, void * aContext)
+    {
+        TestContext * ctx = static_cast<TestContext *>(aContext);
+        uint32_t counter  = ICDConfigurationData::GetInstance().GetICDCounter();
+        ctx->mICDManager.IncrementCounter();
+        uint32_t counter2 = ICDConfigurationData::GetInstance().GetICDCounter();
+        NL_TEST_ASSERT(aSuite, (counter + 1) == counter2);
+    }
 };
 
 } // namespace app
@@ -329,6 +338,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("TestICDModeDurations",         TestICDManager::TestICDModeDurations),
     NL_TEST_DEF("TestKeepActivemodeRequests",   TestICDManager::TestKeepActivemodeRequests),
     NL_TEST_DEF("TestICDMRegisterUnregisterEvents", TestICDManager::TestICDMRegisterUnregisterEvents),
+    NL_TEST_DEF("TestICDCounter", TestICDManager::TestICDCounter),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/app/tests/suites/TestIcdManagementCluster.yaml
+++ b/src/app/tests/suites/TestIcdManagementCluster.yaml
@@ -135,8 +135,11 @@ tests:
                 value: "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"
       response:
           values:
-              - name: "ICDCounter"
-                value: 0
+              - name: "ICDCounter"      
+                constraints:
+                    type: int32u
+                    minValue: 0x0
+                    maxValue: 0xFFFFFFFF
 
     - label: "Register 2.1"
       command: "RegisterClient"
@@ -151,8 +154,11 @@ tests:
                     "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f"
       response:
           values:
-              - name: "ICDCounter"
-                value: 0
+              - name: "ICDCounter"      
+                constraints:
+                    type: int32u
+                    minValue: 0x0
+                    maxValue: 0xFFFFFFFF
 
     - label: "Register 3.1"
       command: "RegisterClient"
@@ -189,8 +195,11 @@ tests:
                 value: "\x01\x11\x21\x31\x41\x51\x61\x71\x81\x91\xa1\xb1\xc1\xd1\xe1\xf1"
       response:
           values:
-              - name: "ICDCounter"
-                value: 0
+              - name: "ICDCounter"      
+                constraints:
+                    type: int32u
+                    minValue: 0x0
+                    maxValue: 0xFFFFFFFF
 
     - label: "Read RegisteredClients"
       command: "readAttribute"
@@ -217,8 +226,11 @@ tests:
                     "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2f\x2f"
       response:
           values:
-              - name: "ICDCounter"
-                value: 0
+              - name: "ICDCounter"      
+                constraints:
+                    type: int32u
+                    minValue: 0x0
+                    maxValue: 0xFFFFFFFF
 
     - label: "Read RegisteredClients"
       command: "readAttribute"

--- a/src/app/tests/suites/TestIcdManagementCluster.yaml
+++ b/src/app/tests/suites/TestIcdManagementCluster.yaml
@@ -56,7 +56,10 @@ tests:
       command: "readAttribute"
       attribute: "ICDCounter"
       response:
-          value: 0
+          constraints:
+              type: int32u
+              minValue: 0x0
+              maxValue: 0xFFFFFFFF
 
     - label: "Read ClientsSupportedPerFabric"
       command: "readAttribute"
@@ -135,7 +138,7 @@ tests:
                 value: "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"
       response:
           values:
-              - name: "ICDCounter"      
+              - name: "ICDCounter"
                 constraints:
                     type: int32u
                     minValue: 0x0
@@ -154,7 +157,7 @@ tests:
                     "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f"
       response:
           values:
-              - name: "ICDCounter"      
+              - name: "ICDCounter"
                 constraints:
                     type: int32u
                     minValue: 0x0
@@ -195,7 +198,7 @@ tests:
                 value: "\x01\x11\x21\x31\x41\x51\x61\x71\x81\x91\xa1\xb1\xc1\xd1\xe1\xf1"
       response:
           values:
-              - name: "ICDCounter"      
+              - name: "ICDCounter"
                 constraints:
                     type: int32u
                     minValue: 0x0
@@ -226,7 +229,7 @@ tests:
                     "\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2f\x2f"
       response:
           values:
-              - name: "ICDCounter"      
+              - name: "ICDCounter"
                 constraints:
                     type: int32u
                     minValue: 0x0

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -134,6 +134,9 @@ public:
     static StorageKeyName GroupDataCounter() { return StorageKeyName::FromConst("g/gdc"); }
     static StorageKeyName GroupControlCounter() { return StorageKeyName::FromConst("g/gcc"); }
 
+    // ICD Check-In Counter
+    static StorageKeyName ICDCheckInCounter() { return StorageKeyName::FromConst("icd/cic"); }
+
     // Device Information Provider
     static StorageKeyName UserLabelLengthKey(EndpointId endpoint) { return StorageKeyName::Formatted("g/userlbl/%x", endpoint); }
     static StorageKeyName UserLabelIndexKey(EndpointId endpoint, uint32_t index)


### PR DESCRIPTION
Fix #29184 

Implement a simple persistent counter for the Check-In message. The same counter is used across all fabric by design.

Since the client side needs to check if the received counter is within range and the counter, once initialized, is never reset, not much logic is needed on the Server side.
