### PR TITLE
Add ability for chip-repl to grab MaxPathsPerInvoke of remote node

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -53,7 +53,7 @@ from .clusters import Objects as GeneratedObjects
 from .clusters.CHIPClusters import ChipClusters
 from .crypto import p256keypair
 from .exceptions import UnknownAttribute, UnknownCommand
-from .interaction_model import InteractionModelError
+from .interaction_model import InteractionModelError, SessionParameters, SessionParametersStruct
 from .interaction_model import delegate as im
 from .native import PyChipError
 
@@ -809,14 +809,34 @@ class ChipDeviceControllerBase():
             device.deviceProxy, upperLayerProcessingTimeoutMs))
         return res
 
-    def GetMaxPathsPerInvoke(self, nodeid) -> int:
-        ''' Returns the Max Paths Per Invoke supported by remote node associated with `nodeid`
+    def GetRemoteSessionParameters(self, nodeid) -> typing.Optional[SessionParameters]:
+        ''' Returns the SessionParameters of reported by the remote node associated with `nodeid`.
+            If there is some error in getting SessionParameters None is returned.
 
             This will result in a session being established if one wasn't already established.
         '''
+
+        # First creating the struct to make building the ByteArray to be sent to CFFI easier.
+        sessionParametersStruct = SessionParametersStruct.parse(b'\x00' * SessionParametersStruct.sizeof())
+        sessionParametersByteArray = SessionParametersStruct.build(sessionParametersStruct)
         device = self.GetConnectedDeviceSync(nodeid)
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_GetMaxPathsPerInvoke(
-            device.deviceProxy))
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_GetRemoteSessionParameters(
+            device.deviceProxy, ctypes.c_char_p(sessionParametersByteArray)))
+
+        # 0 is CHIP_NO_ERROR
+        if res != 0:
+            return None
+
+        sessionParametersStruct = SessionParametersStruct.parse(sessionParametersByteArray)
+        return SessionParameters(
+            sessionIdleInterval=sessionParametersStruct.SessionIdleInterval if sessionParametersStruct.SessionIdleInterval is not 0 else None,
+            sessionActiveInterval=sessionParametersStruct.SessionActiveInterval if sessionParametersStruct.SessionActiveInterval is not 0 else None,
+            sessionActiveThreshold=sessionParametersStruct.SessionActiveThreshold if sessionParametersStruct.SessionActiveThreshold is not 0 else None,
+            dataModelRevision=sessionParametersStruct.DataModelRevision if sessionParametersStruct.DataModelRevision is not 0 else None,
+            interactionModelRevision=sessionParametersStruct.InteractionModelRevision if sessionParametersStruct.InteractionModelRevision is not 0 else None,
+            speficiationVersion=sessionParametersStruct.SpeficiationVersion if sessionParametersStruct.SpeficiationVersion is not 0 else None,
+            maxPathsPerInvoke=sessionParametersStruct.MaxPathsPerInvoke)
+
         return res
 
     async def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(self, nodeid: int, endpoint: int,

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -808,6 +808,18 @@ class ChipDeviceControllerBase():
         res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_ComputeRoundTripTimeout(
             device.deviceProxy, upperLayerProcessingTimeoutMs))
         return res
+    
+
+    def GetMaxPathsPerInvoke(self, nodeid) -> int:
+        ''' Returns the Max Paths Per Invoke supported by remote node associated with `nodeid`
+
+            This will result in a session being established if one wasn't already established.
+        '''
+        device = self.GetConnectedDeviceSync(nodeid)
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_GetMaxPathsPerInvoke(
+            device.deviceProxy))
+        return res
+
 
     async def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(self, nodeid: int, endpoint: int,
                                                                    payload: ClusterObjects.ClusterCommand, responseType=None):

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -829,12 +829,12 @@ class ChipDeviceControllerBase():
 
         sessionParametersStruct = SessionParametersStruct.parse(sessionParametersByteArray)
         return SessionParameters(
-            sessionIdleInterval=sessionParametersStruct.SessionIdleInterval if sessionParametersStruct.SessionIdleInterval is not 0 else None,
-            sessionActiveInterval=sessionParametersStruct.SessionActiveInterval if sessionParametersStruct.SessionActiveInterval is not 0 else None,
-            sessionActiveThreshold=sessionParametersStruct.SessionActiveThreshold if sessionParametersStruct.SessionActiveThreshold is not 0 else None,
-            dataModelRevision=sessionParametersStruct.DataModelRevision if sessionParametersStruct.DataModelRevision is not 0 else None,
-            interactionModelRevision=sessionParametersStruct.InteractionModelRevision if sessionParametersStruct.InteractionModelRevision is not 0 else None,
-            speficiationVersion=sessionParametersStruct.SpeficiationVersion if sessionParametersStruct.SpeficiationVersion is not 0 else None,
+            sessionIdleInterval=sessionParametersStruct.SessionIdleInterval if sessionParametersStruct.SessionIdleInterval != 0 else None,
+            sessionActiveInterval=sessionParametersStruct.SessionActiveInterval if sessionParametersStruct.SessionActiveInterval != 0 else None,
+            sessionActiveThreshold=sessionParametersStruct.SessionActiveThreshold if sessionParametersStruct.SessionActiveThreshold != 0 else None,
+            dataModelRevision=sessionParametersStruct.DataModelRevision if sessionParametersStruct.DataModelRevision != 0 else None,
+            interactionModelRevision=sessionParametersStruct.InteractionModelRevision if sessionParametersStruct.InteractionModelRevision != 0 else None,
+            specficiationVersion=sessionParametersStruct.SpecificationVersion if sessionParametersStruct.SpecificationVersion != 0 else None,
             maxPathsPerInvoke=sessionParametersStruct.MaxPathsPerInvoke)
 
         return res

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -808,7 +808,6 @@ class ChipDeviceControllerBase():
         res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_ComputeRoundTripTimeout(
             device.deviceProxy, upperLayerProcessingTimeoutMs))
         return res
-    
 
     def GetMaxPathsPerInvoke(self, nodeid) -> int:
         ''' Returns the Max Paths Per Invoke supported by remote node associated with `nodeid`
