### PR TITLE
ESP32: Update esp-idf to v5.1.2

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-28 : [NXP] Add support for RW61x SDK
+29 : [ESP] Update esp-idf to v5.1.2

--- a/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v5.1.1 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v5.1.2 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}


### PR DESCRIPTION
Upgrade to ESP-IDF release v5.1.2

Tests:
i. Compilation of all-clusters-app
ii. Commissioning and cluster control using chip-tool

