### PR TITLE
Refactored SL_SYSTEM_VIEW to SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -122,7 +122,7 @@ extern uint32_t SystemCoreClock;
 #include "sl_component_catalog.h"
 #endif
 
-#if SL_SYSTEM_VIEW
+#if SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT
 #include "SEGGER_SYSVIEW_FreeRTOS.h"
 #endif
 

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -48,7 +48,7 @@ extern "C" {
 #include "uart.h"
 #endif
 
-#if SL_SYSTEM_VIEW
+#if SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT
 #include "SEGGER_SYSVIEW.h"
 #endif
 }
@@ -73,7 +73,7 @@ CHIP_ERROR SilabsPlatform::Init(void)
     sl_ot_sys_init();
 #endif
 
-#if SL_SYSTEM_VIEW
+#if SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT
     SEGGER_SYSVIEW_Conf();
     SEGGER_SYSVIEW_Start();
 #endif

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -380,7 +380,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/util/third_party/segger/systemview/profiles/freertos_v10/",
       ]
 
-      defines += [ "SL_SYSTEM_VIEW=1" ]
+      defines += [ "SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT=1" ]
     }
 
     defines += board_defines


### PR DESCRIPTION
This change is specific to Silicon Labs implementations.

Renamed **SL_SYSTEM_VIEW** to **SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT** as the component within the GSDK that enables Segger System View within Simplicity Studio contributes this define to the auto-generated template.

Prior to this change, users would have to add SL_SYSTEM_VIEW define manually as well as enable the component to get Segger SystemView to work properly.
