### PR TITLE
Linux tv-casting-app: simplified Endpoints APIs and post-connection flow

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -73,7 +73,10 @@ The Casting Client is expected to consume the Matter TV Casting library built
 for its respective platform which implements the APIs described in this
 document. Refer to the tv-casting-app READMEs for [Linux](linux/README.md),
 Android and [iOS](darwin/TvCasting/README.md) to understand how to build and
-consume each platform's specific libraries.
+consume each platform's specific libraries. The libraries MUST be built with the
+client's specific values for `CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID` and
+`CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID` updated in the
+[CHIPProjectAppConfig.h](tv-casting-common/include/CHIPProjectAppConfig.h) file.
 
 ### Initialize the Casting Client
 
@@ -474,11 +477,21 @@ to a `CastingPlayer`, once the Casting client has been commissioned by it. After
 that, the Casting client is able to skip the full UDC process by establishing
 CASE with the `CastingPlayer` directly. Once connected, the `CastingPlayer`
 object will contain the list of available Endpoints on that `CastingPlayer`.
+Optionally, the following arguments may also be passed in. The optional
+`commissioningWindowTimeoutSec` indicates how long to keep the commissioning
+window open, if commissioning is required. And `DesiredEndpointFilter` specifies
+the attributes, such as Vendor ID and Product ID of the `Endpoint`, the Casting
+client desires to interact with after connecting. This forces the Matter TV
+Casting library to go through the full UDC process in search of the desired
+Endpoint, in cases where it is not available in the Casting client's cache.
 
 On Linux, the Casting Client can connect to a `CastingPlayer` by successfully
 calling `VerifyOrEstablishConnection` on it.
 
 ```c
+
+const uint16_t kDesiredEndpointVendorId = 65521;
+
 void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer)
 {
     ChipLogProgress(AppServer, "ConnectionHandler called with %" CHIP_ERROR_FORMAT, err.Format());
@@ -486,7 +499,11 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
 
 ...
 // targetCastingPlayer is a discovered CastingPlayer
-targetCastingPlayer->VerifyOrEstablishConnection(ConnectionHandler);
+matter::casting::core::EndpointFilter desiredEndpointFilter;
+desiredEndpointFilter.vendorId = kDesiredEndpointVendorId;
+targetCastingPlayer->VerifyOrEstablishConnection(ConnectionHandler,
+                                                    matter::casting::core::kCommissioningWindowTimeoutSec,
+                                                    desiredEndpointFilter);
 ...
 ```
 

