### PR TITLE
[Chef] Fix AirQualitySensor hardcoded endpointId as 1

### DIFF
--- a/examples/chef/common/chef-air-quality.cpp
+++ b/examples/chef/common/chef-air-quality.cpp
@@ -35,9 +35,9 @@ static std::map<int, Instance *> gAirQualityClusterInstance{};
 
 void emberAfAirQualityClusterInitCallback(chip::EndpointId endpointId)
 {
-    Instance * clusterInstance = new Instance(1, airQualityFeatures);
+    Instance * clusterInstance = new Instance(endpointId, airQualityFeatures);
     clusterInstance->Init();
-    gAirQualityClusterInstance[1] = clusterInstance;
+    gAirQualityClusterInstance[endpointId] = clusterInstance;
 }
 
 EmberAfStatus chefAirQualityWriteCallback(EndpointId endpoint, ClusterId clusterId,


### PR DESCRIPTION
Fix previous PR https://github.com/project-chip/connectedhomeip/pull/30822 the endpointId was hardcoded as 1 which was incorrect.