@@ -819,7 +818,6 @@ class ChipDeviceControllerBase():
         res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_GetMaxPathsPerInvoke(
             device.deviceProxy))
         return res
-
 
     async def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(self, nodeid: int, endpoint: int,
                                                                    payload: ClusterObjects.ClusterCommand, responseType=None):

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -26,10 +26,12 @@ import enum
 
 from chip.exceptions import ChipStackException
 
-from .delegate import AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct, EventPath, EventPathIBstruct
+from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct,
+                       EventPath, EventPathIBstruct, SessionParameters, SessionParametersStruct)
 
 __all__ = ["AttributePath", "AttributePathIBstruct", "DataVersionFilterIBstruct",
-           "EventPath", "EventPathIBstruct", "Status", "InteractionModelError"]
+           "EventPath", "EventPathIBstruct", "InteractionModelError",
+           "SessionParameters", "SessionParametersStruct", "Status"]
 
 
 # defined src/controller/python/chip/interaction_model/Delegate.h

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -26,8 +26,8 @@ import enum
 
 from chip.exceptions import ChipStackException
 
-from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct,
-                       EventPath, EventPathIBstruct, SessionParameters, SessionParametersStruct)
+from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct, EventPath, EventPathIBstruct,
+                       SessionParameters, SessionParametersStruct)
 
 __all__ = ["AttributePath", "AttributePathIBstruct", "DataVersionFilterIBstruct",
            "EventPath", "EventPathIBstruct", "InteractionModelError",

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -69,6 +69,16 @@ DataVersionFilterIBstruct = Struct(
     "DataVersion" / Int32ul,
 )
 
+SessionParametersStruct = Struct(
+    "SessionIdleInterval" / Int32ul,
+    "SessionActiveInterval" / Int32ul,
+    "SessionActiveThreshold" / Int16ul,
+    "DataModelRevision" / Int16ul,
+    "InteractionModelRevision" / Int16ul,
+    "SpeficiationVersion" / Int32ul,
+    "MaxPathsPerInvoke" / Int16ul,
+)
+
 
 @dataclass
 class AttributePath:
@@ -105,6 +115,17 @@ class EventReadResult:
 class AttributeWriteResult:
     path: AttributePath
     status: int
+
+
+@dataclass
+class SessionParameters:
+    sessionIdleInterval: typing.Optional[int]
+    sessionActiveInterval: typing.Optional[int]
+    sessionActiveThreshold: typing.Optional[int]
+    dataModelRevision: typing.Optional[int]
+    interactionModelRevision: typing.Optional[int]
+    speficiationVersion: typing.Optional[int]
+    maxPathsPerInvoke: int
 
 
 # typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -75,7 +75,7 @@ SessionParametersStruct = Struct(
     "SessionActiveThreshold" / Int16ul,
     "DataModelRevision" / Int16ul,
     "InteractionModelRevision" / Int16ul,
-    "SpeficiationVersion" / Int32ul,
+    "SpecificationVersion" / Int32ul,
     "MaxPathsPerInvoke" / Int16ul,
 )
 