--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -38,8 +38,8 @@ Commissioner. In the context of the
 [Matter Video Player architecture](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/VideoPlayerArchitecture.adoc),
 a `CastingPlayer` would map to
 [Casting "Video" Player](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/VideoPlayerArchitecture.adoc#1-introduction).
-The `CastingPlayer` is expected to be hosting one or more `Endpoints` (similar
-to
+The `CastingPlayer` is expected to be hosting one or more `Endpoints` (some of
+which can represent
 [Content Apps](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/VideoPlayerArchitecture.adoc#1-introduction)
 in the Matter Video Player architecture) that support one or more Matter Media
 `Clusters`.

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -16,6 +16,8 @@
  */
 #include "simple-app-helper.h"
 
+#include "clusters/ContentLauncherCluster.h"
+
 #include "app/clusters/bindings/BindingManager.h"
 #include <inttypes.h>
 #include <lib/core/CHIPCore.h>
@@ -26,6 +28,9 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+
+// VendorId of the Endpoint on the CastingPlayer that the CastingApp desires to interact with after connection
+const uint16_t kDesiredEndpointVendorId = 65521;
 
 DiscoveryDelegateImpl * DiscoveryDelegateImpl::_discoveryDelegateImpl = nullptr;
 
@@ -102,7 +107,11 @@ CHIP_ERROR CommandHandler(int argc, char ** argv)
         VerifyOrReturnValue(0 <= index && index < castingPlayers.size(), CHIP_ERROR_INVALID_ARGUMENT,
                             ChipLogError(AppServer, "Invalid casting player index provided: %lu", index));
         std::shared_ptr<matter::casting::core::CastingPlayer> targetCastingPlayer = castingPlayers.at(index);
-        targetCastingPlayer->VerifyOrEstablishConnection(ConnectionHandler);
+
+        matter::casting::core::EndpointFilter desiredEndpointFilter;
+        desiredEndpointFilter.vendorId = kDesiredEndpointVendorId;
+        targetCastingPlayer->VerifyOrEstablishConnection(ConnectionHandler, matter::casting::core::kCommissioningWindowTimeoutSec,
+                                                         desiredEndpointFilter);
         return CHIP_NO_ERROR;
     }
     if (strcmp(argv[0], "print-bindings") == 0)

--- a/examples/tv-casting-app/linux/simple-app-helper.h
+++ b/examples/tv-casting-app/linux/simple-app-helper.h
@@ -21,7 +21,6 @@
 #include "core/CastingPlayer.h"
 #include "core/CastingPlayerDiscovery.h"
 #include "core/Types.h"
-
 #include <platform/CHIPDeviceLayer.h>
 
 /**

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -93,12 +93,18 @@ chip_data_model("tv-casting-common") {
 
   # Add simplified casting API files here
   sources += [
+    "clusters/ContentLauncherCluster.h",
+    "clusters/MediaPlaybackCluster.h",
+    "clusters/TargetNavigatorCluster.h",
+    "core/Attribute.h",
     "core/CastingApp.cpp",
     "core/CastingApp.h",
     "core/CastingPlayer.cpp",
     "core/CastingPlayer.h",
     "core/CastingPlayerDiscovery.cpp",
     "core/CastingPlayerDiscovery.h",
+    "core/Cluster.h",
+    "core/Endpoint.h",
     "core/Types.h",
     "support/AppParameters.h",
     "support/CastingStore.cpp",
@@ -106,6 +112,8 @@ chip_data_model("tv-casting-common") {
     "support/ChipDeviceEventHandler.cpp",
     "support/ChipDeviceEventHandler.h",
     "support/DataProvider.h",
+    "support/EndpointListLoader.cpp",
+    "support/EndpointListLoader.h",
   ]
 
   deps = [

--- a/examples/tv-casting-app/tv-casting-common/clusters/ContentLauncherCluster.h
+++ b/examples/tv-casting-app/tv-casting-common/clusters/ContentLauncherCluster.h
@@ -18,40 +18,27 @@
 
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include "core/Endpoint.h"
+#include "core/Types.h"
 
-#include <cstdint>
-#include <memory>
+#include "lib/support/logging/CHIPLogging.h"
 
 namespace matter {
 namespace casting {
+namespace clusters {
 
-namespace memory {
+class ContentLauncherCluster : public core::BaseCluster
+{
+private:
+protected:
+public:
+    ContentLauncherCluster(memory::Weak<core::Endpoint> endpoint) : core::BaseCluster(endpoint) {}
 
-template <typename T>
-using Weak = std::weak_ptr<T>;
+    // TODO:
+    // LaunchURL(const char * contentUrl, const char * contentDisplayStr,
+    //       chip::Optional<chip::app::Clusters::ContentLauncher::Structs::BrandingInformationStruct::Type> brandingInformation);
+};
 
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
-namespace core {
-
-class CastingApp;
-
-}; // namespace core
-
-namespace support {
-
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
-
-class EndpointListLoader;
-
-} // namespace support
-
+}; // namespace clusters
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/clusters/MediaPlaybackCluster.h
+++ b/examples/tv-casting-app/tv-casting-common/clusters/MediaPlaybackCluster.h
@@ -18,40 +18,25 @@
 
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include "core/Endpoint.h"
+#include "core/Types.h"
 
-#include <cstdint>
-#include <memory>
+#include "lib/support/logging/CHIPLogging.h"
 
 namespace matter {
 namespace casting {
+namespace clusters {
 
-namespace memory {
+class MediaPlaybackCluster : public core::BaseCluster
+{
+private:
+protected:
+public:
+    MediaPlaybackCluster(memory::Weak<core::Endpoint> endpoint) : core::BaseCluster(endpoint) {}
 
-template <typename T>
-using Weak = std::weak_ptr<T>;
+    // TODO: add commands
+};
 
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
-namespace core {
-
-class CastingApp;
-
-}; // namespace core
-
-namespace support {
-
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
-
-class EndpointListLoader;
-
-} // namespace support
-
+}; // namespace clusters
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/clusters/TargetNavigatorCluster.h
+++ b/examples/tv-casting-app/tv-casting-common/clusters/TargetNavigatorCluster.h
@@ -18,40 +18,25 @@
 
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include "core/Endpoint.h"
+#include "core/Types.h"
 
-#include <cstdint>
-#include <memory>
+#include "lib/support/logging/CHIPLogging.h"
 
 namespace matter {
 namespace casting {
+namespace clusters {
 
-namespace memory {
+class TargetNavigatorCluster : public core::BaseCluster
+{
+private:
+protected:
+public:
+    TargetNavigatorCluster(memory::Weak<core::Endpoint> endpoint) : core::BaseCluster(endpoint) {}
 
-template <typename T>
-using Weak = std::weak_ptr<T>;
+    // TODO: add commands
+};
 
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
-namespace core {
-
-class CastingApp;
-
-}; // namespace core
-
-namespace support {
-
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
-
-class EndpointListLoader;
-
-} // namespace support
-
+}; // namespace clusters
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/Attribute.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Attribute.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "Cluster.h"
+#include "Types.h"
+
+#include "lib/support/logging/CHIPLogging.h"
+
+namespace matter {
+namespace casting {
+namespace core {
+
+enum ReadAttributeError
+{
+    READ_ATTRIBUTE_NO_ERROR
+};
+
+enum WriteAttributeError
+{
+    WRITE_ATTRIBUTE_NO_ERROR
+};
+
+template <typename ValueType>
+using ReadAttributeCallback = std::function<void(Optional<ValueType> before, ValueType after, ReadAttributeError)>;
+
+using WriteAttributeCallback = std::function<void(WriteAttributeError)>;
+
+class BaseCluster;
+
+template <typename ValueType>
+class Attribute
+{
+private:
+    memory::Weak<BaseCluster> cluster;
+    ValueType value;
+
+public:
+    Attribute(memory::Weak<BaseCluster> cluster) { this->cluster = cluster; }
+
+    ~Attribute() {}
+
+    Attribute()                       = delete;
+    Attribute(Attribute & other)      = delete;
+    void operator=(const Attribute &) = delete;
+
+protected:
+    memory::Strong<BaseCluster> GetCluster() const { return cluster.lock(); }
+
+public:
+    ValueType GetValue();
+    void Read(ReadAttributeCallback<ValueType> onRead);
+    void Write(ValueType value, WriteAttributeCallback onWrite);
+    bool SubscribeAttribute(AttributeId attributeId, ReadAttributeCallback<ValueType> callback);
+    bool UnsubscribeAttribute(AttributeId attributeId, ReadAttributeCallback<ValueType> callback);
+};
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -125,22 +125,19 @@ exit:
 
 void CastingPlayer::RegisterEndpoint(const memory::Strong<Endpoint> endpoint)
 {
-    if (mEndpoints.size() != 0)
-    {
-        auto it = std::find_if(mEndpoints.begin(), mEndpoints.end(), [endpoint](const memory::Strong<Endpoint> & _endpoint) {
-            return _endpoint->GetId() == endpoint->GetId();
-        });
+    auto it = std::find_if(mEndpoints.begin(), mEndpoints.end(), [endpoint](const memory::Strong<Endpoint> & _endpoint) {
+        return _endpoint->GetId() == endpoint->GetId();
+    });
 
-        // If existing endpoint, update mEndpoints. If new endpoint, add it to the vector mEndpoints
-        if (it != mEndpoints.end())
-        {
-            unsigned index    = (unsigned int) std::distance(mEndpoints.begin(), it);
-            mEndpoints[index] = endpoint;
-        }
-        else
-        {
-            mEndpoints.push_back(endpoint);
-        }
+    // If existing endpoint, update mEndpoints. If new endpoint, add it to the vector mEndpoints
+    if (it != mEndpoints.end())
+    {
+        unsigned index    = (unsigned int) std::distance(mEndpoints.begin(), it);
+        mEndpoints[index] = endpoint;
+    }
+    else
+    {
+        mEndpoints.push_back(endpoint);
     }
 }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "CastingPlayer.h"
+#include "Endpoint.h"
+
 #include "support/CastingStore.h"
 
 #include <app/server/Server.h>
@@ -27,7 +29,8 @@ namespace core {
 
 CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 
-void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, unsigned long long int commissioningWindowTimeoutSec)
+void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, unsigned long long int commissioningWindowTimeoutSec,
+                                                EndpointFilter desiredEndpointFilter)
 {
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection called");
 
@@ -46,40 +49,49 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
     mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
     mTargetCastingPlayer           = this;
 
-    // If this CastingPlayer is the cache of CastingPlayers the app previously connected to (and has nodeId and fabricIndex of),
-    // simply Find or Re-establish the CASE session and return early
+    // If *this* CastingPlayer was previously connected to, its nodeId, fabricIndex and other attributes should be present
+    // in the CastingStore cache. If that is the case, AND, the cached data contains the endpoint desired by the client, if any,
+    // as per desiredEndpointFilter, simply Find or Re-establish the CASE session and return early
     if (cachedCastingPlayers.size() != 0)
     {
         it = std::find_if(cachedCastingPlayers.begin(), cachedCastingPlayers.end(),
                           [this](const core::CastingPlayer & castingPlayerParam) { return castingPlayerParam == *this; });
 
+        // found the CastingPlayer in cache
         if (it != cachedCastingPlayers.end())
         {
             unsigned index = (unsigned int) std::distance(cachedCastingPlayers.begin(), it);
-            *this          = cachedCastingPlayers[index];
+            if (ContainsDesiredEndpoint(&cachedCastingPlayers[index], desiredEndpointFilter))
+            {
+                *this = cachedCastingPlayers[index];
 
-            FindOrEstablishSession(
-                nullptr,
-                [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
-                    ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer successful");
-                    CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
-                    support::CastingStore::GetInstance()->AddOrUpdate(*CastingPlayer::GetTargetCastingPlayer());
-                    VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
-                    CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_NO_ERROR, CastingPlayer::GetTargetCastingPlayer());
-                },
-                [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-                    ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer failed");
-                    CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-                    support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
-                    VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
-                    CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
-                    mTargetCastingPlayer = nullptr;
-                });
-            return; // FindOrEstablishSession called. Return early.
+                FindOrEstablishSession(
+                    nullptr,
+                    [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
+                        ChipLogProgress(AppServer,
+                                        "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer successful");
+                        CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
+
+                        // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
+                        // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
+                        support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
+                        support::EndpointListLoader::GetInstance()->Load();
+                    },
+                    [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
+                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer failed");
+                        CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
+                        support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
+                        VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
+                        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
+                        mTargetCastingPlayer = nullptr;
+                    });
+                return; // FindOrEstablishSession called. Return early.
+            }
         }
     }
 
-    // this CastingPlayer is not in the list of cached CastingPlayers previously connected to. This VerifyOrEstablishConnection call
+    // this CastingPlayer is not in the list of cached CastingPlayers previously connected to or the cached data
+    // does not contain the endpoint the client desires to interact with. So, this VerifyOrEstablishConnection call
     // will require User Directed Commissioning.
     if (chip::Server::GetInstance().GetFailSafeContext().IsFailSafeArmed())
     {
@@ -101,13 +113,34 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
 exit:
     if (err != CHIP_NO_ERROR)
     {
+        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection failed with %" CHIP_ERROR_FORMAT, err.Format());
         support::ChipDeviceEventHandler::SetUdcStatus(false);
         mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
         mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-        mOnCompleted                   = nullptr;
         mTargetCastingPlayer           = nullptr;
-        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection failed with %" CHIP_ERROR_FORMAT, err.Format());
         mOnCompleted(err, nullptr);
+        mOnCompleted = nullptr;
+    }
+}
+
+void CastingPlayer::RegisterEndpoint(const memory::Strong<Endpoint> endpoint)
+{
+    if (mEndpoints.size() != 0)
+    {
+        auto it = std::find_if(mEndpoints.begin(), mEndpoints.end(), [endpoint](const memory::Strong<Endpoint> & _endpoint) {
+            return _endpoint->GetId() == endpoint->GetId();
+        });
+
+        // If existing endpoint, update mEndpoints. If new endpoint, add it to the vector mEndpoints
+        if (it != mEndpoints.end())
+        {
+            unsigned index    = (unsigned int) std::distance(mEndpoints.begin(), it);
+            mEndpoints[index] = endpoint;
+        }
+        else
+        {
+            mEndpoints.push_back(endpoint);
+        }
     }
 }
 
@@ -163,6 +196,24 @@ void CastingPlayer::FindOrEstablishSession(void * clientContext, chip::OnDeviceC
     chip::Server::GetInstance().GetCASESessionManager()->FindOrEstablishSession(
         chip::ScopedNodeId(mAttributes.nodeId, mAttributes.fabricIndex), connectionContext->mOnConnectedCallback,
         connectionContext->mOnConnectionFailureCallback);
+}
+
+bool CastingPlayer::ContainsDesiredEndpoint(core::CastingPlayer * cachedCastingPlayer, EndpointFilter desiredEndpointFilter)
+{
+    std::vector<memory::Strong<Endpoint>> cachedEndpoints = cachedCastingPlayer->GetEndpoints();
+    for (const auto & cachedEndpoint : cachedEndpoints)
+    {
+        bool match = true;
+        match = match && (desiredEndpointFilter.vendorId == 0 || cachedEndpoint->GetVendorId() == desiredEndpointFilter.vendorId);
+        match =
+            match && (desiredEndpointFilter.productId == 0 || cachedEndpoint->GetProductId() == desiredEndpointFilter.productId);
+        // TODO: check deviceTypeList
+        if (match)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 void CastingPlayer::LogDetail() const

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -43,6 +43,7 @@ const unsigned long long int kCommissioningWindowTimeoutSec = 3 * 60; // 3 minut
  */
 struct EndpointFilter
 {
+    // value of 0 means unspecified
     uint16_t vendorId  = 0;
     uint16_t productId = 0;
     std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> requiredDeviceTypes;
@@ -119,9 +120,11 @@ public:
      *
      * @param onCompleted for success - called back with CHIP_NO_ERROR and CastingPlayer *.
      * For failure - called back with an error and nullptr.
-     * @param commissioningWindowTimeoutSec time (in sec) to keep the commissioning window open, if commissioning is required.
-     * Defaults to kCommissioningWindowTimeoutSec.
-     * @param desiredEndpointFilter
+     * @param commissioningWindowTimeoutSec (Optional) time (in sec) to keep the commissioning window open, if commissioning is
+     * required. Defaults to kCommissioningWindowTimeoutSec.
+     * @param desiredEndpointFilter (Optional) Attributes (such as VendorId) describing an Endpoint that the client wants to
+     * interact with after commissioning. If this value is passed in, the VerifyOrEstablishConnection will force User Directed
+     * Commissioning, in case the desired Endpoint is not found in the on device CastingStore.
      */
     void VerifyOrEstablishConnection(ConnectCallback onCompleted,
                                      unsigned long long int commissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec,

--- a/examples/tv-casting-app/tv-casting-common/core/Cluster.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Cluster.h
@@ -18,40 +18,37 @@
 
 #pragma once
 
-#include "core/CastingApp.h"
-#include "support/AppParameters.h"
+#include "Endpoint.h"
+#include "Types.h"
 
-#include <cstdint>
-#include <memory>
+#include "lib/support/logging/CHIPLogging.h"
 
 namespace matter {
 namespace casting {
-
-namespace memory {
-
-template <typename T>
-using Weak = std::weak_ptr<T>;
-
-template <typename T>
-using Strong = std::shared_ptr<T>;
-
-} // namespace memory
-
 namespace core {
 
-class CastingApp;
+class Endpoint;
+
+// Base cluster class
+class BaseCluster
+{
+private:
+protected:
+    memory::Weak<Endpoint> endpoint;
+
+public:
+    BaseCluster(memory::Weak<Endpoint> endpoint) { this->endpoint = endpoint; }
+
+    virtual ~BaseCluster() {}
+
+    BaseCluster()                       = delete;
+    BaseCluster(BaseCluster & other)    = delete;
+    void operator=(const BaseCluster &) = delete;
+
+protected:
+    memory::Weak<Endpoint> GetEndpoint() const { return endpoint.lock(); }
+};
 
 }; // namespace core
-
-namespace support {
-
-class AppParameters;
-class ByteSpanDataProvider;
-class ServerInitParamsProvider;
-
-class EndpointListLoader;
-
-} // namespace support
-
 }; // namespace casting
 }; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/Cluster.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Cluster.h
@@ -34,10 +34,10 @@ class BaseCluster
 {
 private:
 protected:
-    memory::Weak<Endpoint> endpoint;
+    memory::Weak<Endpoint> mEndpoint;
 
 public:
-    BaseCluster(memory::Weak<Endpoint> endpoint) { this->endpoint = endpoint; }
+    BaseCluster(memory::Weak<Endpoint> endpoint) { this->mEndpoint = endpoint; }
 
     virtual ~BaseCluster() {}
 
@@ -46,7 +46,7 @@ public:
     void operator=(const BaseCluster &) = delete;
 
 protected:
-    memory::Weak<Endpoint> GetEndpoint() const { return endpoint.lock(); }
+    memory::Weak<Endpoint> GetEndpoint() const { return mEndpoint.lock(); }
 };
 
 }; // namespace core

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <memory>
 #include <type_traits>
+#include <vector>
 
 namespace matter {
 namespace casting {

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -1,0 +1,125 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "CastingPlayer.h"
+#include "Cluster.h"
+#include "Types.h"
+
+#include "lib/support/logging/CHIPLogging.h"
+#include <app-common/zap-generated/cluster-objects.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <type_traits>
+
+namespace matter {
+namespace casting {
+namespace core {
+
+class EndpointAttributes
+{
+public:
+    chip::EndpointId mId = 0;
+    uint16_t mVendorId   = 0;
+    uint16_t mProductId  = 0;
+    std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> mDeviceTypeList;
+};
+
+class CastingPlayer;
+
+class Endpoint : public std::enable_shared_from_this<Endpoint>
+{
+
+private:
+    CastingPlayer * mCastingPlayer;
+
+    EndpointAttributes mAttributes;
+    std::map<chip::ClusterId, memory::Strong<BaseCluster>> mClusters;
+
+protected:
+    CastingPlayer * GetCastingPlayer() const { return mCastingPlayer; }
+
+public:
+    Endpoint(CastingPlayer * castingPlayer, const EndpointAttributes & attributes)
+    {
+        this->mCastingPlayer = castingPlayer;
+        this->mAttributes    = attributes;
+    }
+
+    ~Endpoint() {}
+
+    Endpoint()                       = delete;
+    Endpoint(Endpoint & other)       = delete;
+    void operator=(const Endpoint &) = delete;
+
+    /**
+     * @brief Compares based on the Id
+     */
+    bool operator==(const Endpoint & other) const { return this->mAttributes.mId == other.mAttributes.mId; }
+
+    chip::EndpointId GetId() const { return mAttributes.mId; }
+
+    uint16_t GetProductId() const { return mAttributes.mProductId; }
+
+    uint16_t GetVendorId() const { return mAttributes.mVendorId; }
+
+    std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> GetDeviceTypeList() const
+    {
+        return mAttributes.mDeviceTypeList;
+    }
+
+    std::vector<chip::ClusterId> GetServerList()
+    {
+        std::vector<chip::ClusterId> serverList;
+        for (auto const & cluster : mClusters)
+        {
+            serverList.push_back(cluster.first);
+        }
+        return serverList;
+    }
+
+    template <typename T>
+    void RegisterCluster(const chip::ClusterId clusterId)
+    {
+        static_assert(std::is_base_of<BaseCluster, T>::value, "T must be derived from BaseCluster");
+        auto cluster         = std::make_shared<T>(shared_from_this());
+        mClusters[clusterId] = std::static_pointer_cast<BaseCluster>(cluster);
+    }
+
+    template <typename T>
+    memory::Strong<T> GetCluster()
+    {
+        static_assert(std::is_base_of<BaseCluster, T>::value, "T must be derived from BaseCluster");
+        for (const auto & pair : mClusters)
+        {
+            auto cluster = std::dynamic_pointer_cast<T>(pair.second);
+            if (cluster)
+            {
+                return cluster;
+            }
+        }
+        return nullptr;
+    }
+};
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -37,6 +37,7 @@ namespace core {
 class EndpointAttributes
 {
 public:
+    // value of 0 means the attribute could not be read for the corresponding Endpoint
     chip::EndpointId mId = 0;
     uint16_t mVendorId   = 0;
     uint16_t mProductId  = 0;
@@ -45,6 +46,9 @@ public:
 
 class CastingPlayer;
 
+/**
+ * @brief An Endpoint on a CastingPlayer e.g. a Speaker or a Matter Content App
+ */
 class Endpoint : public std::enable_shared_from_this<Endpoint>
 {
 
@@ -77,15 +81,27 @@ public:
 
     chip::EndpointId GetId() const { return mAttributes.mId; }
 
+    /**
+     * @return uint16_t - value 0 indicates no ProductId was returned for this Endpoint
+     */
     uint16_t GetProductId() const { return mAttributes.mProductId; }
 
+    /**
+     * @return uint16_t - value 0 indicates no VendorId was returned for this Endpoint
+     */
     uint16_t GetVendorId() const { return mAttributes.mVendorId; }
 
+    /**
+     * @return uint16_t - empty vector indicates no DeviceTypeList was returned for this Endpoint
+     */
     std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> GetDeviceTypeList() const
     {
         return mAttributes.mDeviceTypeList;
     }
 
+    /**
+     * @return uint16_t - empty vector indicates no ServerList was returned for this Endpoint
+     */
     std::vector<chip::ClusterId> GetServerList()
     {
         std::vector<chip::ClusterId> serverList;
@@ -96,6 +112,10 @@ public:
         return serverList;
     }
 
+    /**
+     * @brief Registers a cluster of type T against the passed in clusterId
+     * for this Endpoint
+     */
     template <typename T>
     void RegisterCluster(const chip::ClusterId clusterId)
     {
@@ -104,6 +124,9 @@ public:
         mClusters[clusterId] = std::static_pointer_cast<BaseCluster>(cluster);
     }
 
+    /**
+     * @brief Returns a cluster of type T, if applicable. Returns nullptr otherwise
+     */
     template <typename T>
     memory::Strong<T> GetCluster()
     {

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -125,6 +125,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                             ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
         core::CastingPlayerAttributes attributes;
+        std::vector<core::EndpointAttributes> endpointAttributesList;
         while ((err = reader.Next()) == CHIP_NO_ERROR)
         {
             chip::TLV::Tag castingPlayerContainerTag = reader.GetTag();
@@ -196,13 +197,170 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                 continue;
             }
 
+            if (castingPlayerContainerTagNum == kCastingPlayerEndpointsContainerTag)
+            {
+                // Entering Endpoints container
+                chip::TLV::TLVType endpointsContainerType = chip::TLV::kTLVType_Array;
+                err                                       = reader.EnterContainer(endpointsContainerType);
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+                core::EndpointAttributes endpointAttributes;
+                while ((err = reader.Next()) == CHIP_NO_ERROR)
+                {
+                    // Entering Endpoint container
+                    chip::TLV::TLVType endpointContainerType = chip::TLV::kTLVType_Structure;
+                    err                                      = reader.EnterContainer(endpointContainerType);
+                    VerifyOrReturnValue(
+                        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                        ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                    while ((err = reader.Next()) == CHIP_NO_ERROR)
+                    {
+                        chip::TLV::Tag endpointContainerTag = reader.GetTag();
+                        VerifyOrReturnValue(chip::TLV::IsContextTag(endpointContainerTag), std::vector<core::CastingPlayer>(),
+                                            ChipLogError(AppServer, "Unexpected non-context TLV tag"));
+
+                        uint8_t endpointContainerTagNum = static_cast<uint8_t>(chip::TLV::TagNumFromTag(endpointContainerTag));
+                        if (endpointContainerTagNum == kCastingPlayerEndpointIdTag)
+                        {
+                            err = reader.Get(endpointAttributes.mId);
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                                ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                            continue;
+                        }
+
+                        if (endpointContainerTagNum == kCastingPlayerEndpointVendorIdTag)
+                        {
+                            err = reader.Get(endpointAttributes.mVendorId);
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                                ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                            continue;
+                        }
+
+                        if (endpointContainerTagNum == kCastingPlayerEndpointProductIdTag)
+                        {
+                            err = reader.Get(endpointAttributes.mProductId);
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                                ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                            continue;
+                        }
+
+                        std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> deviceTypeList;
+                        if (endpointContainerTagNum == kCastingPlayerEndpointDeviceTypeListContainerTag)
+                        {
+                            // Entering DeviceTypeList container
+                            chip::TLV::TLVType deviceTypeListContainerType = chip::TLV::kTLVType_Array;
+                            err                                            = reader.EnterContainer(deviceTypeListContainerType);
+                            VerifyOrReturnValue(
+                                err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                            while ((err = reader.Next()) == CHIP_NO_ERROR)
+                            {
+                                // Entering DeviceTypeStruct container
+                                chip::TLV::TLVType deviceTypeStructContainerType = chip::TLV::kTLVType_Structure;
+                                err = reader.EnterContainer(deviceTypeStructContainerType);
+                                VerifyOrReturnValue(
+                                    err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                                chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType deviceTypeStruct;
+                                while ((err = reader.Next()) == CHIP_NO_ERROR)
+                                {
+                                    chip::TLV::Tag deviceTypeStructContainerTag = reader.GetTag();
+                                    VerifyOrReturnValue(chip::TLV::IsContextTag(deviceTypeStructContainerTag),
+                                                        std::vector<core::CastingPlayer>(),
+                                                        ChipLogError(AppServer, "Unexpected non-context TLV tag"));
+
+                                    uint8_t deviceTypeStructContainerTagNum =
+                                        static_cast<uint8_t>(chip::TLV::TagNumFromTag(deviceTypeStructContainerTag));
+                                    if (deviceTypeStructContainerTagNum == kCastingPlayerEndpointDeviceTypeTag)
+                                    {
+                                        err = reader.Get(deviceTypeStruct.deviceType);
+                                        VerifyOrReturnValue(
+                                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                            ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                                        continue;
+                                    }
+
+                                    if (deviceTypeStructContainerTagNum == kCastingPlayerEndpointDeviceTypeRevisionTag)
+                                    {
+                                        err = reader.Get(deviceTypeStruct.revision);
+                                        VerifyOrReturnValue(
+                                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                            ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                                        continue;
+                                    }
+                                }
+
+                                if (err == CHIP_END_OF_TLV)
+                                {
+                                    // Exiting DeviceTypeStruct container
+                                    err = reader.ExitContainer(deviceTypeStructContainerType);
+                                    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                                        ChipLogError(AppServer,
+                                                                     "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT,
+                                                                     err.Format()));
+
+                                    deviceTypeList.push_back(deviceTypeStruct);
+                                    break;
+                                }
+                            }
+                            if (err == CHIP_END_OF_TLV)
+                            {
+                                // Exiting DeviceTypeList container
+                                err = reader.ExitContainer(deviceTypeListContainerType);
+                                VerifyOrReturnValue(
+                                    err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                                endpointAttributes.mDeviceTypeList = deviceTypeList;
+                                break;
+                            }
+                            continue;
+                        }
+                    }
+
+                    if (err == CHIP_END_OF_TLV)
+                    {
+                        // Exiting Endpoint container
+                        err = reader.ExitContainer(endpointContainerType);
+                        VerifyOrReturnValue(
+                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                            ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                        endpointAttributesList.push_back(endpointAttributes);
+                        break;
+                    }
+                }
+
+                if (err == CHIP_END_OF_TLV)
+                {
+                    // Exiting Endpoints container
+                    err = reader.ExitContainer(endpointsContainerType);
+                    VerifyOrReturnValue(
+                        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                        ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+                    break;
+                }
+
+                continue;
+            }
+
             if (err == CHIP_END_OF_TLV)
             {
                 // Exiting CastingPlayer container
                 err = reader.ExitContainer(castingPlayerContainerType);
                 VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+                // create a castingPlayer with Endpoints and add it to the castingPlayers to be returned
                 core::CastingPlayer castingPlayer(attributes);
+                for (core::EndpointAttributes endpointAttributes : endpointAttributesList)
+                {
+                    std::shared_ptr<core::Endpoint> endpoint(new core::Endpoint(&castingPlayer, endpointAttributes));
+                    castingPlayer.RegisterEndpoint(endpoint);
+                }
                 castingPlayers.push_back(castingPlayer);
                 break;
             }
@@ -321,6 +479,65 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.PutBytes(chip::TLV::ContextTag(kCastingPlayerHostNameTag),
                                                 (const uint8_t *) castingPlayer.GetHostName(),
                                                 static_cast<uint32_t>(strlen(castingPlayer.GetHostName()) + 1)));
+
+        // Endpoints container starts
+        chip::TLV::TLVType endpointsContainerType = chip::TLV::kTLVType_Array;
+        ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointsContainerTag),
+                                                      chip::TLV::kTLVType_Array, endpointsContainerType));
+        std::vector<memory::Strong<core::Endpoint>> endpoints = core::CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
+        for (memory::Strong<core::Endpoint> endpoint : endpoints)
+        {
+            chip::TLV::TLVType endpointContainerType = chip::TLV::kTLVType_Structure;
+            // Endpoint container starts
+            ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointContainerTag),
+                                                          chip::TLV::kTLVType_Structure, endpointContainerType));
+            ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointIdTag), endpoint->GetId()));
+            ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointVendorIdTag), endpoint->GetVendorId()));
+            ReturnErrorOnFailure(
+                tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointProductIdTag), endpoint->GetProductId()));
+
+            // DeviceTypeList container starts
+            chip::TLV::TLVType deviceTypeListContainerType = chip::TLV::kTLVType_Array;
+            ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointDeviceTypeListContainerTag),
+                                                          chip::TLV::kTLVType_Array, deviceTypeListContainerType));
+            std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> deviceTypeList =
+                endpoint->GetDeviceTypeList();
+            for (chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType deviceTypeStruct : deviceTypeList)
+            {
+                chip::TLV::TLVType deviceTypeStructContainerType = chip::TLV::kTLVType_Structure;
+                // DeviceTypeStruct container starts
+                ReturnErrorOnFailure(
+                    tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointDeviceTypeStructContainerTag),
+                                             chip::TLV::kTLVType_Structure, deviceTypeStructContainerType));
+                ReturnErrorOnFailure(
+                    tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointDeviceTypeTag), deviceTypeStruct.deviceType));
+                ReturnErrorOnFailure(
+                    tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointDeviceTypeRevisionTag), deviceTypeStruct.revision));
+
+                // DeviceTypeStruct container ends
+                ReturnErrorOnFailure(tlvWriter.EndContainer(deviceTypeStructContainerType));
+            }
+            // DeviceTypeList container ends
+            ReturnErrorOnFailure(tlvWriter.EndContainer(deviceTypeListContainerType));
+
+            // ServerList container starts
+            chip::TLV::TLVType serverListContainerType = chip::TLV::kTLVType_Array;
+            ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointServerListContainerTag),
+                                                          chip::TLV::kTLVType_Array, serverListContainerType));
+            std::vector<chip::ClusterId> serverList = endpoint->GetServerList();
+            for (chip::ClusterId clusterId : serverList)
+            {
+                ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerEndpointServerClusterIdTag), clusterId));
+            }
+            // ServerList container ends
+            ReturnErrorOnFailure(tlvWriter.EndContainer(serverListContainerType));
+
+            // Endpoint container ends
+            ReturnErrorOnFailure(tlvWriter.EndContainer(endpointContainerType));
+        }
+        // Endpoints container ends
+        ReturnErrorOnFailure(tlvWriter.EndContainer(endpointsContainerType));
+
         // CastingPlayer container ends
         ReturnErrorOnFailure(tlvWriter.EndContainer(castingPlayerContainerType));
     }

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -356,7 +356,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
 
                 // create a castingPlayer with Endpoints and add it to the castingPlayers to be returned
                 core::CastingPlayer castingPlayer(attributes);
