### PR TITLE
Add UI config cluster to RAC device type

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1871,6 +1871,7 @@ limitations under the License.
             <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Scenes" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>            
             <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>


### PR DESCRIPTION
This PR adds the XML bits to matter-devices.xml to add the thermostat user interface cluster to the SDK.

Reference spec PR [#8567](https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/8567)

Fixes #30612 
