### PR TITLE
Remove pair step before calling any cluster API

### DIFF
--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
@@ -41,6 +41,9 @@ class PairOnNetworkLongImInvokeCommand(
       try {
         val identifyTime: UShort = 1u
         val identifyCluster = IdentifyCluster(controller = currentCommissioner(), endpointId = 0u)
+
+        // By running command identify, we are implicitly requesting CASE to be established if it's
+        // not already present.
         identifyCluster.identify(identifyTime)
         logger.log(Level.INFO, "Invoke command succeeded")
       } catch (ex: Exception) {

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImInvokeCommand.kt
@@ -37,17 +37,6 @@ class PairOnNetworkLongImInvokeCommand(
     DiscoveryFilterType.LONG_DISCRIMINATOR
   ) {
   override fun runCommand() {
-    currentCommissioner()
-      .pairDevice(
-        getNodeId(),
-        getRemoteAddr().address.hostAddress,
-        MATTER_PORT,
-        getDiscriminator(),
-        getSetupPINCode(),
-      )
-    currentCommissioner().setCompletionListener(this)
-    waitCompleteMs(getTimeoutMillis())
-
     runBlocking {
       try {
         val identifyTime: UShort = 1u

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
@@ -17,17 +17,6 @@ class PairOnNetworkLongImReadCommand(controller: MatterController, credsIssue: C
     DiscoveryFilterType.LONG_DISCRIMINATOR
   ) {
   override fun runCommand() {
-    currentCommissioner()
-      .pairDevice(
-        getNodeId(),
-        getRemoteAddr().address.hostAddress,
-        MATTER_PORT,
-        getDiscriminator(),
-        getSetupPINCode(),
-      )
-    currentCommissioner().setCompletionListener(this)
-    waitCompleteMs(getTimeoutMillis())
-
     runBlocking {
       try {
         val basicInformationCluster =

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImReadCommand.kt
@@ -22,6 +22,9 @@ class PairOnNetworkLongImReadCommand(controller: MatterController, credsIssue: C
         val basicInformationCluster =
           BasicInformationCluster(controller = currentCommissioner(), endpointId = DEFAULT_ENDPOINT)
         val vendorName = basicInformationCluster.readVendorNameAttribute()
+
+        // By running command readVendorIDAttribute, we are implicitly requesting CASE to be
+        // established if it's not already present.
         val vendorId = basicInformationCluster.readVendorIDAttribute()
         logger.log(Level.INFO, "Read command succeeded, Verdor Name:${vendorName} (ID:${vendorId})")
       } catch (ex: Exception) {

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
@@ -37,17 +37,6 @@ class PairOnNetworkLongImWriteCommand(
     DiscoveryFilterType.LONG_DISCRIMINATOR
   ) {
   override fun runCommand() {
-    currentCommissioner()
-      .pairDevice(
-        getNodeId(),
-        getRemoteAddr().address.hostAddress,
-        MATTER_PORT,
-        getDiscriminator(),
-        getSetupPINCode(),
-      )
-    currentCommissioner().setCompletionListener(this)
-    waitCompleteMs(getTimeoutMillis())
-
     runBlocking {
       try {
         val basicInformationCluster =

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImWriteCommand.kt
@@ -41,6 +41,9 @@ class PairOnNetworkLongImWriteCommand(
       try {
         val basicInformationCluster =
           BasicInformationCluster(controller = currentCommissioner(), endpointId = DEFAULT_ENDPOINT)
+
+        // By running command writeNodeLabelAttribute, we are implicitly requesting CASE to be
+        // established if it's not already present.
         basicInformationCluster.writeNodeLabelAttribute("Test Node Label")
         logger.log(Level.INFO, "Write command succeeded")
 


### PR DESCRIPTION
Kotlin Cluster API is able to establish the CASE connection with node automatically if needed, no need to explicitly pair the device before calling any cluster API

