### PR TITLE
Not call onError in BufferedReadCallback

### DIFF
--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -39,7 +39,7 @@ void BufferedReadCallback::OnReportEnd()
     CHIP_ERROR err = DispatchBufferedData(mBufferedPath, StatusIB(), true);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DataManagment, "Fail to dispatch buffered data with error %s in path %s", err.toString(), mBufferedPath.LogPath())
+        ChipLogError(DataManagement, "Fail to dispatch buffered data with error %s in path %s", err.toString(), mBufferedPath.LogPath())
         return;
     }
 
@@ -259,7 +259,7 @@ void BufferedReadCallback::OnAttributeData(const ConcreteDataAttributePath & aPa
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DataManagment, "Fail in OnAttributeData with error %s in path %s", err.toString(), aPath.LogPath())
+        ChipLogError(DataManagement, "Fail in OnAttributeData with error %s in path %s", err.toString(), aPath.LogPath())
     }
 }
 

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -39,7 +39,7 @@ void BufferedReadCallback::OnReportEnd()
     CHIP_ERROR err = DispatchBufferedData(mBufferedPath, StatusIB(), true);
     if (err != CHIP_NO_ERROR)
     {
-        mCallback.OnError(err);
+        ChipLogError(DataManagment, "Fail to dispatch buffered data with error %s in path %s", err.toString(), mBufferedPath.LogPath())
         return;
     }
 
@@ -259,7 +259,7 @@ void BufferedReadCallback::OnAttributeData(const ConcreteDataAttributePath & aPa
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        mCallback.OnError(err);
+        ChipLogError(DataManagment, "Fail in OnAttributeData with error %s in path %s", err.toString(), aPath.LogPath())
     }
 }
 


### PR DESCRIPTION
If onError has been called from BufferedReadCallback when processing multiple attrbitues, potentially onError or onAttribute or onEvent could be called again from ReadClient, as a result, the behavior in application could be unexpected, crash is possible. onError should be called only with  close path from readClient.
