### PR TITLE
[ICD] Add Hmac Key handle to ICDCheckInSender to support PSA backend

### DIFF
--- a/examples/lit-icd-app/silabs/src/ShellCommands.cpp
+++ b/examples/lit-icd-app/silabs/src/ShellCommands.cpp
@@ -18,9 +18,6 @@
 #if defined(ENABLE_CHIP_SHELL)
 
 #include "ShellCommands.h"
-#include "BindingHandler.h"
-
-#include <app/clusters/bindings/bindings.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/commands/Help.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -81,6 +81,7 @@ source_set("sender") {
   ]
 
   public_deps = [
+    ":configuration-data",
     ":monitoring-table",
     ":notifier",
     "${chip_root}/src/credentials:credentials",

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -53,7 +53,7 @@ void ICDCheckInSender::OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP
 
 CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
 {
-    System::PacketBufferHandle buffer = MessagePacketBuffer::New(CheckinMessage::sMinPayloadSize);
+    System::PacketBufferHandle buffer = MessagePacketBuffer::New(CheckinMessage::kMinPayloadSize);
 
     VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
     MutableByteSpan output{ buffer->Start(), buffer->MaxDataLength() };

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -15,15 +15,12 @@
  *    limitations under the License.
  */
 
-#include "ICDCheckInSender.h"
-
-#include "ICDNotifier.h"
-
-#include <system/SystemPacketBuffer.h>
-
-#include <protocols/secure_channel/CheckinMessage.h>
-
+#include <app/icd/ICDCheckInSender.h>
+#include <app/icd/ICDConfigurationData.h>
+#include <app/icd/ICDNotifier.h>
 #include <lib/dnssd/Resolver.h>
+#include <protocols/secure_channel/CheckinMessage.h>
+#include <system/SystemPacketBuffer.h>
 
 namespace chip {
 namespace app {
@@ -61,7 +58,13 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
     MutableByteSpan output{ buffer->Start(), buffer->MaxDataLength() };
 
-    ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mAesKeyHandle, mICDCounter, ByteSpan(), output));
+    // Encoded ActiveModeThreshold in littleEndian for Check-In message application data
+    uint8_t activeModeThresholdBuffer[2] = {};
+    ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
+    Encoding::LittleEndian::Put16((uint8_t *) activeModeThresholdByteSpan.data(), ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
+
+    ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mAes128KeyHandle, mHmac128KeyHandle, mICDCounter,
+                                                                       activeModeThresholdByteSpan, output));
     buffer->SetDataLength(static_cast<uint16_t>(output.size()));
 
     VerifyOrReturnError(mExchangeManager->GetSessionManager() != nullptr, CHIP_ERROR_INTERNAL);
@@ -89,8 +92,11 @@ CHIP_ERROR ICDCheckInSender::RequestResolve(ICDMonitoringEntry & entry, FabricTa
 
     AddressResolve::NodeLookupRequest request(peerId);
 
-    memcpy(mAesKeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
+    memcpy(mAes128KeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
            entry.aesKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
+
+    memcpy(mHmac128KeyHandle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(),
+           entry.hmacKeyHandle.As<Crypto::Symmetric128BitsKeyByteArray>(), sizeof(Crypto::Symmetric128BitsKeyByteArray));
 
     CHIP_ERROR err = AddressResolve::Resolver::Instance().LookupNode(request, mAddressLookupHandle);
 

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     MutableByteSpan output{ buffer->Start(), buffer->MaxDataLength() };
 
     // Encoded ActiveModeThreshold in littleEndian for Check-In message application data
-    uint8_t activeModeThresholdBuffer[2] = {};
+    uint8_t activeModeThresholdBuffer[kApplicationDataSize] = { 0 };
     Encoding::LittleEndian::Put16(activeModeThresholdBuffer, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
     ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
 

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -60,9 +60,9 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
 
     // Encoded ActiveModeThreshold in littleEndian for Check-In message application data
     uint8_t activeModeThresholdBuffer[2] = {};
-    ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
-    Encoding::LittleEndian::Put16((uint8_t *) activeModeThresholdByteSpan.data(),
+    Encoding::LittleEndian::Put16(activeModeThresholdBuffer,
                                   ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
+    ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
 
     ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mAes128KeyHandle, mHmac128KeyHandle, mICDCounter,
                                                                        activeModeThresholdByteSpan, output));

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -60,8 +60,7 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
 
     // Encoded ActiveModeThreshold in littleEndian for Check-In message application data
     uint8_t activeModeThresholdBuffer[2] = {};
-    Encoding::LittleEndian::Put16(activeModeThresholdBuffer,
-                                  ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
+    Encoding::LittleEndian::Put16(activeModeThresholdBuffer, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
     ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
 
     ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mAes128KeyHandle, mHmac128KeyHandle, mICDCounter,

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -61,7 +61,8 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     // Encoded ActiveModeThreshold in littleEndian for Check-In message application data
     uint8_t activeModeThresholdBuffer[2] = {};
     ByteSpan activeModeThresholdByteSpan(activeModeThresholdBuffer);
-    Encoding::LittleEndian::Put16((uint8_t *) activeModeThresholdByteSpan.data(), ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
+    Encoding::LittleEndian::Put16((uint8_t *) activeModeThresholdByteSpan.data(),
+                                  ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
 
     ReturnErrorOnFailure(CheckinMessage::GenerateCheckinMessagePayload(mAes128KeyHandle, mHmac128KeyHandle, mICDCounter,
                                                                        activeModeThresholdByteSpan, output));

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR ICDCheckInSender::SendCheckInMsg(const Transport::PeerAddress & addr)
     {
         uint8_t activeModeThresholdBuffer[kApplicationDataSize] = { 0 };
         size_t writtenBytes                                     = 0;
-        Encoding::LittleEndian::BufferWriter writer(activeModeThresholdBuffer, kApplicationDataSize);
+        Encoding::LittleEndian::BufferWriter writer(activeModeThresholdBuffer, sizeof(activeModeThresholdBuffer));
 
         writer.Put16(ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
         VerifyOrReturnError(writer.Fit(writtenBytes), CHIP_ERROR_INTERNAL);

--- a/src/app/icd/ICDCheckInSender.h
+++ b/src/app/icd/ICDCheckInSender.h
@@ -50,7 +50,8 @@ private:
 
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 
-    Crypto::Aes128KeyHandle mAesKeyHandle = Crypto::Aes128KeyHandle();
+    Crypto::Aes128KeyHandle mAes128KeyHandle   = Crypto::Aes128KeyHandle();
+    Crypto::Hmac128KeyHandle mHmac128KeyHandle = Crypto::Hmac128KeyHandle();
 
     uint32_t mICDCounter = 0;
 };

--- a/src/app/icd/ICDCheckInSender.h
+++ b/src/app/icd/ICDCheckInSender.h
@@ -43,6 +43,8 @@ public:
     bool mResolveInProgress = false;
 
 private:
+    static constexpr uint8_t kApplicationDataSize = 2; // ActiveModeThreshold is 2 bytes
+
     CHIP_ERROR SendCheckInMsg(const Transport::PeerAddress & addr);
 
     // This is used when a node address is required.

--- a/src/app/icd/ICDConfigurationData.cpp
+++ b/src/app/icd/ICDConfigurationData.cpp
@@ -28,9 +28,9 @@ System::Clock::Milliseconds32 ICDConfigurationData::GetSlowPollingInterval()
     // When in SIT mode, the slow poll interval SHOULDN'T be greater than the SIT mode polling threshold, per spec.
     // This is important for ICD device configured for LIT operation but currently operating as a SIT
     // due to a lack of client registration
-    if (mICDMode == ICDMode::SIT && GetSlowPollingInterval() > GetSITPollingThreshold())
+    if (mICDMode == ICDMode::SIT && mSlowPollingInterval > kSITPollingThreshold)
     {
-        return GetSITPollingThreshold();
+        return kSITPollingThreshold;
     }
 #endif
     return mSlowPollingInterval;

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -275,15 +275,6 @@ void ICDManager::UpdateOperationState(OperationalState state)
 
         System::Clock::Milliseconds32 slowPollInterval = ICDConfigurationData::GetInstance().GetSlowPollingInterval();
 
-#if ICD_ENFORCE_SIT_SLOW_POLL_LIMIT
-        // When in SIT mode, the slow poll interval SHOULDN'T be greater than the SIT mode polling threshold, per spec.
-        if (ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT &&
-            GetSlowPollingInterval() > GetSITPollingThreshold())
-        {
-            slowPollInterval = GetSITPollingThreshold();
-        }
-#endif
-
         // Going back to Idle, all Check-In messages are sent
         mICDSenderPool.ReleaseAll();
 

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
                                                        MutableByteSpan & output)
 {
     VerifyOrReturnError(output.size() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_INVALID_ARGUMENT);
-    
+
     uint8_t nonceWorkBuffer[CHIP_CRYPTO_HASH_LEN_BYTES] = { 0 };
 
     chip::Crypto::HMAC_sha shaHandler;

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -35,7 +35,7 @@ CHIP_ERROR CheckinMessage::GenerateCheckinMessagePayload(const Crypto::Aes128Key
                                                          const CounterType & counter, const ByteSpan & appData,
                                                          MutableByteSpan & output)
 {
-    VerifyOrReturnError(output.size() >= (appData.size() + sMinPayloadSize), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(output.size() >= (appData.size() + sMinPayloadSize), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     CHIP_ERROR err            = CHIP_NO_ERROR;
     uint8_t * appDataStartPtr = output.data() + CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES;
@@ -61,13 +61,13 @@ CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(const Crypto::Aes128KeyHan
                                                       const Crypto::Hmac128KeyHandle & hmacKeyHandle, ByteSpan & payload,
                                                       CounterType & counter, MutableByteSpan & appData)
 {
-    VerifyOrReturnError(payload.size() >= sMinPayloadSize, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(payload.size() >= sMinPayloadSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     CHIP_ERROR err     = CHIP_NO_ERROR;
     size_t appDataSize = GetAppDataSize(payload);
 
     // To prevent workbuffer usage, appData size needs to be large enough to hold both the appData and the counter
-    VerifyOrReturnError(appData.size() >= sizeof(CounterType) + appDataSize, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(appData.size() >= sizeof(CounterType) + appDataSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     ByteSpan nonce         = payload.SubSpan(0, CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES);
     ByteSpan encryptedData = payload.SubSpan(CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, sizeof(CounterType) + appDataSize);
@@ -89,7 +89,7 @@ CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(const Crypto::Aes128KeyHan
 CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
                                                        MutableByteSpan & output)
 {
-    VerifyOrReturnError(output.size() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(output.size() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     uint8_t nonceWorkBuffer[CHIP_CRYPTO_HASH_LEN_BYTES] = { 0 };
 

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -47,17 +47,17 @@ public:
      * @brief Generate Check-in Message payload
      *
      * @note Function requires two key handles to generate the Check-In message.
-     *       Due to PSA requirements, the same key handle cannot be used for AES-CCM and HMAC-SHA-256 operations.
+     *       Due to the way some key stores work, the same key handle cannot be used for AES-CCM and HMAC-SHA-256 operations.
      *
-     * @param[in]  aes128KeyHandle   Key handle with which to encrypt the check-in payload with the AEAD
-     * @param[in]  hmac128KeyHandle  Key handle with which to generate the nonce the check-in payload with the HMAC
+     * @param[in]  aes128KeyHandle   Key handle with which to encrypt the check-in payload (using AEAD).
+     * @param[in]  hmac128KeyHandle  Key handle with which to generate the nonce for the check-in payload (using HMAC).
      * @param[in]  counter           Check-in counter
      * @param[in]  appData           Application Data to incorporate within the Check-in message. Allowed to be empty.
      * @param[out] output            Buffer in Which to store the generated payload. SUFFICIENT SPACE MUST BE ALLOCATED by the
      *                               caller Required Buffer Size is : GetCheckinPayloadSize(appData.size())
      *
      * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
-     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to generate the Check-In message
+     *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message
      */
     static CHIP_ERROR GenerateCheckinMessagePayload(const Crypto::Aes128KeyHandle & aes128KeyHandle,
                                                     const Crypto::Hmac128KeyHandle & hmacKeyHandle, const CounterType & counter,
@@ -73,13 +73,14 @@ public:
      * @param[in]       hmac128KeyHandle  Key handle with which to generate the nonce for the check-in payload with the HMAC
      * @param[in]       payload           The received payload to decrypt and parse
      * @param[out]      counter           The counter value retrieved from the payload
-     * @param[in,out]   appData           The optional application data decrypted. The size of appData must be at least the size of
-     *                                    GetAppDataSize(payload) + sizeof(CounterType).
-     *                                    appData is used as a work buffer for the decryption process
+     * @param[in,out]   appData           The optional application data decrypted. The input size of appData must be at least the size of
+     *                                    GetAppDataSize(payload) + sizeof(CounterType), because
+     *                                    appData is used as a work buffer for the decryption process.  The output size
+     *                                    on success will be GetAppDataSize(payload).
      *
      * @return CHIP_ERROR_INVALID_MESSAGE_LENGTH if the payload is shorter than the minimum payload size
      *         CHIP_ERROR_BUFFER_TOO_SMALL if appData buffer is too small
-     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to parse the Check-In message
+     *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to parse the Check-In message
      */
     static CHIP_ERROR ParseCheckinMessagePayload(const Crypto::Aes128KeyHandle & aes128KeyHandle,
                                                  const Crypto::Hmac128KeyHandle & hmacKeyHandle, ByteSpan & payload,
@@ -109,7 +110,7 @@ private:
      *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
      *
      * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
-     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to generate the Check-In message Nonce
+     *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message Nonce
      */
     static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
                                                   Encoding::LittleEndian::BufferWriter & writer);

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -76,7 +76,8 @@ public:
      *                                    GetAppDataSize(payload) + sizeof(CounterType).
      *                                    appData is used as a work buffer for the decryption process
      *
-     * @return CHIP_ERROR_BUFFER_TOO_SMALL if appData buffer is too small
+     * @return CHIP_ERROR_INVALID_MESSAGE_LENGTH if the payload is shorter than the minimum payload size
+     *         CHIP_ERROR_BUFFER_TOO_SMALL if appData buffer is too small
      *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to parse the Check-In message
      */
     static CHIP_ERROR ParseCheckinMessagePayload(const Crypto::Aes128KeyHandle & aes128KeyHandle,
@@ -110,7 +111,7 @@ private:
      *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to generate the Check-In message Nonce
      */
     static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
-                                                  MutableByteSpan & output);
+                                                  Encoding::LittleEndian::BufferWriter & writer);
 };
 
 } // namespace SecureChannel

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -53,8 +53,10 @@ public:
      * @param[in]  counter           Check-in counter
      * @param[in]  appData           Application Data to incorporate within the Check-in message. Allowed to be empty.
      * @param[out] output            Buffer in Which to store the generated payload. SUFFICIENT SPACE MUST BE ALLOCATED by the
-     * caller Required Buffer Size is : GetCheckinPayloadSize(appData.size())
-     * @return CHIP_ERROR
+     *                               caller Required Buffer Size is : GetCheckinPayloadSize(appData.size())
+     *
+     * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
+     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to generate the Check-In message
      */
     static CHIP_ERROR GenerateCheckinMessagePayload(const Crypto::Aes128KeyHandle & aes128KeyHandle,
                                                     const Crypto::Hmac128KeyHandle & hmacKeyHandle, const CounterType & counter,
@@ -73,7 +75,9 @@ public:
      * @param[in,out]   appData           The optional application data decrypted. The size of appData must be at least the size of
      *                                    GetAppDataSize(payload) + sizeof(CounterType).
      *                                    appData is used as a work buffer for the decryption process
-     * @return CHIP_ERROR
+     *
+     * @return CHIP_ERROR_BUFFER_TOO_SMALL if appData buffer is too small
+     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to parse the Check-In message
      */
     static CHIP_ERROR ParseCheckinMessagePayload(const Crypto::Aes128KeyHandle & aes128KeyHandle,
                                                  const Crypto::Hmac128KeyHandle & hmacKeyHandle, ByteSpan & payload,
@@ -101,7 +105,9 @@ private:
      * @param[out]  output        output buffer for the generated Nonce.
      *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
      *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
-     * @return CHIP_ERROR
+     *
+     * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
+     *         CHIP_ERROR_INVALID_ARGUMENTS if the provide arguments cannot be used to generate the Check-In message Nonce
      */
     static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
                                                   MutableByteSpan & output);

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/Span.h>
 #include <stdint.h>
 

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -62,7 +62,7 @@ public:
 
     /**
      * @brief Parse Check-in Message payload
-     * 
+     *
      * @note Function requires two key handles to generate the Check-In message.
      *       Due to PSA requirements, the same key handle cannot be used for AES-CCM and HMAC-SHA-256 operations.
      *
@@ -96,13 +96,13 @@ private:
 
     /**
      * @brief Generate the Nonce for the Check-In message
-     * 
+     *
      * @param[in]   hmacKeyHandle Key handle to use with the HMAC algorithm
      * @param[in]   counter       Check-In Counter value to use as message of the HMAC algorithm
      * @param[out]  output        output buffer for the generated Nonce.
      *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
-     *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES 
-     * @return CHIP_ERROR 
+     *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
+     * @return CHIP_ERROR
      */
     static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
                                                   MutableByteSpan & output);

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -93,7 +93,6 @@ public:
         CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
 
 private:
-
     /**
      * @brief Generate the Nonce for the Check-In message
      *

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -56,7 +56,7 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
     {
         const ccm_128_test_vector & test = *testPtr;
 
-        // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+        // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
         Symmetric128BitsKeyByteArray aesKeyMaterial;
         memcpy(aesKeyMaterial, test.key, test.key_len);
 

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -94,7 +94,7 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         uint8_t data[]                   = { "This is some user Data. It should be encrypted" };
         userData                         = chip::ByteSpan(data);
         const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
-        uint8_t gargantuaBuffer[2048]    = { 0 };
+        uint8_t veryLargeBuffer[2048]    = { 0 };
 
         // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
         Symmetric128BitsKeyByteArray aesKeyMaterial;
@@ -129,7 +129,7 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
 
         // Test output buffer smaller than the ApplicationData
-        userData = chip::ByteSpan(gargantuaBuffer, sizeof(gargantuaBuffer));
+        userData = chip::ByteSpan(veryLargeBuffer, sizeof(veryLargeBuffer));
         err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
         NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
 

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -126,12 +126,12 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         // Testing empty output buffer
         MutableByteSpan empty;
         err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, emptyData, empty);
-        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_INVALID_ARGUMENT == err));
+        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
 
-        // Test incorrect output buffer size
+        // Test output buffer smaller than the ApplicationData
         userData = chip::ByteSpan(gargantuaBuffer, sizeof(gargantuaBuffer));
         err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
-        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_INVALID_ARGUMENT == err));
+        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
 
         // Cleanup
         keystore.DestroyKey(aes128KeyHandle);

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -56,17 +56,24 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
     {
         const ccm_128_test_vector & test = *testPtr;
 
-        Symmetric128BitsKeyByteArray keyMaterial;
-        memcpy(keyMaterial, test.key, test.key_len);
+        // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+        Symmetric128BitsKeyByteArray aesKeyMaterial;
+        memcpy(aesKeyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
+        Symmetric128BitsKeyByteArray hmacKeyMaterial;
+        memcpy(hmacKeyMaterial, test.key, test.key_len);
+
+        Aes128KeyHandle aes128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+        Hmac128KeyHandle hmac128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
         // Validate that counter change, indeed changes the output buffer content
         counter = 0;
         for (uint8_t j = 0; j < 5; j++)
         {
-            err = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, userData, outputBuffer);
+            err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
             NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
             // Verifiy that the output buffer changed
@@ -77,21 +84,30 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
             counter += chip::Crypto::GetRandU32() + 1;
             outputBuffer = MutableByteSpan(a);
         }
-        keystore.DestroyKey(keyHandle);
+
+        keystore.DestroyKey(aes128KeyHandle);
+        keystore.DestroyKey(hmac128KeyHandle);
     }
 
     // Parameter check
     {
-        uint8_t data[]                                               = { "This is some user Data. It should be encrypted" };
-        userData                                                     = chip::ByteSpan(data);
-        const ccm_128_test_vector & test                             = *ccm_128_test_vectors[0];
-        uint8_t gargantuaBuffer[2 * CheckinMessage::sMaxAppDataSize] = { 0 };
+        uint8_t data[]                   = { "This is some user Data. It should be encrypted" };
+        userData                         = chip::ByteSpan(data);
+        const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
+        uint8_t gargantuaBuffer[2048]    = { 0 };
 
-        Symmetric128BitsKeyByteArray keyMaterial;
-        memcpy(keyMaterial, test.key, test.key_len);
+        // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+        Symmetric128BitsKeyByteArray aesKeyMaterial;
+        memcpy(aesKeyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
+        Symmetric128BitsKeyByteArray hmacKeyMaterial;
+        memcpy(hmacKeyMaterial, test.key, test.key_len);
+
+        Aes128KeyHandle aes128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+        Hmac128KeyHandle hmac128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
         // As of now passing an empty key handle while using PSA crypto will result in a failure.
         // However when using OpenSSL this same test result in a success.
@@ -102,20 +118,24 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         // ChipLogError(Inet, "%s", err.AsString());
         // NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
+        // Testing empty application data
         ByteSpan emptyData;
-        err = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, emptyData, outputBuffer);
+        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, emptyData, outputBuffer);
         NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
+        // Testing empty output buffer
         MutableByteSpan empty;
-        err = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, emptyData, empty);
+        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, emptyData, empty);
         NL_TEST_ASSERT(inSuite, (CHIP_ERROR_INVALID_ARGUMENT == err));
 
+        // Test incorrect output buffer size
         userData = chip::ByteSpan(gargantuaBuffer, sizeof(gargantuaBuffer));
-        err      = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, userData, outputBuffer);
+        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
         NL_TEST_ASSERT(inSuite, (CHIP_ERROR_INVALID_ARGUMENT == err));
 
         // Cleanup
-        keystore.DestroyKey(keyHandle);
+        keystore.DestroyKey(aes128KeyHandle);
+        keystore.DestroyKey(hmac128KeyHandle);
     }
 }
 
@@ -137,27 +157,38 @@ void TestCheckin_Parse(nlTestSuite * inSuite, void * inContext)
     userData                         = chip::ByteSpan(data);
     const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
 
-    Symmetric128BitsKeyByteArray keyMaterial;
-    memcpy(keyMaterial, test.key, test.key_len);
+    // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+    Symmetric128BitsKeyByteArray aesKeyMaterial;
+    memcpy(aesKeyMaterial, test.key, test.key_len);
 
-    Aes128KeyHandle keyHandle;
-    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
+    Symmetric128BitsKeyByteArray hmacKeyMaterial;
+    memcpy(hmacKeyMaterial, test.key, test.key_len);
+
+    Aes128KeyHandle aes128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+    Hmac128KeyHandle hmac128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
     //=================Encrypt=======================
 
-    err              = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, userData, outputBuffer);
+    err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
     ByteSpan payload = chip::ByteSpan(outputBuffer.data(), outputBuffer.size());
     NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
     //=================Decrypt=======================
 
     MutableByteSpan empty;
-    err = CheckinMessage::ParseCheckinMessagePayload(keyHandle, payload, decryptedCounter, empty);
+    err = CheckinMessage::ParseCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, payload, decryptedCounter, empty);
     NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR != err));
 
     ByteSpan emptyPayload;
-    err = CheckinMessage::ParseCheckinMessagePayload(keyHandle, emptyPayload, decryptedCounter, buffer);
+    err = CheckinMessage::ParseCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, emptyPayload, decryptedCounter, buffer);
     NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR != err));
+
+    // Cleanup
+    keystore.DestroyKey(aes128KeyHandle);
+    keystore.DestroyKey(hmac128KeyHandle);
 }
 
 void TestCheckin_GenerateParse(nlTestSuite * inSuite, void * inContext)
@@ -180,22 +211,29 @@ void TestCheckin_GenerateParse(nlTestSuite * inSuite, void * inContext)
     {
         const ccm_128_test_vector & test = *testPtr;
 
-        Symmetric128BitsKeyByteArray keyMaterial;
-        memcpy(keyMaterial, test.key, test.key_len);
+        // Two disctint key material to force the PSA unit tests to create two different Key IDs
+        Symmetric128BitsKeyByteArray aesKeyMaterial;
+        memcpy(aesKeyMaterial, test.key, test.key_len);
 
-        Aes128KeyHandle keyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(keyMaterial, keyHandle));
+        Symmetric128BitsKeyByteArray hmacKeyMaterial;
+        memcpy(hmacKeyMaterial, test.key, test.key_len);
+
+        Aes128KeyHandle aes128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+        Hmac128KeyHandle hmac128KeyHandle;
+        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
         //=================Encrypt=======================
 
-        err = CheckinMessage::GenerateCheckinMessagePayload(keyHandle, counter, userData, outputBuffer);
+        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
         NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
         //=================Decrypt=======================
         uint32_t decryptedCounter = 0;
         ByteSpan payload          = chip::ByteSpan(outputBuffer.data(), outputBuffer.size());
 
-        err = CheckinMessage::ParseCheckinMessagePayload(keyHandle, payload, decryptedCounter, buffer);
+        err = CheckinMessage::ParseCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, payload, decryptedCounter, buffer);
         NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
 
         NL_TEST_ASSERT(inSuite, (memcmp(data, buffer.data(), sizeof(data)) == 0));
@@ -208,7 +246,10 @@ void TestCheckin_GenerateParse(nlTestSuite * inSuite, void * inContext)
         buffer       = MutableByteSpan(b);
 
         counter += chip::Crypto::GetRandU32() + 1;
-        keystore.DestroyKey(keyHandle);
+
+        // Cleanup
+        keystore.DestroyKey(aes128KeyHandle);
+        keystore.DestroyKey(hmac128KeyHandle);
     }
 }
 

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -96,7 +96,7 @@ void TestCheckin_Generate(nlTestSuite * inSuite, void * inContext)
         const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
         uint8_t gargantuaBuffer[2048]    = { 0 };
 
-        // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+        // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
         Symmetric128BitsKeyByteArray aesKeyMaterial;
         memcpy(aesKeyMaterial, test.key, test.key_len);
 
@@ -157,7 +157,7 @@ void TestCheckin_Parse(nlTestSuite * inSuite, void * inContext)
     userData                         = chip::ByteSpan(data);
     const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
 
-    // Two disctint key material buffers to force the PSA unit tests to create two different Key IDs
+    // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
     Symmetric128BitsKeyByteArray aesKeyMaterial;
     memcpy(aesKeyMaterial, test.key, test.key_len);
 


### PR DESCRIPTION
#### Description
PR adds the Hmac128KeyHandle to the Check-In message process to support PSA backend that does not allow the same key handle to be used for AES-CCM operations and HMAC operations.

- Add HmacKeyHandle to Check-In message process
- PR adds the ActiveModeThreshold value to the ICD Check-In message
- Fixes the `ICD_ENFORCE_SIT_SLOW_POLL_LIMIT` configuration flag (was broken with the introduction of the `ICDConfigurationData` class)
- FIxes a build issue for the Silabs Lit ICD app when matter shell is enabled

parly fixes https://github.com/project-chip/connectedhomeip/pull/30926
fixes #30886 

#### Notes to reviewers
The test don't validate the generation and parsing in depth. A follow up PR will be done to add more extensive test cases.
Follow up is necessary because the second implementation needs to be updated first.

#### Tests

- Updated Tests to validate Check-In message
- CI to validate regression
- Manual tests to validate the `ICD_ENFORCE_SIT_SLOW_POLL_LIMIT` configuration

