### PR TITLE
Revert "Bump actions/labeler from 4 to 5 (#30911)"

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit e15db829cde4a484a283c0e935df4738f572bb4c.

Upgrade from 4 to 5 is a breaking change in config file format.

https://github.com/actions/labeler?tab=readme-ov-file#breaking-changes-in-v5