### PR TITLE
ChipDeviceCtrl: Fix type & doc for WriteAttribute

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -880,7 +880,7 @@ class ChipDeviceControllerBase():
         return None
 
     async def WriteAttribute(self, nodeid: int,
-                             attributes: typing.List[typing.Tuple[int, ClusterObjects.ClusterAttributeDescriptor, int]],
+                             attributes: typing.List[typing.Tuple[int, ClusterObjects.ClusterAttributeDescriptor]],
                              timedRequestTimeoutMs: typing.Union[None, int] = None,
                              interactionTimeoutMs: typing.Union[None, int] = None, busyWaitMs: typing.Union[None, int] = None):
         '''
@@ -897,7 +897,7 @@ class ChipDeviceControllerBase():
             to the XYZ attribute on the test cluster to endpoint 1
 
         Returns:
-            - [PyChipError] (list - one for each pth)
+            - [AttributeStatus] (list - one for each pth)
         '''
         self.CheckIsActive()
 


### PR DESCRIPTION
I went one layer too low when I wrote the documentation for the return type. Also, the type hint for attributes is wrong - I think this was copied from events, which include urgency. But write does not have or need that. Documentation and normal usage match the new type hint.

