### PR TITLE
[Crypto] Add HMAC key handle support in Crypto PAL

### DIFF
--- a/src/app/icd/ICDCheckInSender.h
+++ b/src/app/icd/ICDCheckInSender.h
@@ -50,7 +50,7 @@ private:
 
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 
-    Crypto::Aes128KeyHandle mKey = Crypto::Aes128KeyHandle();
+    Crypto::Aes128BitsKeyHandle mKey = Crypto::Aes128BitsKeyHandle();
 
     uint32_t mICDCounter = 0;
 };

--- a/src/app/icd/ICDMonitoringTable.h
+++ b/src/app/icd/ICDMonitoringTable.h
@@ -104,7 +104,7 @@ struct ICDMonitoringEntry : public PersistentData<kICDMonitoringBufferSize>
     chip::FabricIndex fabricIndex                 = kUndefinedFabricIndex;
     chip::NodeId checkInNodeID                    = kUndefinedNodeId;
     uint64_t monitoredSubject                     = static_cast<uint64_t>(0);
-    Crypto::Aes128KeyHandle key                   = Crypto::Aes128KeyHandle();
+    Crypto::Aes128BitsKeyHandle key                   = Crypto::Aes128BitsKeyHandle();
     bool keyHandleValid                           = false;
     uint16_t index                                = 0;
     Crypto::SymmetricKeystore * symmetricKeystore = nullptr;

--- a/src/app/icd/ICDMonitoringTable.h
+++ b/src/app/icd/ICDMonitoringTable.h
@@ -104,7 +104,7 @@ struct ICDMonitoringEntry : public PersistentData<kICDMonitoringBufferSize>
     chip::FabricIndex fabricIndex                 = kUndefinedFabricIndex;
     chip::NodeId checkInNodeID                    = kUndefinedNodeId;
     uint64_t monitoredSubject                     = static_cast<uint64_t>(0);
-    Crypto::Aes128BitsKeyHandle key                   = Crypto::Aes128BitsKeyHandle();
+    Crypto::Aes128BitsKeyHandle key               = Crypto::Aes128BitsKeyHandle();
     bool keyHandleValid                           = false;
     uint16_t index                                = 0;
     Crypto::SymmetricKeystore * symmetricKeystore = nullptr;

--- a/src/app/icd/client/ICDClientInfo.h
+++ b/src/app/icd/client/ICDClientInfo.h
@@ -40,7 +40,7 @@ struct ICDClientInfo
     uint32_t user_active_mode_trigger_hint                                           = 0;
     char user_active_mode_trigger_instruction[kUserActiveModeTriggerInstructionSize] = { 0 };
     bool has_instruction                                                             = false;
-    Crypto::Aes128BitsKeyHandle shared_key                                               = Crypto::Aes128BitsKeyHandle();
+    Crypto::Aes128BitsKeyHandle shared_key                                           = Crypto::Aes128BitsKeyHandle();
 
     ICDClientInfo() {}
     ICDClientInfo(const ICDClientInfo & other) { *this = other; }

--- a/src/app/icd/client/ICDClientInfo.h
+++ b/src/app/icd/client/ICDClientInfo.h
@@ -40,7 +40,7 @@ struct ICDClientInfo
     uint32_t user_active_mode_trigger_hint                                           = 0;
     char user_active_mode_trigger_instruction[kUserActiveModeTriggerInstructionSize] = { 0 };
     bool has_instruction                                                             = false;
-    Crypto::Aes128KeyHandle shared_key                                               = Crypto::Aes128KeyHandle();
+    Crypto::Aes128BitsKeyHandle shared_key                                               = Crypto::Aes128BitsKeyHandle();
 
     ICDClientInfo() {}
     ICDClientInfo(const ICDClientInfo & other) { *this = other; }

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -201,8 +201,8 @@ protected:
     protected:
         GroupDataProviderImpl & mProvider;
         uint16_t mKeyHash = 0;
