### PR TITLE
[Silabs]Remove UpdateLCDStatusScreen from the onPlatformEvent

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -744,10 +744,6 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     {
         BaseApplication::sIsProvisioned = event->ServiceProvisioningChange.IsServiceProvisioned;
     }
-
-#ifdef DISPLAY_ENABLED
-    UpdateLCDStatusScreen();
-#endif
 }
 
 void BaseApplication::OutputQrCode(bool refreshLCD)


### PR DESCRIPTION
Problem:
App hangs on commissioning.
UpdateLCDStatusScreen can't get chip stack lock as this event is already posted by the chip task which has the lock. 
