### PR TITLE
Update Darwin storage documentation for new key.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDemuxingStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDemuxingStorage.mm
@@ -159,6 +159,9 @@ static bool IsMemoryOnlyGlobalKey(NSString * key)
     // We do not expect to see the "g/ts/tts", "g/ts/dntp", "g/ts/tz",
     // "g/ts/dsto" Time Synchronization keys.
 
+    // We do not expect to see the "g/icd/cic" key; that's only used for an ICD
+    // that sends check-in messages.
+
     return false;
 }
 


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/30843 is adding a new global key; we need to document why it's not relevant to us.
