### PR TITLE
Fix NsdService error due to subtypes on Android 14

### DIFF
--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -138,20 +138,13 @@ public class NsdManagerServiceResolver implements ServiceResolver {
     serviceInfo.setServiceName(serviceName);
 
     /**
-     * Note, subtypes registration is using an undocumented feature of android dns-sd
-     * service/mDNSResponder which MAY STOP WORKING in future Android versions. Here, set type =
-     * "${type},${subtypes1},${subtypes2},...", then subtypes1, subtypes2 etc are all registered to
-     * this dns-sd server, we can usd `dns-sd -B ${type},${subtypes}` or avahi-browse
-     * ${subtypes}._sub.${type} -r to browser it
+     * TODO: Add subtypes registration when the Android NsdManager provides a documented mechanism
+     * to publish them. See https://issuetracker.google.com/u/3/issues/314256875
      */
-    StringBuilder sb = new StringBuilder(type);
-    for (String subType : subTypes) {
-      sb.append(",").append(subType);
-    }
-    serviceInfo.setServiceType(sb.toString());
+    serviceInfo.setServiceType(type);
 
     serviceInfo.setPort(port);
-    Log.i(TAG, "publish serviceName=" + serviceName + " type=" + sb.toString() + " port=" + port);
+    Log.i(TAG, "publish serviceName=" + serviceName + " type=" + type + " port=" + port);
     int cnt = Math.min(textEntriesDatas.length, textEntriesKeys.length);
     for (int i = 0; i < cnt; i++) {
       String value = new String(textEntriesDatas[i]);


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/30827

### Problem
On Android 14, the Matter SDK throws an error when trying to register a DNS-SD service with sub-types (such as `_matterc._udp,_V65521,_T41,_S15,_L3840,_CM`). See error log below:

> NsdService: Invalid service type: _matterc._udp,_V65521,_T41,_S15,_L3840,_CM

See steps to repro in the issue linked above

### Change summary
This change removes the addition of subtypes to the service type registered via the NsdManagerServiceResolver on Android, which was making use of an undocumented feature of the Android NsdManager. This feature is not supported anymore, as tested on Android 14.

Also see issue raised on Google's issue tracker to request support be added to publish subtypes: https://issuetracker.google.com/u/3/issues/314256875

### Testing
Tested with the Android tv-casting-app commissioning against a Linux tv-app instance.