### PR TITLE
[NXP] Remove circular dependency on application code in platform file ConfigurationManagerImpl.cpp

### DIFF
--- a/examples/all-clusters-app/nxp/common/main/AppTask.cpp
+++ b/examples/all-clusters-app/nxp/common/main/AppTask.cpp
@@ -473,5 +473,7 @@ void AppTask::SwitchCommissioningStateHandler(void)
 
 void AppTask::FactoryResetHandler(void)
 {
-    ConfigurationMgr().InitiateFactoryReset();
+    /* Emit the ShutDown event before factory reset */
+    chip::Server::GetInstance().GenerateShutDownEvent();
+    chip::Server::GetInstance().ScheduleFactoryReset();
 }

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -27,7 +27,6 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include "NXPConfig.h"
-#include <app/server/Server.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
@@ -148,12 +147,7 @@ bool ConfigurationManagerImpl::CanFactoryReset()
 
 void ConfigurationManagerImpl::InitiateFactoryReset()
 {
-    PlatformMgr().ScheduleWork([](intptr_t) {
-        // Emit ShutDown event and delete all fabrics.
-        PlatformMgr().HandleServerShuttingDown();
-        Server::GetInstance().GetFabricTable().DeleteAllFabrics();
-        DoFactoryReset(0);
-    });
+    PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,


### PR DESCRIPTION
The aim of this PR is to fix #30599 layering inversion issue in 'src/platform/nxp/common/ConfigurationManagerImpl.cpp' , by removing the dependency on application code in the platform file.
