### PR TITLE
[Telink] change Docker version 26 -> 29

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -96,7 +96,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:26
+            image: ghcr.io/project-chip/chip-build-telink:29
             options: --user root
 
         steps:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:26
+            image: ghcr.io/project-chip/chip-build-telink:29
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -163,7 +163,7 @@ portpicker==1.5.2
     # via
     #   -r requirements.all.txt
     #   mobly
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.24.4
     # via


### PR DESCRIPTION
Failing bootstrap after Docker version updated in other places ( possibly "29 : [ESP] Update esp-idf to v5.1.2" #30920 ).
In fact, Github CI wouldn't show any build failures as it used 26 version.
Tests manually on Telink platform showed issues during bootstrap with python module `prompt_toolkit`.
Changing its version in `scripts/setup/constraints.txt` to `3.0.43` fixed bootstrap issues 