-        Crypto::Aes128KeyHandle mEncryptionKey;
-        Crypto::Aes128KeyHandle mPrivacyKey;
+        Crypto::Aes128BitsKeyHandle mEncryptionKey;
+        Crypto::Aes128BitsKeyHandle mPrivacyKey;
     };
 
     class KeySetIteratorImpl : public KeySetIterator

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -779,7 +779,7 @@ CHIP_ERROR EcdsaAsn1SignatureToRaw(size_t fe_length_bytes, const ByteSpan & asn1
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AES_CTR_crypt(const uint8_t * input, size_t input_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+CHIP_ERROR AES_CTR_crypt(const uint8_t * input, size_t input_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                          size_t nonce_length, uint8_t * output)
 {
     // Discard tag portion of CCM to apply only CTR mode encryption/decryption.

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -233,6 +233,11 @@ CHIP_ERROR Find16BitUpperCaseHexAfterPrefix(const ByteSpan & buffer, const char 
 
 } // namespace
 
+Symmetric128BitsKeyHandle::~Symmetric128BitsKeyHandle()
+{
+    ClearSecretData(mContext.mOpaque);
+}
+
 using HKDF_sha_crypto = HKDF_sha;
 
 CHIP_ERROR Spake2p::InternalHash(const uint8_t * in, size_t in_len)

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -565,23 +565,28 @@ protected:
 using Symmetric128BitsKeyByteArray = uint8_t[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
 
 /**
- * @brief Platform-specific AES key
+ * @brief Platform-specific Symmetric key handle
  *
- * The class represents AES key used by Matter stack either in the form of raw key material or key
+ * The class represents key used by Matter stack either in the form of raw key material or key
  * reference, depending on the platform. To achieve that, it contains an opaque context that can be
  * cast to a concrete representation used by the given platform. Note that currently Matter uses
  * 128-bit symmetric keys only.
+ *
+ * @note Symmetric128BitsKeyHandle is an abstract class to force child classes for each key handle type.
+ *       Symmetric128BitsKeyHandle class implements all the necessary components for handles.
+ *       Child classes only need to implement a constructor, implement a destructor and delete all the copy operators.
  */
-class Aes128BitsKeyHandle
+class Symmetric128BitsKeyHandle
 {
 public:
-    Aes128BitsKeyHandle() = default;
-    ~Aes128BitsKeyHandle() { ClearSecretData(mContext.mOpaque); }
+    Symmetric128BitsKeyHandle() = default;
+    // Destructor is implemented in the .cpp. It is pure virtual only to force the class to be abstract.
+    virtual ~Symmetric128BitsKeyHandle() = 0;
 
-    Aes128BitsKeyHandle(const Aes128BitsKeyHandle &) = delete;
-    Aes128BitsKeyHandle(Aes128BitsKeyHandle &&)      = delete;
-    void operator=(const Aes128BitsKeyHandle &)  = delete;
-    void operator=(Aes128BitsKeyHandle &&)       = delete;
+    Symmetric128BitsKeyHandle(const Symmetric128BitsKeyHandle &) = delete;
+    Symmetric128BitsKeyHandle(Symmetric128BitsKeyHandle &&)      = delete;
+    void operator=(const Symmetric128BitsKeyHandle &)            = delete;
+    void operator=(Symmetric128BitsKeyHandle &&)                 = delete;
 
     /**
      * @brief Get internal context cast to the desired key representation
@@ -608,6 +613,36 @@ private:
     {
         uint8_t mOpaque[kContextSize] = {};
     } mContext;
+};
+
+/**
+ * @brief Platform-specific AES key handle
+ */
+class Aes128BitsKeyHandle : public Symmetric128BitsKeyHandle
+{
+public:
+    Aes128BitsKeyHandle() = default;
+    virtual ~Aes128BitsKeyHandle() {}
+
+    Aes128BitsKeyHandle(const Aes128BitsKeyHandle &) = delete;
+    Aes128BitsKeyHandle(Aes128BitsKeyHandle &&)      = delete;
+    void operator=(const Aes128BitsKeyHandle &)      = delete;
+    void operator=(Aes128BitsKeyHandle &&)           = delete;
+};
+
+/**
+ * @brief Platform-specific HMAC key handle
+ */
+class Hmac128BitsKeyHandle : public Symmetric128BitsKeyHandle
+{
+public:
+    Hmac128BitsKeyHandle() = default;
+    virtual ~Hmac128BitsKeyHandle() {}
+
+    Hmac128BitsKeyHandle(const Hmac128BitsKeyHandle &) = delete;
+    Hmac128BitsKeyHandle(Hmac128BitsKeyHandle &&)      = delete;
+    void operator=(const Hmac128BitsKeyHandle &)       = delete;
+    void operator=(Hmac128BitsKeyHandle &&)            = delete;
 };
 
 /**

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -572,16 +572,16 @@ using Symmetric128BitsKeyByteArray = uint8_t[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BY
  * cast to a concrete representation used by the given platform. Note that currently Matter uses
  * 128-bit symmetric keys only.
  */
-class Aes128KeyHandle
+class Aes128BitsKeyHandle
 {
 public:
-    Aes128KeyHandle() = default;
-    ~Aes128KeyHandle() { ClearSecretData(mContext.mOpaque); }
+    Aes128BitsKeyHandle() = default;
+    ~Aes128BitsKeyHandle() { ClearSecretData(mContext.mOpaque); }
 
-    Aes128KeyHandle(const Aes128KeyHandle &) = delete;
-    Aes128KeyHandle(Aes128KeyHandle &&)      = delete;
-    void operator=(const Aes128KeyHandle &)  = delete;
-    void operator=(Aes128KeyHandle &&)       = delete;
+    Aes128BitsKeyHandle(const Aes128BitsKeyHandle &) = delete;
+    Aes128BitsKeyHandle(Aes128BitsKeyHandle &&)      = delete;
+    void operator=(const Aes128BitsKeyHandle &)  = delete;
+    void operator=(Aes128BitsKeyHandle &&)       = delete;
 
     /**
      * @brief Get internal context cast to the desired key representation
@@ -697,7 +697,7 @@ CHIP_ERROR ConvertIntegerRawToDerWithoutTag(const ByteSpan & raw_integer, Mutabl
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length);
 
 /**
@@ -721,7 +721,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext);
 
 /**
@@ -740,7 +740,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
  * @param output Buffer to write output into
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR AES_CTR_crypt(const uint8_t * input, size_t input_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+CHIP_ERROR AES_CTR_crypt(const uint8_t * input, size_t input_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                          size_t nonce_length, uint8_t * output);
 
 /**

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -567,7 +567,7 @@ using Symmetric128BitsKeyByteArray = uint8_t[CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BY
 /**
  * @brief Platform-specific Symmetric key handle
  *
- * The class represents key used by Matter stack either in the form of raw key material or key
+ * The class represents a key used by the Matter stack either in the form of raw key material or key
  * reference, depending on the platform. To achieve that, it contains an opaque context that can be
  * cast to a concrete representation used by the given platform. Note that currently Matter uses
  * 128-bit symmetric keys only.

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -147,7 +147,7 @@ static int _compareDaysAndSeconds(const int days, const int seconds)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
 #if CHIP_CRYPTO_BORINGSSL
@@ -282,7 +282,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
 #if CHIP_CRYPTO_BORINGSSL

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -69,7 +69,7 @@ bool isValidTag(const uint8_t * tag, size_t tag_length)
 } // namespace
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     VerifyOrReturnError(isBufferNonEmpty(nonce, nonce_length), CHIP_ERROR_INVALID_ARGUMENT);
@@ -123,7 +123,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     VerifyOrReturnError(isBufferNonEmpty(nonce, nonce_length), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -75,7 +75,7 @@ static bool _isValidTagLength(size_t tag_length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -113,7 +113,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/crypto/PSASessionKeystore.cpp
+++ b/src/crypto/PSASessionKeystore.cpp
@@ -60,6 +60,8 @@ public:
 
     ~HmacKeyAttributes() { psa_reset_key_attributes(&mAttrs); }
 
+    const psa_key_attributes_t & Get() { return mAttrs; }
+
 private:
     psa_key_attributes_t mAttrs = PSA_KEY_ATTRIBUTES_INIT;
 };

--- a/src/crypto/PSASessionKeystore.cpp
+++ b/src/crypto/PSASessionKeystore.cpp
@@ -53,7 +53,7 @@ public:
     HmacKeyAttributes()
     {
         psa_set_key_type(&mAttrs, PSA_KEY_TYPE_HMAC);
-        psa_set_key_algorithm(&mAttrs, PSA_ALG_ANY_HASH);
+        psa_set_key_algorithm(&mAttrs, PSA_ALG_HMAC(PSA_ALG_ANY_HASH));
         psa_set_key_usage_flags(&mAttrs, PSA_KEY_USAGE_SIGN_MESSAGE);
         psa_set_key_bits(&mAttrs, CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES * 8);
     }

--- a/src/crypto/PSASessionKeystore.cpp
+++ b/src/crypto/PSASessionKeystore.cpp
@@ -49,7 +49,7 @@ private:
 
 } // namespace
 
-CHIP_ERROR PSASessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128KeyHandle & key)
+CHIP_ERROR PSASessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key)
 {
     // Destroy the old key if already allocated
     psa_destroy_key(key.As<psa_key_id_t>());
@@ -63,7 +63,7 @@ CHIP_ERROR PSASessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & ke
 }
 
 CHIP_ERROR PSASessionKeystore::DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
-                                         Aes128KeyHandle & key)
+                                         Aes128BitsKeyHandle & key)
 {
     PsaKdf kdf;
     ReturnErrorOnFailure(kdf.Init(PSA_ALG_HKDF(PSA_ALG_SHA_256), secret.Span(), salt, info));
@@ -74,7 +74,7 @@ CHIP_ERROR PSASessionKeystore::DeriveKey(const P256ECDHDerivedSecret & secret, c
 }
 
 CHIP_ERROR PSASessionKeystore::DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info,
-                                                 Aes128KeyHandle & i2rKey, Aes128KeyHandle & r2iKey,
+                                                 Aes128BitsKeyHandle & i2rKey, Aes128BitsKeyHandle & r2iKey,
                                                  AttestationChallenge & attestationChallenge)
 {
     PsaKdf kdf;
@@ -97,7 +97,7 @@ exit:
     return error;
 }
 
-void PSASessionKeystore::DestroyKey(Aes128KeyHandle & key)
+void PSASessionKeystore::DestroyKey(Aes128BitsKeyHandle & key)
 {
     auto & keyId = key.AsMutable<psa_key_id_t>();
 

--- a/src/crypto/PSASessionKeystore.h
+++ b/src/crypto/PSASessionKeystore.h
@@ -25,12 +25,12 @@ namespace Crypto {
 class PSASessionKeystore : public SessionKeystore
 {
 public:
-    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128KeyHandle & key) override;
+    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) override;
     CHIP_ERROR DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
-                         Aes128KeyHandle & key) override;
-    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128KeyHandle & i2rKey,
-                                 Aes128KeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
-    void DestroyKey(Aes128KeyHandle & key) override;
+                         Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128BitsKeyHandle & i2rKey,
+                                 Aes128BitsKeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
+    void DestroyKey(Aes128BitsKeyHandle & key) override;
 };
 
 } // namespace Crypto

--- a/src/crypto/PSASessionKeystore.h
+++ b/src/crypto/PSASessionKeystore.h
@@ -26,11 +26,13 @@ class PSASessionKeystore : public SessionKeystore
 {
 public:
     CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Hmac128BitsKeyHandle & key) override;
     CHIP_ERROR DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
                          Aes128BitsKeyHandle & key) override;
-    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128BitsKeyHandle & i2rKey,
-                                 Aes128BitsKeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
-    void DestroyKey(Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info,
+                                 Aes128BitsKeyHandle & i2rKey, Aes128BitsKeyHandle & r2iKey,
+                                 AttestationChallenge & attestationChallenge) override;
+    void DestroyKey(Symmetric128BitsKeyHandle & key) override;
 };
 
 } // namespace Crypto

--- a/src/crypto/RawKeySessionKeystore.cpp
+++ b/src/crypto/RawKeySessionKeystore.cpp
@@ -30,6 +30,12 @@ CHIP_ERROR RawKeySessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray &
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR RawKeySessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Hmac128BitsKeyHandle & key)
+{
+    memcpy(key.AsMutable<Symmetric128BitsKeyByteArray>(), keyMaterial, sizeof(Symmetric128BitsKeyByteArray));
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR RawKeySessionKeystore::DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
                                             Aes128BitsKeyHandle & key)
 {
@@ -57,7 +63,7 @@ CHIP_ERROR RawKeySessionKeystore::DeriveSessionKeys(const ByteSpan & secret, con
         .StatusCode();
 }
 
-void RawKeySessionKeystore::DestroyKey(Aes128BitsKeyHandle & key)
+void RawKeySessionKeystore::DestroyKey(Symmetric128BitsKeyHandle & key)
 {
     ClearSecretData(key.AsMutable<Symmetric128BitsKeyByteArray>());
 }

--- a/src/crypto/RawKeySessionKeystore.cpp
+++ b/src/crypto/RawKeySessionKeystore.cpp
@@ -24,14 +24,14 @@ namespace Crypto {
 
 using HKDF_sha_crypto = HKDF_sha;
 
-CHIP_ERROR RawKeySessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128KeyHandle & key)
+CHIP_ERROR RawKeySessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key)
 {
     memcpy(key.AsMutable<Symmetric128BitsKeyByteArray>(), keyMaterial, sizeof(Symmetric128BitsKeyByteArray));
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR RawKeySessionKeystore::DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
-                                            Aes128KeyHandle & key)
+                                            Aes128BitsKeyHandle & key)
 {
     HKDF_sha_crypto hkdf;
 
@@ -40,7 +40,7 @@ CHIP_ERROR RawKeySessionKeystore::DeriveKey(const P256ECDHDerivedSecret & secret
 }
 
 CHIP_ERROR RawKeySessionKeystore::DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info,
-                                                    Aes128KeyHandle & i2rKey, Aes128KeyHandle & r2iKey,
+                                                    Aes128BitsKeyHandle & i2rKey, Aes128BitsKeyHandle & r2iKey,
                                                     AttestationChallenge & attestationChallenge)
 {
     HKDF_sha_crypto hkdf;
@@ -57,7 +57,7 @@ CHIP_ERROR RawKeySessionKeystore::DeriveSessionKeys(const ByteSpan & secret, con
         .StatusCode();
 }
 
-void RawKeySessionKeystore::DestroyKey(Aes128KeyHandle & key)
+void RawKeySessionKeystore::DestroyKey(Aes128BitsKeyHandle & key)
 {
     ClearSecretData(key.AsMutable<Symmetric128BitsKeyByteArray>());
 }

--- a/src/crypto/RawKeySessionKeystore.h
+++ b/src/crypto/RawKeySessionKeystore.h
@@ -25,12 +25,12 @@ namespace Crypto {
 class RawKeySessionKeystore : public SessionKeystore
 {
 public:
-    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128KeyHandle & key) override;
+    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) override;
     CHIP_ERROR DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
-                         Aes128KeyHandle & key) override;
-    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128KeyHandle & i2rKey,
-                                 Aes128KeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
-    void DestroyKey(Aes128KeyHandle & key) override;
+                         Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128BitsKeyHandle & i2rKey,
+                                 Aes128BitsKeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
+    void DestroyKey(Aes128BitsKeyHandle & key) override;
 };
 
 } // namespace Crypto

--- a/src/crypto/RawKeySessionKeystore.h
+++ b/src/crypto/RawKeySessionKeystore.h
@@ -26,11 +26,13 @@ class RawKeySessionKeystore : public SessionKeystore
 {
 public:
     CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Hmac128BitsKeyHandle & key) override;
     CHIP_ERROR DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
                          Aes128BitsKeyHandle & key) override;
-    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info, Aes128BitsKeyHandle & i2rKey,
-                                 Aes128BitsKeyHandle & r2iKey, AttestationChallenge & attestationChallenge) override;
-    void DestroyKey(Aes128BitsKeyHandle & key) override;
+    CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info,
+                                 Aes128BitsKeyHandle & i2rKey, Aes128BitsKeyHandle & r2iKey,
+                                 AttestationChallenge & attestationChallenge) override;
+    void DestroyKey(Symmetric128BitsKeyHandle & key) override;
 };
 
 } // namespace Crypto

--- a/src/crypto/SessionKeystore.h
+++ b/src/crypto/SessionKeystore.h
@@ -45,7 +45,7 @@ public:
      * If the method returns no error, the application is responsible for destroying the handle
      * using DestroyKey() method when the key is no longer needed.
      */
-    virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128KeyHandle & key) = 0;
+    virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) = 0;
 
     /**
      * @brief Derive key from a shared secret.
@@ -56,7 +56,7 @@ public:
      * using DestroyKey() method when the key is no longer needed.
      */
     virtual CHIP_ERROR DeriveKey(const P256ECDHDerivedSecret & secret, const ByteSpan & salt, const ByteSpan & info,
-                                 Aes128KeyHandle & key) = 0;
+                                 Aes128BitsKeyHandle & key) = 0;
 
     /**
      * @brief Derive session keys from a shared secret.
@@ -69,7 +69,7 @@ public:
      * release all handles that it allocated so far.
      */
     virtual CHIP_ERROR DeriveSessionKeys(const ByteSpan & secret, const ByteSpan & salt, const ByteSpan & info,
-                                         Aes128KeyHandle & i2rKey, Aes128KeyHandle & r2iKey,
+                                         Aes128BitsKeyHandle & i2rKey, Aes128BitsKeyHandle & r2iKey,
                                          AttestationChallenge & attestationChallenge) = 0;
 
     /**
@@ -78,7 +78,7 @@ public:
      * The method can take an uninitialized handle in which case it is a no-op.
      * As a result of calling this method, the handle is put in the uninitialized state.
      */
-    virtual void DestroyKey(Aes128KeyHandle & key) = 0;
+    virtual void DestroyKey(Aes128BitsKeyHandle & key) = 0;
 };
 
 /**
@@ -90,11 +90,11 @@ public:
     explicit AutoReleaseSessionKey(SessionKeystore & keystore) : mKeystore(keystore) {}
     ~AutoReleaseSessionKey() { mKeystore.DestroyKey(mKeyHandle); }
 
-    Aes128KeyHandle & KeyHandle() { return mKeyHandle; }
+    Aes128BitsKeyHandle & KeyHandle() { return mKeyHandle; }
 
 private:
     SessionKeystore & mKeystore;
-    Aes128KeyHandle mKeyHandle;
+    Aes128BitsKeyHandle mKeyHandle;
 };
 
 } // namespace Crypto

--- a/src/crypto/SessionKeystore.h
+++ b/src/crypto/SessionKeystore.h
@@ -36,7 +36,7 @@ public:
     virtual ~SessionKeystore() {}
 
     /**
-     * @brief Import raw key material and return a key handle.
+     * @brief Import raw key material and return an AES 128 Bits key handle.
      *
      * @note This method should only be used when using the raw key material in the Matter stack
      * cannot be avoided. Ideally, crypto interfaces should allow platforms to perform all the
@@ -46,6 +46,18 @@ public:
      * using DestroyKey() method when the key is no longer needed.
      */
     virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) = 0;
+
+    /**
+     * @brief Import raw key material and return an HMAC 128 Bits key handle.
+     *
+     * @note This method should only be used when using the raw key material in the Matter stack
+     * cannot be avoided. Ideally, crypto interfaces should allow platforms to perform all the
+     * cryptographic operations in a secure environment.
+     *
+     * If the method returns no error, the application is responsible for destroying the handle
+     * using DestroyKey() method when the key is no longer needed.
+     */
+    virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Hmac128BitsKeyHandle & key) = 0;
 
     /**
      * @brief Derive key from a shared secret.
@@ -78,7 +90,7 @@ public:
      * The method can take an uninitialized handle in which case it is a no-op.
      * As a result of calling this method, the handle is put in the uninitialized state.
      */