@@ -124,7 +124,7 @@ class SessionParameters:
     sessionActiveThreshold: typing.Optional[int]
     dataModelRevision: typing.Optional[int]
     interactionModelRevision: typing.Optional[int]
-    speficiationVersion: typing.Optional[int]
+    specficiationVersion: typing.Optional[int]
     maxPathsPerInvoke: int
 
 

--- a/src/controller/python/chip/utils/DeviceProxyUtils.cpp
+++ b/src/controller/python/chip/utils/DeviceProxyUtils.cpp
@@ -42,7 +42,7 @@ struct __attribute__((packed)) SessionParametersStruct
     uint16_t sessionActiveThreshold   = 0;
     uint16_t dataModelRevision        = 0;
     uint16_t interactionModelRevision = 0;
-    uint32_t speficiationVersion      = 0;
+    uint32_t specificationVersion     = 0;
     uint16_t maxPathsPerInvoke        = 0;
 };
 
@@ -97,7 +97,7 @@ PyChipError pychip_DeviceProxy_GetRemoteSessionParameters(DeviceProxy * device, 
     sessionParam->sessionActiveThreshold   = remoteMrpConfig.mActiveThresholdTime.count();
     sessionParam->dataModelRevision        = remoteSessionParameters.GetDataModelRevision().ValueOr(0);
     sessionParam->interactionModelRevision = remoteSessionParameters.GetInteractionModelRevision().ValueOr(0);
-    sessionParam->speficiationVersion      = remoteSessionParameters.GetSpecificationVersion().ValueOr(0);
+    sessionParam->specificationVersion     = remoteSessionParameters.GetSpecificationVersion().ValueOr(0);
     sessionParam->maxPathsPerInvoke        = remoteSessionParameters.GetMaxPathsPerInvoke();
     return ToPyChipError(CHIP_NO_ERROR);
 }

--- a/src/controller/python/chip/utils/DeviceProxyUtils.cpp
+++ b/src/controller/python/chip/utils/DeviceProxyUtils.cpp
@@ -59,4 +59,23 @@ uint32_t pychip_DeviceProxy_ComputeRoundTripTimeout(DeviceProxy * device, uint32
         ->ComputeRoundTripTimeout(System::Clock::Milliseconds32(upperLayerProcessingTimeoutMs))
         .count();
 }
+
+/**
+ * @brief
+ *
+ * This gets the MaxPathsPerInvoke supported by remote node.
+ *
+ * A valid DeviceProxy pointer with a valid, established session is required for this method.
+ */
+uint16_t pychip_DeviceProxy_GetMaxPathsPerInvoke(DeviceProxy * device, uint32_t upperLayerProcessingTimeoutMs)
+{
+    VerifyOrDie(device != nullptr);
+
+    auto * deviceProxy = static_cast<DeviceProxy *>(device);
+    VerifyOrDie(deviceProxy->GetSecureSession().HasValue());
+
+    auto remoteSessionParameters = deviceProxy->GetSecureSession().Value()->GetRemoteSessionParameters();
+
+    return remoteSessionParameters.GetMaxPathsPerInvoke();
+}
 }


### PR DESCRIPTION
TC-IDM-1.4 will require this to determine what test steps to run.

Tests:
* Confirmed it was able to read the correct value compiled into the locally running all-cluster app. Command ran was `devCtrl.GetRemoteSessionParameters(0x12344321)`