-                for (core::EndpointAttributes endpointAttributes : endpointAttributesList)
+                for (auto & endpointAttributes : endpointAttributesList)
                 {
                     std::shared_ptr<core::Endpoint> endpoint(new core::Endpoint(&castingPlayer, endpointAttributes));
                     castingPlayer.RegisterEndpoint(endpoint);
@@ -485,7 +485,7 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointsContainerTag),
                                                       chip::TLV::kTLVType_Array, endpointsContainerType));
         std::vector<memory::Strong<core::Endpoint>> endpoints = core::CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
-        for (memory::Strong<core::Endpoint> endpoint : endpoints)
+        for (auto & endpoint : endpoints)
         {
             chip::TLV::TLVType endpointContainerType = chip::TLV::kTLVType_Structure;
             // Endpoint container starts

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -72,6 +72,7 @@ private:
     enum CastingStoreTLVTag
     {
         kCastingStoreDataVersionTag = 1,
+
         kCastingPlayersContainerTag,
         kCastingPlayerContainerTag,
         kCastingPlayerIdTag,
@@ -82,6 +83,20 @@ private:
         kCastingPlayerDeviceTypeIdTag,
         kCastingPlayerDeviceNameTag,
         kCastingPlayerHostNameTag,
+
+        kCastingPlayerEndpointsContainerTag,
+        kCastingPlayerEndpointContainerTag,
+        kCastingPlayerEndpointIdTag,
+        kCastingPlayerEndpointVendorIdTag,
+        kCastingPlayerEndpointProductIdTag,
+
+        kCastingPlayerEndpointDeviceTypeListContainerTag,
+        kCastingPlayerEndpointDeviceTypeStructContainerTag,
+        kCastingPlayerEndpointDeviceTypeTag,
+        kCastingPlayerEndpointDeviceTypeRevisionTag,
+
+        kCastingPlayerEndpointServerListContainerTag,
+        kCastingPlayerEndpointServerClusterIdTag,
 
         kContextTagMaxNum = UINT8_MAX
     };

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.h
@@ -27,7 +27,7 @@ namespace support {
 /**
  * @brief Handles chip::DeviceLayer::ChipDeviceEvent events (such as kFailSafeTimerExpired, kBindingsChangedViaCluster,
  * kCommissioningComplete) sent by the Matter DeviceLayer.
- * ChipDeviceEventHandlerhelps the CastingPlayer class commission with and connect to a CastingPlayer
+ * ChipDeviceEventHandler helps the CastingPlayer class commission with and connect to a CastingPlayer
  */
 class ChipDeviceEventHandler
 {

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -1,0 +1,258 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "EndpointListLoader.h"
+
+#include "clusters/ContentLauncherCluster.h"
+#include "clusters/MediaPlaybackCluster.h"
+#include "clusters/TargetNavigatorCluster.h"
+#include "core/CastingPlayer.h"
+#include "core/Types.h"
+#include "support/CastingStore.h"
+
+#include "app/clusters/bindings/BindingManager.h"
+
+namespace matter {
+namespace casting {
+namespace support {
+
+using namespace matter::casting::core;
+
+EndpointListLoader * EndpointListLoader::_endpointListLoader = nullptr;
+
+EndpointListLoader::EndpointListLoader() {}
+
+EndpointListLoader * EndpointListLoader::GetInstance()
+{
+    if (_endpointListLoader == nullptr)
+    {
+        _endpointListLoader = new EndpointListLoader();
+    }
+    return _endpointListLoader;
+}
+
+void EndpointListLoader::Initialize(chip::Messaging::ExchangeManager * exchangeMgr, const chip::SessionHandle * sessionHandle)
+{
+    mExchangeMgr   = exchangeMgr;
+    mSessionHandle = sessionHandle;
+
+    for (const auto & binding : chip::BindingTable::GetInstance())
+    {
+        if (binding.type == EMBER_UNICAST_BINDING && CastingPlayer::GetTargetCastingPlayer()->GetNodeId() == binding.nodeId)
+        {
+            // check to see if we discovered a new endpoint in the bindings
+            chip::EndpointId endpointId                     = binding.remote;
+            std::vector<memory::Strong<Endpoint>> endpoints = CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
+            if (std::find_if(endpoints.begin(), endpoints.end(), [&endpointId](const memory::Strong<Endpoint> & endpoint) {
+                    return endpoint->GetId() == endpointId;
+                }) == endpoints.end())
+            {
+                mNewEndpointsToLoad++;
+            }
+        }
+    }
+
+    mPendingAttributeReads  = mNewEndpointsToLoad * kTotalDesiredAttributes;
+    mEndpointAttributesList = new EndpointAttributes[mNewEndpointsToLoad];
+    mEndpointServerLists    = new std::vector<chip::ClusterId>[mNewEndpointsToLoad];
+}
+
+CHIP_ERROR EndpointListLoader::Load()
+{
+    ChipLogProgress(AppServer, "EndpointListLoader::Load() called");
+
+    VerifyOrReturnError(CastingPlayer::GetTargetCastingPlayer() != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    int endpointIndex = -1;
+    for (const auto & binding : chip::BindingTable::GetInstance())
+    {
+        ChipLogProgress(AppServer,
+                        "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
+                        " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
+                        binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
+                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+        if (binding.type == EMBER_UNICAST_BINDING && CastingPlayer::GetTargetCastingPlayer()->GetNodeId() == binding.nodeId)
+        {
+            // if we discovered a new Endpoint from the bindings, read its EndpointAttributes
+            chip::EndpointId endpointId                     = binding.remote;
+            std::vector<memory::Strong<Endpoint>> endpoints = CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
+            if (std::find_if(endpoints.begin(), endpoints.end(), [&endpointId](const memory::Strong<Endpoint> & endpoint) {
+                    return endpoint->GetId() == endpointId;
+                }) == endpoints.end())
+            {
+                // Read attributes and mEndpointAttributesList for (endpointIndex + 1)
+                ChipLogProgress(AppServer, "EndpointListLoader::Load Reading attributes for endpointId %d", endpointId);
+                mEndpointAttributesList[++endpointIndex].mId = endpointId;
+                ReadVendorId(&mEndpointAttributesList[endpointIndex]);
+                ReadProductId(&mEndpointAttributesList[endpointIndex]);
+                ReadDeviceTypeList(&mEndpointAttributesList[endpointIndex]);
+                ReadServerList(&mEndpointServerLists[endpointIndex], endpointId);
+            }
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void EndpointListLoader::Complete()
+{
+    ChipLogProgress(AppServer, "EndpointListLoader::Complete called with mPendingAttributeReads %lu", mPendingAttributeReads);
+    mPendingAttributeReads--;
+    if (mPendingAttributeReads == 0)
+    {
+        ChipLogProgress(AppServer, "EndpointListLoader::Complete ready to complete Loading endpoints");
+        for (unsigned long i = 0; i < mNewEndpointsToLoad; i++)
+        {
+            EndpointAttributes endpointAttributes = mEndpointAttributesList[i];
+            std::shared_ptr<Endpoint> endpoint(new Endpoint(CastingPlayer::GetTargetCastingPlayer(), endpointAttributes));
+            for (chip::ClusterId clusterId : mEndpointServerLists[i])
+            {
+                switch (clusterId)
+                {
+                case chip::app::Clusters::ContentLauncher::Id:
+                    endpoint->RegisterCluster<clusters::ContentLauncherCluster>(clusterId);
+                    break;
+
+                case chip::app::Clusters::MediaPlayback::Id:
+                    endpoint->RegisterCluster<clusters::MediaPlaybackCluster>(clusterId);
+                    break;
+
+                case chip::app::Clusters::TargetNavigator::Id:
+                    endpoint->RegisterCluster<clusters::TargetNavigatorCluster>(clusterId);
+                    break;
+
+                default:
+                    ChipLogProgress(AppServer, "Skipping registration of clusterId %d for endpointId %d", clusterId,
+                                    endpointAttributes.mId);
+                    break;
+                }
+            }
+            CastingPlayer::GetTargetCastingPlayer()->RegisterEndpoint(endpoint);
+        }
+
+        ChipLogProgress(AppServer, "EndpointListLoader::Complete finished Loading endpoints");
+
+        // TODO cleanup
+        // delete mEndpointAttributesList;
+        mEndpointAttributesList = nullptr;
+        // delete mEndpointServerLists;
+        mEndpointServerLists = nullptr;
+        mExchangeMgr         = nullptr;
+        mSessionHandle       = nullptr;
+        mNewEndpointsToLoad  = 0;
+
+        // done loading endpoints, callback client OnCompleted
+        support::CastingStore::GetInstance()->AddOrUpdate(*CastingPlayer::GetTargetCastingPlayer());
+        VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
+        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_NO_ERROR, CastingPlayer::GetTargetCastingPlayer());
+    }
+}
+
+CHIP_ERROR EndpointListLoader::ReadVendorId(EndpointAttributes * endpointAttributes)
+{
+    MediaClusterBase cluster(*mExchangeMgr, *mSessionHandle, endpointAttributes->mId);
+
+    return cluster.template ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo>(
+        endpointAttributes,
+        [](void * context,
+           chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo::DecodableArgType decodableVendorId) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            endpointAttributes->mVendorId           = decodableVendorId;
+            EndpointListLoader::GetInstance()->Complete();
+        },
+        [](void * context, CHIP_ERROR err) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            ChipLogError(AppServer, "EndpointListLoader ReadAttribute(VendorID) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
+                         endpointAttributes->mId, err.Format());
+            EndpointListLoader::GetInstance()->Complete();
+        });
+}
+
+CHIP_ERROR EndpointListLoader::ReadProductId(EndpointAttributes * endpointAttributes)
+{
+    MediaClusterBase cluster(*mExchangeMgr, *mSessionHandle, endpointAttributes->mId);
+
+    return cluster.template ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo>(
+        endpointAttributes,
+        [](void * context,
+           chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo::DecodableArgType decodableProductId) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            endpointAttributes->mProductId          = decodableProductId;
+            EndpointListLoader::GetInstance()->Complete();
+        },
+        [](void * context, CHIP_ERROR err) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            ChipLogError(AppServer,
+                         "EndpointListLoader ReadAttribute(ProductID) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
+                         endpointAttributes->mId, err.Format());
+            EndpointListLoader::GetInstance()->Complete();
+        });
+}
+
+CHIP_ERROR EndpointListLoader::ReadDeviceTypeList(EndpointAttributes * endpointAttributes)
+{
+    MediaClusterBase cluster(*mExchangeMgr, *mSessionHandle, endpointAttributes->mId);
+
+    return cluster.template ReadAttribute<chip::app::Clusters::Descriptor::Attributes::DeviceTypeList::TypeInfo>(
+        endpointAttributes,
+        [](void * context,
+           chip::app::Clusters::Descriptor::Attributes::DeviceTypeList::TypeInfo::DecodableArgType decodableDeviceTypeList) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            auto iter                               = decodableDeviceTypeList.begin();
+            while (iter.Next())
+            {
+                auto & deviceType = iter.GetValue();
+                endpointAttributes->mDeviceTypeList.push_back(deviceType);
+            }
+            EndpointListLoader::GetInstance()->Complete();
+        },
+        [](void * context, CHIP_ERROR err) {
+            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            ChipLogError(AppServer,
+                         "EndpointListLoader ReadAttribute(DeviceTypeList) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
+                         endpointAttributes->mId, err.Format());
+            EndpointListLoader::GetInstance()->Complete();
+        });
+}
+
+CHIP_ERROR EndpointListLoader::ReadServerList(std::vector<chip::ClusterId> * endpointServerList, chip::EndpointId endpointId)
+{
+    MediaClusterBase cluster(*mExchangeMgr, *mSessionHandle, endpointId);
+
+    return cluster.template ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo>(
+        endpointServerList,
+        [](void * context,
+           chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo::DecodableArgType decodableServerList) {
+            std::vector<chip::ClusterId> * endpointServerList = static_cast<std::vector<chip::ClusterId> *>(context);
+            auto iter                                         = decodableServerList.begin();
+            while (iter.Next())
+            {
+                auto & clusterId = iter.GetValue();
+                endpointServerList->push_back(clusterId);
+            }
+            EndpointListLoader::GetInstance()->Complete();
+        },
+        [](void * context, CHIP_ERROR err) {
+            ChipLogError(AppServer, "EndpointListLoader ReadAttribute(ServerList) failed. Err: %" CHIP_ERROR_FORMAT, err.Format());
+            EndpointListLoader::GetInstance()->Complete();
+        });
+}
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -172,14 +172,14 @@ CHIP_ERROR EndpointListLoader::ReadVendorId(EndpointAttributes * endpointAttribu
         endpointAttributes,
         [](void * context,
            chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo::DecodableArgType decodableVendorId) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
-            endpointAttributes->mVendorId           = decodableVendorId;
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
+            _endpointAttributes->mVendorId           = decodableVendorId;
             EndpointListLoader::GetInstance()->Complete();
         },
         [](void * context, CHIP_ERROR err) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
             ChipLogError(AppServer, "EndpointListLoader ReadAttribute(VendorID) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
-                         endpointAttributes->mId, err.Format());
+                         _endpointAttributes->mId, err.Format());
             EndpointListLoader::GetInstance()->Complete();
         });
 }
@@ -192,15 +192,15 @@ CHIP_ERROR EndpointListLoader::ReadProductId(EndpointAttributes * endpointAttrib
         endpointAttributes,
         [](void * context,
            chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo::DecodableArgType decodableProductId) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
-            endpointAttributes->mProductId          = decodableProductId;
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
+            _endpointAttributes->mProductId          = decodableProductId;
             EndpointListLoader::GetInstance()->Complete();
         },
         [](void * context, CHIP_ERROR err) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
             ChipLogError(AppServer,
                          "EndpointListLoader ReadAttribute(ProductID) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
-                         endpointAttributes->mId, err.Format());
+                         _endpointAttributes->mId, err.Format());
             EndpointListLoader::GetInstance()->Complete();
         });
 }