-    virtual void DestroyKey(Aes128BitsKeyHandle & key) = 0;
+    virtual void DestroyKey(Symmetric128BitsKeyHandle & key) = 0;
 };
 
 /**

--- a/src/crypto/SessionKeystore.h
+++ b/src/crypto/SessionKeystore.h
@@ -36,26 +36,26 @@ public:
     virtual ~SessionKeystore() {}
 
     /**
-     * @brief Import raw key material and return an AES 128 Bits key handle.
+     * @brief Import raw key material and return a key handle for a key that be used to do AES 128 encryption.
      *
      * @note This method should only be used when using the raw key material in the Matter stack
      * cannot be avoided. Ideally, crypto interfaces should allow platforms to perform all the
      * cryptographic operations in a secure environment.
      *
      * If the method returns no error, the application is responsible for destroying the handle
-     * using DestroyKey() method when the key is no longer needed.
+     * using the DestroyKey() method when the key is no longer needed.
      */
     virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Aes128BitsKeyHandle & key) = 0;
 
     /**
-     * @brief Import raw key material and return an HMAC 128 Bits key handle.
+     * @brief Import raw key material and return a key handle for a key that can be used to do 128-bit HMAC.
      *
      * @note This method should only be used when using the raw key material in the Matter stack
      * cannot be avoided. Ideally, crypto interfaces should allow platforms to perform all the
      * cryptographic operations in a secure environment.
      *
      * If the method returns no error, the application is responsible for destroying the handle
-     * using DestroyKey() method when the key is no longer needed.
+     * using the DestroyKey() method when the key is no longer needed.
      */
     virtual CHIP_ERROR CreateKey(const Symmetric128BitsKeyByteArray & keyMaterial, Hmac128BitsKeyHandle & key) = 0;
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -196,6 +196,24 @@ public:
     Aes128BitsKeyHandle key;
 };
 
