### PR TITLE
Check mBleEndPoint before sending messages in BLEBase

### DIFF
--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -99,6 +99,7 @@ CHIP_ERROR BLEBase::SetEndPoint(Ble::BLEEndPoint * endPoint)
 CHIP_ERROR BLEBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
 {
     ReturnErrorCodeIf(address.GetTransportType() != Type::kBle, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(mBleEndPoint == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
 
     if (mState == State::kConnected)


### PR DESCRIPTION
When device is powered-off during the commisionning process, there is issue:
OnEndPointConnectionClosed is called immediately after device turned off, but DeviceCommissioner could try to send Disarm request. This request will be queued in mPendingPackets of BLEBase and will break next commisioning process