### PR TITLE
Mark several clusters that are zigbee only as deprecated.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -466,7 +466,7 @@ cluster OnOff = 6 {
 }
 
 /** Attributes and commands for configuring On/Off switching devices. */
-cluster OnOffSwitchConfiguration = 7 {
+deprecated cluster OnOffSwitchConfiguration = 7 {
   revision 1; // NOTE: Default/not specifically set
 
   readonly attribute enum8 switchType = 0;
@@ -605,7 +605,7 @@ cluster LevelControl = 8 {
 }
 
 /** An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. */
-cluster BinaryInputBasic = 15 {
+deprecated cluster BinaryInputBasic = 15 {
   revision 1; // NOTE: Default/not specifically set
 
   attribute optional char_string<16> activeText = 4;
@@ -3790,7 +3790,7 @@ cluster WindowCovering = 258 {
 }
 
 /** This cluster provides control of a barrier (garage door). */
-cluster BarrierControl = 259 {
+deprecated cluster BarrierControl = 259 {
   revision 1; // NOTE: Default/not specifically set
 
   bitmap BarrierControlCapabilities : bitmap8 {
@@ -5321,7 +5321,7 @@ cluster LowPower = 1288 {
 }
 
 /** Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster.. */
-cluster ElectricalMeasurement = 2820 {
+deprecated cluster ElectricalMeasurement = 2820 {
   revision 3;
 
   readonly attribute optional bitmap32 measurementType = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -326,7 +326,7 @@ cluster LevelControl = 8 {
 }
 
 /** An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. */
-cluster BinaryInputBasic = 15 {
+deprecated cluster BinaryInputBasic = 15 {
   revision 1; // NOTE: Default/not specifically set
 
   attribute optional char_string<16> activeText = 4;

--- a/src/app/zap-templates/zcl/data-model/chip/pwm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pwm-cluster.xml
@@ -17,7 +17,8 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" />
 
-    <cluster apiMaturity="provisional">
+    <!-- Deprecated because this is a zigbee-only cluster -->
+    <cluster apiMaturity="deprecated">
         <domain>General</domain>
         <name>Pulse Width Modulation</name>
         <code>0x001c</code>

--- a/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/barrier-control-cluster.xml
@@ -30,7 +30,8 @@ limitations under the License.
     <field name="positionFailure" mask="0x08"/>
   </bitmap>
 
-  <cluster>
+  <!-- Deprecated because this is a zigbee-only cluster -->
+  <cluster apiMaturity="deprecated">
     <name>Barrier Control</name>
     <domain>Closures</domain>
     <code>0x0103</code>

--- a/src/app/zap-templates/zcl/data-model/draft/electrical-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/electrical-measurement-cluster.xml
@@ -17,7 +17,8 @@ limitations under the License.
 <configurator>
   <domain name="Home Automation"/>
 
-  <cluster introducedIn="ha-1.2-05-3520-29">
+  <!-- Deprecated because this is a zigbee-only cluster -->
+  <cluster apiMaturity="deprecated" introducedIn="ha-1.2-05-3520-29">
     <name>Electrical Measurement</name>
     <domain>Home Automation</domain>
     <description>Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..</description>

--- a/src/app/zap-templates/zcl/data-model/draft/electrical-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/electrical-measurement-cluster.xml
@@ -17,7 +17,10 @@ limitations under the License.
 <configurator>
   <domain name="Home Automation"/>
 
-  <!-- Deprecated because this is a zigbee-only cluster -->
+  <!-- 
+    Deprecated because this is a zigbee-only cluster.
+    Matter electrical measurement is 0x90 (see https://github.com/project-chip/connectedhomeip/pull/30389)
+  -->
   <cluster apiMaturity="deprecated" introducedIn="ha-1.2-05-3520-29">
     <name>Electrical Measurement</name>
     <domain>Home Automation</domain>

--- a/src/app/zap-templates/zcl/data-model/draft/input-output-value-clusters.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/input-output-value-clusters.xml
@@ -17,7 +17,8 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <cluster>
+  <!-- Deprecated because this is a zigbee-only cluster -->
+  <cluster apiMaturity="deprecated">
     <name>Binary Input (Basic)</name>
     <domain>General</domain>
     <description>An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. </description>

--- a/src/app/zap-templates/zcl/data-model/draft/onoff-switch-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/draft/onoff-switch-configuration-cluster.xml
@@ -17,7 +17,8 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <cluster>
+  <!-- Deprecated because this is a zigbee-only cluster -->
+  <cluster apiMaturity="deprecated">
     <name>On/off Switch Configuration</name>
     <domain>General</domain>
     <description>Attributes and commands for configuring On/Off switching devices.</description>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -394,7 +394,7 @@ cluster OnOff = 6 {
 }
 
 /** Attributes and commands for configuring On/Off switching devices. */
-cluster OnOffSwitchConfiguration = 7 {
+deprecated cluster OnOffSwitchConfiguration = 7 {
   revision 1; // NOTE: Default/not specifically set
 
   readonly attribute enum8 switchType = 0;
@@ -533,7 +533,7 @@ cluster LevelControl = 8 {
 }
 
 /** An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. */
-cluster BinaryInputBasic = 15 {
+deprecated cluster BinaryInputBasic = 15 {
   revision 1; // NOTE: Default/not specifically set
 
   attribute optional char_string<16> activeText = 4;
@@ -554,7 +554,7 @@ cluster BinaryInputBasic = 15 {
 }
 
 /** Cluster to control pulse width modulation */
-provisional cluster PulseWidthModulation = 28 {
+deprecated cluster PulseWidthModulation = 28 {
   revision 1; // NOTE: Default/not specifically set
 
   readonly attribute command_id generatedCommandList[] = 65528;
@@ -5437,7 +5437,7 @@ cluster WindowCovering = 258 {
 }
 
 /** This cluster provides control of a barrier (garage door). */
-cluster BarrierControl = 259 {
+deprecated cluster BarrierControl = 259 {
   revision 1; // NOTE: Default/not specifically set
 
   bitmap BarrierControlCapabilities : bitmap8 {
@@ -7973,7 +7973,7 @@ cluster ContentAppObserver = 1296 {
 }
 
 /** Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster.. */
-cluster ElectricalMeasurement = 2820 {
+deprecated cluster ElectricalMeasurement = 2820 {
   revision 3;
 
   readonly attribute optional bitmap32 measurementType = 0;


### PR DESCRIPTION
We will still codegen to not break potential existing clients for now.

Generally it is unclear why anyone would use these (they are not real things because zigbee only), however the process of complete removal is probably a lot longer, hence the flagging for now.