+struct TestHmacKey
+{
+public:
+    TestHmacKey(nlTestSuite * inSuite, const uint8_t * keyBytes, size_t keyLength)
+    {
+        Crypto::Symmetric128BitsKeyByteArray keyMaterial;
+        memcpy(&keyMaterial, keyBytes, keyLength);
+
+        CHIP_ERROR err = keystore.CreateKey(keyMaterial, key);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    ~TestHmacKey() { keystore.DestroyKey(key); }
+
+    DefaultSessionKeystore keystore;
+    Hmac128BitsKeyHandle key;
+};
+
 static void TestAES_CTR_128_Encrypt(nlTestSuite * inSuite, const AesCtrTestEntry * vector)
 {
     chip::Platform::ScopedMemoryBuffer<uint8_t> outBuffer;

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -193,7 +193,7 @@ public:
     ~TestAesKey() { keystore.DestroyKey(key); }
 
     DefaultSessionKeystore keystore;
-    Aes128KeyHandle key;
+    Aes128BitsKeyHandle key;
 };
 
 static void TestAES_CTR_128_Encrypt(nlTestSuite * inSuite, const AesCtrTestEntry * vector)

--- a/src/crypto/tests/TestSessionKeystore.cpp
+++ b/src/crypto/tests/TestSessionKeystore.cpp
@@ -113,7 +113,7 @@ void TestBasicImport(nlTestSuite * inSuite, void * inContext)
         Symmetric128BitsKeyByteArray keyMaterial;
         memcpy(keyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
+        Aes128BitsKeyHandle keyHandle;
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
 
         Platform::ScopedMemoryBuffer<uint8_t> ciphertext;
@@ -140,7 +140,7 @@ void TestDeriveKey(nlTestSuite * inSuite, void * inContext)
         memcpy(secret.Bytes(), test.secret, strlen(test.secret));
         secret.SetLength(strlen(test.secret));
 
-        Aes128KeyHandle keyHandle;
+        Aes128BitsKeyHandle keyHandle;
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.DeriveKey(secret, ToSpan(test.salt), ToSpan(test.info), keyHandle));
 
         uint8_t ciphertext[sizeof(test.ciphertext)];
@@ -162,8 +162,8 @@ void TestDeriveSessionKeys(nlTestSuite * inSuite, void * inContext)
         memcpy(secret.Bytes(), test.secret, strlen(test.secret));
         secret.SetLength(strlen(test.secret));
 
-        Aes128KeyHandle i2r;
-        Aes128KeyHandle r2i;
+        Aes128BitsKeyHandle i2r;
+        Aes128BitsKeyHandle r2i;
         AttestationChallenge challenge;
         NL_TEST_ASSERT_SUCCESS(
             inSuite, keystore.DeriveSessionKeys(ToSpan(test.secret), ToSpan(test.salt), ToSpan(test.info), i2r, r2i, challenge));

--- a/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
@@ -124,7 +124,7 @@ static bool _isValidTagLength(size_t tag_length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -162,7 +162,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHost.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHost.cpp
@@ -109,7 +109,7 @@ static bool _isValidTagLength(size_t tag_length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -147,7 +147,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/platform/nxp/k32w/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
+++ b/src/platform/nxp/k32w/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
@@ -115,7 +115,7 @@ static bool _isValidTagLength(size_t tag_length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -153,7 +153,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/platform/nxp/k32w/k32w1/CHIPCryptoPalK32W1.cpp
+++ b/src/platform/nxp/k32w/k32w1/CHIPCryptoPalK32W1.cpp
@@ -122,7 +122,7 @@ static bool _isValidKeyLength(size_t length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -160,7 +160,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
@@ -114,7 +114,7 @@ static bool _isValidTagLength(size_t tag_length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -152,7 +152,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
@@ -158,7 +158,7 @@ static int timeCompare(mbedtls_x509_time * t1, mbedtls_x509_time * t2)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const Aes128KeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
+                           const Aes128BitsKeyHandle & key, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error          = CHIP_NO_ERROR;
@@ -215,7 +215,7 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const Aes128KeyHandle & key, const uint8_t * nonce,
+                           const uint8_t * tag, size_t tag_length, const Aes128BitsKeyHandle & key, const uint8_t * nonce,
                            size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error          = CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -30,7 +30,7 @@ namespace chip {
 namespace Protocols {
 namespace SecureChannel {
 
-CHIP_ERROR CheckinMessage::GenerateCheckinMessagePayload(Crypto::Aes128KeyHandle & key, CounterType counter,
+CHIP_ERROR CheckinMessage::GenerateCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, CounterType counter,
                                                          const ByteSpan & appData, MutableByteSpan & output)
 {
     VerifyOrReturnError(appData.size() <= sMaxAppDataSize, CHIP_ERROR_INVALID_ARGUMENT);
@@ -62,7 +62,7 @@ CHIP_ERROR CheckinMessage::GenerateCheckinMessagePayload(Crypto::Aes128KeyHandle
     return err;
 }
 
-CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(Crypto::Aes128KeyHandle & key, ByteSpan & payload, CounterType & counter,
+CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, ByteSpan & payload, CounterType & counter,
                                                       MutableByteSpan & appData)
 {
     VerifyOrReturnError(payload.size() >= sMinPayloadSize, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -52,8 +52,8 @@ public:
      *                  Required Buffer Size is : GetCheckinPayloadSize(appData.size())
      * @return CHIP_ERROR
      */
-    static CHIP_ERROR GenerateCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, CounterType counter, const ByteSpan & appData,
-                                                    MutableByteSpan & output);
+    static CHIP_ERROR GenerateCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, CounterType counter,
+                                                    const ByteSpan & appData, MutableByteSpan & output);
 
     /**
      * @brief Parse Check-in Message payload

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -52,7 +52,7 @@ public:
      *                  Required Buffer Size is : GetCheckinPayloadSize(appData.size())
      * @return CHIP_ERROR
      */
-    static CHIP_ERROR GenerateCheckinMessagePayload(Crypto::Aes128KeyHandle & key, CounterType counter, const ByteSpan & appData,
+    static CHIP_ERROR GenerateCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, CounterType counter, const ByteSpan & appData,
                                                     MutableByteSpan & output);
 
     /**
@@ -65,7 +65,7 @@ public:
      *                  GetAppDataSize(payload) + sizeof(CounterType)
      * @return CHIP_ERROR
      */
-    static CHIP_ERROR ParseCheckinMessagePayload(Crypto::Aes128KeyHandle & key, ByteSpan & payload, CounterType & counter,
+    static CHIP_ERROR ParseCheckinMessagePayload(Crypto::Aes128BitsKeyHandle & key, ByteSpan & payload, CounterType & counter,
                                                  MutableByteSpan & appData);
 
     static inline size_t GetCheckinPayloadSize(size_t appDataSize) { return appDataSize + sMinPayloadSize; }

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -59,7 +59,7 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         Symmetric128BitsKeyByteArray keyMaterial;
         memcpy(keyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
+        Aes128BitsKeyHandle keyHandle;
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
 
         // Validate that counter change, indeed changes the output buffer content
@@ -90,14 +90,14 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         Symmetric128BitsKeyByteArray keyMaterial;
         memcpy(keyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
+        Aes128BitsKeyHandle keyHandle;
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
 
         // As of now passing an empty key handle while using PSA crypto will result in a failure.
         // However when using OpenSSL this same test result in a success.
         // Issue #28986
 
-        // Aes128KeyHandle emptyKeyHandle;
+        // Aes128BitsKeyHandle emptyKeyHandle;
         // err = CheckinMessage::GenerateCheckinMessagePayload(emptyKeyHandle, counter, userData, outputBuffer);
         // ChipLogError(Inet, "%s", err.AsString());
         // NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
@@ -140,7 +140,7 @@ void TestCheckin_Parse(nlTestSuite * inSuite, void * inContext)
     Symmetric128BitsKeyByteArray keyMaterial;
     memcpy(keyMaterial, test.key, test.key_len);
 
-    Aes128KeyHandle keyHandle;
+    Aes128BitsKeyHandle keyHandle;
     NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
 
     //=================Encrypt=======================
@@ -183,7 +183,7 @@ void TestCheckin_GenerateParse(nlTestSuite * inSuite, void * inContext)
         Symmetric128BitsKeyByteArray keyMaterial;
         memcpy(keyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
+        Aes128BitsKeyHandle keyHandle;
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
 
         //=================Encrypt=======================

--- a/src/transport/CryptoContext.h
+++ b/src/transport/CryptoContext.h
@@ -160,8 +160,8 @@ private:
     SessionRole mSessionRole;
 
     bool mKeyAvailable;
-    Crypto::Aes128KeyHandle mEncryptionKey;
-    Crypto::Aes128KeyHandle mDecryptionKey;
+    Crypto::Aes128BitsKeyHandle mEncryptionKey;
+    Crypto::Aes128BitsKeyHandle mDecryptionKey;
     Crypto::AttestationChallenge mAttestationChallenge;
     Crypto::SessionKeystore * mKeystore       = nullptr;
     Crypto::SymmetricKeyContext * mKeyContext = nullptr;


### PR DESCRIPTION
#### Description

- Rename `Aes128KeyHandle` to `Aes128BitsKeyHandle` for clarity
- PR adds the foundation to support AES and HMAC key handles. PR has **no real functionnal changes** other than the keyhandle inheritance to enable multiple key handle types.

Key lifetimes options will be added in a follow up PR.
partly addresses #30718

#### Tests
CI to validate no regressions where caused

