### PR TITLE
[Tizen] Do not try to get Thread MAC if Thread API is uninitialized

### DIFF
--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -61,6 +61,43 @@
 namespace chip {
 namespace DeviceLayer {
 
+namespace {
+// Return human readable error message for given Thread API error code.
+//
+// This is a temporary workaround for the fact that Tizen common API
+// does not return messages for all Thread API errors.
+//
+// TODO (a.bokowy): To be removed once Tizen fixes this issue.
+const char * get_error_message(int code)
+{
+    switch (code)
+    {
+    case THREAD_ERROR_NOT_INITIALIZED:
+        return "Not initialized";
+    case THREAD_ERROR_NOT_IN_PROGRESS:
+        return "Operation not in progress";
+    case THREAD_ERROR_ALREADY_DONE:
+        return "Operation already done";
+    case THREAD_ERROR_OPERATION_FAILED:
+        return "Operation failed";
+    case THREAD_ERROR_NOT_READY:
+        return "Resource not ready";
+    case THREAD_ERROR_NOT_ENABLED:
+        return "Not enabled";
+    case THREAD_ERROR_NOT_FOUND:
+        return "Not found";
+    case THREAD_ERROR_ALREADY_REGISTERED:
+        return "Already registered";
+    case THREAD_ERROR_DB_FAILED:
+        return "DB operation failed";
+    case THREAD_ERROR_NOT_REGISTERED:
+        return "Not registered";
+    default:
+        return ::get_error_message(code);
+    }
+}
+}; // namespace
+
 ThreadStackManagerImpl ThreadStackManagerImpl::sInstance;
 
 constexpr char ThreadStackManagerImpl::kOpenthreadDeviceRoleDisabled[];

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -460,6 +460,8 @@ CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyFull()
 
 CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
 {
+    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
+
     uint64_t extAddr;
     int threadErr;
 

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -37,6 +37,7 @@
 #include <cstring>
 
 #include <thread.h>
+#include <tizen_error.h>
 
 #include <app/AttributeAccessInterface.h>
 #include <inet/IPAddress.h>
@@ -132,20 +133,24 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     }
 
     threadErr = thread_initialize();
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: initialize thread"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Initialize Thread: %s", get_error_message(threadErr)));
     ChipLogProgress(DeviceLayer, "Thread initialized");
 
     threadErr = thread_enable(&mThreadInstance);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: enable thread"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Enable Thread: %s", get_error_message(threadErr)));
     ChipLogProgress(DeviceLayer, "Thread enabled");
 
     threadErr = thread_get_device_role(mThreadInstance, &deviceRole);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get device role"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Get Thread device role: %s", get_error_message(threadErr)));
     ThreadDeviceRoleChangedHandler(deviceRole);
 
     /* Set callback for change of device role */
     threadErr = thread_set_device_role_changed_cb(mThreadInstance, _ThreadDeviceRoleChangedCb, nullptr);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: set device role changed cb"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Set Thread device role changed cb: %s", get_error_message(threadErr)));
 
     mIsInitialized = true;
     ChipLogProgress(DeviceLayer, "Thread stack manager initialized");
@@ -153,7 +158,6 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
 exit:
     thread_deinitialize();
-    ChipLogError(DeviceLayer, "FAIL: initialize thread stack");
     return CHIP_ERROR_INTERNAL;
 }
 
