### PR TITLE
[icd] integrate ICD management command into CHIP tool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -70,6 +70,8 @@ static_library("chip-tool-utils") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
+    "commands/icd/ICDCommand.cpp",
+    "commands/icd/ICDCommand.h",
     "commands/pairing/OpenCommissioningWindowCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
@@ -100,6 +102,7 @@ static_library("chip-tool-utils") {
 
   public_deps = [
     "${chip_root}/examples/common/tracing:commandline",
+    "${chip_root}/src/app/icd/client:manager",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/controller/data_model",

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -47,7 +47,7 @@ constexpr char kCDTrustStorePathVariable[]      = "CHIPTOOL_CD_TRUST_STORE_PATH"
 
 const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = nullptr;
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
-// All fabrics shares the same ICD client storage.
+// All fabrics share the same ICD client storage.
 chip::app::DefaultICDClientStorage * sICDClientStorage = nullptr;
 
 namespace {

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -101,7 +101,10 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     ReturnLogErrorOnFailure(mOperationalKeystore.Init(&mDefaultStorage));
     ReturnLogErrorOnFailure(mOpCertStore.Init(&mDefaultStorage));
 
-    // Initialized with a non-persistent keystore without PSA(chip-tool has not yet build with PSA)
+    // Initialized with a non-persistent keystore without PSA(chip-tool has not yet build with PSA).
+    // The lifetime for ICD storage is same as chip tool. Currently we use chip-tool interactive mode for 
+    // ICD commissioning and check-in validation, and this lifetime for ICDStorage meets the test requirement.
+    // TODO: Add the real ICD persistent storage for chip-tool
     ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));
 
     chip::Controller::FactoryInitParams factoryInitParams;

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -102,7 +102,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     ReturnLogErrorOnFailure(mOpCertStore.Init(&mDefaultStorage));
 
     // Initialized with a non-persistent keystore without PSA(chip-tool has not yet build with PSA).
-    // The lifetime for ICD storage is same as chip tool. Currently we use chip-tool interactive mode for 
+    // The lifetime for ICD storage is same as chip tool. Currently we use chip-tool interactive mode for
     // ICD commissioning and check-in validation, and this lifetime for ICDStorage meets the test requirement.
     // TODO: Add the real ICD persistent storage for chip-tool
     ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -102,11 +102,11 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     ReturnLogErrorOnFailure(mOperationalKeystore.Init(&mDefaultStorage));
     ReturnLogErrorOnFailure(mOpCertStore.Init(&mDefaultStorage));
 
-    // A non-persistent keystore is initialized without PSA functionality, as the chip-tool does not yet support it.
+    // chip-tool uses a non-persistent keystore.
     // ICD storage lifetime is currently tied to the chip-tool's lifetime. Since chip-tool interactive mode is currently used for
     // ICD commissioning and check-in validation, this temporary storage meets the test requirements.
     // TODO: Implement persistent ICD storage for the chip-tool.
-    ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));
+    ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &sSessionKeystore));
 
     chip::Controller::FactoryInitParams factoryInitParams;
 
@@ -114,7 +114,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     factoryInitParams.operationalKeystore      = &mOperationalKeystore;
     factoryInitParams.opCertStore              = &mOpCertStore;
     factoryInitParams.enableServerInteractions = NeedsOperationalAdvertising();
-    factoryInitParams.sessionKeystore          = &mSessionKeystore;
+    factoryInitParams.sessionKeystore          = &sSessionKeystore;
 
     // Init group data provider that will be used for all group keys and IPKs for the
     // chip-tool-configured fabrics. This is OK to do once since the fabric tables

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -48,8 +48,8 @@ constexpr char kCDTrustStorePathVariable[]      = "CHIPTOOL_CD_TRUST_STORE_PATH"
 const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = nullptr;
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
 // All fabrics share the same ICD client storage.
-chip::app::DefaultICDClientStorage * sICDClientStorage = nullptr;
 
+chip::app::DefaultICDClientStorage sICDClientStorage;
 namespace {
 
 CHIP_ERROR GetAttestationTrustStore(const char * paaTrustStorePath, const chip::Credentials::AttestationTrustStore ** trustStore)
@@ -102,11 +102,8 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     ReturnLogErrorOnFailure(mOperationalKeystore.Init(&mDefaultStorage));
     ReturnLogErrorOnFailure(mOpCertStore.Init(&mDefaultStorage));
 
-    if (sICDClientStorage == nullptr)
-    {
-        ReturnLogErrorOnFailure(mICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));
-        sICDClientStorage = &mICDClientStorage;
-    }
+    // Initialized with a non-persistent keystore without PSA(chip-tool has not yet build with PSA)
+    ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));
 
     chip::Controller::FactoryInitParams factoryInitParams;
 
