### PR TITLE
Fail server init if error on transport init

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -200,6 +200,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #endif
     );
 
+    SuccessOrExit(err);
     err = mListener.Init(this);
     SuccessOrExit(err);
     mGroupsProvider->SetListener(&mListener);


### PR DESCRIPTION
Fixes #30709

In the init function of Server.cpp the error return value of the transport member variable init is not checked. Add a check so that a diagnostic is printed and the caller can handle the error.