### PR TITLE
[ICD] Move Slow Poll enforce define to ICD Config

### DIFF
--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -26,6 +26,7 @@ buildconfig_header("icd_buildconfig") {
     "CHIP_CONFIG_ENABLE_ICD_SERVER=${chip_enable_icd_server}",
     "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_report_on_active_mode}",
     "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
+    "ICD_ENFORCE_SIT_SLOW_POLL_LIMIT=${icd_enforce_sit_slow_poll_limit}",
   ]
 
   visibility = [ ":icd_config" ]
@@ -108,5 +109,8 @@ source_set("configuration-data") {
     "ICDConfigurationData.h",
   ]
 
-  deps = [ "${chip_root}/src/lib/core" ]
+  deps = [
+    ":icd_config",
+    "${chip_root}/src/lib/core",
+  ]
 }

--- a/src/app/icd/ICDConfigurationData.cpp
+++ b/src/app/icd/ICDConfigurationData.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "ICDConfigurationData.h"
+#include <app/icd/ICDConfig.h>
 
 namespace chip {
 

--- a/src/app/icd/ICDConfigurationData.h
+++ b/src/app/icd/ICDConfigurationData.h
@@ -20,11 +20,6 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <system/SystemClock.h>
 
-#ifndef ICD_ENFORCE_SIT_SLOW_POLL_LIMIT
-// Set to 1 to enforce SIT Slow Polling Max value to 15seconds (spec 9.16.1.5)
-#define ICD_ENFORCE_SIT_SLOW_POLL_LIMIT 0
-#endif
-
 namespace chip {
 
 namespace app {

--- a/src/app/icd/icd.gni
+++ b/src/app/icd/icd.gni
@@ -23,5 +23,9 @@ declare_args() {
 
   # Matter SDK Configuration flag to make the ICD manager emit a report on entering active mode
   chip_report_on_active_mode = false
+
   icd_max_notification_subscribers = 1
+
+  # Set to true to enforce SIT Slow Polling Max value to 15seconds (spec 9.16.1.5)
+  icd_enforce_sit_slow_poll_limit = false
 }


### PR DESCRIPTION
#### Description
Move Slow Poll enforce define to ICD Config.
This allows the define to be configured with a build flag instead of needing to modify the source file.