@@ -213,20 +213,20 @@ CHIP_ERROR EndpointListLoader::ReadDeviceTypeList(EndpointAttributes * endpointA
         endpointAttributes,
         [](void * context,
            chip::app::Clusters::Descriptor::Attributes::DeviceTypeList::TypeInfo::DecodableArgType decodableDeviceTypeList) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
-            auto iter                               = decodableDeviceTypeList.begin();
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
+            auto iter                                = decodableDeviceTypeList.begin();
             while (iter.Next())
             {
                 auto & deviceType = iter.GetValue();
-                endpointAttributes->mDeviceTypeList.push_back(deviceType);
+                _endpointAttributes->mDeviceTypeList.push_back(deviceType);
             }
             EndpointListLoader::GetInstance()->Complete();
         },
         [](void * context, CHIP_ERROR err) {
-            EndpointAttributes * endpointAttributes = static_cast<EndpointAttributes *>(context);
+            EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
             ChipLogError(AppServer,
                          "EndpointListLoader ReadAttribute(DeviceTypeList) failed for endpointID %d. Err: %" CHIP_ERROR_FORMAT,
-                         endpointAttributes->mId, err.Format());
+                         _endpointAttributes->mId, err.Format());
             EndpointListLoader::GetInstance()->Complete();
         });
 }
