### PR TITLE
Fix improperly mutable pointers to string constants

### DIFF
--- a/examples/air-purifier-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/air-purifier-app/ameba/main/DeviceCallbacks.cpp
@@ -43,7 +43,7 @@
 #include <ota/OTAInitializer.h>
 #endif
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/air-quality-sensor-app/linux/main.cpp
+++ b/examples/air-quality-sensor-app/linux/main.cpp
@@ -35,7 +35,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 
 namespace {
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_air_quality_fifo_";
+constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_air_quality_fifo_";
 NamedPipeCommands sChipNamedPipeCommands;
 AirQualitySensorAppAttrUpdateDelegate sAirQualitySensorAppCommandDelegate;
 } // namespace

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::Span<const char>(SetupUrl, strlen(SetupUrl)));
 }
 

--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -45,7 +45,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/all-clusters-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-app/esp32/main/AppTask.cpp
@@ -42,7 +42,7 @@
 #define APP_EVENT_QUEUE_SIZE 10
 #define APP_TASK_STACK_SIZE (3072)
 
-static const char * TAG = "app-task";
+static const char TAG[] = "app-task";
 
 namespace {
 TimerHandle_t sFunctionTimer; // FreeRTOS app sw timer

--- a/examples/all-clusters-app/esp32/main/BluetoothWidget.cpp
+++ b/examples/all-clusters-app/esp32/main/BluetoothWidget.cpp
@@ -31,7 +31,7 @@
 #include "ScreenManager.h"
 #endif
 
-extern const char * TAG;
+extern const char TAG[];
 
 void BluetoothWidget::Init()
 {

--- a/examples/all-clusters-app/esp32/main/Button.cpp
+++ b/examples/all-clusters-app/esp32/main/Button.cpp
@@ -35,7 +35,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <vector>
 
-static const char * TAG = "Button.cpp";
+static const char TAG[] = "Button.cpp";
 
 extern Button gButtons[BUTTON_NUMBER];
 

--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -41,7 +41,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #endif
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
@@ -28,7 +28,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-static const char * TAG = "DeviceWithDisplay";
+static const char TAG[] = "DeviceWithDisplay";
 
 #if CONFIG_DEVICE_TYPE_M5STACK
 

--- a/examples/all-clusters-app/esp32/main/QRCodeScreen.cpp
+++ b/examples/all-clusters-app/esp32/main/QRCodeScreen.cpp
@@ -43,7 +43,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 // TODO need sensible library tag when put in library
-extern const char * TAG;
+extern const char TAG[];
 
 namespace {
 

--- a/examples/all-clusters-app/esp32/main/WiFiWidget.cpp
+++ b/examples/all-clusters-app/esp32/main/WiFiWidget.cpp
@@ -31,7 +31,7 @@
 #include "ScreenManager.h"
 #endif
 
-extern const char * TAG;
+extern const char TAG[];
 
 void WiFiWidget::Init()
 {

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -72,7 +72,7 @@ using namespace ::chip::Credentials;
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
-const char * TAG = "all-clusters-app";
+extern const char TAG[] = "all-clusters-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 static AppDeviceCallbacksDelegate sAppDeviceCallbacksDelegate;

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -54,7 +54,7 @@ using namespace chip::DeviceLayer;
 
 namespace {
 
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_all_clusters_fifo_";
+constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_all_clusters_fifo_";
 LowPowerManager sLowPowerManager;
 NamedPipeCommands sChipNamedPipeCommands;
 AllClustersCommandDelegate sAllClustersCommandDelegate;

--- a/examples/all-clusters-app/nxp/mw320/main.cpp
+++ b/examples/all-clusters-app/nxp/mw320/main.cpp
@@ -111,7 +111,7 @@ enum
 };
 static int Matter_Selection = MAX_SELECTION;
 #define RUN_RST_LT_DELAY 10
-static const char * TAG = "mw320";
+static const char TAG[] = "mw320";
 
 /*******************************************************************************
  * Variables

--- a/examples/all-clusters-minimal-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/DeviceCallbacks.cpp
@@ -40,7 +40,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/all-clusters-minimal-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/AppTask.cpp
@@ -41,7 +41,7 @@
 #define APP_EVENT_QUEUE_SIZE 10
 #define APP_TASK_STACK_SIZE (3072)
 
-static const char * TAG = "app-task";
+static const char TAG[] = "app-task";
 
 namespace {
 

--- a/examples/all-clusters-minimal-app/esp32/main/BluetoothWidget.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/BluetoothWidget.cpp
@@ -31,7 +31,7 @@
 #include "ScreenManager.h"
 #endif
 
-extern const char * TAG;
+extern const char TAG[];
 
 void BluetoothWidget::Init()
 {

--- a/examples/all-clusters-minimal-app/esp32/main/Button.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/Button.cpp
@@ -38,7 +38,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <vector>
 
-static const char * TAG = "Button.cpp";
+static const char TAG[] = "Button.cpp";
 
 extern Button gButtons[BUTTON_NUMBER];
 

--- a/examples/all-clusters-minimal-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/DeviceCallbacks.cpp
@@ -40,7 +40,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #endif
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/all-clusters-minimal-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/DeviceWithDisplay.cpp
@@ -27,7 +27,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-static const char * TAG = "DeviceWithDisplay";
+static const char TAG[] = "DeviceWithDisplay";
 
 #if CONFIG_DEVICE_TYPE_M5STACK
 

--- a/examples/all-clusters-minimal-app/esp32/main/QRCodeScreen.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/QRCodeScreen.cpp
@@ -43,7 +43,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 // TODO need sensible library tag when put in library
-extern const char * TAG;
+extern const char TAG[];
 
 namespace {
 

--- a/examples/all-clusters-minimal-app/esp32/main/WiFiWidget.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/WiFiWidget.cpp
@@ -30,7 +30,7 @@
 #if CONFIG_HAVE_DISPLAY
 #include "ScreenManager.h"
 #endif
-extern const char * TAG;
+extern const char TAG[];
 
 void WiFiWidget::Init()
 {

--- a/examples/all-clusters-minimal-app/esp32/main/main.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/main.cpp
@@ -70,7 +70,7 @@ using namespace ::chip::DeviceManager;
 // Used to indicate that an IP address has been added to the QRCode
 #define EXAMPLE_VENDOR_TAG_IP 1
 
-const char * TAG = "all-clusters-minimal-app";
+extern const char TAG[] = "all-clusters-minimal-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 static AppDeviceCallbacksDelegate sAppDeviceCallbacksDelegate;

--- a/examples/bridge-app/asr/src/bridged-actions-stub.cpp
+++ b/examples/bridge-app/asr/src/bridged-actions-stub.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::Span<const char>(SetupUrl, strlen(SetupUrl)));
 }
 

--- a/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
@@ -26,7 +26,7 @@
 
 #include "DeviceCallbacks.h"
 
-static const char * TAG = "bridge-devicecallbacks";
+static const char TAG[] = "bridge-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::app;

--- a/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
@@ -78,7 +78,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::CharSpan::fromCharString(SetupUrl));
 }
 

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -60,7 +60,7 @@ chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 } // namespace
 
-const char * TAG = "bridge-app";
+extern const char TAG[] = "bridge-app";
 
 using namespace ::chip;
 using namespace ::chip::DeviceManager;

--- a/examples/bridge-app/linux/bridged-actions-stub.cpp
+++ b/examples/bridge-app/linux/bridged-actions-stub.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::CharSpan::fromCharString(SetupUrl));
 }
 

--- a/examples/bridge-app/telink/src/DeviceCallbacks.cpp
+++ b/examples/bridge-app/telink/src/DeviceCallbacks.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::CharSpan::fromCharString(SetupUrl));
 }
 

--- a/examples/chef/ameba/main/DeviceCallbacks.cpp
+++ b/examples/chef/ameba/main/DeviceCallbacks.cpp
@@ -43,7 +43,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/chef/esp32/main/QRCodeScreen.cpp
+++ b/examples/chef/esp32/main/QRCodeScreen.cpp
@@ -43,7 +43,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 // TODO need sensible library tag when put in library
-extern const char * TAG;
+extern const char TAG[];
 
 namespace {
 

--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -122,7 +122,7 @@ void DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
     ChipLogProgress(Shell, "Current free heap: %u\n", static_cast<unsigned int>(heap_caps_get_free_size(MALLOC_CAP_8BIT)));
 }
 
-const char * TAG = "chef-app";
+extern const char TAG[] = "chef-app";
 
 #if CONFIG_HAVE_DISPLAY
 void printQRCode()

--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -45,8 +45,8 @@
 
 #include "JsonParser.h"
 
-inline constexpr uint8_t kMaxLabelLength  = UINT8_MAX;
-inline constexpr const char kNullString[] = "null";
+inline constexpr uint8_t kMaxLabelLength = UINT8_MAX;
+inline constexpr char kNullString[]      = "null";
 
 class ComplexArgumentParser
 {

--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -239,8 +239,8 @@ public:
     CHIP_ERROR Parse(const char * label, const char * json)
     {
         Json::Value value;
-        constexpr const char kHexNumPrefix[] = "0x";
-        constexpr size_t kHexNumPrefixLen    = ArraySize(kHexNumPrefix) - 1;
+        static constexpr char kHexNumPrefix[] = "0x";
+        constexpr size_t kHexNumPrefixLen     = ArraySize(kHexNumPrefix) - 1;
         if (strncmp(json, kPayloadHexPrefix, kPayloadHexPrefixLen) == 0 ||
             strncmp(json, kPayloadSignedPrefix, kPayloadSignedPrefixLen) == 0 ||
             strncmp(json, kPayloadUnsignedPrefix, kPayloadUnsignedPrefixLen) == 0 ||

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -23,9 +23,9 @@
 #include "DataModelLogger.h"
 #include "ModelCommand.h"
 
-inline constexpr const char * kWriteCommandKey      = "write";
-inline constexpr const char * kWriteByIdCommandKey  = "write-by-id";
-inline constexpr const char * kForceWriteCommandKey = "force-write";
+inline constexpr char kWriteCommandKey[]      = "write";
+inline constexpr char kWriteByIdCommandKey[]  = "write-by-id";
+inline constexpr char kForceWriteCommandKey[] = "force-write";
 
 enum class WriteCommandType
 {

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -37,13 +37,13 @@ std::set<CHIPCommand *> CHIPCommand::sDeferredCleanups;
 
 using DeviceControllerFactory = chip::Controller::DeviceControllerFactory;
 
-constexpr chip::FabricId kIdentityNullFabricId    = chip::kUndefinedFabricId;
-constexpr chip::FabricId kIdentityAlphaFabricId   = 1;
-constexpr chip::FabricId kIdentityBetaFabricId    = 2;
-constexpr chip::FabricId kIdentityGammaFabricId   = 3;
-constexpr chip::FabricId kIdentityOtherFabricId   = 4;
-constexpr const char * kPAATrustStorePathVariable = "CHIPTOOL_PAA_TRUST_STORE_PATH";
-constexpr const char * kCDTrustStorePathVariable  = "CHIPTOOL_CD_TRUST_STORE_PATH";
+constexpr chip::FabricId kIdentityNullFabricId  = chip::kUndefinedFabricId;
+constexpr chip::FabricId kIdentityAlphaFabricId = 1;
+constexpr chip::FabricId kIdentityBetaFabricId  = 2;
+constexpr chip::FabricId kIdentityGammaFabricId = 3;
+constexpr chip::FabricId kIdentityOtherFabricId = 4;
+constexpr char kPAATrustStorePathVariable[]     = "CHIPTOOL_PAA_TRUST_STORE_PATH";
+constexpr char kCDTrustStorePathVariable[]      = "CHIPTOOL_CD_TRUST_STORE_PATH";
 
 const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = nullptr;
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -34,9 +34,9 @@
 
 #pragma once
 
-inline constexpr const char kIdentityAlpha[] = "alpha";
-inline constexpr const char kIdentityBeta[]  = "beta";
-inline constexpr const char kIdentityGamma[] = "gamma";
+inline constexpr char kIdentityAlpha[] = "alpha";
+inline constexpr char kIdentityBeta[]  = "beta";
+inline constexpr char kIdentityGamma[] = "gamma";
 // The null fabric commissioner is a commissioner that isn't on a fabric.
 // This is a legal configuration in which the commissioner delegates
 // operational communication and invocation of the commssioning complete
@@ -46,7 +46,7 @@ inline constexpr const char kIdentityGamma[] = "gamma";
 // commissioner portion of such an architecture.  The null-fabric-commissioner
 // can carry a commissioning flow up until the point of operational channel
 // (CASE) communcation.
-inline constexpr const char kIdentityNull[] = "null-fabric-commissioner";
+inline constexpr char kIdentityNull[] = "null-fabric-commissioner";
 
 class CHIPCommand : public Command
 {

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -38,7 +38,7 @@
 #include <lib/support/StringSplitter.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-constexpr const char * kOptionalArgumentPrefix = "--";
+constexpr char kOptionalArgumentPrefix[]       = "--";
 constexpr size_t kOptionalArgumentPrefixLength = 2;
 
 bool Command::InitArguments(int argc, char ** argv)
@@ -347,8 +347,8 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
             // By default the parameter separator is ";" in order to not collapse with the argument itself if it contains commas
             // (e.g a struct argument with multiple fields). In case one needs to use ";" it can be overriden with the following
             // environment variable.
-            constexpr const char * kSeparatorVariable = "CHIPTOOL_CUSTOM_ARGUMENTS_SEPARATOR";
-            char * getenvSeparatorVariableResult      = getenv(kSeparatorVariable);
+            static constexpr char kSeparatorVariable[] = "CHIPTOOL_CUSTOM_ARGUMENTS_SEPARATOR";
+            char * getenvSeparatorVariableResult       = getenv(kSeparatorVariable);
             getline(ss, valueAsString, getenvSeparatorVariableResult ? getenvSeparatorVariableResult[0] : ';');
 
             CustomArgument * customArgument = new CustomArgument();

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -37,11 +37,11 @@ namespace {
 
 char kInteractiveModeName[]                         = "";
 constexpr size_t kInteractiveModeArgumentsMaxLength = 32;
-constexpr const char * kOptionalArgumentPrefix      = "--";
-constexpr const char * kJsonClusterKey              = "cluster";
-constexpr const char * kJsonCommandKey              = "command";
-constexpr const char * kJsonCommandSpecifierKey     = "command_specifier";
-constexpr const char * kJsonArgumentsKey            = "arguments";
+constexpr char kOptionalArgumentPrefix[]            = "--";
+constexpr char kJsonClusterKey[]                    = "cluster";
+constexpr char kJsonCommandKey[]                    = "command";
+constexpr char kJsonCommandSpecifierKey[]           = "command_specifier";
+constexpr char kJsonArgumentsKey[]                  = "arguments";
 
 #if !CHIP_DISABLE_PLATFORM_KVS
 template <typename T>

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -23,7 +23,7 @@ using namespace chip::Dnssd;
 
 #if CONFIG_NETWORK_LAYER_BLE
 using namespace chip::Ble;
-constexpr const char * kBleKey = "BLE";
+constexpr char kBleKey[] = "BLE";
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 CHIP_ERROR DeviceScanner::Start()

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -21,21 +21,21 @@
 #include <lib/support/SafeInt.h>
 #include <lib/support/jsontlv/TlvJson.h>
 
-constexpr const char * kEventNumberKey    = "eventNumber";
-constexpr const char * kDataVersionKey    = "dataVersion";
-constexpr const char * kClusterIdKey      = "clusterId";
-constexpr const char * kEndpointIdKey     = "endpointId";
-constexpr const char * kAttributeIdKey    = "attributeId";
-constexpr const char * kEventIdKey        = "eventId";
-constexpr const char * kCommandIdKey      = "commandId";
-constexpr const char * kErrorIdKey        = "error";
-constexpr const char * kClusterErrorIdKey = "clusterError";
-constexpr const char * kValueKey          = "value";
-constexpr const char * kNodeIdKey         = "nodeId";
-constexpr const char * kNOCKey            = "NOC";
-constexpr const char * kICACKey           = "ICAC";
-constexpr const char * kRCACKey           = "RCAC";
-constexpr const char * kIPKKey            = "IPK";
+constexpr char kEventNumberKey[]    = "eventNumber";
+constexpr char kDataVersionKey[]    = "dataVersion";
+constexpr char kClusterIdKey[]      = "clusterId";
+constexpr char kEndpointIdKey[]     = "endpointId";
+constexpr char kAttributeIdKey[]    = "attributeId";
+constexpr char kEventIdKey[]        = "eventId";
+constexpr char kCommandIdKey[]      = "commandId";
+constexpr char kErrorIdKey[]        = "error";
+constexpr char kClusterErrorIdKey[] = "clusterError";
+constexpr char kValueKey[]          = "value";
+constexpr char kNodeIdKey[]         = "nodeId";
+constexpr char kNOCKey[]            = "NOC";
+constexpr char kICACKey[]           = "ICAC";
+constexpr char kRCACKey[]           = "RCAC";
+constexpr char kIPKKey[]            = "IPK";
 
 namespace {
 RemoteDataModelLoggerDelegate * gDelegate;

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -22,12 +22,12 @@
 
 #include <editline.h>
 
-constexpr const char * kInteractiveModePrompt          = ">>> ";
-constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/chip_tool_history";
-constexpr const char * kInteractiveModeStopCommand     = "quit()";
-constexpr const char * kCategoryError                  = "Error";
-constexpr const char * kCategoryProgress               = "Info";
-constexpr const char * kCategoryDetail                 = "Debug";
+constexpr char kInteractiveModePrompt[]          = ">>> ";
+constexpr char kInteractiveModeHistoryFilePath[] = "/tmp/chip_tool_history";
+constexpr char kInteractiveModeStopCommand[]     = "quit()";
+constexpr char kCategoryError[]                  = "Error";
+constexpr char kCategoryProgress[]               = "Info";
+constexpr char kCategoryDetail[]                 = "Debug";
 
 namespace {
 

--- a/examples/chip-tool/commands/pairing/ToTLVCert.cpp
+++ b/examples/chip-tool/commands/pairing/ToTLVCert.cpp
@@ -21,8 +21,8 @@
 #include <credentials/CHIPCert.h>
 #include <lib/support/Base64.h>
 
-constexpr const char kBase64Header[] = "base64:";
-constexpr size_t kBase64HeaderLen    = ArraySize(kBase64Header) - 1;
+constexpr char kBase64Header[]    = "base64:";
+constexpr size_t kBase64HeaderLen = ArraySize(kBase64Header) - 1;
 
 CHIP_ERROR ToBase64(const chip::ByteSpan & input, std::string & outputAsPrefixedBase64)
 {

--- a/examples/common/screen-framework/Display.cpp
+++ b/examples/common/screen-framework/Display.cpp
@@ -46,7 +46,7 @@
 // The M5Stack's backlight is on Channel 7
 #define BACKLIGHT_CHANNEL LEDC_CHANNEL_7
 
-static const char * TAG = "Display";
+static const char TAG[] = "Display";
 
 uint16_t DisplayHeight = 0;
 uint16_t DisplayWidth  = 0;

--- a/examples/common/tracing/TraceDecoder.cpp
+++ b/examples/common/tracing/TraceDecoder.cpp
@@ -28,7 +28,7 @@
 #include <transport/raw/MessageHeader.h>
 
 constexpr uint16_t kMaxLineLen    = 4096;
-constexpr const char * jsonPrefix = "    json\t";
+constexpr const char jsonPrefix[] = "    json\t";
 
 namespace chip {
 namespace trace {

--- a/examples/common/tracing/TraceDecoder.cpp
+++ b/examples/common/tracing/TraceDecoder.cpp
@@ -35,24 +35,24 @@ namespace trace {
 namespace {
 
 // Json keys
-constexpr const char * kProtocolIdKey         = "protocol_id";
-constexpr const char * kProtocolCodeKey       = "protocol_opcode";
-constexpr const char * kSessionIdKey          = "session_id";
-constexpr const char * kExchangeIdKey         = "exchange_id";
-constexpr const char * kMessageCounterKey     = "msg_counter";
-constexpr const char * kSecurityFlagsKey      = "security_flags";
-constexpr const char * kMessageFlagsKey       = "msg_flags";
-constexpr const char * kSourceNodeIdKey       = "source_node_id";
-constexpr const char * kDestinationNodeIdKey  = "dest_node_id";
-constexpr const char * kDestinationGroupIdKey = "group_id";
-constexpr const char * kExchangeFlagsKey      = "exchange_flags";
-constexpr const char * kIsInitiatorKey        = "is_initiator";
-constexpr const char * kNeedsAckKey           = "is_ack_requested";
-constexpr const char * kAckMsgKey             = "acknowledged_msg_counter";
-constexpr const char * kPayloadDataKey        = "payload_hex";
-constexpr const char * kPayloadSizeKey        = "payload_size";
-constexpr const char * kDirectionKey          = "direction";
-constexpr const char * kPeerAddress           = "peer_address";
+constexpr char kProtocolIdKey[]         = "protocol_id";
+constexpr char kProtocolCodeKey[]       = "protocol_opcode";
+constexpr char kSessionIdKey[]          = "session_id";
+constexpr char kExchangeIdKey[]         = "exchange_id";
+constexpr char kMessageCounterKey[]     = "msg_counter";
+constexpr char kSecurityFlagsKey[]      = "security_flags";
+constexpr char kMessageFlagsKey[]       = "msg_flags";
+constexpr char kSourceNodeIdKey[]       = "source_node_id";
+constexpr char kDestinationNodeIdKey[]  = "dest_node_id";
+constexpr char kDestinationGroupIdKey[] = "group_id";
+constexpr char kExchangeFlagsKey[]      = "exchange_flags";
+constexpr char kIsInitiatorKey[]        = "is_initiator";
+constexpr char kNeedsAckKey[]           = "is_ack_requested";
+constexpr char kAckMsgKey[]             = "acknowledged_msg_counter";
+constexpr char kPayloadDataKey[]        = "payload_hex";
+constexpr char kPayloadSizeKey[]        = "payload_size";
+constexpr char kDirectionKey[]          = "direction";
+constexpr char kPeerAddress[]           = "peer_address";
 
 bool IsOutbound(const Json::Value & json)
 {

--- a/examples/common/tracing/TraceDecoderArgumentParser.cpp
+++ b/examples/common/tracing/TraceDecoderArgumentParser.cpp
@@ -56,7 +56,7 @@ OptionDef sProgramOptionDefs[] = {
     {}
 };
 
-const char * sProgramOptionHelp = "  --source <filepath>\n"
+const char sProgramOptionHelp[] = "  --source <filepath>\n"
                                   "       The log file to decode.\n"
                                   // Protocol
                                   "  --disable-protocol-secure-channel\n"

--- a/examples/common/tracing/decoder/TraceDecoderProtocols.cpp
+++ b/examples/common/tracing/decoder/TraceDecoderProtocols.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 
-constexpr const char * kUnknown = "Unknown";
+constexpr char kUnknown[] = "Unknown";
 
 void ENFORCE_FORMAT(1, 2) TLVPrettyPrinter(const char * aFormat, ...)
 {

--- a/examples/common/tracing/decoder/bdx/Decoder.cpp
+++ b/examples/common/tracing/decoder/bdx/Decoder.cpp
@@ -21,19 +21,19 @@
 #include <protocols/bdx/BdxMessages.h>
 
 namespace {
-constexpr const char * kProtocolName = "Bulk Data Exchange";
+constexpr char kProtocolName[] = "Bulk Data Exchange";
 
-constexpr const char * kUnknown            = "Unknown";
-constexpr const char * kSendInit           = "Send Init";
-constexpr const char * kSendAccept         = "Send Accept";
-constexpr const char * kReceiveInit        = "Receive Init";
-constexpr const char * kReceiveAccept      = "Receive Accept";
-constexpr const char * kBlockQuery         = "Block Query";
-constexpr const char * kBlock              = "Block";
-constexpr const char * kBlockEOF           = "Block End Of File";
-constexpr const char * kBlockAck           = "Block Ack";
-constexpr const char * kBlockAckEOF        = "Block Ack End Of File";
-constexpr const char * kBlockQueryWithSkip = "Block Query With Skip";
+constexpr char kUnknown[]            = "Unknown";
+constexpr char kSendInit[]           = "Send Init";
+constexpr char kSendAccept[]         = "Send Accept";
+constexpr char kReceiveInit[]        = "Receive Init";
+constexpr char kReceiveAccept[]      = "Receive Accept";
+constexpr char kBlockQuery[]         = "Block Query";
+constexpr char kBlock[]              = "Block";
+constexpr char kBlockEOF[]           = "Block End Of File";
+constexpr char kBlockAck[]           = "Block Ack";
+constexpr char kBlockAckEOF[]        = "Block Ack End Of File";
+constexpr char kBlockQueryWithSkip[] = "Block Query With Skip";
 } // namespace
 
 using MessageType = chip::bdx::MessageType;

--- a/examples/common/tracing/decoder/echo/Decoder.cpp
+++ b/examples/common/tracing/decoder/echo/Decoder.cpp
@@ -21,11 +21,11 @@
 #include <protocols/echo/Echo.h>
 
 namespace {
-constexpr const char * kProtocolName = "Echo";
+constexpr char kProtocolName[] = "Echo";
 
-constexpr const char * kUnknown      = "Unknown";
-constexpr const char * kEchoRequest  = "Echo Request";
-constexpr const char * kEchoResponse = "Echo Response";
+constexpr char kUnknown[]      = "Unknown";
+constexpr char kEchoRequest[]  = "Echo Request";
+constexpr char kEchoResponse[] = "Echo Response";
 } // namespace
 
 using MessageType = chip::Protocols::Echo::MsgType;

--- a/examples/common/tracing/decoder/interaction_model/Decoder.cpp
+++ b/examples/common/tracing/decoder/interaction_model/Decoder.cpp
@@ -31,19 +31,19 @@
 #include <app/MessageDef/WriteResponseMessage.h>
 
 namespace {
-constexpr const char * kProtocolName = "Interaction Model";
+constexpr char kProtocolName[] = "Interaction Model";
 
-constexpr const char * kUnknown               = "Unknown";
-constexpr const char * kStatusResponse        = "Status Response";
-constexpr const char * kReadRequest           = "Read Request";
-constexpr const char * kSubscribeRequest      = "Subscribe Request";
-constexpr const char * kSubscribeResponse     = "Subscribe Response";
-constexpr const char * kReportData            = "Report Data";
-constexpr const char * kWriteRequest          = "Write Request";
-constexpr const char * kWriteResponse         = "Write Response";
-constexpr const char * kInvokeCommandRequest  = "InvokeCommandRequest";
-constexpr const char * kInvokeCommandResponse = "InvokeCommandResponse";
-constexpr const char * kTimedRequest          = "Timed Request";
+constexpr char kUnknown[]               = "Unknown";
+constexpr char kStatusResponse[]        = "Status Response";
+constexpr char kReadRequest[]           = "Read Request";
+constexpr char kSubscribeRequest[]      = "Subscribe Request";
+constexpr char kSubscribeResponse[]     = "Subscribe Response";
+constexpr char kReportData[]            = "Report Data";
+constexpr char kWriteRequest[]          = "Write Request";
+constexpr char kWriteResponse[]         = "Write Response";
+constexpr char kInvokeCommandRequest[]  = "InvokeCommandRequest";
+constexpr char kInvokeCommandResponse[] = "InvokeCommandResponse";
+constexpr char kTimedRequest[]          = "Timed Request";
 
 } // namespace
 

--- a/examples/common/tracing/decoder/logging/ToCertificateString.cpp
+++ b/examples/common/tracing/decoder/logging/ToCertificateString.cpp
@@ -103,16 +103,16 @@ namespace logging {
 
 const char * ToCertificateString(const ByteSpan & source, MutableCharSpan destination)
 {
-    constexpr const char * kCertificateHeader = "-----BEGIN CERTIFICATE-----";
-    constexpr const char * kCertificateFooter = "-----END CERTIFICATE-----";
+    static constexpr char kCertificateHeader[] = "-----BEGIN CERTIFICATE-----";
+    static constexpr char kCertificateFooter[] = "-----END CERTIFICATE-----";
 
     return ToCertificate(source, destination, kCertificateHeader, kCertificateFooter);
 }
 
 const char * ToCertificateRequestString(const ByteSpan & source, MutableCharSpan destination)
 {
-    constexpr const char * kCertificateHeader = "-----BEGIN CERTIFICATE REQUEST-----";
-    constexpr const char * kCertificateFooter = "-----END CERTIFICATE REQUEST-----";
+    static constexpr char kCertificateHeader[] = "-----BEGIN CERTIFICATE REQUEST-----";
+    static constexpr char kCertificateFooter[] = "-----END CERTIFICATE REQUEST-----";
 
     return ToCertificate(source, destination, kCertificateHeader, kCertificateFooter);
 }

--- a/examples/common/tracing/decoder/secure_channel/Decoder.cpp
+++ b/examples/common/tracing/decoder/secure_channel/Decoder.cpp
@@ -24,22 +24,22 @@
 #include <protocols/secure_channel/PASESession.h>
 
 namespace {
-constexpr const char * kProtocolName = "Secure Channel";
+constexpr char kProtocolName[] = "Secure Channel";
 
-constexpr const char * kUnknown            = "Unknown";
-constexpr const char * kMsgCounterSyncReq  = "Message Counter Sync Request";
-constexpr const char * kMsgCounterSyncResp = "Message Counter Sync Response";
-constexpr const char * kStandaloneAck      = "Standalone Ack";
-constexpr const char * kPBKDFParamRequest  = "Password-Based Key Derivation Parameters Request";
-constexpr const char * kPBKDFParamResponse = "Password-Based Key Derivation Parameters Response";
-constexpr const char * kPASE_Pake1         = "Password Authenticated Session Establishment '1'";
-constexpr const char * kPASE_Pake2         = "Password Authenticated Session Establishment '2'";
-constexpr const char * kPASE_Pake3         = "Password Authenticated Session Establishment '3'";
-constexpr const char * kCASE_Sigma1        = "Certificate Authenticated Session Establishment Sigma '1'";
-constexpr const char * kCASE_Sigma2        = "Certificate Authenticated Session Establishment Sigma '2'";
-constexpr const char * kCASE_Sigma3        = "Certificate Authenticated Session Establishment Sigma '3'";
-constexpr const char * kCASE_Sigma2Resume  = "Certificate Authenticated Session Establishment Sigma '2' Resume";
-constexpr const char * kStatusReport       = "Status Report";
+constexpr char kUnknown[]            = "Unknown";
+constexpr char kMsgCounterSyncReq[]  = "Message Counter Sync Request";
+constexpr char kMsgCounterSyncResp[] = "Message Counter Sync Response";
+constexpr char kStandaloneAck[]      = "Standalone Ack";
+constexpr char kPBKDFParamRequest[]  = "Password-Based Key Derivation Parameters Request";
+constexpr char kPBKDFParamResponse[] = "Password-Based Key Derivation Parameters Response";
+constexpr char kPASE_Pake1[]         = "Password Authenticated Session Establishment '1'";
+constexpr char kPASE_Pake2[]         = "Password Authenticated Session Establishment '2'";
+constexpr char kPASE_Pake3[]         = "Password Authenticated Session Establishment '3'";
+constexpr char kCASE_Sigma1[]        = "Certificate Authenticated Session Establishment Sigma '1'";
+constexpr char kCASE_Sigma2[]        = "Certificate Authenticated Session Establishment Sigma '2'";
+constexpr char kCASE_Sigma3[]        = "Certificate Authenticated Session Establishment Sigma '3'";
+constexpr char kCASE_Sigma2Resume[]  = "Certificate Authenticated Session Establishment Sigma '2' Resume";
+constexpr char kStatusReport[]       = "Status Report";
 } // namespace
 
 using MessageType = chip::Protocols::SecureChannel::MsgType;

--- a/examples/common/tracing/decoder/udc/Decoder.cpp
+++ b/examples/common/tracing/decoder/udc/Decoder.cpp
@@ -21,10 +21,10 @@
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
 
 namespace {
-constexpr const char * kProtocolName = "User Directed Commissioning";
+constexpr char kProtocolName[] = "User Directed Commissioning";
 
-constexpr const char * kUnknown                   = "Unknown";
-constexpr const char * kIdentificationDeclaration = "Identification Declaration";
+constexpr char kUnknown[]                   = "Unknown";
+constexpr char kIdentificationDeclaration[] = "Identification Declaration";
 } // namespace
 
 using MessageType = chip::Protocols::UserDirectedCommissioning::MsgType;

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -28,9 +28,9 @@
 
 #pragma once
 
-inline constexpr const char kIdentityAlpha[] = "alpha";
-inline constexpr const char kIdentityBeta[] = "beta";
-inline constexpr const char kIdentityGamma[] = "gamma";
+inline constexpr char kIdentityAlpha[] = "alpha";
+inline constexpr char kIdentityBeta[] = "beta";
+inline constexpr char kIdentityGamma[] = "gamma";
 
 class CHIPCommandBridge : public Command {
 public:

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -31,7 +31,7 @@ std::set<CHIPCommandBridge *> CHIPCommandBridge::sDeferredCleanups;
 std::map<std::string, MTRDeviceController *> CHIPCommandBridge::mControllers;
 dispatch_queue_t CHIPCommandBridge::mOTAProviderCallbackQueue;
 OTAProviderDelegate * CHIPCommandBridge::mOTADelegate;
-constexpr const char * kTrustStorePathVariable = "PAA_TRUST_STORE_PATH";
+constexpr char kTrustStorePathVariable[] = "PAA_TRUST_STORE_PATH";
 
 CHIPToolKeypair * gNocSigner = [[CHIPToolKeypair alloc] init];
 

--- a/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.mm
+++ b/examples/darwin-framework-tool/commands/common/RemoteDataModelLogger.mm
@@ -27,15 +27,15 @@
 
 #include <string>
 
-constexpr const char * kClusterIdKey = "clusterId";
-constexpr const char * kEndpointIdKey = "endpointId";
-constexpr const char * kAttributeIdKey = "attributeId";
-constexpr const char * kCommandIdKey = "commandId";
-constexpr const char * kErrorIdKey = "error";
-constexpr const char * kClusterErrorIdKey = "clusterError";
-constexpr const char * kValueKey = "value";
+constexpr char kClusterIdKey[] = "clusterId";
+constexpr char kEndpointIdKey[] = "endpointId";
+constexpr char kAttributeIdKey[] = "attributeId";
+constexpr char kCommandIdKey[] = "commandId";
+constexpr char kErrorIdKey[] = "error";
+constexpr char kClusterErrorIdKey[] = "clusterError";
+constexpr char kValueKey[] = "value";
 
-constexpr const char kBase64Header[] = "base64:";
+constexpr char kBase64Header[] = "base64:";
 
 namespace {
 RemoteDataModelLoggerDelegate * gDelegate;

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -23,12 +23,12 @@
 
 #include <editline.h>
 
-constexpr const char * kInteractiveModePrompt = "Stop and restart stack: [Ctrl+_] & [Ctrl+^] \nQuit Interactive: 'quit()'\n>>> ";
-constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/darwin_framework_tool_history";
-constexpr const char * kInteractiveModeStopCommand = "quit()";
-constexpr const char * kCategoryError = "Error";
-constexpr const char * kCategoryProgress = "Info";
-constexpr const char * kCategoryDetail = "Debug";
+constexpr char kInteractiveModePrompt[] = "Stop and restart stack: [Ctrl+_] & [Ctrl+^] \nQuit Interactive: 'quit()'\n>>> ";
+constexpr char kInteractiveModeHistoryFilePath[] = "/tmp/darwin_framework_tool_history";
+constexpr char kInteractiveModeStopCommand[] = "quit()";
+constexpr char kCategoryError[] = "Error";
+constexpr char kCategoryProgress[] = "Info";
+constexpr char kCategoryDetail[] = "Debug";
 
 namespace {
 

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -41,7 +41,7 @@ const char basePath[] = "./src/app/tests/suites/commands/delay/scripts/";
 const char * getScriptsFolder() { return basePath; }
 } // namespace
 
-inline constexpr const char * kDefaultKey = "default";
+inline constexpr char kDefaultKey[] = "default";
 
 @interface TestDeviceControllerDelegate : NSObject <MTRDeviceControllerDelegate>
 @property TestCommandBridge * commandBridge;

--- a/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
@@ -44,7 +44,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/light-switch-app/esp32/main/AppTask.cpp
+++ b/examples/light-switch-app/esp32/main/AppTask.cpp
@@ -29,7 +29,7 @@
 
 using namespace chip;
 
-static const char * TAG = "app-task";
+static const char TAG[] = "app-task";
 
 Button AppButton;
 

--- a/examples/light-switch-app/esp32/main/Button.cpp
+++ b/examples/light-switch-app/esp32/main/Button.cpp
@@ -22,7 +22,7 @@
 #define GPIO_INPUT_PIN_SEL (1ULL << GPIO_INPUT_IO_0)
 #define ESP_INTR_FLAG_DEFAULT 0
 
-static const char * TAG = "Button";
+static const char TAG[] = "Button";
 
 static Button::ButtonPressCallback button_press_handler = nullptr;
 

--- a/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
@@ -26,7 +26,7 @@
 #include "DeviceCallbacks.h"
 #include <lib/support/logging/CHIPLogging.h>
 
-static const char * TAG = "light-switch-app-callbacks";
+static const char TAG[] = "light-switch-app-callbacks";
 
 using namespace chip;
 using namespace chip::Inet;

--- a/examples/light-switch-app/esp32/main/main.cpp
+++ b/examples/light-switch-app/esp32/main/main.cpp
@@ -69,7 +69,7 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 } // namespace
 
-static const char * TAG = "light-switch-app";
+static const char TAG[] = "light-switch-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 static AppDeviceCallbacksDelegate sAppDeviceCallbacksDelegate;

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -43,7 +43,7 @@
 #include <ota/OTAInitializer.h>
 #endif
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/lighting-app/beken/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/beken/main/DeviceCallbacks.cpp
@@ -38,7 +38,7 @@
 #include <support/logging/CHIPLogging.h>
 #include <support/logging/Constants.h>
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/lighting-app/esp32/main/AppTask.cpp
+++ b/examples/lighting-app/esp32/main/AppTask.cpp
@@ -35,7 +35,7 @@ using namespace ::chip::app;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
-static const char * TAG = "app-task";
+static const char TAG[] = "app-task";
 
 LEDWidget AppLED;
 

--- a/examples/lighting-app/esp32/main/Button.cpp
+++ b/examples/lighting-app/esp32/main/Button.cpp
@@ -30,7 +30,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <vector>
 
-static const char * TAG = "Button.cpp";
+static const char TAG[] = "Button.cpp";
 
 extern Button gButtons[BUTTON_NUMBER];
 

--- a/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
@@ -29,7 +29,7 @@
 #include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-static const char * TAG = "light-app-callbacks";
+static const char TAG[] = "light-app-callbacks";
 
 extern LEDWidget AppLED;
 

--- a/examples/lighting-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/lighting-app/esp32/main/DeviceWithDisplay.cpp
@@ -30,7 +30,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-static const char * TAG = "DeviceWithDisplay";
+static const char TAG[] = "DeviceWithDisplay";
 
 #if CONFIG_DEVICE_TYPE_M5STACK
 

--- a/examples/lighting-app/esp32/main/LEDWidget.cpp
+++ b/examples/lighting-app/esp32/main/LEDWidget.cpp
@@ -22,7 +22,7 @@
 #endif
 #include "led_strip.h"
 
-static const char * TAG = "LEDWidget";
+static const char TAG[] = "LEDWidget";
 
 void LEDWidget::Init(void)
 {

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -75,7 +75,7 @@ extern const char insights_auth_key_start[] asm("_binary_insights_auth_key_txt_s
 extern const char insights_auth_key_end[] asm("_binary_insights_auth_key_txt_end");
 #endif
 
-static const char * TAG = "light-app";
+static const char TAG[] = "light-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 static AppDeviceCallbacksDelegate sAppDeviceCallbacksDelegate;

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -40,7 +40,7 @@ using namespace chip::app::Clusters;
 
 namespace {
 
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_lighting_fifo_";
+constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_lighting_fifo_";
 NamedPipeCommands sChipNamedPipeCommands;
 LightingAppCommandDelegate sLightingAppCommandDelegate;
 } // namespace

--- a/examples/lock-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/esp32/main/DeviceCallbacks.cpp
@@ -29,7 +29,7 @@
 
 #include <app-common/zap-generated/ids/Clusters.h>
 
-static const char * TAG = "lock-devicecallbacks";
+static const char TAG[] = "lock-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -68,7 +68,7 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 } // namespace
 
-static const char * TAG = "lock-app";
+static const char TAG[] = "lock-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 

--- a/examples/lock-app/linux/main.cpp
+++ b/examples/lock-app/linux/main.cpp
@@ -27,7 +27,7 @@ using namespace chip::app;
 
 namespace {
 // Variables for handling named pipe commands
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_lock_app_fifo-";
+constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_lock_app_fifo-";
 NamedPipeCommands sChipNamedPipeCommands;
 LockAppCommandDelegate sLockAppCommandDelegate;
 

--- a/examples/ota-provider-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/ota-provider-app/esp32/main/DeviceCallbacks.cpp
@@ -24,7 +24,7 @@
  **/
 #include "DeviceCallbacks.h"
 
-static const char * TAG = "echo-devicecallbacks";
+static const char TAG[] = "echo-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -58,7 +58,7 @@ void OnTransferComplete(void * context);
 void OnTransferFailed(void * context, BdxSenderErrorTypes status);
 
 namespace {
-const char * TAG               = "ota-provider-app";
+extern const char TAG[]        = "ota-provider-app";
 const uint8_t kMaxImagePathlen = 35;
 static AppDeviceCallbacks EchoCallbacks;
 

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -45,7 +45,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/ota-requestor-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/esp32/main/DeviceCallbacks.cpp
@@ -24,7 +24,7 @@
  **/
 #include "DeviceCallbacks.h"
 
-static const char * TAG = "echo-devicecallbacks";
+static const char TAG[] = "echo-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -58,7 +58,7 @@ using namespace chip::Shell;
 using namespace ::chip::Credentials;
 
 namespace {
-const char * TAG = "ota-requester-app";
+extern const char TAG[] = "ota-requester-app";
 static AppDeviceCallbacks EchoCallbacks;
 
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;

--- a/examples/persistent-storage/KeyValueStorageTest.cpp
+++ b/examples/persistent-storage/KeyValueStorageTest.cpp
@@ -49,8 +49,8 @@ namespace {
 
 CHIP_ERROR TestEmptyString()
 {
-    const char * kTestKey   = "str_key";
-    const char kTestValue[] = "";
+    static const char kTestKey[]   = "str_key";
+    static const char kTestValue[] = "";
     char read_value[sizeof(kTestValue)];
     size_t read_size;
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
@@ -63,8 +63,8 @@ CHIP_ERROR TestEmptyString()
 
 CHIP_ERROR TestString()
 {
-    const char * kTestKey   = "str_key";
-    const char kTestValue[] = "test_value";
+    static const char kTestKey[]   = "str_key";
+    static const char kTestValue[] = "test_value";
     char read_value[sizeof(kTestValue)];
     size_t read_size;
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
@@ -77,8 +77,8 @@ CHIP_ERROR TestString()
 
 CHIP_ERROR TestUint32()
 {
-    const char * kTestKey = "uint32_key";
-    uint32_t kTestValue   = 5;
+    static const char kTestKey[] = "uint32_key";
+    uint32_t kTestValue          = 5;
     uint32_t read_value;
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
     ReturnErrorOnFailure(KeyValueStoreMgr().Get(kTestKey, &read_value));
@@ -89,8 +89,8 @@ CHIP_ERROR TestUint32()
 
 CHIP_ERROR TestArray()
 {
-    const char * kTestKey  = "array_key";
-    uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
+    static const char kTestKey[] = "array_key";
+    uint32_t kTestValue[5]       = { 1, 2, 3, 4, 5 };
     uint32_t read_value[5];
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
     ReturnErrorOnFailure(KeyValueStoreMgr().Get(kTestKey, &read_value));
@@ -106,7 +106,7 @@ CHIP_ERROR TestStruct()
         uint8_t value1;
         uint32_t value2;
     };
-    const char * kTestKey = "struct_key";
+    static const char kTestKey[] = "struct_key";
     SomeStruct kTestValue{ value1 : 1, value2 : 2 };
     SomeStruct read_value;
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
@@ -119,7 +119,7 @@ CHIP_ERROR TestStruct()
 
 CHIP_ERROR TestUpdateValue()
 {
-    const char * kTestKey = "update_key";
+    static const char kTestKey[] = "update_key";
     uint32_t read_value;
     for (size_t i = 0; i < 10; i++)
     {
@@ -133,8 +133,8 @@ CHIP_ERROR TestUpdateValue()
 
 CHIP_ERROR TestMultiRead()
 {
-    const char * kTestKey  = "multi_key";
-    uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
+    static const char kTestKey[] = "multi_key";
+    uint32_t kTestValue[5]       = { 1, 2, 3, 4, 5 };
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
     for (size_t i = 0; i < 5; i++)
     {

--- a/examples/persistent-storage/esp32/main/main.cpp
+++ b/examples/persistent-storage/esp32/main/main.cpp
@@ -23,7 +23,7 @@
 #include <lib/core/ErrorStr.h>
 #include <platform/KeyValueStoreManager.h>
 
-const char * TAG = "persistent-storage";
+extern const char TAG[] = "persistent-storage";
 
 extern "C" void app_main()
 {

--- a/examples/pigweed-app/esp32/main/main.cpp
+++ b/examples/pigweed-app/esp32/main/main.cpp
@@ -33,7 +33,7 @@
 #include "lwip/sockets.h"
 #include "lwip/sys.h"
 
-const char * TAG = "chip-pigweed-app";
+extern const char TAG[] = "chip-pigweed-app";
 
 namespace {
 using std::byte;

--- a/examples/placeholder/linux/InteractiveServer.cpp
+++ b/examples/placeholder/linux/InteractiveServer.cpp
@@ -26,18 +26,18 @@
 using namespace chip::DeviceLayer;
 
 namespace {
-constexpr const char * kClusterIdKey                = "clusterId";
-constexpr const char * kEndpointIdKey               = "endpointId";
-constexpr const char * kAttributeIdKey              = "attributeId";
-constexpr const char * kWaitTypeKey                 = "waitType";
-constexpr const char * kAttributeWriteKey           = "writeAttribute";
-constexpr const char * kAttributeReadKey            = "readAttribute";
-constexpr const char * kCommandIdKey                = "commandId";
-constexpr const char * kWaitForCommissioningCommand = "WaitForCommissioning";
-constexpr const char * kCategoryError               = "Error";
-constexpr const char * kCategoryProgress            = "Info";
-constexpr const char * kCategoryDetail              = "Debug";
-constexpr const char * kCategoryAutomation          = "Automation";
+constexpr char kClusterIdKey[]                = "clusterId";
+constexpr char kEndpointIdKey[]               = "endpointId";
+constexpr char kAttributeIdKey[]              = "attributeId";
+constexpr char kWaitTypeKey[]                 = "waitType";
+constexpr char kAttributeWriteKey[]           = "writeAttribute";
+constexpr char kAttributeReadKey[]            = "readAttribute";
+constexpr char kCommandIdKey[]                = "commandId";
+constexpr char kWaitForCommissioningCommand[] = "WaitForCommissioning";
+constexpr char kCategoryError[]               = "Error";
+constexpr char kCategoryProgress[]            = "Info";
+constexpr char kCategoryDetail[]              = "Debug";
+constexpr char kCategoryAutomation[]          = "Automation";
 
 struct InteractiveServerResultLog
 {

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -35,9 +35,9 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app-common/zap-generated/ids/Commands.h>
 
-inline constexpr const char kIdentityAlpha[] = "";
-inline constexpr const char kIdentityBeta[]  = "";
-inline constexpr const char kIdentityGamma[] = "";
+inline constexpr char kIdentityAlpha[] = "";
+inline constexpr char kIdentityBeta[]  = "";
+inline constexpr char kIdentityGamma[] = "";
 
 class TestCommand : public TestRunner,
                     public PICSChecker,

--- a/examples/placeholder/linux/src/bridged-actions-stub.cpp
+++ b/examples/placeholder/linux/src/bridged-actions-stub.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, Att
 
 CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    const char SetupUrl[] = "https://example.com";
+    static const char SetupUrl[] = "https://example.com";
     return aEncoder.Encode(chip::Span<const char>(SetupUrl, strlen(SetupUrl)));
 }
 

--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -29,7 +29,7 @@
 #include <ota/OTAHelper.h>
 #endif
 
-static const char * TAG = "app-devicecallbacks";
+static const char TAG[] = "app-devicecallbacks";
 
 using namespace chip;
 using namespace chip::DeviceLayer;

--- a/examples/platform/nrfconnect/util/DFUTrigger.cpp
+++ b/examples/platform/nrfconnect/util/DFUTrigger.cpp
@@ -24,8 +24,8 @@
 #include <zephyr/shell/shell.h>
 
 namespace {
-constexpr const char * kGPIOController = "GPIO_0";
-constexpr gpio_pin_t kGPIOResetPin     = 19;
+constexpr char kGPIOController[]   = "GPIO_0";
+constexpr gpio_pin_t kGPIOResetPin = 19;
 
 int cmd_dfu(const struct shell * shell, size_t argc, char ** argv)
 {

--- a/examples/platform/telink/common/src/mainCommon.cpp
+++ b/examples/platform/telink/common/src/mainCommon.cpp
@@ -39,7 +39,7 @@ using namespace ::chip::DeviceLayer;
 
 #ifdef CONFIG_CHIP_ENABLE_POWER_ON_FACTORY_RESET
 static constexpr uint32_t kFactoryResetOnBootMaxCnt       = 5;
-static constexpr const char * kFactoryResetOnBootStoreKey = "TelinkFactoryResetOnBootCnt";
+static constexpr char kFactoryResetOnBootStoreKey[]       = "TelinkFactoryResetOnBootCnt";
 static constexpr uint32_t kFactoryResetUsualBootTimeoutMs = 5000;
 
 static k_timer FactoryResetUsualBootTimer;

--- a/examples/rvc-app/linux/main.cpp
+++ b/examples/rvc-app/linux/main.cpp
@@ -26,7 +26,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 
 namespace {
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_rvc_fifo_";
+constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_rvc_fifo_";
 NamedPipeCommands sChipNamedPipeCommands;
 RvcAppCommandDelegate sRvcAppCommandDelegate;
 } // namespace

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -24,7 +24,7 @@
  **/
 #include "DeviceCallbacks.h"
 
-static const char * TAG = "echo-devicecallbacks";
+static const char TAG[] = "echo-devicecallbacks";
 
 using namespace ::chip;
 using namespace ::chip::Inet;

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -66,7 +66,7 @@ using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::Credentials;
 
-const char * TAG = "temperature-measurement-app";
+extern const char TAG[] = "temperature-measurement-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 

--- a/examples/tv-app/tv-common/clusters/wake-on-lan/WakeOnLanManager.cpp
+++ b/examples/tv-app/tv-common/clusters/wake-on-lan/WakeOnLanManager.cpp
@@ -23,7 +23,7 @@
 #include <platform/ConfigurationManager.h>
 #include <string>
 
-constexpr const char * kNullHexMACAddress = "000000000000";
+constexpr char kNullHexMACAddress[] = "000000000000";
 
 using namespace chip;
 using namespace chip::app::Clusters::WakeOnLan;

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -26,8 +26,8 @@ using namespace chip::DeviceLayer;
 using namespace chip::Dnssd;
 
 // TODO: Accept these values over CLI
-const char * kContentUrl        = "https://www.test.com/videoid";
-const char * kContentDisplayStr = "Test video";
+const char kContentUrl[]        = "https://www.test.com/videoid";
+const char kContentDisplayStr[] = "Test video";
 int gInitialContextVal          = 121212;
 
 CHIP_ERROR DiscoverCommissioners()

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -124,11 +124,11 @@ char * GetCatStringForLogging(char * buf, size_t size, const CATValues & cats)
     //   2 for 0x prefix
     //   8 for 32-bit hex value
     //   1 for null terminator (at end)
-    constexpr char fmtWithoutComma[] = "0x%08" PRIX32;
-    constexpr char fmtWithComma[]    = ",0x%08" PRIX32;
-    constexpr int countWithoutComma  = 10;
-    constexpr int countWithComma     = countWithoutComma + 1;
-    bool withComma                   = false;
+    static constexpr char fmtWithoutComma[] = "0x%08" PRIX32;
+    static constexpr char fmtWithComma[]    = ",0x%08" PRIX32;
+    constexpr int countWithoutComma         = 10;
+    constexpr int countWithComma            = countWithoutComma + 1;
+    bool withComma                          = false;
     for (auto cat : cats.values)
     {
         if (cat == chip::kUndefinedCAT)

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -184,8 +184,8 @@ bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
 
     const char * desc = nullptr;
 #if !CHIP_CONFIG_SHORT_ERROR_STR
-    constexpr char generalFormat[] = "General error: " ChipLogFormatIMStatus;
-    constexpr char clusterFormat[] = "Cluster-specific error: 0x%02x";
+    static constexpr char generalFormat[] = "General error: " ChipLogFormatIMStatus;
+    static constexpr char clusterFormat[] = "Cluster-specific error: 0x%02x";
 
     // Formatting an 8-bit int will take at most 2 chars, and replace the '%02x'
     // so a buffer big enough to hold our format string will also hold our

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -219,7 +219,7 @@ static inline bool isCharUnreservedInRfc3986(const char c)
 
 CHIP_ERROR EncodeQRCodeToUrl(const char * aQRCode, size_t aLen, char * aUrl, size_t aMaxSize)
 {
-    const char upperHexDigits[] = "0123456789ABCDEF";
+    static const char upperHexDigits[] = "0123456789ABCDEF";
     size_t i = 0, j = 0;
 
     VerifyOrReturnError((aQRCode != nullptr) && (aUrl != nullptr), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -913,8 +913,8 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
     _this->mpSuite = apSuite;
     _this->SetupBuf();
 
-    const char structStr[]      = "something";
-    const uint8_t structBytes[] = { 1, 8, 17 };
+    static const char structStr[] = "something";
+    const uint8_t structBytes[]   = { 1, 8, 17 };
     Clusters::UnitTesting::Structs::SimpleStruct::Type myStruct;
     myStruct.a = 17;
     myStruct.b = true;
@@ -930,8 +930,8 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
     // Encode
     {
         // str needs to live until we call DataModel::Encode.
-        const char str[] = "abc";
-        CharSpan strSpan = CharSpan::fromCharString(str);
+        static const char str[] = "abc";
+        CharSpan strSpan        = CharSpan::fromCharString(str);
         Encodable encodable;
         if (encodeNulls)
         {
@@ -1012,8 +1012,8 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
         }
         else if (encodeValues)
         {
-            const char str[] = "abc";
-            CharSpan strSpan = CharSpan::fromCharString(str);
+            static const char str[] = "abc";
+            CharSpan strSpan        = CharSpan::fromCharString(str);
 
             NL_TEST_ASSERT(apSuite, !decodable.nullableInt.IsNull());
             NL_TEST_ASSERT(apSuite, decodable.nullableInt.Value() == 5);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -379,8 +379,8 @@ void TestWriteInteraction::TestWriteRoundtripWithClusterObjects(nlTestSuite * ap
     attributePathParams.mClusterId   = 3;
     attributePathParams.mAttributeId = 4;
 
-    const uint8_t byteSpanData[] = { 0xde, 0xad, 0xbe, 0xef };
-    const char charSpanData[]    = "a simple test string";
+    const uint8_t byteSpanData[]     = { 0xde, 0xad, 0xbe, 0xef };
+    static const char charSpanData[] = "a simple test string";
 
     app::Clusters::UnitTesting::Structs::SimpleStruct::Type dataTx;
     dataTx.a = 12;

--- a/src/app/tests/suites/commands/delay/DelayCommands.cpp
+++ b/src/app/tests/suites/commands/delay/DelayCommands.cpp
@@ -26,7 +26,7 @@ const char * getScriptsFolder()
 }
 } // namespace
 
-constexpr const char * kDefaultKey = "default";
+constexpr char kDefaultKey[] = "default";
 
 CHIP_ERROR DelayCommands::WaitForMs(const char * identity,
                                     const chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type & value)

--- a/src/app/tests/suites/commands/system/SystemCommands.cpp
+++ b/src/app/tests/suites/commands/system/SystemCommands.cpp
@@ -28,9 +28,9 @@ const char * getScriptsFolder()
 }
 } // namespace
 
-constexpr size_t kCommandMaxLen    = 256;
-constexpr size_t kArgumentMaxLen   = 128;
-constexpr const char * kDefaultKey = "default";
+constexpr size_t kCommandMaxLen  = 256;
+constexpr size_t kArgumentMaxLen = 128;
+constexpr char kDefaultKey[]     = "default";
 
 CHIP_ERROR SystemCommands::Start(const char * identity, const chip::app::Clusters::SystemCommands::Commands::Start::Type & value)
 {

--- a/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
+++ b/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
@@ -196,14 +196,14 @@ TestHarnessDACProvider::TestHarnessDACProvider()
 
 void TestHarnessDACProvider::Init(const char * filepath)
 {
-    constexpr const char kDacCertKey[]      = "dac_cert";
-    constexpr const char kDacPrivateKey[]   = "dac_private_key";
-    constexpr const char kDacPublicKey[]    = "dac_public_key";
-    constexpr const char kPaiCertKey[]      = "pai_cert";
-    constexpr const char kCertDecKey[]      = "certification_declaration";
-    constexpr const char kFirmwareInfoKey[] = "firmware_information";
-    constexpr const char kIsSuccessKey[]    = "is_success_case";
-    constexpr const char kDescription[]     = "description";
+    static constexpr char kDacCertKey[]      = "dac_cert";
+    static constexpr char kDacPrivateKey[]   = "dac_private_key";
+    static constexpr char kDacPublicKey[]    = "dac_public_key";
+    static constexpr char kPaiCertKey[]      = "pai_cert";
+    static constexpr char kCertDecKey[]      = "certification_declaration";
+    static constexpr char kFirmwareInfoKey[] = "firmware_information";
+    static constexpr char kIsSuccessKey[]    = "is_success_case";
+    static constexpr char kDescription[]     = "description";
 
     std::ifstream json(filepath, std::ifstream::binary);
     if (!json)

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -30,10 +30,10 @@
 namespace chip {
 namespace Controller {
 
-constexpr const char kOperationalCredentialsIssuerKeypairStorage[]             = "ExampleOpCredsCAKey";
-constexpr const char kOperationalCredentialsIntermediateIssuerKeypairStorage[] = "ExampleOpCredsICAKey";
-constexpr const char kOperationalCredentialsRootCertificateStorage[]           = "ExampleCARootCert";
-constexpr const char kOperationalCredentialsIntermediateCertificateStorage[]   = "ExampleCAIntermediateCert";
+constexpr char kOperationalCredentialsIssuerKeypairStorage[]             = "ExampleOpCredsCAKey";
+constexpr char kOperationalCredentialsIntermediateIssuerKeypairStorage[] = "ExampleOpCredsICAKey";
+constexpr char kOperationalCredentialsRootCertificateStorage[]           = "ExampleCARootCert";
+constexpr char kOperationalCredentialsIntermediateCertificateStorage[]   = "ExampleCAIntermediateCert";
 
 using namespace Credentials;
 using namespace Crypto;

--- a/src/controller/ExamplePersistentStorage.cpp
+++ b/src/controller/ExamplePersistentStorage.cpp
@@ -32,12 +32,12 @@ using namespace ::chip::Controller;
 using namespace ::chip::IniEscaping;
 using namespace ::chip::Logging;
 
-constexpr const char kDefaultSectionName[]  = "Default";
-constexpr const char kPortKey[]             = "ListenPort";
-constexpr const char kLoggingKey[]          = "LoggingLevel";
-constexpr const char kLocalNodeIdKey[]      = "LocalNodeId";
-constexpr const char kCommissionerCATsKey[] = "CommissionerCATs";
-constexpr LogCategory kDefaultLoggingLevel  = kLogCategory_Automation;
+constexpr char kDefaultSectionName[]       = "Default";
+constexpr char kPortKey[]                  = "ListenPort";
+constexpr char kLoggingKey[]               = "LoggingLevel";
+constexpr char kLocalNodeIdKey[]           = "LocalNodeId";
+constexpr char kCommissionerCATsKey[]      = "CommissionerCATs";
+constexpr LogCategory kDefaultLoggingLevel = kLogCategory_Automation;
 
 const char * GetUsedDirectory(const char * directory)
 {

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -35,8 +35,8 @@
 
 namespace chip {
 namespace Controller {
-constexpr const char kOperationalCredentialsIssuerKeypairStorage[]   = "AndroidDeviceControllerKey";
-constexpr const char kOperationalCredentialsRootCertificateStorage[] = "AndroidCARootCert";
+constexpr char kOperationalCredentialsIssuerKeypairStorage[]   = "AndroidDeviceControllerKey";
+constexpr char kOperationalCredentialsRootCertificateStorage[] = "AndroidCARootCert";
 
 using namespace Credentials;
 using namespace Crypto;

--- a/src/controller/python/chip/server/Options.cpp
+++ b/src/controller/python/chip/server/Options.cpp
@@ -46,7 +46,7 @@ OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOpti
 #endif // CHIP_ENABLE_OPENTHREAD
                                   {} };
 
-const char * sDeviceOptionHelp = "  --ble-device <number>\n"
+const char sDeviceOptionHelp[] = "  --ble-device <number>\n"
                                  "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
                                  "\n"

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -42,9 +42,9 @@ namespace chip {
 namespace app {
 namespace TestGroups {
 
-static const char * kKey1   = "abc/def";
-static const char * kValue1 = "abc/def";
-static const char * kValue2 = "abc/ghi/xyz";
+static const char kKey1[]   = "abc/def";
+static const char kValue1[] = "abc/def";
+static const char kValue2[] = "abc/ghi/xyz";
 static const size_t kSize1  = strlen(kValue1) + 1;
 static const size_t kSize2  = strlen(kValue2) + 1;
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -55,8 +55,8 @@ inline constexpr size_t kMaxCertificateSerialNumberLength      = 20;
 inline constexpr size_t kMaxCertificateDistinguishedNameLength = 200;
 inline constexpr size_t kMaxCRLDistributionPointURLLength      = 100;
 
-inline constexpr const char * kValidCDPURIHttpPrefix  = "http://";
-inline constexpr const char * kValidCDPURIHttpsPrefix = "https://";
+inline constexpr char kValidCDPURIHttpPrefix[]  = "http://";
+inline constexpr char kValidCDPURIHttpsPrefix[] = "https://";
 
 inline constexpr size_t CHIP_CRYPTO_GROUP_SIZE_BYTES      = kP256_FE_Length;
 inline constexpr size_t CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES = kP256_Point_Length;

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -33,7 +33,7 @@ using namespace chip::DeviceLayer;
 using namespace chip::Ble;
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-constexpr const char * kBleKey = "BLE";
+constexpr char kBleKey[] = "BLE";
 
 @implementation MTRCommissionableBrowserResultInterfaces
 @end

--- a/src/darwin/Framework/CHIP/MTROperationalBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalBrowser.mm
@@ -25,8 +25,8 @@
 #include <platform/LockTracker.h>
 
 namespace {
-constexpr const char kLocalDot[] = "local.";
-constexpr const char kOperationalType[] = "_matter._tcp";
+constexpr char kLocalDot[] = "local.";
+constexpr char kOperationalType[] = "_matter._tcp";
 constexpr DNSServiceFlags kBrowseFlags = 0;
 }
 

--- a/src/include/platform/internal/CHIPDeviceLayerInternal.h
+++ b/src/include/platform/internal/CHIPDeviceLayerInternal.h
@@ -25,7 +25,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-extern const char * const TAG;
+extern const char TAG[];
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -625,7 +625,7 @@ protected:
 template <>
 struct EndPointProperties<TCPEndPoint>
 {
-    static constexpr const char * kName   = "TCP";
+    static constexpr char kName[]         = "TCP";
     static constexpr size_t kNumEndPoints = INET_CONFIG_NUM_TCP_ENDPOINTS;
     static constexpr int kSystemStatsKey  = System::Stats::kInetLayer_NumTCPEps;
 };

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -301,7 +301,7 @@ protected:
 template <>
 struct EndPointProperties<UDPEndPoint>
 {
-    static constexpr const char * kName   = "UDP";
+    static constexpr char kName[]         = "UDP";
     static constexpr size_t kNumEndPoints = INET_CONFIG_NUM_UDP_ENDPOINTS;
     static constexpr int kSystemStatsKey  = System::Stats::kInetLayer_NumUDPEps;
 };

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -67,8 +67,8 @@ enum
 // clang-format off
 static uint8_t kTestVal_09_BitString_AsOctetString[] = { 0xE7, 0xC0 };
 static uint8_t kTestVal_20_OctetString[]        = { 0x01, 0x03, 0x05, 0x07, 0x10, 0x30, 0x50, 0x70, 0x00 };
-static const char * kTestVal_21_PrintableString = "Sudden death in Venice";
-static const char * kTestVal_22_UTFString       = "Ond bra\xCC\x8A""d do\xCC\x88""d i Venedig";
+static const char kTestVal_21_PrintableString[] = "Sudden death in Venice";
+static const char kTestVal_22_UTFString[]       = "Ond bra\xCC\x8A""d do\xCC\x88""d i Venedig";
 // clang-format on
 
 // Manually copied from ASN1OID.h for testing.

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -4438,7 +4438,7 @@ static void AssertCannotReadString(nlTestSuite * inSuite, ContiguousBufferTLVRea
 static void CheckGetStringView(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t buf[256];
-    const char testString[] = "This is a test";
+    static const char testString[] = "This is a test";
     {
         TLVWriter writer;
         writer.Init(buf);

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
@@ -61,14 +61,14 @@ void TestFlatAllocatedQName(nlTestSuite * inSuite, void * inContext)
 
 void SizeCompare(nlTestSuite * inSuite, void * inContext)
 {
-    const char kThis[]    = "this";
-    const char kIs[]      = "is";
-    const char kA[]       = "a";
-    const char kTest[]    = "test";
-    const char kVest[]    = "vest";
-    const char kBee[]     = "bee";
-    const char kRobbery[] = "robbery";
-    const char kExtra[]   = "extra";
+    static const char kThis[]    = "this";
+    static const char kIs[]      = "is";
+    static const char kA[]       = "a";
+    static const char kTest[]    = "test";
+    static const char kVest[]    = "vest";
+    static const char kBee[]     = "bee";
+    static const char kRobbery[] = "robbery";
+    static const char kExtra[]   = "extra";
 
     const char * kSameArraySameSize[4]        = { kThis, kIs, kA, kTest };
     const char * kDifferentArraySameSize[4]   = { kThis, kIs, kA, kVest };
@@ -97,11 +97,11 @@ void SizeCompare(nlTestSuite * inSuite, void * inContext)
 
 void BuildCompare(nlTestSuite * inSuite, void * inContext)
 {
-    const char kThis[]  = "this";
-    const char kIs[]    = "is";
-    const char kA[]     = "a";
-    const char kTest[]  = "test";
-    const char kExtra[] = "extra";
+    static const char kThis[]  = "this";
+    static const char kIs[]    = "is";
+    static const char kA[]     = "a";
+    static const char kTest[]  = "test";
+    static const char kExtra[] = "extra";
 
     const char * kSameArraySameSize[4]  = { kThis, kIs, kA, kTest };
     const char * kSameArrayExtraWord[5] = { kThis, kIs, kA, kTest, kExtra };

--- a/src/lib/shell/MainLoopSilabs.cpp
+++ b/src/lib/shell/MainLoopSilabs.cpp
@@ -32,7 +32,7 @@ using chip::Shell::streamer_get;
 
 namespace {
 
-constexpr const char kShellPrompt[] = "matterCli> ";
+constexpr char kShellPrompt[] = "matterCli> ";
 
 // To track carriage returns of Windows return cases of '\r\n'
 bool haveCR = false;

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -56,7 +56,7 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     } theSuite;
     auto * inSuite = &theSuite;
 
-    const char * kLongKeyString = "aKeyThatIsExactlyMaxKeyLengthhhh";
+    static const char kLongKeyString[] = "aKeyThatIsExactlyMaxKeyLengthhhh";
     // Start fresh.
     (void) storage.SyncDeleteKeyValue("roboto");
     (void) storage.SyncDeleteKeyValue("key2");
@@ -83,8 +83,8 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     // Add basic key, read it back, erase it
-    const char * kStringValue1 = "abcd";
-    err                        = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
+    static const char kStringValue1[] = "abcd";
+    err = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     memset(&buf[0], 0, sizeof(buf));
@@ -104,9 +104,9 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
 
     // Validate adding 2 different keys
-    const char * kStringValue2 = "0123abcd";
-    const char * kStringValue3 = "cdef89";
-    err                        = storage.SyncSetKeyValue("key2", kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
+    static const char kStringValue2[] = "0123abcd";
+    static const char kStringValue3[] = "cdef89";
+    err = storage.SyncSetKeyValue("key2", kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = storage.SyncSetKeyValue("key3", kStringValue3, static_cast<uint16_t>(strlen(kStringValue3)));
@@ -237,8 +237,8 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
     // Using key and value with base64 symbols
-    const char * kBase64SymbolsKey   = "key+/=";
-    const char * kBase64SymbolValues = "value+/=";
+    static const char kBase64SymbolsKey[]   = "key+/=";
+    static const char kBase64SymbolValues[] = "value+/=";
     err = storage.SyncSetKeyValue(kBase64SymbolsKey, kBase64SymbolValues, static_cast<uint16_t>(strlen(kBase64SymbolValues)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 

--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -67,8 +67,8 @@ struct KeyContext
 //
 static constexpr uint16_t kMaxStringLen = 1280;
 
-constexpr const char kBase64Header[] = "base64:";
-constexpr size_t kBase64HeaderLen    = ArraySize(kBase64Header) - 1;
+constexpr char kBase64Header[]    = "base64:";
+constexpr size_t kBase64HeaderLen = ArraySize(kBase64Header) - 1;
 
 namespace chip {
 

--- a/src/lib/support/tests/TestCHIPMemString.cpp
+++ b/src/lib/support/tests/TestCHIPMemString.cpp
@@ -74,8 +74,8 @@ struct TestBuffers
 
 static void TestCopyString(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr char testWord[] = "testytest";
-    ByteSpan testWordSpan     = ByteSpan(reinterpret_cast<const uint8_t *>(testWord), sizeof(testWord) - 1);
+    static constexpr char testWord[] = "testytest";
+    ByteSpan testWordSpan            = ByteSpan(reinterpret_cast<const uint8_t *>(testWord), sizeof(testWord) - 1);
     CharSpan testWordSpan2(testWord, sizeof(testWord) - 1);
     TestBuffers<sizeof(testWord)> testBuffers;
 
@@ -130,8 +130,8 @@ static void TestCopyString(nlTestSuite * inSuite, void * inContext)
 
 static void TestMemoryAllocString(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr char testStr[] = "testytestString";
-    char * allocatedStr      = MemoryAllocString(testStr, sizeof(testStr));
+    static constexpr char testStr[] = "testytestString";
+    char * allocatedStr             = MemoryAllocString(testStr, sizeof(testStr));
     NL_TEST_ASSERT(inSuite, allocatedStr != nullptr);
     if (allocatedStr == nullptr)
     {
@@ -145,7 +145,7 @@ static void TestScopedBuffer(nlTestSuite * inSuite, void * inContext)
 {
     // Scoped buffer has its own tests that check the memory properly. Here we are just testing that the string is copied in
     // properly.
-    constexpr char testStr[]        = "testytestString";
+    static constexpr char testStr[] = "testytestString";
     ScopedMemoryString scopedString = ScopedMemoryString(testStr, sizeof(testStr));
     NL_TEST_ASSERT(inSuite, strcmp(scopedString.Get(), testStr) == 0);
 }

--- a/src/lib/support/tests/TestErrorStr.cpp
+++ b/src/lib/support/tests/TestErrorStr.cpp
@@ -131,8 +131,8 @@ static void CheckFormatErr(nlTestSuite * inSuite, void * inContext)
 #else // CHIP_CONFIG_SHORT_ERROR_STR
     static const size_t kBufSize = 1024;
     static char buf[kBufSize];
-    static const char * subsys = "subsys";
-    static const char * desc   = "desc";
+    static const char subsys[] = "subsys";
+    static const char desc[]   = "desc";
 
     strcpy(buf, "hi");
     // shouldn't touch the buffer

--- a/src/lib/support/tests/TestFixedBufferAllocator.cpp
+++ b/src/lib/support/tests/TestFixedBufferAllocator.cpp
@@ -32,8 +32,8 @@ void TestClone(nlTestSuite * inSuite, void * inContext)
     uint8_t buffer[128];
     FixedBufferAllocator alloc(buffer);
 
-    const char * kTestString     = "Test string";
-    const char * allocatedString = alloc.Clone(kTestString);
+    static const char kTestString[] = "Test string";
+    const char * allocatedString    = alloc.Clone(kTestString);
 
     NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, allocatedString != nullptr);
     NL_TEST_ASSERT(inSuite, allocatedString != kTestString);
@@ -56,7 +56,7 @@ void TestOutOfMemory(nlTestSuite * inSuite, void * inContext)
     uint8_t buffer[16];
     FixedBufferAllocator alloc(buffer);
 
-    const char * kTestData = "0123456789abcdef";
+    static const char kTestData[] = "0123456789abcdef";
 
     // Allocating 16 bytes still works...
     NL_TEST_ASSERT(inSuite, alloc.Clone(kTestData, 16) != nullptr);

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -276,7 +276,7 @@ static void TestFromZclString(nlTestSuite * inSuite, void * inContext)
     // Purposefully larger size than data.
     constexpr uint8_t array[16] = { 3, 0x41, 0x63, 0x45 };
 
-    constexpr char str[] = "AcE";
+    static constexpr char str[] = "AcE";
 
     ByteSpan s1 = ByteSpan::fromZclString(array);
     NL_TEST_ASSERT(inSuite, s1.data_equal(ByteSpan(&array[1], 3)));
@@ -287,7 +287,7 @@ static void TestFromZclString(nlTestSuite * inSuite, void * inContext)
 
 static void TestFromCharString(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr char str[] = "AcE";
+    static constexpr char str[] = "AcE";
 
     CharSpan s1 = CharSpan::fromCharString(str);
     NL_TEST_ASSERT(inSuite, s1.data_equal(CharSpan(str, 3)));

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -72,8 +72,8 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     // Add basic key, read it back, erase it
-    const char * kStringValue1 = "abcd";
-    err                        = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
+    static const char kStringValue1[] = "abcd";
+    err = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     memset(&buf[0], 0, sizeof(buf));
@@ -93,9 +93,9 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
 
     // Validate adding 2 different keys
-    const char * kStringValue2 = "0123abcd";
-    const char * kStringValue3 = "cdef89";
-    err                        = storage.SyncSetKeyValue("key2", kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
+    static const char kStringValue2[] = "0123abcd";
+    static const char kStringValue3[] = "cdef89";
+    err = storage.SyncSetKeyValue("key2", kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = storage.SyncSetKeyValue("key3", kStringValue3, static_cast<uint16_t>(strlen(kStringValue3)));
@@ -231,8 +231,8 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
     // Using key and value with base64 symbols
-    const char * kBase64SymbolsKey   = "key+/=";
-    const char * kBase64SymbolValues = "value+/=";
+    static const char kBase64SymbolsKey[]   = "key+/=";
+    static const char kBase64SymbolValues[] = "value+/=";
     err = storage.SyncSetKeyValue(kBase64SymbolsKey, kBase64SymbolValues, static_cast<uint16_t>(strlen(kBase64SymbolValues)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -318,8 +318,8 @@ void TestClearStorage(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, size == sizeof(buf));
 
     // Add basic key, read it back
-    const char * kStringValue1 = "abcd";
-    err                        = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
+    static const char kStringValue1[] = "abcd";
+    err = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == 1);
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -110,8 +110,8 @@ void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState)
 
 CHIP_ERROR SendEchoRequest()
 {
-    CHIP_ERROR err              = CHIP_NO_ERROR;
-    const char kRequestFormat[] = "Echo Message %" PRIu64 "\n";
+    CHIP_ERROR err                     = CHIP_NO_ERROR;
+    static const char kRequestFormat[] = "Echo Message %" PRIu64 "\n";
     char requestData[(sizeof kRequestFormat) + 20 /* uint64_t decimal digits */];
     snprintf(requestData, sizeof requestData, kRequestFormat, gEchoCount);
     chip::System::PacketBufferHandle && payloadBuf = chip::MessagePacketBuffer::NewWithData(requestData, strlen(requestData));

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -44,7 +44,7 @@ constexpr uint64_t kScanningWithDiscriminatorTimeoutInSeconds = 60;
 constexpr uint64_t kScanningWithoutDelegateTimeoutInSeconds = 120;
 constexpr uint64_t kCachePeripheralTimeoutInSeconds
     = static_cast<uint64_t>(CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MAX / 1000.0 * 8.0 * 0.625);
-constexpr const char * kBleWorkQueueName = "org.csa-iot.matter.framework.ble.workqueue";
+constexpr char kBleWorkQueueName[] = "org.csa-iot.matter.framework.ble.workqueue";
 
 typedef NS_ENUM(uint8_t, BleConnectionMode) {
     kUndefined = 0,

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -28,7 +28,7 @@ namespace {
 
 constexpr uint8_t kDnssdKeyMaxSize          = 32;
 constexpr uint8_t kDnssdTxtRecordMaxEntries = 20;
-constexpr const char * kLocalDot            = "local.";
+constexpr char kLocalDot[]                  = "local.";
 
 bool IsLocalDomain(const char * domain)
 {

--- a/src/platform/Darwin/DnssdHostNameRegistrar.cpp
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.cpp
@@ -37,18 +37,18 @@ namespace Dnssd {
 namespace {
 
 #if CHIP_PROGRESS_LOGGING
-constexpr const char * kPathStatusInvalid     = "Invalid";
-constexpr const char * kPathStatusUnsatisfied = "Unsatisfied";
-constexpr const char * kPathStatusSatisfied   = "Satisfied";
-constexpr const char * kPathStatusSatisfiable = "Satisfiable";
-constexpr const char * kPathStatusUnknown     = "Unknown";
+constexpr char kPathStatusInvalid[]     = "Invalid";
+constexpr char kPathStatusUnsatisfied[] = "Unsatisfied";
+constexpr char kPathStatusSatisfied[]   = "Satisfied";
+constexpr char kPathStatusSatisfiable[] = "Satisfiable";
+constexpr char kPathStatusUnknown[]     = "Unknown";
 
-constexpr const char * kInterfaceTypeCellular = "Cellular";
-constexpr const char * kInterfaceTypeWiFi     = "WiFi";
-constexpr const char * kInterfaceTypeWired    = "Wired";
-constexpr const char * kInterfaceTypeLoopback = "Loopback";
-constexpr const char * kInterfaceTypeOther    = "Other";
-constexpr const char * kInterfaceTypeUnknown  = "Unknown";
+constexpr char kInterfaceTypeCellular[] = "Cellular";
+constexpr char kInterfaceTypeWiFi[]     = "WiFi";
+constexpr char kInterfaceTypeWired[]    = "Wired";
+constexpr char kInterfaceTypeLoopback[] = "Loopback";
+constexpr char kInterfaceTypeOther[]    = "Other";
+constexpr char kInterfaceTypeUnknown[]  = "Unknown";
 
 const char * GetPathStatusString(nw_path_status_t status)
 {

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -31,7 +31,7 @@ using namespace chip::Dnssd::Internal;
 
 namespace {
 
-constexpr const char * kLocalDot = "local.";
+constexpr char kLocalDot[] = "local.";
 
 constexpr DNSServiceFlags kRegisterFlags        = kDNSServiceFlagsNoAutoRename;
 constexpr DNSServiceFlags kBrowseFlags          = 0;

--- a/src/platform/Darwin/DnssdType.cpp
+++ b/src/platform/Darwin/DnssdType.cpp
@@ -19,8 +19,8 @@
 
 #include <sstream>
 
-constexpr const char * kProtocolTcp = "._tcp";
-constexpr const char * kProtocolUdp = "._udp";
+constexpr char kProtocolTcp[] = "._tcp";
+constexpr char kProtocolUdp[] = "._udp";
 
 namespace chip {
 namespace Dnssd {

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.h
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.h
@@ -45,7 +45,7 @@ public:
     CHIP_ERROR EraseAll(void);
 
 private:
-    const char * kNamespace = "CHIP_KVS";
+    static inline const char kNamespace[] = "CHIP_KVS";
 
     // ===== Members for internal use by the following friends.
     friend KeyValueStoreManager & KeyValueStoreMgr();

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -53,7 +53,7 @@ chip::System::LayerSockets & SystemLayerSockets()
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 namespace Internal {
-const char * const TAG = "CHIP[DL]";
+extern const char TAG[] = "CHIP[DL]";
 } // namespace Internal
 
 } // namespace DeviceLayer

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -163,10 +163,10 @@ private:
 
     struct SrpClient
     {
-        static constexpr uint8_t kMaxServicesNumber      = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
-        static constexpr const char * kDefaultDomainName = "default.service.arpa";
-        static constexpr uint8_t kDefaultDomainNameSize  = 20;
-        static constexpr uint8_t kMaxDomainNameSize      = 32;
+        static constexpr uint8_t kMaxServicesNumber     = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
+        static constexpr char kDefaultDomainName[]      = "default.service.arpa";
+        static constexpr uint8_t kDefaultDomainNameSize = 20;
+        static constexpr uint8_t kMaxDomainNameSize     = 32;
 
         // SRP is used for both operational and commissionable services, so buffers sizes must be worst case.
         static constexpr size_t kSubTypeMaxNumber   = Dnssd::Common::kSubTypeMaxNumber;

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -85,13 +85,13 @@ struct BLEConnection
 };
 
 /* CHIPoBLE UUID strings */
-const char * chip_ble_service_uuid    = "0000FFF6-0000-1000-8000-00805F9B34FB";
-const char * chip_ble_char_c1_tx_uuid = "18EE2EF5-263D-4559-959F-4F9C429F9D11";
-const char * chip_ble_char_c2_rx_uuid = "18EE2EF5-263D-4559-959F-4F9C429F9D12";
+const char chip_ble_service_uuid[]    = "0000FFF6-0000-1000-8000-00805F9B34FB";
+const char chip_ble_char_c1_tx_uuid[] = "18EE2EF5-263D-4559-959F-4F9C429F9D11";
+const char chip_ble_char_c2_rx_uuid[] = "18EE2EF5-263D-4559-959F-4F9C429F9D12";
 /* CCCD */
-const char * desc_uuid_short = "2902";
+const char desc_uuid_short[] = "2902";
 
-const char * chip_ble_service_uuid_short = "FFF6";
+const char chip_ble_service_uuid_short[] = "FFF6";
 
 /* Tizen Default Scan Timeout */
 static constexpr System::Clock::Timeout kNewConnectionScanTimeout = System::Clock::Seconds16(10);

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -41,8 +41,8 @@ namespace DeviceLayer {
 namespace Internal {
 
 // CHIPoBLE UUID strings
-const char * chip_service_uuid       = "0000FFF6-0000-1000-8000-00805F9B34FB";
-const char * chip_service_uuid_short = "FFF6";
+const char chip_service_uuid[]       = "0000FFF6-0000-1000-8000-00805F9B34FB";
+const char chip_service_uuid_short[] = "FFF6";
 
 ChipDeviceScanner::ChipDeviceScanner(ChipDeviceScannerDelegate * delegate) : mDelegate(delegate) {}
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -47,8 +47,8 @@
 
 namespace {
 
-constexpr uint8_t kDnssdKeyMaxSize       = 32;
-constexpr const char * kEmptyAddressIpv6 = "0000:0000:0000:0000:0000:0000:0000:0000";
+constexpr uint8_t kDnssdKeyMaxSize = 32;
+constexpr char kEmptyAddressIpv6[] = "0000:0000:0000:0000:0000:0000:0000:0000";
 
 // The number of miliseconds which must elapse without a new "found" event before
 // mDNS browsing is considered finished. We need this timeout because Tizen Native

--- a/src/platform/Tizen/Logging.cpp
+++ b/src/platform/Tizen/Logging.cpp
@@ -34,7 +34,7 @@ namespace Platform {
  */
 void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-    constexpr const char * kLogTag                = "CHIP";
+    static constexpr char kLogTag[]               = "CHIP";
     char msgBuf[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = {
         0,
     };

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -53,8 +53,8 @@ jmethodID sRemoveServicesMethod   = nullptr;
 
 // Implementation of functions declared in lib/dnssd/platform/Dnssd.h
 
-constexpr const char * kProtocolTcp = "._tcp";
-constexpr const char * kProtocolUdp = "._udp";
+constexpr char kProtocolTcp[] = "._tcp";
+constexpr char kProtocolUdp[] = "._udp";
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {

--- a/src/platform/bouffalolab/common/BLConfig.h
+++ b/src/platform/bouffalolab/common/BLConfig.h
@@ -34,48 +34,48 @@ public:
 
     /** Key definitions for well-known keys */
     /** Manufacturing config keys, which should be saved in a specified place */
-    static constexpr const char * kConfigKey_SerialNum             = ("serial-num");
-    static constexpr const char * kConfigKey_MfrDeviceId           = ("device-id");
-    static constexpr const char * kConfigKey_MfrDeviceCert         = ("device-cert");
-    static constexpr const char * kConfigKey_MfrDeviceICACerts     = ("device-ca-certs");
-    static constexpr const char * kConfigKey_MfrDevicePrivateKey   = ("device-key");
-    static constexpr const char * kConfigKey_ManufacturingDate     = ("mfg-date");
-    static constexpr const char * kConfigKey_SetupPinCode          = ("pin-code");
-    static constexpr const char * kConfigKey_SetupDiscriminator    = ("discriminator");
-    static constexpr const char * kConfigKey_Spake2pIterationCount = ("iteration-count");
-    static constexpr const char * kConfigKey_Spake2pSalt           = ("salt");
-    static constexpr const char * kConfigKey_Spake2pVerifier       = ("verifier");
-    static constexpr const char * kConfigKey_UniqueId              = ("unique-id");
+    static constexpr char kConfigKey_SerialNum[]             = ("serial-num");
+    static constexpr char kConfigKey_MfrDeviceId[]           = ("device-id");
+    static constexpr char kConfigKey_MfrDeviceCert[]         = ("device-cert");
+    static constexpr char kConfigKey_MfrDeviceICACerts[]     = ("device-ca-certs");
+    static constexpr char kConfigKey_MfrDevicePrivateKey[]   = ("device-key");
+    static constexpr char kConfigKey_ManufacturingDate[]     = ("mfg-date");
+    static constexpr char kConfigKey_SetupPinCode[]          = ("pin-code");
+    static constexpr char kConfigKey_SetupDiscriminator[]    = ("discriminator");
+    static constexpr char kConfigKey_Spake2pIterationCount[] = ("iteration-count");
+    static constexpr char kConfigKey_Spake2pSalt[]           = ("salt");
+    static constexpr char kConfigKey_Spake2pVerifier[]       = ("verifier");
+    static constexpr char kConfigKey_UniqueId[]              = ("unique-id");
 
     /** Config keys, which should be droped after a factory reset */
-    static constexpr const char * kConfigKey_FabricId                    = ("fabric-id");
-    static constexpr const char * kConfigKey_ServiceConfig               = ("service-config");
-    static constexpr const char * kConfigKey_PairedAccountId             = ("account-id");
-    static constexpr const char * kConfigKey_ServiceId                   = ("service-id");
-    static constexpr const char * kConfigKey_FabricSecret                = ("fabric-secret");
-    static constexpr const char * kConfigKey_HardwareVersion             = ("hardware-ver");
-    static constexpr const char * kConfigKey_LastUsedEpochKeyId          = ("last-ek-id");
-    static constexpr const char * kConfigKey_FailSafeArmed               = ("fail-safe-armed");
-    static constexpr const char * kConfigKey_OperationalDeviceId         = ("op-device-id");
-    static constexpr const char * kConfigKey_OperationalDeviceCert       = ("op-device-cert");
-    static constexpr const char * kConfigKey_OperationalDeviceICACerts   = ("op-device-ca-certs");
-    static constexpr const char * kConfigKey_OperationalDevicePrivateKey = ("op-device-key");
-    static constexpr const char * kConfigKey_RegulatoryLocation          = ("regulatory-location");
-    static constexpr const char * kConfigKey_CountryCode                 = ("country-code");
-    static constexpr const char * kConfigKey_ActiveLocale                = ("active-locale");
-    static constexpr const char * kConfigKey_Breadcrumb                  = ("breadcrumb");
-    static constexpr const char * kConfigKey_GroupKeyIndex               = ("group-key-index");
-    static constexpr const char * kConfigKey_LifeTimeCounter             = ("life-time-counter");
+    static constexpr char kConfigKey_FabricId[]                    = ("fabric-id");
+    static constexpr char kConfigKey_ServiceConfig[]               = ("service-config");
+    static constexpr char kConfigKey_PairedAccountId[]             = ("account-id");
+    static constexpr char kConfigKey_ServiceId[]                   = ("service-id");
+    static constexpr char kConfigKey_FabricSecret[]                = ("fabric-secret");
+    static constexpr char kConfigKey_HardwareVersion[]             = ("hardware-ver");
+    static constexpr char kConfigKey_LastUsedEpochKeyId[]          = ("last-ek-id");
+    static constexpr char kConfigKey_FailSafeArmed[]               = ("fail-safe-armed");
+    static constexpr char kConfigKey_OperationalDeviceId[]         = ("op-device-id");
+    static constexpr char kConfigKey_OperationalDeviceCert[]       = ("op-device-cert");
+    static constexpr char kConfigKey_OperationalDeviceICACerts[]   = ("op-device-ca-certs");
+    static constexpr char kConfigKey_OperationalDevicePrivateKey[] = ("op-device-key");
+    static constexpr char kConfigKey_RegulatoryLocation[]          = ("regulatory-location");
+    static constexpr char kConfigKey_CountryCode[]                 = ("country-code");
+    static constexpr char kConfigKey_ActiveLocale[]                = ("active-locale");
+    static constexpr char kConfigKey_Breadcrumb[]                  = ("breadcrumb");
+    static constexpr char kConfigKey_GroupKeyIndex[]               = ("group-key-index");
+    static constexpr char kConfigKey_LifeTimeCounter[]             = ("life-time-counter");
 
-    static constexpr const char * kConfigKey_WiFiSSID     = ("bl-wifi-ssid");
-    static constexpr const char * kConfigKey_WiFiPassword = ("bl-wifi-pass");
+    static constexpr char kConfigKey_WiFiSSID[]     = ("bl-wifi-ssid");
+    static constexpr char kConfigKey_WiFiPassword[] = ("bl-wifi-pass");
 
     /** Counter Keys, diagnostic information  */
-    static constexpr const char * kCounterKey_RebootCount           = ("reboot-count");
-    static constexpr const char * kCounterKey_TotalOperationalHours = ("total-hours");
-    static constexpr const char * kCounterKey_UpTime                = ("up-time");
+    static constexpr char kCounterKey_RebootCount[]           = ("reboot-count");
+    static constexpr char kCounterKey_TotalOperationalHours[] = ("total-hours");
+    static constexpr char kCounterKey_UpTime[]                = ("up-time");
 
-    static constexpr const char * kBLKey_factoryResetFlag = ("__factory_reset_pending");
+    static constexpr char kBLKey_factoryResetFlag[] = ("__factory_reset_pending");
 
     static void Init(void);
 

--- a/src/platform/mbed/Logging.cpp
+++ b/src/platform/mbed/Logging.cpp
@@ -38,7 +38,7 @@
 #define DEFAULT_TRACE_FILTER_LENGTH 24
 #endif
 
-static const char * TRACE_GROUP = "CHIP";
+static const char TRACE_GROUP[] = "CHIP";
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/mt793x/DnssdImpl.cpp
+++ b/src/platform/mt793x/DnssdImpl.cpp
@@ -52,9 +52,9 @@ extern void mDNSPlatformWriteLogRedirect(void (*)(const char *, const char *));
 }
 
 namespace {
-constexpr const char * kLocalDot        = "local.";
-constexpr const char * kProtocolTcp     = "._tcp";
-constexpr const char * kProtocolUdp     = "._udp";
+constexpr char kLocalDot[]              = "local.";
+constexpr char kProtocolTcp[]           = "._tcp";
+constexpr char kProtocolUdp[]           = "._udp";
 static constexpr uint32_t kTimeoutMilli = 3000;
 static constexpr size_t kMaxResults     = 20;
 

--- a/src/platform/mt793x/KeyValueStoreManagerImpl.h
+++ b/src/platform/mt793x/KeyValueStoreManagerImpl.h
@@ -78,7 +78,7 @@ public:
     CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);
 
 private:
-    const char * kNamespace = "CHIP_KVS";
+    static inline const char kNamespace[] = "CHIP_KVS";
     static CHIP_ERROR MapNvdmStatus(nvdm_status_t nvdm_status);
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -48,8 +48,8 @@ class NrfWiFiDriver final : public WiFiDriver
 public:
     // Define non-volatile storage keys for SSID and password.
     // The naming convention is aligned with DefaultStorageKeyAllocator class.
-    static constexpr const char * kSsidKey = "g/wi/s";
-    static constexpr const char * kPassKey = "g/wi/p";
+    static constexpr char kSsidKey[] = "g/wi/s";
+    static constexpr char kPassKey[] = "g/wi/p";
 
     class WiFiNetworkIterator final : public NetworkIterator
     {

--- a/src/platform/nxp/common/NXPConfig.cpp
+++ b/src/platform/nxp/common/NXPConfig.cpp
@@ -109,8 +109,8 @@ NVM_RegisterDataSet((void *) &chipConfigRamStructKeyString, 1, sizeof(chipConfig
                     NVM_ID_CHIP_CONFIG_DATA_KEY_STRING, gNVM_MirroredInRam_c);
 
 #elif (CHIP_PLAT_NVM_SUPPORT == CHIP_PLAT_LITTLEFS)
-const char * mt_key_int_file_name    = "mt_key_int";
-const char * mt_key_str_file_name    = "mt_key_str";
+const char mt_key_int_file_name[]    = "mt_key_int";
+const char mt_key_str_file_name[]    = "mt_key_str";
 #if CHIP_PLAT_SAVE_NVM_DATA_ON_IDLE
 static bool mt_key_int_save_in_flash = false;
 static bool mt_key_str_save_in_flash = false;

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -36,9 +36,9 @@ using namespace chip::DeviceLayer::PersistedStorage;
 
 static void TestKeyValueStoreMgr_EmptyString(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey   = "str_key";
-    constexpr const char kTestValue[] = "";
-    constexpr size_t kTestValueLen    = 0;
+    static constexpr char kTestKey[]   = "str_key";
+    static constexpr char kTestValue[] = "";
+    constexpr size_t kTestValueLen     = 0;
 
     char readValue[sizeof(kTestValue)];
     size_t readSize;
@@ -71,8 +71,8 @@ static void TestKeyValueStoreMgr_EmptyString(nlTestSuite * inSuite, void * inCon
 
 static void TestKeyValueStoreMgr_String(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey   = "str_key";
-    constexpr const char kTestValue[] = "test_value";
+    static constexpr char kTestKey[]   = "str_key";
+    static constexpr char kTestValue[] = "test_value";
 
     char readValue[sizeof(kTestValue)];
     size_t readSize;
@@ -97,7 +97,7 @@ static void TestKeyValueStoreMgr_String(nlTestSuite * inSuite, void * inContext)
 
 static void TestKeyValueStoreMgr_Uint32(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey     = "uint32_key";
+    static constexpr char kTestKey[]    = "uint32_key";
     constexpr const uint32_t kTestValue = 5;
 
     uint32_t readValue = UINT32_MAX;
@@ -121,7 +121,7 @@ static void TestKeyValueStoreMgr_Uint32(nlTestSuite * inSuite, void * inContext)
 
 static void TestKeyValueStoreMgr_Array(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey  = "array_key";
+    static constexpr char kTestKey[] = "array_key";
     constexpr uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
 
     uint32_t readValue[5];
@@ -153,7 +153,7 @@ static void TestKeyValueStoreMgr_Struct(nlTestSuite * inSuite, void * inContext)
         uint32_t value2;
     };
 
-    constexpr const char * kTestKey = "struct_key";
+    static constexpr char kTestKey[] = "struct_key";
     constexpr TestStruct kTestValue{ 1, 2 };
 
     TestStruct readValue;
@@ -180,7 +180,7 @@ static void TestKeyValueStoreMgr_Struct(nlTestSuite * inSuite, void * inContext)
 
 static void TestKeyValueStoreMgr_UpdateValue(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey = "update_key";
+    static constexpr char kTestKey[] = "update_key";
 
     CHIP_ERROR err;
     uint32_t readValue;
@@ -201,8 +201,8 @@ static void TestKeyValueStoreMgr_UpdateValue(nlTestSuite * inSuite, void * inCon
 
 static void TestKeyValueStoreMgr_TooSmallBufferRead(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey = "too_small_buffer_read_key";
-    constexpr uint8_t kTestValue[]  = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    static constexpr char kTestKey[] = "too_small_buffer_read_key";
+    constexpr uint8_t kTestValue[]   = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
     uint8_t readValue[9];
     size_t readSize;
@@ -254,7 +254,7 @@ static void TestKeyValueStoreMgr_AllCharactersKey(nlTestSuite * inSuite, void * 
 
 static void TestKeyValueStoreMgr_NonExistentDelete(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey = "non_existent";
+    static constexpr char kTestKey[] = "non_existent";
 
     CHIP_ERROR err = KeyValueStoreMgr().Delete(kTestKey);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
@@ -263,7 +263,7 @@ static void TestKeyValueStoreMgr_NonExistentDelete(nlTestSuite * inSuite, void *
 #if !defined(__ZEPHYR__) && !defined(__MBED__)
 static void TestKeyValueStoreMgr_MultiRead(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kTestKey  = "multi_key";
+    static constexpr char kTestKey[] = "multi_key";
     constexpr uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
@@ -289,8 +289,8 @@ static void TestKeyValueStoreMgr_MultiRead(nlTestSuite * inSuite, void * inConte
 #ifdef __ZEPHYR__
 static void TestKeyValueStoreMgr_DoFactoryReset(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kStrKey  = "string_with_weird_chars\\=_key";
-    constexpr const char * kUintKey = "some_uint_key";
+    static constexpr char kStrKey[]  = "string_with_weird_chars\\=_key";
+    static constexpr char kUintKey[] = "some_uint_key";
 
     NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Put(kStrKey, "some_string") == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Put(kUintKey, uint32_t(1234)) == CHIP_NO_ERROR);

--- a/src/protocols/Protocols.cpp
+++ b/src/protocols/Protocols.cpp
@@ -24,7 +24,7 @@
 namespace chip {
 namespace Protocols {
 
-static const char * sUnknownTypeName = "----";
+static const char sUnknownTypeName[] = "----";
 
 static const char * LookupMessageTypeName(const MessageTypeNameLookup * lookupTable, size_t tableSize, uint8_t msgType)
 {

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -35,7 +35,7 @@ namespace bdx {
 
 inline constexpr uint16_t kMaxFileDesignatorLen = 0xFF;
 
-inline constexpr const char * kProtocolName = "BDX";
+inline constexpr char kProtocolName[] = "BDX";
 
 enum class MessageType : uint8_t
 {

--- a/src/protocols/bdx/BdxUri.h
+++ b/src/protocols/bdx/BdxUri.h
@@ -22,7 +22,7 @@
 namespace chip {
 namespace bdx {
 
-inline constexpr const char kScheme[] = "bdx://";
+inline constexpr char kScheme[] = "bdx://";
 
 /**
  * Parses the URI into NodeId and File Designator

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -38,7 +38,7 @@ namespace chip {
 namespace Protocols {
 namespace Echo {
 
-inline constexpr const char * kProtocolName = "Echo";
+inline constexpr char kProtocolName[] = "Echo";
 
 /**
  * Echo Protocol Message Types

--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -45,7 +45,7 @@ namespace chip {
 namespace Protocols {
 namespace InteractionModel {
 
-inline constexpr const char * kProtocolName = "IM";
+inline constexpr char kProtocolName[] = "IM";
 
 /**
  * Version of the Interaction Model used by the node.

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -43,7 +43,7 @@ namespace chip {
 namespace Protocols {
 namespace SecureChannel {
 
-inline constexpr const char * kProtocolName = "SecureChannel";
+inline constexpr char kProtocolName[] = "SecureChannel";
 
 /**
  * SecureChannel Protocol Message Types

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -54,9 +54,9 @@ using namespace Crypto;
 using namespace Messaging;
 using namespace Protocols::SecureChannel;
 
-const char * kSpake2pContext        = "CHIP PAKE V1 Commissioning";
-const char * kSpake2pI2RSessionInfo = "Commissioning I2R Key";
-const char * kSpake2pR2ISessionInfo = "Commissioning R2I Key";
+const char kSpake2pContext[]        = "CHIP PAKE V1 Commissioning";
+const char kSpake2pI2RSessionInfo[] = "Commissioning I2R Key";
+const char kSpake2pR2ISessionInfo[] = "Commissioning R2I Key";
 
 // Amounts of time to allow for server-side processing of messages.
 //

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -41,8 +41,8 @@
 
 namespace chip {
 
-extern const char * kSpake2pI2RSessionInfo;
-extern const char * kSpake2pR2ISessionInfo;
+extern const char kSpake2pI2RSessionInfo[];
+extern const char kSpake2pR2ISessionInfo[];
 
 inline constexpr uint16_t kPBKDFParamRandomNumberSize = 32;
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -41,7 +41,7 @@ namespace chip {
 namespace Protocols {
 namespace UserDirectedCommissioning {
 
-inline constexpr const char * kProtocolName = "UserDirectedCommissioning";
+inline constexpr char kProtocolName[] = "UserDirectedCommissioning";
 
 // Cache contains 16 clients. This may need to be tweaked.
 inline constexpr uint8_t kMaxUDCClients = 16;

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -39,7 +39,7 @@ const uint32_t kOptionalDefaultIntValue = 12;
 inline constexpr char kSerialNumberDefaultStringValue[] = "123456789";
 const uint32_t kSerialNumberDefaultUInt32Value          = 123456789;
 
-inline constexpr const char * kDefaultPayloadQRCode = "MT:M5L90MP500K64J00000";
+inline constexpr char kDefaultPayloadQRCode[] = "MT:M5L90MP500K64J00000";
 
 inline SetupPayload GetDefaultPayload()
 {

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1779,9 +1779,9 @@ void PacketBufferTest::CheckHandleRightSize(nlTestSuite * inSuite, void * inCont
     PacketBufferTest * const test         = theContext->test;
     NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    const char kPayload[]     = "Joy!";
-    PacketBufferHandle handle = PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSizeWithoutReserve, 0);
-    PacketBuffer * buffer     = handle.mBuffer;
+    static const char kPayload[] = "Joy!";
+    PacketBufferHandle handle    = PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSizeWithoutReserve, 0);
+    PacketBuffer * buffer        = handle.mBuffer;
 
     memcpy(handle->Start(), kPayload, sizeof kPayload);
     buffer->SetDataLength(sizeof kPayload);
@@ -1940,7 +1940,7 @@ void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inC
     PacketBufferTest * const test         = theContext->test;
     NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    const char kPayload[] = "Hello, world!";
+    static const char kPayload[] = "Hello, world!";
 
     PacketBufferWriter yay(PacketBufferHandle::New(sizeof(kPayload)));
     PacketBufferWriter nay(PacketBufferHandle::New(sizeof(kPayload)), sizeof(kPayload) - 2);

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -36,7 +36,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-const char * TAG = "CHIP-tests";
+const char TAG[] = "CHIP-tests";
 
 static void tester_task(void * pvParameters)
 {

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -231,14 +231,14 @@ bool HasStringPrefix(const uint8_t * buffer, size_t len, const char * prefix)
 CertFormat DetectCertFormat(const uint8_t * cert, uint32_t certLen)
 {
     static const uint8_t chipRawPrefix[]           = { 0x15, 0x30, 0x01 };
-    static const char * chipHexPrefix              = "153001";
-    static const char * chipB64Prefix              = "FTAB";
+    static const char chipHexPrefix[]              = "153001";
+    static const char chipB64Prefix[]              = "FTAB";
     static const uint8_t chipCompactPdcRawPrefix[] = { 0x15, 0x30, 0x09 };
-    static const char * chipCompactPdcHexPrefix    = "153009";
-    static const char * chipCompactPdcB64Prefix    = "FTAJ";
+    static const char chipCompactPdcHexPrefix[]    = "153009";
+    static const char chipCompactPdcB64Prefix[]    = "FTAJ";
     static const uint8_t derRawPrefix[]            = { 0x30, 0x82 };
-    static const char * derHexPrefix               = "30820";
-    static const char * pemMarker                  = "-----BEGIN CERTIFICATE-----";
+    static const char derHexPrefix[]               = "30820";
+    static const char pemMarker[]                  = "-----BEGIN CERTIFICATE-----";
 
     VerifyOrReturnError(cert != nullptr, kCertFormat_Unknown);
 

--- a/src/tools/chip-cert/Cmd_PrintCD.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCD.cpp
@@ -135,8 +135,8 @@ CDFormat DetectCDFormat(const uint8_t * cd, uint32_t cdLen)
 {
     static const uint8_t cdRawPrefix1[] = { 0x30, 0x81 };
     static const uint8_t cdRawPrefix2[] = { 0x30, 0x82 };
-    static const char * cdHexPrefix     = "308";
-    static const char * cdB64Prefix     = "MI";
+    static const char cdHexPrefix[]     = "308";
+    static const char cdB64Prefix[]     = "MI";
 
     VerifyOrReturnError(cd != nullptr, kCDFormat_Unknown);
 

--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -44,13 +44,13 @@ KeyFormat DetectKeyFormat(const uint8_t * key, uint32_t keyLen)
 {
     static uint32_t p256SerializedKeypairLen = kP256_PublicKey_Length + kP256_PrivateKey_Length;
     static const uint8_t chipRawPrefix[]     = { 0x04 };
-    static const char * chipHexPrefix        = "04";
-    static const char * chipB64Prefix        = "B";
+    static const char chipHexPrefix[]        = "04";
+    static const char chipB64Prefix[]        = "B";
     static const uint8_t derRawPrefix[]      = { 0x30, 0x77, 0x02, 0x01, 0x01, 0x04 };
-    static const char * derHexPrefix         = "307702010104";
-    static const char * ecPEMMarker          = "-----BEGIN EC PRIVATE KEY-----";
-    static const char * pkcs8PEMMarker       = "-----BEGIN PRIVATE KEY-----";
-    static const char * ecPUBPEMMarker       = "-----BEGIN PUBLIC KEY-----";
+    static const char derHexPrefix[]         = "307702010104";
+    static const char ecPEMMarker[]          = "-----BEGIN EC PRIVATE KEY-----";
+    static const char pkcs8PEMMarker[]       = "-----BEGIN PRIVATE KEY-----";
+    static const char ecPUBPEMMarker[]       = "-----BEGIN PUBLIC KEY-----";
 
     VerifyOrReturnError(key != nullptr, kKeyFormat_Unknown);
 

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -75,9 +75,9 @@
 namespace chip {
 namespace trace {
 
-inline constexpr const char * kTraceMessageEvent              = "SecureMsg";
-inline constexpr const char * kTraceMessageSentDataFormat     = "SecMsgSent";
-inline constexpr const char * kTraceMessageReceivedDataFormat = "SecMsgReceived";
+inline constexpr char kTraceMessageEvent[]              = "SecureMsg";
+inline constexpr char kTraceMessageSentDataFormat[]     = "SecMsgSent";
+inline constexpr char kTraceMessageReceivedDataFormat[] = "SecMsgReceived";
 
 struct TraceSecureMessageSentData
 {


### PR DESCRIPTION
The declaration

```
  const char * kStringConstant = "value";
```

declares a mutable pointer to const C string, and so the following assignment is legal:

```
  kStringConstant = "other value";
```

Obviously this is not desired. Declaring as "const char * const" avoids this, but this declares an unnecessary pointer.

Change these declarations to "const(expr) char []".

These edits were made by the following command:

```
find . -name .git -prune -o -name .environment -prune -o -name third_party -prune -o -name zzz_generated -prune -o -name out -prune -o -type f \( -name '*.cpp' -o -name '*.h' \) -exec sed -i 's,^\( *\)\(static \|extern \|\)\(inline \|\)\(constexpr \|\)const char *\* * k\([A-Z][^][ ;()]*\)\( \|;\),\1\2\3\4const char k\5[]\6,g; s,^\([^()]*\)constexpr const char k\([^()]*\)\( \|;\),\1constexpr char k\2\3,g; s,^\(  *\)const\(expr\|\) char \([^()]*\)\[\] *= ",\1static const\2 char \3[] = ",g' {} +
```

with 2 fixes to add "inline" in constants defined in headers.