@@ -178,33 +182,30 @@ void ThreadStackManagerImpl::ThreadDeviceRoleChangedHandler(thread_device_role_e
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     int threadErr = THREAD_ERROR_NONE;
-
     if (role == THREAD_DEVICE_ROLE_DISABLED)
     {
         /* start srp client */
         threadErr = thread_srp_client_start(mThreadInstance);
         if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-            ChipLogError(DeviceLayer, "FAIL: thread_srp_client_start");
+            ChipLogError(DeviceLayer, "FAIL: Start Thread SRP client: %s", get_error_message(threadErr));
     }
     else if (role == THREAD_DEVICE_ROLE_ROUTER || role == THREAD_DEVICE_ROLE_CHILD)
     {
         threadErr = thread_srp_server_stop(mThreadInstance);
         if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-            ChipLogError(DeviceLayer, "FAIL: thread_srp_server_stop");
-
+            ChipLogError(DeviceLayer, "FAIL: Stop Thread SRP server: %s", get_error_message(threadErr));
         threadErr = thread_srp_client_start(mThreadInstance);
         if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-            ChipLogError(DeviceLayer, "FAIL: thread_srp_client_start");
+            ChipLogError(DeviceLayer, "FAIL: Start Thread SRP client: %s", get_error_message(threadErr));
     }
     else if (role == THREAD_DEVICE_ROLE_LEADER)
     {
         threadErr = thread_srp_client_stop(mThreadInstance);
         if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-            ChipLogError(DeviceLayer, "FAIL: thread_srp_client_stop");
-
+            ChipLogError(DeviceLayer, "FAIL: Stop Thread SRP client: %s", get_error_message(threadErr));
         threadErr = thread_srp_server_start(mThreadInstance);
         if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-            ChipLogError(DeviceLayer, "FAIL: thread_srp_server_start");
+            ChipLogError(DeviceLayer, "FAIL: Start Thread SRP server: %s", get_error_message(threadErr));
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -228,13 +229,14 @@ void ThreadStackManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
 CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(ByteSpan netInfo)
 {
-    int threadErr = THREAD_ERROR_NONE;
-
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
     VerifyOrReturnError(Thread::OperationalDataset::IsValid(netInfo), CHIP_ERROR_INVALID_ARGUMENT);
 
+    int threadErr = THREAD_ERROR_NONE;
+
     threadErr = thread_network_set_active_dataset_tlvs(mThreadInstance, netInfo.data(), netInfo.size());
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: set active dataset tlvs"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Thread set active dataset TLVs: %s", get_error_message(threadErr)));
 
     // post an event alerting other subsystems about change in provisioning state
     ChipDeviceEvent event;
@@ -242,34 +244,33 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(ByteSpan netInfo)
     event.ServiceProvisioningChange.IsServiceProvisioned = true;
     PlatformMgr().PostEventOrDie(&event);
 
-    ChipLogProgress(DeviceLayer, "Thread set active dtaset tlvs");
+    ChipLogProgress(DeviceLayer, "Thread set active dataset TLVs");
 
     return CHIP_NO_ERROR;
 
 exit:
-    ChipLogError(DeviceLayer, "FAIL: set thread provision");
     return CHIP_ERROR_INTERNAL;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_GetThreadProvision(Thread::OperationalDataset & dataset)
 {
+    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
+
     int threadErr      = THREAD_ERROR_NONE;
     uint8_t * tlvsData = nullptr;
     int tlvsLen;
 
-    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
-
     threadErr = thread_network_get_active_dataset_tlvs(mThreadInstance, &tlvsData, &tlvsLen);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get active dataset tlvs"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Thread get active dataset TLVs: %s", get_error_message(threadErr)));
 
-    ChipLogProgress(DeviceLayer, "Thread get active dataset tlvs size [%u]", tlvsLen);
+    ChipLogProgress(DeviceLayer, "Thread get active dataset TLVs size [%u]", tlvsLen);
     mDataset.Init(ByteSpan(tlvsData, tlvsLen));
     dataset.Init(mDataset.AsByteSpan());
 
     return CHIP_NO_ERROR;
 
 exit:
-    ChipLogError(DeviceLayer, "FAIL: get thread provision");
     return CHIP_ERROR_INTERNAL;
 }
 
@@ -285,13 +286,14 @@ void ThreadStackManagerImpl::_ErasePersistentInfo()
 
 bool ThreadStackManagerImpl::_IsThreadEnabled()
 {
+    VerifyOrReturnError(mIsInitialized, false);
+
     int threadErr = THREAD_ERROR_NONE;
     thread_device_role_e deviceRole;
 
-    VerifyOrReturnError(mIsInitialized, false);
-
     threadErr = thread_get_device_role(mThreadInstance, &deviceRole);
-    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, false);
+    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, false,
+                        ChipLogError(DeviceLayer, "FAIL: Get Thread device role: %s", get_error_message(threadErr)));
 
     ChipLogProgress(DeviceLayer, "Thread device role [%s]", _ThreadRoleToStr(deviceRole));
     return deviceRole != THREAD_DEVICE_ROLE_DISABLED;
@@ -304,9 +306,9 @@ bool ThreadStackManagerImpl::_IsThreadAttached()
 
 CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
 {
-    int threadErr = THREAD_ERROR_NONE;
-
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
+
+    int threadErr  = THREAD_ERROR_NONE;
     bool isEnabled = sInstance._IsThreadEnabled();
 
     if (val && !isEnabled)
@@ -319,8 +321,8 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
                 this->mpConnectCallback = nullptr;
             }
         });
