### PR TITLE
Fix session eviction handling of eviction hints.

### DIFF
--- a/src/transport/SecureSessionTable.cpp
+++ b/src/transport/SecureSessionTable.cpp
@@ -265,8 +265,31 @@ void SecureSessionTable::DefaultEvictionPolicy(EvictionPolicyContext & evictionC
             return a.mNumMatchingOnPeer > b.mNumMatchingOnPeer;
         }
 
-        int doesAMatchSessionHint = a.mSession->GetPeer() == evictionContext.GetSessionEvictionHint();
-        int doesBMatchSessionHint = b.mSession->GetPeer() == evictionContext.GetSessionEvictionHint();
+        // We have an evicton hint in two cases:
+        //
+        // 1) When we just established CASE as a responder, the hint is the node
+        //    we just established CASE to.
+        // 2) When starting to establish CASE as an initiator, the hint is the
+        //    node we are going to establish CASE to.
+        //
+        // In case 2, we should not end up here if there is an active session to
+        // the peer at all (because that session should have been used instead
+        // of establishing a new one).
+        //
+        // In case 1, we know we have a session matching the hint, but we don't
+        // want to pick that one for eviction, because we just established it.
+        // So we should not consider a session as matching a hint if it's active
+        // and is the only session to our peer.
+        //
+        // Checking for the "active" state in addition to the "only session to
+        // peer" state allows us to prioritize evicting defuct sessions that
+        // match the hint against other defunct sessions.
+        auto sessionMatchesEvictionHint = [&evictionContext](const SortableSession & session) -> int {
+            return session.mSession->GetPeer() == evictionContext.GetSessionEvictionHint() &&
+                (!session.mSession->IsActiveSession() || session.mNumMatchingOnPeer > 0);
+        };
+        int doesAMatchSessionHint = sessionMatchesEvictionHint(a);
+        int doesBMatchSessionHint = sessionMatchesEvictionHint(b);
 
         //
         // Sorting on Key4

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -206,7 +206,7 @@ private:
      * the session that is most ahead as the best candidate for eviction:
      *
      *  - Key1:  Sessions on fabrics that have more sessions in the table are placed ahead of sessions on fabrics
-     *           with lesser sessions. We conclusively know that if a particular fabric has more sessions in the table
+     *           with fewer sessions. We conclusively know that if a particular fabric has more sessions in the table
      *           than another, then that fabric is definitely over minimas (assuming a minimally sized session table
      *           conformant to spec minimas).
      *


### PR DESCRIPTION
When we establish a session as a CASE responder, we try to allocate a new session to listen to session establishments, and use the just-established-session's peer ID as the eviction hint.

If we had a bunch of active sessions on a fabric, all to different nodes, this would cause the just-established session to be evicted, since it matched the hint.

The fix is to only consider sessions for eviction based on the hint if they are either non-active or not unique sessions to the peer (at which point, the just-established session should be last in priority order for eviction).

Fixes https://github.com/project-chip/connectedhomeip/issues/30728
