### PR TITLE
Set CHIP_CONFIG_MDNS_RESOLVE_LOOKUP_RESULTS in linux platform

### DIFF
--- a/src/platform/Linux/SystemPlatformConfig.h
+++ b/src/platform/Linux/SystemPlatformConfig.h
@@ -41,3 +41,4 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1
 
 // ========== Platform-specific Configuration Overrides =========
+#define CHIP_CONFIG_MDNS_RESOLVE_LOOKUP_RESULTS 5


### PR DESCRIPTION
This commit makes possible to try next IP address if connection on current IP address was failed on Linux platform

Now it works only on Darwin platform, because CHIP_CONFIG_MDNS_RESOLVE_LOOKUP_RESULTS is 5 on this platform. 
https://github.com/rus084/connectedhomeip/blob/cce6c2419d5e46d2b2892b931fb49735af75716d/src/platform/Darwin/SystemPlatformConfig.h#L52

But in linux platform by default CHIP_CONFIG_MDNS_RESOLVE_LOOKUP_RESULTS is 1 and there is no "next" ip address