### PR TITLE
ESP32: Add a menuconfig option to enable/disable persist subscription

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -185,6 +185,12 @@ if ((CONFIG_BT_ENABLED) AND (CONFIG_ENABLE_CHIPOBLE))
         endif()
 endif()
 
+if (CONFIG_ENABLE_PERSIST_SUBSCRIPTIONS)
+    chip_gn_arg_append("chip_persist_subscriptions"                 "true")
+else()
+    chip_gn_arg_append("chip_persist_subscriptions"                 "false")
+endif()
+
 if (CONFIG_ENABLE_ESP32_BLE_CONTROLLER)
     chip_gn_arg_append("chip_enable_ble_controller"             "true")
 endif()

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -132,7 +132,7 @@ menu "CHIP Core"
 
         config ENABLE_PERSIST_SUBSCRIPTIONS
             bool "Enable persist subscriptions"
-            default n
+            default y
             help
                 Enable persist subscriptions to make the device resume the subscriptions from the persist
                 subscriptions information after reboot.

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -130,6 +130,13 @@ menu "CHIP Core"
             help
                 Some device types don't require the read client. Enabling this option may save some flash/ram.
 
+        config ENABLE_PERSIST_SUBSCRIPTIONS
+            bool "Enable persist subscriptions"
+            default n
+            help
+                Enable persist subscriptions to make the device resume the subscriptions from the persist
+                subscriptions information after reboot.
+
         config BUILD_CHIP_TESTS
             bool "Build CHIP tests"
             default n

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -108,8 +108,8 @@ declare_args() {
 
   # Enable Subscription persistence / resumption for CI and supported platforms
   if (chip_device_platform == "darwin" || chip_device_platform == "linux" ||
-      chip_device_platform == "esp32" || chip_device_platform == "fake" ||
-      chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
+      chip_device_platform == "fake" || chip_device_platform == "efr32" ||
+      chip_device_platform == "SiWx917") {
     chip_persist_subscriptions = true
   } else {
     chip_persist_subscriptions = false


### PR DESCRIPTION
Add a menuconfig option to enable/disable persist subscription for ESP32.
