### PR TITLE
[Docker][NXP] Use tag instead of branch name for K32W0 SDK

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-26 : [Telink] Update Docker image (Zephyr update)
+27 : [NXP] Update K32W0 Docker image

--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/sdk
 
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west==1.0.0 \
-    && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "release/2.6.x_k32w0" \
+    && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.6.13_K32W0" \
     && west update \
     && chmod +x core/tools/imagetool/sign_images.sh \
     && ln -sf ../rtos core \


### PR DESCRIPTION
Previous Dockerfile was using branch name for K32W0 SDK, which meant the Docker image would not be updated upon a new SDK release. Using tags should fix this issue.