### PR TITLE
[ESP32] Limit number of returned WiFi scan results to configured limit

### DIFF
--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -345,6 +345,10 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
         mpScanCallback = nullptr;
         return;
     }
+
+    // Since this is the dynamic memory allocation, restrict it to a configured limit
+    ap_number = std::min(static_cast<uint16_t>(CHIP_DEVICE_CONFIG_MAX_SCAN_NETWORKS_RESULTS), ap_number);
+
     std::unique_ptr<wifi_ap_record_t[]> ap_buffer_ptr(new wifi_ap_record_t[ap_number]);
     if (ap_buffer_ptr == NULL)
     {


### PR DESCRIPTION
Scan results are allocated on the heap and on a resource critical device where heap is less, this may fail if there are a lot of APs in the vicinity.

Default is 10 APs.