### PR TITLE
Ensure fields are always initialized in TLVWriters

### DIFF
--- a/src/lib/core/TLVUpdater.cpp
+++ b/src/lib/core/TLVUpdater.cpp
@@ -98,6 +98,8 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterReader.ImplicitProfileId = aReader.ImplicitProfileId;
     mUpdaterReader.AppData           = aReader.AppData;
 
+    // TODO(#30825): Need to ensure we use TLVWriter public API rather than touch the innards.
+
     // Initialize the internal writer object
     mUpdaterWriter.mBackingStore  = nullptr;
     mUpdaterWriter.mBufStart      = buf - readDataLen;
@@ -110,6 +112,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterWriter.SetCloseContainerReserved(false);
 
     mUpdaterWriter.ImplicitProfileId = aReader.ImplicitProfileId;
+    mUpdaterWriter.mInitializationCookie = TLVWriter::kExpectedInitializationCookie;
 
     // Cache element start address for internal use
     mElementStartAddr = buf + freeLen;
@@ -142,6 +145,8 @@ CHIP_ERROR TLVUpdater::Next()
 
 CHIP_ERROR TLVUpdater::Move()
 {
+    VerifyOrReturnError(mUpdaterWriter.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+
     const uint8_t * elementEnd;
     uint32_t copyLen;
 
@@ -171,6 +176,8 @@ CHIP_ERROR TLVUpdater::Move()
 
 void TLVUpdater::MoveUntilEnd()
 {
+    VerifyOrDie(mUpdaterWriter.IsInitialized());
+
     const uint8_t * buffEnd = mUpdaterReader.GetReadPoint() + mUpdaterReader.GetRemainingLength();
 
     uint32_t copyLen = static_cast<uint32_t>(buffEnd - mElementStartAddr);
@@ -178,6 +185,7 @@ void TLVUpdater::MoveUntilEnd()
     // Move all elements till end to output TLV
     memmove(mUpdaterWriter.mWritePoint, mElementStartAddr, copyLen);
 
+    // TODO(#30825): Need to ensure public API is used rather than touching the innards.
     // Adjust the updater state
     mElementStartAddr += copyLen;
     mUpdaterWriter.mWritePoint += copyLen;
@@ -197,6 +205,8 @@ void TLVUpdater::MoveUntilEnd()
 
 CHIP_ERROR TLVUpdater::EnterContainer(TLVType & outerContainerType)
 {
+    VerifyOrReturnError(mUpdaterWriter.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+
     TLVType containerType;
 
     VerifyOrReturnError(TLVTypeIsContainer(static_cast<TLVType>(mUpdaterReader.mControlByte & kTLVTypeMask)),
@@ -232,6 +242,8 @@ CHIP_ERROR TLVUpdater::ExitContainer(TLVType outerContainerType)
  */
 void TLVUpdater::AdjustInternalWriterFreeSpace()
 {
+    VerifyOrDie(mUpdaterWriter.IsInitialized());
+
     const uint8_t * nextElementStart = mUpdaterReader.mReadPoint;
 
     if (nextElementStart != mElementStartAddr)

--- a/src/lib/core/TLVUpdater.cpp
+++ b/src/lib/core/TLVUpdater.cpp
@@ -111,7 +111,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterWriter.SetContainerOpen(false);
     mUpdaterWriter.SetCloseContainerReserved(false);
 
-    mUpdaterWriter.ImplicitProfileId = aReader.ImplicitProfileId;
+    mUpdaterWriter.ImplicitProfileId     = aReader.ImplicitProfileId;
     mUpdaterWriter.mInitializationCookie = TLVWriter::kExpectedInitializationCookie;
 
     // Cache element start address for internal use

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -47,7 +47,10 @@
 #if 0
 #define ABORT_ON_UNINITIALIZED_IF_ENABLED() VerifyOrDie(IsInitialized() == true)
 #else
-#define ABORT_ON_UNINITIALIZED_IF_ENABLED() do {} while (0)
+#define ABORT_ON_UNINITIALIZED_IF_ENABLED()                                                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
 #endif
 namespace chip {
 namespace TLV {
@@ -61,18 +64,18 @@ NO_INLINE void TLVWriter::Init(uint8_t * buf, size_t maxLen)
 
     // TODO(#30825): Need to ensure a single init path for this complex data.
     mInitializationCookie = 0;
-    mBackingStore           = nullptr;
-    mBufStart               = buf;
-    mWritePoint             = buf;
-    mRemainingLen           = actualMaxLen;
-    mLenWritten             = 0;
-    mMaxLen                 = actualMaxLen;
-    mContainerType          = kTLVType_NotSpecified;
-    mReservedSize           = 0;
+    mBackingStore         = nullptr;
+    mBufStart             = buf;
+    mWritePoint           = buf;
+    mRemainingLen         = actualMaxLen;
+    mLenWritten           = 0;
+    mMaxLen               = actualMaxLen;
+    mContainerType        = kTLVType_NotSpecified;
+    mReservedSize         = 0;
     SetContainerOpen(false);
     SetCloseContainerReserved(true);
 
-    ImplicitProfileId = kProfileIdNotSpecified;
+    ImplicitProfileId     = kProfileIdNotSpecified;
     mInitializationCookie = kExpectedInitializationCookie;
 }
 
@@ -106,7 +109,8 @@ CHIP_ERROR TLVWriter::Finalize()
     if (mBackingStore != nullptr)
         err = mBackingStore->FinalizeBuffer(*this, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
 
-    // TODO(#30825) The following should be safe, but in some cases (without mBackingStore), there are incremental writes that start failing.
+        // TODO(#30825) The following should be safe, but in some cases (without mBackingStore), there are incremental writes that
+        // start failing.
 #if 0
     if (err == CHIP_NO_ERROR)
         mInitializationCookie = 0;
@@ -514,7 +518,7 @@ CHIP_ERROR TLVWriter::OpenContainer(Tag tag, TLVType containerType, TLVWriter & 
     containerWriter.mContainerType = containerType;
     containerWriter.SetContainerOpen(false);
     containerWriter.SetCloseContainerReserved(IsCloseContainerReserved());
-    containerWriter.ImplicitProfileId = ImplicitProfileId;
+    containerWriter.ImplicitProfileId     = ImplicitProfileId;
     containerWriter.mInitializationCookie = kExpectedInitializationCookie;
 
     SetContainerOpen(true);

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -57,6 +57,21 @@ namespace TLV {
 
 using namespace chip::Encoding;
 
+TLVWriter::TLVWriter() :
+    ImplicitProfileId(kProfileIdNotSpecified),
+    AppData(nullptr),
+    mBackingStore(nullptr),
+    mBufStart(nullptr),
+    mWritePoint(nullptr),
+    mRemainingLen(0),
+    mLenWritten(0),
+    mMaxLen(0),
+    mReservedSize(0),
+    mContainerType(kTLVType_NotSpecified),
+    mInitializationCookie(0),
+    mContainerOpen(false),
+    mCloseContainerReserved(true) {}
+
 NO_INLINE void TLVWriter::Init(uint8_t * buf, size_t maxLen)
 {
     // TODO: Maybe we can just make mMaxLen, LenWritten, mRemainingLen size_t instead?

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -58,19 +58,10 @@ namespace TLV {
 using namespace chip::Encoding;
 
 TLVWriter::TLVWriter() :
-    ImplicitProfileId(kProfileIdNotSpecified),
-    AppData(nullptr),
-    mBackingStore(nullptr),
-    mBufStart(nullptr),
-    mWritePoint(nullptr),
-    mRemainingLen(0),
-    mLenWritten(0),
-    mMaxLen(0),
-    mReservedSize(0),
-    mContainerType(kTLVType_NotSpecified),
-    mInitializationCookie(0),
-    mContainerOpen(false),
-    mCloseContainerReserved(true) {}
+    ImplicitProfileId(kProfileIdNotSpecified), AppData(nullptr), mBackingStore(nullptr), mBufStart(nullptr), mWritePoint(nullptr),
+    mRemainingLen(0), mLenWritten(0), mMaxLen(0), mReservedSize(0), mContainerType(kTLVType_NotSpecified), mInitializationCookie(0),
+    mContainerOpen(false), mCloseContainerReserved(true)
+{}
 
 NO_INLINE void TLVWriter::Init(uint8_t * buf, size_t maxLen)
 {

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -129,6 +129,7 @@ public:
      * (See @p OpenContainer()).
      *
      * @retval #CHIP_NO_ERROR      If the encoding was finalized successfully.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -141,10 +142,12 @@ public:
      * Reserve some buffer for encoding future fields.
      *
      * @retval #CHIP_NO_ERROR        Successfully reserved required buffer size.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_NO_MEMORY The reserved buffer size cannot fits into the remaining buffer size.
      */
     CHIP_ERROR ReserveBuffer(uint32_t aBufferSize)
     {
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mRemainingLen >= aBufferSize, CHIP_ERROR_NO_MEMORY);
         mReservedSize += aBufferSize;
         mRemainingLen -= aBufferSize;
@@ -155,10 +158,12 @@ public:
      * Release previously reserved buffer.
      *
      * @retval #CHIP_NO_ERROR        Successfully released reserved buffer size.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_NO_MEMORY The released buffer is larger than previously reserved buffer size.
      */
     CHIP_ERROR UnreserveBuffer(uint32_t aBufferSize)
     {
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mReservedSize >= aBufferSize, CHIP_ERROR_NO_MEMORY);
         mReservedSize -= aBufferSize;
         mRemainingLen += aBufferSize;
@@ -175,6 +180,7 @@ public:
      * @param[in]   v               The value to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -207,6 +213,7 @@ public:
      *                              are strongly encouraged to set this parameter to false.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -265,6 +272,7 @@ public:
      * @param[in]   v               The value to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -355,6 +363,7 @@ public:
      * @param[in]   v               The value to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -388,6 +397,7 @@ public:
      * @param[in]   data            A ByteSpan object containing the bytes string to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -445,6 +455,7 @@ public:
      * @param[in]   v               The value to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -486,6 +497,7 @@ public:
      * @param[in]   len             The number of bytes to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -514,6 +526,7 @@ public:
      * @param[in]   buf             A pointer to the null-terminated UTF-8 string to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -543,6 +556,7 @@ public:
      * @param[in]   len             The length (in bytes) of the string to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -571,6 +585,7 @@ public:
      * @param[in]   str             A Span containing a pointer and a length of the string to be encoded.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -694,6 +709,7 @@ public:
      *                              ContextTag() or CommonTag().
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -730,7 +746,7 @@ public:
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on an element.
+     *                              If the supplied reader is not positioned on an element or if the writer is not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -779,7 +795,7 @@ public:
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on an element.
+     *                              If the supplied reader is not positioned on an element or if the writer is not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -829,6 +845,7 @@ public:
      *                              writer.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_WRONG_TLV_TYPE
      *                              If the value specified for containerType is incorrect.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
@@ -869,7 +886,7 @@ public:
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If a corresponding StartContainer() call was not made.
+     *                              If a corresponding StartContainer() call was not made or if the TLVWriter is not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -917,6 +934,7 @@ public:
      *                              associated with the supplied object is overwritten.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_WRONG_TLV_TYPE
      *                              If the value specified for containerType is incorrect.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
@@ -954,7 +972,7 @@ public:
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied container writer is not in the correct state.
+     *                              If the supplied container writer is not in the correct state or if the TLVWriter is not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If another container writer has been opened on the supplied
      *                              container writer and not yet closed.
@@ -993,6 +1011,7 @@ public:
      * @param[in]   dataLen         The number of bytes in the @p data buffer.
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_WRONG_TLV_TYPE
      *                              If the value specified for containerType is incorrect.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
@@ -1032,7 +1051,7 @@ public:
      * @retval #CHIP_ERROR_INVALID_ARGUMENT
      *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on a container element.
+     *                              If the supplied reader is not positioned on a container element or if the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -1084,7 +1103,7 @@ public:
      * @retval #CHIP_ERROR_INVALID_ARGUMENT
      *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on a container element.
+     *                              If the supplied reader is not positioned on a container element or of the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -1131,6 +1150,7 @@ public:
      * @param[in] encodedContainerLen   The length in bytes of the pre-encoded container.
      *
      * @retval #CHIP_NO_ERROR          If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE  If the TLVWriter was not initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                                  If a container writer has been opened on the current writer and not
      *                                  yet closed.

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -63,7 +63,7 @@ class DLL_EXPORT TLVWriter
     friend class TLVUpdater;
 
 public:
-    TLVWriter() = default;
+    TLVWriter();
 
     // TODO(#30825): We do not cleanly handle copies for all backing stores, but we don't disallow copy...
 #if 0
@@ -1201,27 +1201,27 @@ public:
      * @note The value of the @p ImplicitProfileId member affects the encoding of profile-specific
      * tags only; the encoding of context-specific tags is unchanged.
      */
-    uint32_t ImplicitProfileId = kProfileIdNotSpecified;
+    uint32_t ImplicitProfileId;
 
     /**
      * A pointer field that can be used for application-specific data.
      */
-    void * AppData = nullptr;
+    void * AppData;
 
 protected:
-    TLVBackingStore * mBackingStore = nullptr;
-    uint8_t * mBufStart             = nullptr;
-    uint8_t * mWritePoint           = nullptr;
-    uint32_t mRemainingLen          = 0;
-    uint32_t mLenWritten            = 0;
-    uint32_t mMaxLen                = 0;
-    uint32_t mReservedSize          = 0;
-    TLVType mContainerType          = kTLVType_NotSpecified;
-    uint16_t mInitializationCookie  = 0;
+    TLVBackingStore * mBackingStore;
+    uint8_t * mBufStart;
+    uint8_t * mWritePoint;
+    uint32_t mRemainingLen;
+    uint32_t mLenWritten;
+    uint32_t mMaxLen;
+    uint32_t mReservedSize;
+    TLVType mContainerType;
+    uint16_t mInitializationCookie;
 
 private:
-    bool mContainerOpen          = false;
-    bool mCloseContainerReserved = true;
+    bool mContainerOpen;
+    bool mCloseContainerReserved;
 
 protected:
     bool IsContainerOpen() const { return mContainerOpen; }

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <lib/core/TLVTags.h>
+
 #include "TLVCommon.h"
 
 #include "TLVBackingStore.h"
@@ -61,6 +63,18 @@ class DLL_EXPORT TLVWriter
     friend class TLVUpdater;
 
 public:
+    TLVWriter() = default;
+
+    // TODO(#30825): We do not cleanly handle copies for all backing stores, but we don't disallow copy...
+#if 0
+    // Disable copy (and move) semantics.
+    TLVWriter(const TLVWriter&) = delete;
+    TLVWriter& operator=(const TLVWriter&) = delete;
+#endif
+
+    // Initialization cookie that is set when properly initialized. Randomly-picked 16 bit value.
+    static constexpr uint16_t kExpectedInitializationCookie = 0x52b1;
+
     /**
      * Initializes a TLVWriter object to write into a single output buffer.
      *
@@ -1165,6 +1179,12 @@ public:
      * @return the total remaining number of bytes.
      */
     uint32_t GetRemainingFreeLength() const { return mRemainingLen; }
+
+    /**
+     * @brief Returns true if this TLVWriter was properly initialized.
+     */
+    bool IsInitialized() const { return mInitializationCookie == kExpectedInitializationCookie; }
+
     /**
      * The profile id of tags that should be encoded in implicit form.
      *
@@ -1181,26 +1201,27 @@ public:
      * @note The value of the @p ImplicitProfileId member affects the encoding of profile-specific
      * tags only; the encoding of context-specific tags is unchanged.
      */
-    uint32_t ImplicitProfileId;
+    uint32_t ImplicitProfileId = kProfileIdNotSpecified;
 
     /**
      * A pointer field that can be used for application-specific data.
      */
-    void * AppData;
+    void * AppData = nullptr;
 
 protected:
-    TLVBackingStore * mBackingStore;
-    uint8_t * mBufStart;
-    uint8_t * mWritePoint;
-    uint32_t mRemainingLen;
-    uint32_t mLenWritten;
-    uint32_t mMaxLen;
-    uint32_t mReservedSize;
-    TLVType mContainerType;
+    TLVBackingStore * mBackingStore = nullptr;
+    uint8_t * mBufStart = nullptr;
+    uint8_t * mWritePoint = nullptr;
+    uint32_t mRemainingLen = 0;
+    uint32_t mLenWritten = 0;
+    uint32_t mMaxLen = 0;
+    uint32_t mReservedSize = 0;
+    TLVType mContainerType = kTLVType_NotSpecified;
+    uint16_t mInitializationCookie = 0;
 
 private:
-    bool mContainerOpen;
-    bool mCloseContainerReserved;
+    bool mContainerOpen = false;
+    bool mCloseContainerReserved = true;
 
 protected:
     bool IsContainerOpen() const { return mContainerOpen; }

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -1210,17 +1210,17 @@ public:
 
 protected:
     TLVBackingStore * mBackingStore = nullptr;
-    uint8_t * mBufStart = nullptr;
-    uint8_t * mWritePoint = nullptr;
-    uint32_t mRemainingLen = 0;
-    uint32_t mLenWritten = 0;
-    uint32_t mMaxLen = 0;
-    uint32_t mReservedSize = 0;
-    TLVType mContainerType = kTLVType_NotSpecified;
-    uint16_t mInitializationCookie = 0;
+    uint8_t * mBufStart             = nullptr;
+    uint8_t * mWritePoint           = nullptr;
+    uint32_t mRemainingLen          = 0;
+    uint32_t mLenWritten            = 0;
+    uint32_t mMaxLen                = 0;
+    uint32_t mReservedSize          = 0;
+    TLVType mContainerType          = kTLVType_NotSpecified;
+    uint16_t mInitializationCookie  = 0;
 
 private:
-    bool mContainerOpen = false;
+    bool mContainerOpen          = false;
     bool mCloseContainerReserved = true;
 
 protected:

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -972,7 +972,8 @@ public:
      *
      * @retval #CHIP_NO_ERROR      If the method succeeded.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied container writer is not in the correct state or if the TLVWriter is not initialized.
+     *                              If the supplied container writer is not in the correct state or if the TLVWriter is not
+     * initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If another container writer has been opened on the supplied
      *                              container writer and not yet closed.
@@ -1051,7 +1052,8 @@ public:
      * @retval #CHIP_ERROR_INVALID_ARGUMENT
      *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on a container element or if the TLVWriter was not initialized.
+     *                              If the supplied reader is not positioned on a container element or if the TLVWriter was not
+     * initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.
@@ -1103,7 +1105,8 @@ public:
      * @retval #CHIP_ERROR_INVALID_ARGUMENT
      *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
      * @retval #CHIP_ERROR_INCORRECT_STATE
-     *                              If the supplied reader is not positioned on a container element or of the TLVWriter was not initialized.
+     *                              If the supplied reader is not positioned on a container element or of the TLVWriter was not
+     * initialized.
      * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
      *                              If a container writer has been opened on the current writer and not
      *                              yet closed.

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -4647,270 +4647,279 @@ static void CheckTLVScopedBuffer(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-static void TestUninitializedWriter(nlTestSuite * inSuite, void * inContext) {
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, !writer.IsInitialized());
-  }
+static void TestUninitializedWriter(nlTestSuite * inSuite, void * inContext)
+{
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, !writer.IsInitialized());
+    }
 
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.Finalize() == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.Finalize() == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.ReserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.ReserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.UnreserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.UnreserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint8_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint8_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int8_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int8_t v          = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int16_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int16_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int16_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int16_t v         = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int32_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int32_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int32_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int32_t v         = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int64_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int64_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      int64_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        int64_t v         = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint8_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint8_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint8_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint8_t v         = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint16_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint16_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint16_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint16_t v        = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint32_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint32_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint32_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint32_t v        = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint64_t v = 3;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint64_t v = 3;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      uint64_t v = 3;
-      bool preserveSize = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        uint64_t v        = 3;
+        bool preserveSize = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v, preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      double v = 1.23;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        double v = 1.23;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      float v = 1.23f;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        float v = 1.23f;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      bool v = true;
-      NL_TEST_ASSERT(inSuite, writer.PutBoolean(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        bool v = true;
+        NL_TEST_ASSERT(inSuite, writer.PutBoolean(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      bool v = true;
-      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        bool v = true;
+        NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1), v) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      const uint8_t buf[] = { 1, 2, 3};
-      NL_TEST_ASSERT(inSuite, writer.PutBytes(ContextTag(1), buf, static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        const uint8_t buf[] = { 1, 2, 3 };
+        NL_TEST_ASSERT(inSuite,
+                       writer.PutBytes(ContextTag(1), buf, static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      const char* buf = "abc";
-      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), buf) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        const char * buf = "abc";
+        NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), buf) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      const char* buf = "abc";
-      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), buf, static_cast<uint32_t>(strlen(buf))) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        const char * buf = "abc";
+        NL_TEST_ASSERT(inSuite,
+                       writer.PutString(ContextTag(1), buf, static_cast<uint32_t>(strlen(buf))) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      CharSpan str = "abc"_span;
-      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), str) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        CharSpan str = "abc"_span;
+        NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), str) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.PutStringF(ContextTag(1), "%d", 1) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.PutStringF(ContextTag(1), "%d", 1) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.PutNull(ContextTag(1)) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.PutNull(ContextTag(1)) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      const uint8_t buf[] {0, 0, 0};
-      TLVReader reader;
-      reader.Init(buf);
+    {
+        const uint8_t buf[]{ 0, 0, 0 };
+        TLVReader reader;
+        reader.Init(buf);
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CopyElement(reader) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.CopyElement(reader) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      const uint8_t buf[] {0, 0, 0};
-      TLVReader reader;
-      reader.Init(buf);
+    {
+        const uint8_t buf[]{ 0, 0, 0 };
+        TLVReader reader;
+        reader.Init(buf);
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CopyElement(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.CopyElement(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      TLVType outerContainerType;
+    {
+        TLVWriter writer;
+        TLVType outerContainerType;
 
-      NL_TEST_ASSERT(inSuite, writer.StartContainer(ContextTag(1), TLVType::kTLVType_Structure, outerContainerType) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        NL_TEST_ASSERT(inSuite,
+                       writer.StartContainer(ContextTag(1), TLVType::kTLVType_Structure, outerContainerType) ==
+                           CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter writer;
-      TLVType outerContainerType = TLVType::kTLVType_Structure;
-      NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        TLVWriter writer;
+        TLVType outerContainerType = TLVType::kTLVType_Structure;
+        NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter innerWriter;
-      uint8_t buf[] {0, 0, 0};
-      innerWriter.Init(buf);
-      NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
+    {
+        TLVWriter innerWriter;
+        uint8_t buf[]{ 0, 0, 0 };
+        innerWriter.Init(buf);
+        NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.OpenContainer(ContextTag(1), TLVType::kTLVType_Structure, innerWriter) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite,
+                       writer.OpenContainer(ContextTag(1), TLVType::kTLVType_Structure, innerWriter) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      TLVWriter innerWriter;
-      uint8_t buf[] {0, 0, 0};
-      innerWriter.Init(buf);
-      NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
+    {
+        TLVWriter innerWriter;
+        uint8_t buf[]{ 0, 0, 0 };
+        innerWriter.Init(buf);
+        NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CloseContainer(innerWriter) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.CloseContainer(innerWriter) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      uint8_t buf[] {0, 0, 0};
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.PutPreEncodedContainer(ContextTag(1), TLVType::kTLVType_Structure, buf, static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
-  }
+    {
+        uint8_t buf[]{ 0, 0, 0 };
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite,
+                       writer.PutPreEncodedContainer(ContextTag(1), TLVType::kTLVType_Structure, buf,
+                                                     static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      const uint8_t buf[] {0, 0, 0};
-      TLVReader reader;
-      reader.Init(buf);
+    {
+        const uint8_t buf[]{ 0, 0, 0 };
+        TLVReader reader;
+        reader.Init(buf);
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CopyContainer(reader) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.CopyContainer(reader) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      const uint8_t buf[] {0, 0, 0};
-      TLVReader reader;
-      reader.Init(buf);
+    {
+        const uint8_t buf[]{ 0, 0, 0 };
+        TLVReader reader;
+        reader.Init(buf);
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CopyContainer(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite, writer.CopyContainer(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
+    }
 
-  {
-      uint8_t buf[] {0, 0, 0};
+    {
+        uint8_t buf[]{ 0, 0, 0 };
 
-      TLVWriter writer;
-      NL_TEST_ASSERT(inSuite, writer.CopyContainer(ContextTag(1), buf, static_cast<uint16_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
-  }
+        TLVWriter writer;
+        NL_TEST_ASSERT(inSuite,
+                       writer.CopyContainer(ContextTag(1), buf, static_cast<uint16_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+    }
 }
 
 // Test Suite

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -36,6 +36,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
 #include <lib/support/UnitTestContext.h>
 #include <lib/support/UnitTestExtendedAssertions.h>
 #include <lib/support/UnitTestRegistration.h>
@@ -4646,6 +4647,272 @@ static void CheckTLVScopedBuffer(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+static void TestUninitializedWriter(nlTestSuite * inSuite, void * inContext) {
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, !writer.IsInitialized());
+  }
+
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.Finalize() == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.ReserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.UnreserveBuffer(123) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint8_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int8_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int16_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int16_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int32_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int32_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int64_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      int64_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint8_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint8_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint16_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint16_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint32_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint32_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint64_t v = 3;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      uint64_t v = 3;
+      bool preserveSize = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v,  preserveSize) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      double v = 1.23;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      float v = 1.23f;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      bool v = true;
+      NL_TEST_ASSERT(inSuite, writer.PutBoolean(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      bool v = true;
+      NL_TEST_ASSERT(inSuite, writer.Put(ContextTag(1),  v) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      const uint8_t buf[] = { 1, 2, 3};
+      NL_TEST_ASSERT(inSuite, writer.PutBytes(ContextTag(1), buf, static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      const char* buf = "abc";
+      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), buf) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      const char* buf = "abc";
+      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), buf, static_cast<uint32_t>(strlen(buf))) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      CharSpan str = "abc"_span;
+      NL_TEST_ASSERT(inSuite, writer.PutString(ContextTag(1), str) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.PutStringF(ContextTag(1), "%d", 1) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.PutNull(ContextTag(1)) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      const uint8_t buf[] {0, 0, 0};
+      TLVReader reader;
+      reader.Init(buf);
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CopyElement(reader) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      const uint8_t buf[] {0, 0, 0};
+      TLVReader reader;
+      reader.Init(buf);
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CopyElement(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      TLVType outerContainerType;
+
+      NL_TEST_ASSERT(inSuite, writer.StartContainer(ContextTag(1), TLVType::kTLVType_Structure, outerContainerType) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter writer;
+      TLVType outerContainerType = TLVType::kTLVType_Structure;
+      NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter innerWriter;
+      uint8_t buf[] {0, 0, 0};
+      innerWriter.Init(buf);
+      NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.OpenContainer(ContextTag(1), TLVType::kTLVType_Structure, innerWriter) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      TLVWriter innerWriter;
+      uint8_t buf[] {0, 0, 0};
+      innerWriter.Init(buf);
+      NL_TEST_ASSERT(inSuite, innerWriter.IsInitialized());
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CloseContainer(innerWriter) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      uint8_t buf[] {0, 0, 0};
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.PutPreEncodedContainer(ContextTag(1), TLVType::kTLVType_Structure, buf, static_cast<uint32_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      const uint8_t buf[] {0, 0, 0};
+      TLVReader reader;
+      reader.Init(buf);
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CopyContainer(reader) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      const uint8_t buf[] {0, 0, 0};
+      TLVReader reader;
+      reader.Init(buf);
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CopyContainer(ContextTag(1), reader) == CHIP_ERROR_INCORRECT_STATE);
+  }
+
+  {
+      uint8_t buf[] {0, 0, 0};
+
+      TLVWriter writer;
+      NL_TEST_ASSERT(inSuite, writer.CopyContainer(ContextTag(1), buf, static_cast<uint16_t>(sizeof(buf))) == CHIP_ERROR_INCORRECT_STATE);
+  }
+}
+
 // Test Suite
 
 /**
@@ -4684,6 +4951,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("CHIP TLV GetStringView Test",         CheckGetStringView),
     NL_TEST_DEF("CHIP TLV GetByteView Test",           CheckGetByteView),
     NL_TEST_DEF("Int Min/Max Test",                    TestIntMinMax),
+    NL_TEST_DEF("Uninitialized Writer Test",           TestUninitializedWriter),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
- It was found through static analysis that in some cases, TLVWriters did not have all fields initialized and this led to no errors, but possibly could lead to bad states.
- None of the code making use of uninitialized TLVWriters was found in the SDK, but there may be usages.
- In adding the checks, marked several areas that could be improved in TLVWriter data access/management.

Issue #30825

Testing done:
- All tests still pass.
- There is never uninitialized used of a TLVWriter.