-
-        VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: attach thread network"));
+        VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "FAIL: Attach Thread network: %s", get_error_message(threadErr)));
 
         threadErr = thread_start(mThreadInstance);
         DeviceLayer::SystemLayer().ScheduleLambda([&, threadErr]() {
@@ -332,75 +334,70 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
                 this->mpConnectCallback = nullptr;
             }
         });
-        VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: start thread network"));
+        VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "FAIL: Start Thread network: %s", get_error_message(threadErr)));
     }
     else if (!val && isEnabled)
     {
         threadErr = thread_stop(mThreadInstance);
-        VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: thread stop"));
+        VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "FAIL: Stop Thread: %s", get_error_message(threadErr)));
     }
 
     thread_device_role_e deviceRole;
     threadErr = thread_get_device_role(mThreadInstance, &deviceRole);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get device role"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Get Thread device role: %s", get_error_message(threadErr)));
     ThreadDeviceRoleChangedHandler(deviceRole);
 
     ChipLogProgress(DeviceLayer, "Thread set enabled [%s]", val ? "attach" : "reset");
     return CHIP_NO_ERROR;
 
 exit:
-    ChipLogError(DeviceLayer, "FAIL: set thread enabled [%d]", val);
+    ChipLogError(DeviceLayer, "FAIL: Set Thread enabled [%s]", val ? "attach" : "reset");
     return CHIP_ERROR_INTERNAL;
 }
 
 ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceType()
 {
+    VerifyOrReturnError(mIsInitialized, ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported,
+                        ChipLogError(DeviceLayer, "Thread stack not initialized"));
+
     int threadErr = THREAD_ERROR_NONE;
     thread_device_type_e devType;
-    ConnectivityManager::ThreadDeviceType deviceType;
-
-    VerifyOrExit(mIsInitialized, ChipLogError(DeviceLayer, "Thread stack not initialized"));
 
     threadErr = thread_get_device_type(mThreadInstance, &devType);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get device type"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Get Thread device type: %s", get_error_message(threadErr)));
 
     ChipLogProgress(DeviceLayer, "Thread device type [%s]", _ThreadTypeToStr(devType));
 
     switch (devType)
     {
     case THREAD_DEVICE_TYPE_NOT_SUPPORTED:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     case THREAD_DEVICE_TYPE_ROUTER:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
     case THREAD_DEVICE_TYPE_FULL_END_DEVICE:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_FullEndDevice;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_FullEndDevice;
     case THREAD_DEVICE_TYPE_MINIMAL_END_DEVICE:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_MinimalEndDevice;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_MinimalEndDevice;
     case THREAD_DEVICE_TYPE_SLEEPY_END_DEVICE:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_SleepyEndDevice;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_SleepyEndDevice;
     default:
-        deviceType = ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
-        break;
+        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     }
 
-    return deviceType;
-
 exit:
-    ChipLogError(DeviceLayer, "FAIL: get thread device type");
     return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)
 {
+    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
+
     int threadErr = THREAD_ERROR_NONE;
     thread_device_type_e devType;
-
-    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
 
     switch (deviceType)
     {
@@ -425,13 +422,13 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::Thr
     }
 
     threadErr = thread_set_device_type(mThreadInstance, devType);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: set device type"));
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "FAIL: Set Thread device type: %s", get_error_message(threadErr)));
 
     ChipLogProgress(DeviceLayer, "Thread set device type [%s]", _ThreadTypeToStr(devType));
     return CHIP_NO_ERROR;
 
 exit:
-    ChipLogError(DeviceLayer, "FAIL: set thread device type [%d]", deviceType);
     return CHIP_ERROR_INTERNAL;
 }
 
@@ -467,7 +464,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
 
     threadErr = thread_get_extended_address(mThreadInstance, &extAddr);
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "thread_get_extended_address() failed. ret: %d", threadErr));
+                        ChipLogError(DeviceLayer, "FAIL: Get Thread extended address: %s", get_error_message(threadErr)));
 
     extAddr = htobe64(extAddr);
     memcpy(buf, &extAddr, sizeof(extAddr));
