### PR TITLE
[windows] Fix build on windows

### DIFF
--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -52,11 +52,11 @@ function(chip_codegen TARGET_NAME)
 
         # Python is expected to be in the path
         #
-        # find_package(Python3 REQUIRED)
+        find_package(Python3 REQUIRED)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND "${CHIP_ROOT}/scripts/codegen.py"
-            ARGS "--generator" "${ARG_GENERATOR}"
+            COMMAND ${Python3_EXECUTABLE} "${CHIP_ROOT}/scripts/codegen.py"
+                 "--generator" "${ARG_GENERATOR}"
                  "--output-dir" "${GEN_FOLDER}"
                  "--expected-outputs" "${GEN_FOLDER}/expected.outputs"
                  "${ARG_INPUT}"
@@ -172,18 +172,14 @@ function(chip_zapgen TARGET_NAME)
             message(SEND_ERROR "Unsupported zap generator: ${ARG_GENERATOR}")
         endif()
 
-        # Python is expected to be in the path
-        #
-        # find_package(Python3 REQUIRED)
-        #
         # TODO: lockfile support should be removed as this serializes zap
         # (slower), however this is currently done because on Darwin zap startup
         # may conflict and error out with:
         #    Error: EEXIST: file already exists, mkdir '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pkg/465fcc8a6282e28dc7a166859d5814d34e2fb94249a72fa9229033b5b32dff1a'
+        find_package(Python3 REQUIRED)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND "${CHIP_ROOT}/scripts/tools/zap/generate.py"
-            ARGS
+            COMMAND ${Python3_EXECUTABLE} "${CHIP_ROOT}/scripts/tools/zap/generate.py"
                 "--no-prettify-output"
                 "--templates" "${TEMPLATE_PATH}"
                 "--output-dir" "${GEN_FOLDER}/${OUTPUT_SUBDIR}"

--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -121,7 +121,7 @@ macro(matter_build target)
         BUILD_COMMAND           ${CMAKE_COMMAND} -E echo "Starting Matter library build in ${CMAKE_CURRENT_BINARY_DIR}"
         COMMAND                 ${Python3_EXECUTABLE} ${CHIP_ROOT}/config/common/cmake/make_gn_args.py @args.tmp > args.gn.tmp
         # Replace the config only if it has changed to avoid triggering unnecessary rebuilds
-        COMMAND                 bash -c "(! diff -q args.gn.tmp args.gn && mv args.gn.tmp args.gn) || true"
+        COMMAND                 ${CMAKE_COMMAND} -E compare_files args.gn.tmp args.gn || ${CMAKE_COMMAND} -E rename args.gn.tmp args.gn
         # Regenerate the ninja build system
         COMMAND                 ${GN_EXECUTABLE}
                                     --root=${CHIP_ROOT}

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -16,9 +16,9 @@
 #
 
 import argparse
-import fcntl
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -29,6 +29,13 @@ from pathlib import Path
 from typing import Optional
 
 from zap_execution import ZapTool
+
+def isWindows():
+    return platform.system() == "Windows"
+
+# fcntl is not supported on Windows platform due to lack of necessity of I/O control on file descriptor
+if not isWindows():
+    import fcntl
 
 
 @dataclass
@@ -326,7 +333,8 @@ def runClangPrettifier(templates_file, output_dir):
 
 class LockFileSerializer:
     def __init__(self, path):
-        self.lock_file_path = path
+        # fcntl is not supported on Windows platform due to lack of necessity of I/O control on file descriptor
+        self.lock_file_path = None if isWindows() else path
         self.lock_file = None
 
     def __enter__(self):

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -30,8 +30,10 @@ from typing import Optional
 
 from zap_execution import ZapTool
 
+
 def isWindows():
     return platform.system() == "Windows"
+
 
 # fcntl is not supported on Windows platform due to lack of necessity of I/O control on file descriptor
 if not isWindows():

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -16,6 +16,10 @@
 
 set(CHIP_APP_BASE_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+if (NOT CHIP_ROOT)
+    get_filename_component(CHIP_ROOT ${CHIP_APP_BASE_DIR}/../.. REALPATH)
+endif()
+
 include("${CHIP_ROOT}/build/chip/chip_codegen.cmake")
 
 # Configure ${APP_TARGET} with source files associated with ${CLUSTER} cluster


### PR DESCRIPTION
Adjust build scripts to make build work on Windows:
 * use CMake commands instead of bash in build script
 * use Python3_EXECUTABLE CMake variable instead of relying on shebang line processing
 * bypass file locking on Windows
