### PR TITLE
configure: Add support for pre-generated code

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -55,6 +55,14 @@ function usage() { # status
     info "  environment variables (CC, CXX, AR, CFLAGS, CXXFLAGS, ...), falling back to"
     info "  default tool names (CC=cc, ...). When using this script within an external"
     info "  build system, toolchain environment variables should be populated."
+    info ""
+    info "Code generation:"
+    info "  By default, some code generation will happen at build time using zap-cli."
+    info "  If zap-cli is not available on PATH, configure will attempt to download it."
+    info "  Alternatively, if a directory called 'zzz_pregenerated' exists at the root"
+    info "  of the project or the root of the SDK, pre-generated code from this directory"
+    info "  will be used. In this case, build time code generation will be disabled and"
+    info "  zap-cli is not required."
     exit "$1"
 }
 
@@ -63,6 +71,8 @@ function main() { # ...
     BUILD_ENV_DEPS=(
         "${CHIP_ROOT}/scripts/setup/requirements.build.txt"
         "${CHIP_ROOT}/scripts/setup/constraints.txt"
+    )
+    BUILD_ENV_DEPS_CODEGEN=(
         "${CHIP_ROOT}/scripts/setup/zap.version"
     )
 
@@ -97,8 +107,18 @@ function main() { # ...
         info "WARNING: A Pigweed environment appears to be active, this is usually a misconfiguration."
     fi
 
-    check_binary gn GN
-    check_binary ninja NINJA
+    # Check for pre-generated code. CHIP_PREGEN_DIR will be picked up by process_project_args.
+    local pregen_dir="zzz_pregenerated"
+    if [[ -n "$PROJECT_PATH" && -d "${PROJECT_PATH}/${pregen_dir}" ]]; then
+        info "Will use pre-generated code from ${PROJECT}/${pregen_dir}, no zap-cli required."
+        export CHIP_PREGEN_DIR="//${pregen_dir}"
+    elif [[ -d "${CHIP_ROOT}/${pregen_dir}" ]]; then
+        info "Will use pre-generated code from ${pregen_dir}, no zap-cli required."
+        export CHIP_PREGEN_DIR="\${chip_root}/${pregen_dir}"
+    else
+        BUILD_ENV_DEPS+=("${BUILD_ENV_DEPS_CODEGEN[@]}")
+        unset CHIP_PREGEN_DIR
+    fi
 
     # Work out build and environment directories
     if [[ "$PWD" == "$CHIP_ROOT" ]]; then
@@ -119,11 +139,15 @@ function main() { # ...
         BUILD_ENV_PATH="${BUILD_DIR}/${BUILD_ENV_DIR}"
     fi
 
+    # Check required tools are present
+    check_binary gn GN
+    check_binary ninja NINJA
+
     # Create the build environment if necessary
     if ! check_build_env; then
         check_python
         configure_python_env
-        if ! check_binary zap-cli; then
+        if [[ -z "$CHIP_PREGEN_DIR" ]] && ! check_binary zap-cli; then
             download_zap
         fi
         finalize_build_env
@@ -188,6 +212,7 @@ function gn_generate() { # [project options]
     {
         echo "# ${CONFIGURE_MARKER}"
         echo "# project root: ${PROJECT_PATH}"
+        echo "import(\"//build_overrides/chip.gni\")"
     } >"${BUILD_DIR}/args.gn"
     "${gn[@]}" -q gen "$BUILD_DIR"
 

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -38,7 +38,6 @@ def download_and_extract_zip(url, dest_dir, *member_names):
 
 def process_project_args(gn_args_json_file, *params):
     processor = ProjectArgProcessor(gn_args_json_file)
-    processor.process_defaults()
     processor.process_env()
     processor.process_parameters(params)
     for arg, value in processor.args.items():
@@ -63,11 +62,10 @@ class ProjectArgProcessor:
             for arg in json.load(fh):
                 self.gn_args[arg['name']] = arg['default']['value'][0].translate(argtype)
 
-    def process_defaults(self):
-        self.add_default('custom_toolchain', 'custom')
-
     def process_env(self):
         self.add_env_arg('chip_code_pre_generated_directory', 'CHIP_PREGEN_DIR')
+
+        self.add_default('custom_toolchain', 'custom')
         self.add_env_arg('target_cc', 'CC', 'cc')
         self.add_env_arg('target_cxx', 'CXX', 'cxx')
         self.add_env_arg('target_ar', 'AR', 'ar')

--- a/scripts/configure.impl.py
+++ b/scripts/configure.impl.py
@@ -67,6 +67,7 @@ class ProjectArgProcessor:
         self.add_default('custom_toolchain', 'custom')
 
     def process_env(self):
+        self.add_env_arg('chip_code_pre_generated_directory', 'CHIP_PREGEN_DIR')
         self.add_env_arg('target_cc', 'CC', 'cc')
         self.add_env_arg('target_cxx', 'CXX', 'cxx')
         self.add_env_arg('target_ar', 'AR', 'ar')


### PR DESCRIPTION
If zzz_pregenerated is  present it is used, and zap-cli is not required.