@@ -565,7 +562,7 @@ CHIP_ERROR ThreadStackManagerImpl::_AddSrpService(const char * aInstanceName, co
     threadErr = thread_srp_client_register_service_full(mThreadInstance, aInstanceName, aName, aPort, 0, 0, entries.data(),
                                                         static_cast<uint8_t>(entries.size()));
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "thread_srp_client_register_service() failed. ret: %d", threadErr));
+                        ChipLogError(DeviceLayer, "FAIL: Register Thread SRP client service: %s", get_error_message(threadErr)));
 
     SrpClientService service;
     Platform::CopyString(service.mInstanceName, aInstanceName);
@@ -586,7 +583,7 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveSrpService(const char * aInstanceName,
 
     threadErr = thread_srp_client_remove_service(mThreadInstance, aInstanceName, aName);
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "thread_srp_client_remove_service() failed. ret: %d", threadErr));
+                        ChipLogError(DeviceLayer, "FAIL: Remove Thread SRP client service: %s", get_error_message(threadErr)));
 
     return CHIP_NO_ERROR;
 }
@@ -621,23 +618,17 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveInvalidSrpServices()
 
 void ThreadStackManagerImpl::_ThreadIpAddressCb(int index, char * ipAddr, thread_ipaddr_type_e ipAddrType, void * userData)
 {
-    int threadErr = THREAD_ERROR_NONE;
-
-    VerifyOrExit(ipAddr, ChipLogError(DeviceLayer, "FAIL: invalid argument, ipAddr not found"));
-    VerifyOrExit(strlen(ipAddr) >= 6, ChipLogError(DeviceLayer, "FAIL: invalid ipAddr"));
+    VerifyOrReturn(ipAddr != nullptr, ChipLogError(DeviceLayer, "FAIL: Invalid argument: Thread ipAddr not found"));
+    VerifyOrReturn(strlen(ipAddr) >= 6, ChipLogError(DeviceLayer, "FAIL: Invalid Thread ipAddr"));
 
     ChipLogProgress(DeviceLayer, "_ThreadIpAddressCb index:[%d] ipAddr:[%s] type:[%d]", index, ipAddr, ipAddrType);
 
     if (ipAddrType != THREAD_IPADDR_TYPE_MLEID)
         return;
-    threadErr = thread_srp_client_set_host_address(sInstance.mThreadInstance, ipAddr);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE,
-                 ChipLogError(DeviceLayer, "FAIL: Thread library API failed"));
 
-    return;
-
-exit:
-    ChipLogError(DeviceLayer, "FAIL: thread_srp_client_set_host_address");
+    auto threadErr = thread_srp_client_set_host_address(sInstance.mThreadInstance, ipAddr);
+    VerifyOrReturn(threadErr == THREAD_ERROR_NONE || threadErr == THREAD_ERROR_ALREADY_DONE,
+                   ChipLogError(DeviceLayer, "FAIL: Set Thread SRP client host address: %s", get_error_message(threadErr)));
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_SetupSrpHost(const char * aHostName)
@@ -650,12 +641,12 @@ CHIP_ERROR ThreadStackManagerImpl::_SetupSrpHost(const char * aHostName)
 
     threadErr = thread_srp_client_set_host_name(mThreadInstance, aHostName);
     if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-        ChipLogError(DeviceLayer, "thread_srp_client_set_host_name() failed. ret: %d", threadErr);
+        ChipLogError(DeviceLayer, "FAIL: Set Thread SRP client host name: %s", get_error_message(threadErr));
 
-    /* Get external ip address */
+    /* Get external IP address */
     threadErr = thread_get_ipaddr(mThreadInstance, _ThreadIpAddressCb, THREAD_IPADDR_TYPE_MLEID, nullptr);
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "thread_get_ipaddr() failed. ret: %d", threadErr));
+                        ChipLogError(DeviceLayer, "FAIL: Get Thread IP address: %s", get_error_message(threadErr)));
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
### Problem

It is not possible to use Tizen Thread API before it is initialized.

```
D/CHIP    ( 1351): DL: DNSsd UnregisterAllServices: 1
E/CHIP    ( 1351): DL: thread_get_extended_address() failed. ret: 301924353
D/CHIP    ( 1351): DL: Using wifi MAC for hostname
```

### Changes

- check if Tread stack manager is initialized before trying to get MAC address
- update error handling to print human readable message instead of error code

### Testing

Tested locally that the "thread_get_extended_address() failed" error is not printed.