### PR TITLE
[ESP32] Fix compile error when bt is disabled

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -493,7 +493,7 @@ foreach(phy_blob ${phy_blobs})
     list(APPEND chip_libraries "${esp_phy_dir}/lib/${target_name}/lib${phy_blob}.a")
 endforeach()
 
-set(components_to_link esp_event hal esp_system soc efuse vfs driver esp_coex freertos)
+set(components_to_link esp_event hal esp_system soc efuse vfs driver esp_coex freertos esp_timer)
 idf_build_get_property(build_components BUILD_COMPONENTS)
 foreach(component ${components_to_link})
     # Some of the components are not present in IDF v4.x

--- a/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/light-switch-app/esp32/main/DeviceCallbacks.cpp
@@ -24,6 +24,7 @@
  **/
 
 #include "DeviceCallbacks.h"
+#include <esp_log.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 static const char TAG[] = "light-switch-app-callbacks";


### PR DESCRIPTION
Disabled bt through menuconfig or sdkconfig and try to compile the esp32 example, it fails at linking stage for few `ets_timer_*` functions definitions.

When bt is enabled, esp_timer gets pulled in through dependencies. when bt is disabled, esp_timer isn't present anymore hence linking errors.

Added esp_timer as dependency for chip component.