### PR TITLE
Revert "Update Java8 Optional handling in JniReferences (#30071)"

### DIFF
--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -190,12 +190,8 @@ private:
     jobject mClassLoader       = nullptr;
     jmethodID mFindClassMethod = nullptr;
 
-    // These are global refs and therefore safe to persist.
     jclass mHashMapClass   = nullptr;
     jclass mListClass      = nullptr;
     jclass mArrayListClass = nullptr;
-    jclass mOptionalClass  = nullptr;
-
-    bool use_java8_optional = false;
 };
 } // namespace chip


### PR DESCRIPTION
This reverts commit 4e438d69c63d259dafdc3fc3bb1748d7de27e044.

https://github.com/project-chip/connectedhomeip/pull/30071 employs a randomly selected class to assess if the Java code supports Java 8 properly. The chosen class and method, sourced from src/controller/java, are arbitrary. However, it's important to note that all classes in this package are exclusively for controller functionalities. For commissionable devices, the implementation is confined to src/platform/android/java/chip/platform. Therefore, this approach may not be effective.

Additionally, considering that some vendors may opt for their own Android platform implementations, finding a common Java method using an Optional parameter and shared by both commissioner and commissionee devices is not feasible.

Fix: #30702 