@@ -173,11 +170,6 @@ void CHIPCommand::MaybeTearDownStack()
     if (IsInteractive())
     {
         return;
-    }
-
-    if (sICDClientStorage == &mICDClientStorage)
-    {
-        sICDClientStorage = nullptr;
     }
 
     //
@@ -428,8 +420,7 @@ chip::Controller::DeviceCommissioner & CHIPCommand::GetCommissioner(std::string 
 chip::app::DefaultICDClientStorage & CHIPCommand::GetICDClientStorage()
 {
     // This method should not be called before MaybeSetUpStack or after MaybeShutdownStack
-    VerifyOrDie(sICDClientStorage != nullptr);
-    return *sICDClientStorage;
+    return sICDClientStorage;
 }
 
 void CHIPCommand::ShutdownCommissioner(const CommissionerIdentity & key)

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -49,6 +49,7 @@ const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = null
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
 // All fabrics share the same ICD client storage.
 chip::app::DefaultICDClientStorage CHIPCommand::sICDClientStorage;
+
 namespace {
 
 CHIP_ERROR GetAttestationTrustStore(const char * paaTrustStorePath, const chip::Credentials::AttestationTrustStore ** trustStore)

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -49,7 +49,7 @@ const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = null
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
 // All fabrics share the same ICD client storage.
 chip::app::DefaultICDClientStorage CHIPCommand::sICDClientStorage;
-
+chip::Crypto::RawKeySessionKeystore CHIPCommand::sSessionKeystore;
 namespace {
 
 CHIP_ERROR GetAttestationTrustStore(const char * paaTrustStorePath, const chip::Credentials::AttestationTrustStore ** trustStore)

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -50,6 +50,7 @@ chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGr
 // All fabrics share the same ICD client storage.
 chip::app::DefaultICDClientStorage CHIPCommand::sICDClientStorage;
 chip::Crypto::RawKeySessionKeystore CHIPCommand::sSessionKeystore;
+
 namespace {
 
 CHIP_ERROR GetAttestationTrustStore(const char * paaTrustStorePath, const chip::Credentials::AttestationTrustStore ** trustStore)

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -48,8 +48,7 @@ constexpr char kCDTrustStorePathVariable[]      = "CHIPTOOL_CD_TRUST_STORE_PATH"
 const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = nullptr;
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
 // All fabrics share the same ICD client storage.
-
-chip::app::DefaultICDClientStorage sICDClientStorage;
+chip::app::DefaultICDClientStorage CHIPCommand::sICDClientStorage;
 namespace {
 
 CHIP_ERROR GetAttestationTrustStore(const char * paaTrustStorePath, const chip::Credentials::AttestationTrustStore ** trustStore)

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -101,10 +101,10 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     ReturnLogErrorOnFailure(mOperationalKeystore.Init(&mDefaultStorage));
     ReturnLogErrorOnFailure(mOpCertStore.Init(&mDefaultStorage));
 
-    // Initialized with a non-persistent keystore without PSA(chip-tool has not yet build with PSA).
-    // The lifetime for ICD storage is same as chip tool. Currently we use chip-tool interactive mode for
-    // ICD commissioning and check-in validation, and this lifetime for ICDStorage meets the test requirement.
-    // TODO: Add the real ICD persistent storage for chip-tool
+    // A non-persistent keystore is initialized without PSA functionality, as the chip-tool does not yet support it.
+    // ICD storage lifetime is currently tied to the chip-tool's lifetime. Since chip-tool interactive mode is currently used for
+    // ICD commissioning and check-in validation, this temporary storage meets the test requirements.
+    // TODO: Implement persistent ICD storage for the chip-tool.
     ReturnLogErrorOnFailure(sICDClientStorage.Init(&mDefaultStorage, &mSessionKeystore));
 
     chip::Controller::FactoryInitParams factoryInitParams;

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -416,12 +416,6 @@ chip::Controller::DeviceCommissioner & CHIPCommand::GetCommissioner(std::string 
     return *item->second;
 }
 
-chip::app::DefaultICDClientStorage & CHIPCommand::GetICDClientStorage()
-{
-    // This method should not be called before MaybeSetUpStack or after MaybeShutdownStack
-    return sICDClientStorage;
-}
-
 void CHIPCommand::ShutdownCommissioner(const CommissionerIdentity & key)
 {
     mCommissioners[key].get()->Shutdown();
@@ -496,7 +490,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(CommissionerIdentity & identity, 
             chip::Credentials::SetSingleIpkEpochKey(&sGroupDataProvider, fabricIndex, defaultIpk, compressed_fabric_id_span));
     }
 
-    GetICDClientStorage().UpdateFabricList(commissioner->GetFabricIndex());
+    CHIPCommand::sICDClientStorage.UpdateFabricList(commissioner->GetFabricIndex());
 
     mCommissioners[identity] = std::move(commissioner);
 

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -25,6 +25,7 @@
 #include "Command.h"
 
 #include <TracingCommandLineArgument.h>
+#include <app/icd/client/DefaultICDClientStorage.h>
 #include <commands/common/CredentialIssuerCommands.h>
 #include <commands/example/ExampleCredentialIssuerCommands.h>
 #include <credentials/GroupDataProviderImpl.h>
@@ -156,6 +157,7 @@ protected:
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
     chip::Crypto::RawKeySessionKeystore mSessionKeystore;
+    chip::app::DefaultICDClientStorage mICDClientStorage;
 
     static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
     CredentialIssuerCommands * mCredIssuerCmds;
@@ -171,6 +173,8 @@ protected:
     ChipDeviceCommissioner & CurrentCommissioner();
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
+
+    chip::app::DefaultICDClientStorage & GetICDClientStorage();
 
 private:
     CHIP_ERROR MaybeSetUpStack();

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -157,7 +157,6 @@ protected:
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
     chip::Crypto::RawKeySessionKeystore mSessionKeystore;
-    chip::app::DefaultICDClientStorage mICDClientStorage;
 
     static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
     CredentialIssuerCommands * mCredIssuerCmds;

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -156,7 +156,7 @@ protected:
 #endif // CONFIG_USE_LOCAL_STORAGE
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
-    chip::Crypto::RawKeySessionKeystore mSessionKeystore;
+    static chip::Crypto::RawKeySessionKeystore sSessionKeystore;
 
     static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
     static chip::app::DefaultICDClientStorage sICDClientStorage;

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -159,6 +159,7 @@ protected:
     chip::Crypto::RawKeySessionKeystore mSessionKeystore;
 
     static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
+    static chip::app::DefaultICDClientStorage sICDClientStorage;
     CredentialIssuerCommands * mCredIssuerCmds;
 
     std::string GetIdentity();

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -174,8 +174,6 @@ protected:
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
 
-    chip::app::DefaultICDClientStorage & GetICDClientStorage();
-
 private:
     CHIP_ERROR MaybeSetUpStack();
     void MaybeTearDownStack();

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -66,5 +66,5 @@ void registerCommandsICD(Commands & commands, CredentialIssuerCommands * credsIs
         make_unique<ICDListCommand>(credsIssuerConfig),
     };
 
-    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for ICD management.");
+    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for client-side ICD management.");
 }

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -1,0 +1,70 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "ICDCommand.h"
+
+#include <crypto/DefaultSessionKeystore.h>
+#include <crypto/RawKeySessionKeystore.h>
+
+using namespace ::chip;
+
+CHIP_ERROR ICDListCommand::RunCommand()
+{
+    app::ICDClientInfo info;
+    auto iter = GetICDClientStorage().IterateICDClientInfo();
+    char icdSymmetricKeyHex[Crypto::kAES_CCM128_Key_Length * 2 + 1];
+
+    fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | %-75s |\n", "Known ICDs:");
+    fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | %20s | %15s | %15s | %16s |\n", "Fabric Index:Node ID", "Start Counter", "Counter Offset",
+            "MonitoredSubject");
+
+    while (iter->Next(info))
+    {
+        fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
+        fprintf(stderr, "  | %3" PRIu32 ":" ChipLogFormatX64 " | %15" PRIu32 " | %15" PRIu32 " | " ChipLogFormatX64 " |\n",
+                static_cast<uint32_t>(info.peer_node.GetFabricIndex()), ChipLogValueX64(info.peer_node.GetNodeId()),
+                info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
+
+        if (std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value)
+        {
+            // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
+            Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
+                                 icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
+            fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);
+        }
+    }
+
+    fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
+
+    iter->Release();
+    SetCommandExitStatus(CHIP_NO_ERROR);
+    return CHIP_NO_ERROR;
+}
+
+void registerCommandsICD(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
+{
+    const char * clusterName = "ICD";
+
+    commands_list clusterCommands = {
+        make_unique<ICDListCommand>(credsIssuerConfig),
+    };
+
+    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for ICD management.");
+}

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         static_assert(std::is_same<decltype(CHIPCommand::sSessionKeystore), Crypto::RawKeySessionKeystore>::value,
-                      "`CHIPCommand::sSessionKeystore` is expected to be `RawKeySessionKeystore`");
+                      "CHIP Tool does not use the PSA crypto backend and only use RawKeySessionKeystore");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -59,9 +59,9 @@ void registerCommandsICD(Commands & commands, CredentialIssuerCommands * credsIs
 {
     const char * name = "ICD";
 
-    commands_list commands = {
+    commands_list list = {
         make_unique<ICDListCommand>(credsIssuerConfig),
     };
 
-    commands.RegisterCommandSet(name, commands, "Commands for client-side ICD management.");
+    commands.RegisterCommandSet(name, list, "Commands for client-side ICD management.");
 }

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -26,7 +26,7 @@ using namespace ::chip;
 CHIP_ERROR ICDListCommand::RunCommand()
 {
     app::ICDClientInfo info;
-    auto iter = GetICDClientStorage().IterateICDClientInfo();
+    auto iter = CHIPCommand::sICDClientStorage.IterateICDClientInfo();
     char icdSymmetricKeyHex[Crypto::kAES_CCM128_Key_Length * 2 + 1];
 
     fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         static_assert(std::is_same<decltype(CHIPCommand::sSessionKeystore), Crypto::RawKeySessionKeystore>::value,
-                      "CHIP Tool does not use the PSA crypto backend and only use RawKeySessionKeystore");
+                      "The following BytesToHex can copy/encode the key bytes from sharedKey to hexadecimal format, which only works for RawKeySessionKeystore");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -44,7 +44,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
 
         // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
-                                icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
+                             icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);
     }
 

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,7 +43,8 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         static_assert(std::is_same<decltype(CHIPCommand::sSessionKeystore), Crypto::RawKeySessionKeystore>::value,
-                      "The following BytesToHex can copy/encode the key bytes from sharedKey to hexadecimal format, which only works for RawKeySessionKeystore");
+                      "The following BytesToHex can copy/encode the key bytes from sharedKey to hexadecimal format, which only "
+                      "works for RawKeySessionKeystore");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 static_cast<uint32_t>(info.peer_node.GetFabricIndex()), ChipLogValueX64(info.peer_node.GetNodeId()),
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
-        static_assert(std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value,
+        static_assert(std::is_same<decltype(CHIPCommand::sSessionKeystore), Crypto::RawKeySessionKeystore>::value,
                       "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,7 +43,8 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
-        static_assert(std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value, "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
+        static_assert(std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value,
+                      "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         static_assert(std::is_same<decltype(CHIPCommand::sSessionKeystore), Crypto::RawKeySessionKeystore>::value,
-                      "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
+                      "`CHIPCommand::sSessionKeystore` is expected to be `RawKeySessionKeystore`");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -42,13 +42,10 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 static_cast<uint32_t>(info.peer_node.GetFabricIndex()), ChipLogValueX64(info.peer_node.GetNodeId()),
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
-        if (std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value)
-        {
-            // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
-            Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
-                                 icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
-            fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);
-        }
+        // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
+        Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
+                                icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
+        fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);
     }
 
     fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
@@ -60,11 +57,11 @@ CHIP_ERROR ICDListCommand::RunCommand()
 
 void registerCommandsICD(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
 {
-    const char * clusterName = "ICD";
+    const char * name = "ICD";
 
-    commands_list clusterCommands = {
+    commands_list commands = {
         make_unique<ICDListCommand>(credsIssuerConfig),
     };
 
-    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for client-side ICD management.");
+    commands.RegisterCommandSet(name, commands, "Commands for client-side ICD management.");
 }

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -42,7 +42,6 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 static_cast<uint32_t>(info.peer_node.GetFabricIndex()), ChipLogValueX64(info.peer_node.GetNodeId()),
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
-        // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
         static_assert(std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value,
                       "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -43,6 +43,7 @@ CHIP_ERROR ICDListCommand::RunCommand()
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject));
 
         // The following cast is valid only when `DefaultSessionKeystore` is `RawKeySessionKeystore`.
+        static_assert(std::is_same<Crypto::DefaultSessionKeystore, Crypto::RawKeySessionKeystore>::value, "DefaultSessionKeystore` is expected to be `RawKeySessionKeystore`");
         Encoding::BytesToHex(info.shared_key.As<Crypto::Symmetric128BitsKeyByteArray>(), Crypto::kAES_CCM128_Key_Length,
                              icdSymmetricKeyHex, sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
         fprintf(stderr, "  | Symmetric Key: %60s |\n", icdSymmetricKeyHex);

--- a/examples/chip-tool/commands/icd/ICDCommand.h
+++ b/examples/chip-tool/commands/icd/ICDCommand.h
@@ -1,0 +1,45 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+#include "commands/common/Commands.h"
+
+#include <lib/support/Span.h>
+
+class ICDCommand : public CHIPCommand
+{
+public:
+    ICDCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds, const char * description) :
+        CHIPCommand(commandName, credIssuerCmds, description)
+    {}
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
+};
+
+class ICDListCommand : public ICDCommand
+{
+public:
+    ICDListCommand(CredentialIssuerCommands * credIssuerCmds) :
+        ICDCommand("list", credIssuerCmds, "List ICDs registed by this controller.")
+    {}
+    CHIP_ERROR RunCommand() override;
+};
+
+void registerCommandsICD(Commands & commands, CredentialIssuerCommands * credsIssuerConfig);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -390,7 +390,7 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
         if (mDeviceIsICD)
         {
             CHIP_ERROR deleteEntryError =
-                GetICDClientStorage().DeleteEntry(chip::ScopedNodeId(mNodeId, CurrentCommissioner().GetFabricIndex()));
+                GetICDClientStorage().DeleteEntry(ScopedNodeId(mNodeId, CurrentCommissioner().GetFabricIndex()));
             if (deleteEntryError != CHIP_NO_ERROR)
             {
                 ChipLogError(chipTool, "Failed to delete ICD entry: %s", ErrorStr(err));

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -37,6 +37,8 @@ CHIP_ERROR PairingCommand::RunCommand()
     // Clear the CATs in OperationalCredentialsIssuer
     mCredIssuerCmds->SetCredentialIssuerCATValues(kUndefinedCATs);
 
+    mDeviceIsICD = false;
+
     if (mCASEAuthTags.HasValue() && mCASEAuthTags.Value().size() <= kMaxSubjectCATAttributeCount)
     {
         CATValues cats = kUndefinedCATs;
@@ -381,6 +383,10 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
 {
     if (err == CHIP_NO_ERROR)
     {
+        if (mDeviceIsICD)
+        {
+            PersistIcdInfo();
+        }
         ChipLogProgress(chipTool, "Device commissioning completed with success");
     }
     else
@@ -391,26 +397,55 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
     SetCommandExitStatus(err);
 }
 
-void PairingCommand::OnICDRegistrationInfoRequired()
-{
-    // Since we compute our ICD Registration info up front, we can call ICDRegistrationInfoReady() directly.
-    CurrentCommissioner().ICDRegistrationInfoReady();
-}
-
-void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounter)
+void PairingCommand::PersistIcdInfo()
 {
     char icdSymmetricKeyHex[chip::Crypto::kAES_CCM128_Key_Length * 2 + 1];
 
     chip::Encoding::BytesToHex(mICDSymmetricKey.Value().data(), mICDSymmetricKey.Value().size(), icdSymmetricKeyHex,
                                sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
 
-    // TODO: Persist symmetric key.
+    chip::app::ICDClientInfo clientInfo;
+    clientInfo.peer_node         = chip::ScopedNodeId(mNodeId, CurrentCommissioner().GetFabricIndex());
+    clientInfo.monitored_subject = mICDMonitoredSubject.Value();
+    CHIP_ERROR err               = GetICDClientStorage().SetKey(clientInfo, mICDSymmetricKey.Value());
+    if (err == CHIP_NO_ERROR)
+    {
+        err = GetICDClientStorage().StoreEntry(clientInfo);
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(chipTool, "Saved ICD Symmetric key for " ChipLogFormatX64, ChipLogValueX64(mNodeId));
+    }
+    else
+    {
+        // StoreEntry is unlikely to fail since it is a local operation for CHIP Tool.
+        ChipLogError(chipTool, "Failed to persist symmetric key for " ChipLogFormatX64 ": %s", ChipLogValueX64(mNodeId),
+                     err.AsString());
+        SetCommandExitStatus(err);
+        return;
+    }
 
     ChipLogProgress(chipTool,
                     "ICD Registration Complete for device " ChipLogFormatX64 " / Check-In NodeID: " ChipLogFormatX64
                     " / Monitored Subject: " ChipLogFormatX64 " / Symmetric Key: %s",
-                    ChipLogValueX64(nodeId), ChipLogValueX64(mICDCheckInNodeId.Value()),
+                    ChipLogValueX64(mNodeId), ChipLogValueX64(mICDCheckInNodeId.Value()),
                     ChipLogValueX64(mICDMonitoredSubject.Value()), icdSymmetricKeyHex);
+}
+
+void PairingCommand::OnICDRegistrationInfoRequired()
+{
+    // Since we compute our ICD Registration info up front, we can call ICDRegistrationInfoReady() directly.
+    CurrentCommissioner().ICDRegistrationInfoReady();
+    mDeviceIsICD = true;
+}
+
+void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounter)
+{
+    // Note: For chip-tool, it is OK to persist the information in `OnCommissioningComplete`.
+    // For some real world cases, we may want to save the information and revert it if further
+    // commissioning steps failed so we won't miss any check-in messages.
+    mICDCounter = icdCounter;
 }
 
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -416,7 +416,7 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
     chip::Encoding::BytesToHex(mICDSymmetricKey.Value().data(), mICDSymmetricKey.Value().size(), icdSymmetricKeyHex,
                                sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
 
-    chip::app::ICDClientInfo clientInfo;
+    app::ICDClientInfo clientInfo;
     clientInfo.peer_node         = ScopedNodeId(nodeId, CurrentCommissioner().GetFabricIndex());
     clientInfo.monitored_subject = mICDMonitoredSubject.Value();
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -417,7 +417,7 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
                                sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
 
     chip::app::ICDClientInfo clientInfo;
-    clientInfo.peer_node         = chip::ScopedNodeId(nodeId, CurrentCommissioner().GetFabricIndex());
+    clientInfo.peer_node         = ScopedNodeId(nodeId, CurrentCommissioner().GetFabricIndex());
     clientInfo.monitored_subject = mICDMonitoredSubject.Value();
 
     CHIP_ERROR err = GetICDClientStorage().SetKey(clientInfo, mICDSymmetricKey.Value());

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -430,7 +430,7 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
     {
         // StoreEntry is unlikely to fail since it is a local operation for CHIP Tool.
         ChipLogError(chipTool, "Failed to persist symmetric key for " ChipLogFormatX64 ": %s", ChipLogValueX64(nodeId),
-                     ErrorStr(err));
+                     err.AsString());
         SetCommandExitStatus(err);
         return;
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -391,7 +391,7 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
         if (mDeviceIsICD)
         {
             CHIP_ERROR deleteEntryError =
-                GetICDClientStorage().DeleteEntry(ScopedNodeId(mNodeId, CurrentCommissioner().GetFabricIndex()));
+                CHIPCommand::sICDClientStorage.DeleteEntry(ScopedNodeId(mNodeId, CurrentCommissioner().GetFabricIndex()));
             if (deleteEntryError != CHIP_NO_ERROR)
             {
                 ChipLogError(chipTool, "Failed to delete ICD entry: %s", ErrorStr(err));
@@ -422,15 +422,15 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
     clientInfo.monitored_subject = mICDMonitoredSubject.Value();
     clientInfo.start_icd_counter = icdCounter;
 
-    CHIP_ERROR err = GetICDClientStorage().SetKey(clientInfo, mICDSymmetricKey.Value());
+    CHIP_ERROR err = CHIPCommand::sICDClientStorage.SetKey(clientInfo, mICDSymmetricKey.Value());
     if (err == CHIP_NO_ERROR)
     {
-        err = GetICDClientStorage().StoreEntry(clientInfo);
+        err = CHIPCommand::sICDClientStorage.StoreEntry(clientInfo);
     }
 
     if (err != CHIP_NO_ERROR)
     {
-        GetICDClientStorage().RemoveKey(clientInfo);
+        CHIPCommand::sICDClientStorage.RemoveKey(clientInfo);
         ChipLogError(chipTool, "Failed to persist symmetric key for " ChipLogFormatX64 ": %s", ChipLogValueX64(nodeId),
                      err.AsString());
         SetCommandExitStatus(err);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -387,6 +387,7 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
     }
     else
     {
+        // When ICD device commissioning fails, the ICDClientInfo stored in OnICDRegistrationComplete needs to be removed.
         if (mDeviceIsICD)
         {
             CHIP_ERROR deleteEntryError =

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -420,6 +420,7 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
     app::ICDClientInfo clientInfo;
     clientInfo.peer_node         = ScopedNodeId(nodeId, CurrentCommissioner().GetFabricIndex());
     clientInfo.monitored_subject = mICDMonitoredSubject.Value();
+    clientInfo.start_icd_counter = icdCounter;
 
     CHIP_ERROR err = GetICDClientStorage().SetKey(clientInfo, mICDSymmetricKey.Value());
     if (err == CHIP_NO_ERROR)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -428,7 +428,7 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
 
     if (err != CHIP_NO_ERROR)
     {
-        // StoreEntry is unlikely to fail since it is a local operation for CHIP Tool.
+        GetICDClientStorage().RemoveKey(clientInfo);
         ChipLogError(chipTool, "Failed to persist symmetric key for " ChipLogFormatX64 ": %s", ChipLogValueX64(nodeId),
                      err.AsString());
         SetCommandExitStatus(err);

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -253,6 +253,8 @@ private:
     uint64_t mDiscoveryFilterCode;
     char * mDiscoveryFilterInstanceName;
 
+    bool mDeviceIsICD;
+    uint32_t mICDCounter;
     uint8_t mRandomGeneratedICDSymmetricKey[chip::Crypto::kAES_CCM128_Key_Length];
 
     // For unpair
@@ -260,4 +262,5 @@ private:
     chip::Callback::Callback<chip::Controller::OnCurrentFabricRemove> mCurrentFabricRemoveCallback;
 
     static void OnCurrentFabricRemove(void * context, NodeId remoteNodeId, CHIP_ERROR status);
+    void PersistIcdInfo();
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -254,7 +254,6 @@ private:
     char * mDiscoveryFilterInstanceName;
 
     bool mDeviceIsICD;
-    uint32_t mICDCounter;
     uint8_t mRandomGeneratedICDSymmetricKey[chip::Crypto::kAES_CCM128_Key_Length];
 
     // For unpair

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -23,6 +23,7 @@
 #include "commands/delay/Commands.h"
 #include "commands/discover/Commands.h"
 #include "commands/group/Commands.h"
+#include "commands/icd/ICDCommand.h"
 #include "commands/interactive/Commands.h"
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
@@ -40,6 +41,7 @@ int main(int argc, char * argv[])
     Commands commands;
     registerCommandsDelay(commands, &credIssuerCommands);
     registerCommandsDiscover(commands, &credIssuerCommands);
+    registerCommandsICD(commands, &credIssuerCommands);
     registerCommandsInteractive(commands, &credIssuerCommands);
     registerCommandsPayload(commands);
     registerCommandsPairing(commands, &credIssuerCommands);

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -110,6 +110,7 @@ chip_data_model("tv-casting-common") {
 
   deps = [
     "${chip_root}/examples/common/tracing:commandline",
+    "${chip_root}/src/app/icd/client:manager",
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/tracing",

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -52,6 +52,10 @@ public:
 
     ICDClientInfoIterator * IterateICDClientInfo() override;
 
+   /**
+     * In order to add an ICD ClientInfo to the ClientInfoStore using its fabric index as the key and further iterate clientInfos in storage,
+     * this function need to store fabric index in dedicated table.
+     */
     CHIP_ERROR UpdateFabricList(FabricIndex fabricIndex);
 
     CHIP_ERROR SetKey(ICDClientInfo & clientInfo, const ByteSpan keyData) override;

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -53,13 +53,15 @@ public:
     ICDClientInfoIterator * IterateICDClientInfo() override;
 
     /**
-     * When decrypting check-in message, we need to run through all keys from all ICD clientInfos, 
-     * ICDClientInfos for the same fabric are stored in storage using fabricIndex as the key, in order to 
-     * retrieve all ICD ClientInfo from stroage, we need to know all fabricIndex in advance. UpdateFabricList
-     * function provides a way to inject new created fabricIndex into a dedicated table. It is recommended to
-     * be called whenever  the fabric is successfully created.
-     * 
-     * @param[in] fabricIndex  the new created fabric index
+     * When decrypting check-in messages, the system needs to iterate through all keys
+     * from all ICD clientInfos. ICDClientInfos for the same fabric are stored in
+     * storage using the fabricIndex as the key. To retrieve all relevant ICDClientInfos
+     * from storage, the system needs to know all fabricIndices in advance. The
+     * `UpdateFabricList` function provides a way to inject newly created fabricIndices
+     * into a dedicated table. It is recommended to call this function whenever a new
+     * fabric is successfully created.
+     *
+     * @param[in] fabricIndex The newly created fabric index.
      */
     CHIP_ERROR UpdateFabricList(FabricIndex fabricIndex);
 

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -58,8 +58,8 @@ public:
      * storage using the fabricIndex as the key. To retrieve all relevant ICDClientInfos
      * from storage, the system needs to know all fabricIndices in advance. The
      * `UpdateFabricList` function provides a way to inject newly created fabricIndices
-     * into a dedicated table. It is recommended to call this function whenever a new
-     * fabric is successfully created.
+     * into a dedicated table. It is recommended to call this function whenever a controller is created
+     * with a new fabric index.
      *
      * @param[in] fabricIndex The newly created fabric index.
      */

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-// Do not use the DefaultICDClientStorage class in settings where fabric indices are not stable. 
-// This class relies on the stability of fabric indices for efficient storage and retrieval of ICD client information. 
+// Do not use the DefaultICDClientStorage class in settings where fabric indices are not stable.
+// This class relies on the stability of fabric indices for efficient storage and retrieval of ICD client information.
 // If fabric indices are not stable, the functionality of this class will be compromised and can lead to unexpected behavior.
 
 #pragma once

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -54,7 +54,7 @@ public:
 
     /**
      * When decrypting check-in messages, the system needs to iterate through all keys
-     * from all ICD clientInfos. ICDClientInfos for the same fabric are stored in
+     * from all ICD clientInfos. In DefaultICDClientStorage, ICDClientInfos for the same fabric are stored in
      * storage using the fabricIndex as the key. To retrieve all relevant ICDClientInfos
      * from storage, the system needs to know all fabricIndices in advance. The
      * `UpdateFabricList` function provides a way to inject newly created fabricIndices

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -52,9 +52,9 @@ public:
 
     ICDClientInfoIterator * IterateICDClientInfo() override;
 
-   /**
-     * In order to add an ICD ClientInfo to the ClientInfoStore using its fabric index as the key and further iterate clientInfos in storage,
-     * this function need to store fabric index in dedicated table.
+    /**
+     * In order to add an ICD ClientInfo to the ClientInfoStore using its fabric index as the key and further iterate clientInfos in
+     * storage, this function need to store fabric index in dedicated table.
      */
     CHIP_ERROR UpdateFabricList(FabricIndex fabricIndex);
 

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -15,6 +15,10 @@
  *    limitations under the License.
  */
 
+// Do not use the DefaultICDClientStorage class in settings where fabric indices are not stable. 
+// This class relies on the stability of fabric indices for efficient storage and retrieval of ICD client information. 
+// If fabric indices are not stable, the functionality of this class will be compromised and can lead to unexpected behavior.
+
 #pragma once
 
 #include "ICDClientStorage.h"

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -53,8 +53,13 @@ public:
     ICDClientInfoIterator * IterateICDClientInfo() override;
 
     /**
-     * In order to add an ICD ClientInfo to the ClientInfoStore using its fabric index as the key and further iterate clientInfos in
-     * storage, this function need to store fabric index in dedicated table.
+     * When decrypting check-in message, we need to run through all keys from all ICD clientInfos, 
+     * ICDClientInfos for the same fabric are stored in storage using fabricIndex as the key, in order to 
+     * retrieve all ICD ClientInfo from stroage, we need to know all fabricIndex in advance. UpdateFabricList
+     * function provides a way to inject new created fabricIndex into a dedicated table. It is recommended to
+     * be called whenever  the fabric is successfully created.
+     * 
+     * @param[in] fabricIndex  the new created fabric index
      */
     CHIP_ERROR UpdateFabricList(FabricIndex fabricIndex);
 


### PR DESCRIPTION
This PR adds the code to persist ICD information after successfully commissioned an ICD device.

This PR also adds a new command set `icd` to `chip-tool`, and provides `list` command currently.

Example output of `chip-tool icd list`:

```
  +-----------------------------------------------------------------------------+
  | Known ICDs:                                                                 |
  +-----------------------------------------------------------------------------+
  | Fabric Index:Node ID |   Start Counter |  Counter Offset | MonitoredSubject |
  +-----------------------------------------------------------------------------+
  |   1:00000000000030AE |               0 |               0 | 000000000001B669 |
  | Symmetric Key:                             b47914a840034891086307703f0c2bcf |
  +-----------------------------------------------------------------------------+
  |   1:000000000000486E |               0 |               0 | 000000000001B669 |
  | Symmetric Key:                             758336c24898dec72da580cf7040b3d0 |
  +-----------------------------------------------------------------------------+
  |   2:00000000000180EE |               0 |               0 | 000000000001B669 |
  | Symmetric Key:                             22a56cb594166422534ae0e4d46629c9 |
  +-----------------------------------------------------------------------------+
```

Note: Symmetric Key will only be printed when `DefaultSessionKeystore` is `RawKeySessionKeystore`

https://github.com/project-chip/connectedhomeip/issues/29393