@@ -239,12 +239,12 @@ CHIP_ERROR EndpointListLoader::ReadServerList(std::vector<chip::ClusterId> * end
         endpointServerList,
         [](void * context,
            chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo::DecodableArgType decodableServerList) {
-            std::vector<chip::ClusterId> * endpointServerList = static_cast<std::vector<chip::ClusterId> *>(context);
-            auto iter                                         = decodableServerList.begin();
+            std::vector<chip::ClusterId> * _endpointServerList = static_cast<std::vector<chip::ClusterId> *>(context);
+            auto iter                                          = decodableServerList.begin();
             while (iter.Next())
             {
                 auto & clusterId = iter.GetValue();
-                endpointServerList->push_back(clusterId);
+                _endpointServerList->push_back(clusterId);
             }
             EndpointListLoader::GetInstance()->Complete();
         },

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -119,7 +119,8 @@ void EndpointListLoader::Complete()
         for (unsigned long i = 0; i < mNewEndpointsToLoad; i++)
         {
             EndpointAttributes endpointAttributes = mEndpointAttributesList[i];
-            std::shared_ptr<Endpoint> endpoint(new Endpoint(CastingPlayer::GetTargetCastingPlayer(), endpointAttributes));
+            std::shared_ptr<Endpoint> endpoint =
+                std::make_shared<Endpoint>(CastingPlayer::GetTargetCastingPlayer(), endpointAttributes);
             for (chip::ClusterId clusterId : mEndpointServerLists[i])
             {
                 switch (clusterId)

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.h
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.h
@@ -1,0 +1,119 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "core/Endpoint.h"
+#include "core/Types.h"
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/server/Server.h>
+#include <controller/CHIPCluster.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+/**
+ * @brief EndpointListLoader builds Endpoints corresponding to the CastingPlayer::GetTargetCastingPlayer by reading Bindings and
+ * fetching Endpoint attributes (like VendorID, ProductID, DeviceTypeList, ServerList, etc). It then loads all of these Endpoints
+ * into the CastingPlayer::GetTargetCastingPlayer. Finally, it calls mOnCompleted() on the CastingPlayer::GetTargetCastingPlayer to
+ * report the status of the Connection process to the client.
+ */
+class EndpointListLoader
+{
+public:
+    static EndpointListLoader * GetInstance();
+
+    /**
+     * @brief Initializes EndpointListLoader with session info of the session the CastingApp just connected on.
+     */
+    void Initialize(chip::Messaging::ExchangeManager * exchangeMgr, const chip::SessionHandle * sessionHandle);
+
+    /**
+     * @brief Reads Bindings and fetches attributes (like VendorID, ProductID, DeviceTypeList, ServerList, etc) for each Endpoint
+     * discovered in them.
+     */
+    CHIP_ERROR Load();
+
+private:
+    EndpointListLoader();
+    static EndpointListLoader * _endpointListLoader;
+
+    /**
+     * @brief When all DesiredAttributes reads are completed, this function creates the list of Endpoints and loads/registers them
+     * on the CastingPlayer::GetTargetCastingPlayer
+     */
+    void Complete();
+
+    /**
+     * @brief Fetches the VendorId for the endpoint with passed in endpointAttributes->mID
+     */
+    CHIP_ERROR ReadVendorId(core::EndpointAttributes * endpointAttributes);
+
+    /**
+     * @brief Fetches the ProductId for the endpoint with passed in endpointAttributes->mID
+     */
+    CHIP_ERROR ReadProductId(core::EndpointAttributes * endpointAttributes);
+
+    /**
+     * @brief Fetches the DeviceTypeList for the endpoint with passed in endpointAttributes->mID
+     */
+    CHIP_ERROR ReadDeviceTypeList(core::EndpointAttributes * endpointAttributes);
+
+    /**
+     * @brief Fetches the ServerList for the endpoint with passed in endpointAttributes->mID
+     */
+    CHIP_ERROR ReadServerList(std::vector<chip::ClusterId> * endpointServerList, chip::EndpointId endpointId);
+
+    chip::Messaging::ExchangeManager * mExchangeMgr     = nullptr;
+    const chip::SessionHandle * mSessionHandle          = nullptr;
+    unsigned long mNewEndpointsToLoad                   = 0;
+    unsigned long mPendingAttributeReads                = 0;
+    core::EndpointAttributes * mEndpointAttributesList  = nullptr;
+    std::vector<chip::ClusterId> * mEndpointServerLists = nullptr;
+};
+
+/**
+ * @brief Enumerated list of all Endpoint Attributes that need to be fetched
+ */
+enum DesiredAttributes
+{
+    kVendorId = 0,
+    kProductId,
+    kDeviceTypeList,
+    kServerList,
+
+    kTotalDesiredAttributes
+};
+
+/**
+ * @brief MediaClusterBase is used by the EndpointListLoader to invoke controller/CHIPCluster.h#ReadAttribute() API calls
+ */
+class MediaClusterBase : public chip::Controller::ClusterBase
+{
+public:
+    MediaClusterBase(chip::Messaging::ExchangeManager & exchangeManager, const chip::SessionHandle & session,
+                     chip::EndpointId endpoint) :
+        ClusterBase(exchangeManager, session, endpoint)
+    {}
+};
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter


### PR DESCRIPTION
This change simplifies and decouples the implementation of the post-connection flow and Endpoint attribute fetching logic for the CastingApp from the old CastingServer.h/cpp.

### Change summary

1.  A separate EndpointListLoader class now hosts the post-connection logic that fetches Endpoint information. It additionally fetches the VendorId, ProductId, etc. in addition to the ServerList that the old CastingServer.cpp used to fetch.
2. The CastingPlayer.VerifyOrEstablishConnection() now takes an additional argument `desiredEndpointFilter` that lets the client specify values like the vendor/productId of the Endpoint it wants to interact with after connecting. 
3.  Provided an example of how to use it with a Linux OS in simple-app-helper.cpp
4.  Also, added documentation for the casting APIs that have been simplified so far in APIs.md (more docs will be added in following PRs as the remaining APIs are simplified)

### Testing

Verified and tested locally with Linux TV app