### PR TITLE
Drop enum support for larger than 16 bit.

### DIFF
--- a/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
+++ b/scripts/py_matter_idl/examples/matter_idl_plugin/__init__.py
@@ -56,7 +56,7 @@ def toEnumEntryName(enumEntry, enumName):
 def toProtobufType(zapType: str) -> str:
     """ Convert zap type to protobuf type """
     u32Types = [
-        "uint32", "enum8", "enum16", "enum32", "bitmap8",
+        "uint32", "enum8", "enum16", "bitmap8",
         "bitmap16", "bitmap32", "cluster_id", "attrib_id",
         "event_id", "command_id", "endpoint_no", "group_id",
         "devtype_id", "fabric_idx", "vendor_id", "status_code",

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -245,7 +245,7 @@ class EnumHandler(BaseHandler):
         if not self._enum.entries:
             return
 
-        # try to find the best enum size that fits out of enum8, enum32 and enum32
+        # try to find the best enum size that fits out of enum8 and enum16
         # TODO: this is a pure heuristic. XML containing this would be better.
         #       https://github.com/csa-data-model/projects/issues/345
         acceptable = {8, 16}

--- a/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/java/__init__.py
@@ -126,8 +126,6 @@ _KNOWN_DECODABLE_TYPES = {
     # non-named enums
     'enum8': 'uint8_t',
     'enum16': 'uint16_t',
-    'enum32': 'uint32_t',
-    'enum64': 'uint64_t',
 }
 
 
@@ -320,8 +318,6 @@ def _IsUsingGlobalCallback(field: Field, context: TypeLookupContext):
         "int64u",
         "enum8",
         "enum16",
-        "enum32",
-        "enum64",
         "bitmap8",
         "bitmap16",
         "bitmap32",

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
@@ -126,8 +126,6 @@ _KNOWN_DECODABLE_TYPES = {
     # non-named enums
     'enum8': 'uint8_t',
     'enum16': 'uint16_t',
-    'enum32': 'uint32_t',
-    'enum64': 'uint64_t',
 }
 
 

--- a/scripts/py_matter_idl/matter_idl/generators/type_definitions.py
+++ b/scripts/py_matter_idl/matter_idl/generators/type_definitions.py
@@ -169,8 +169,6 @@ __CHIP_SIZED_TYPES__ = {
     "bitmap64": BasicInteger(idl_name="bitmap64", byte_count=8, is_signed=False),
     "bitmap8": BasicInteger(idl_name="bitmap8", byte_count=1, is_signed=False),
     "enum16": BasicInteger(idl_name="enum16", byte_count=2, is_signed=False),
-    "enum24": BasicInteger(idl_name="enum24", byte_count=3, is_signed=False),
-    "enum32": BasicInteger(idl_name="enum32", byte_count=4, is_signed=False),
     "enum8": BasicInteger(idl_name="enum8", byte_count=1, is_signed=False),
     "int16s": BasicInteger(idl_name="int16s", byte_count=2, is_signed=True),
     "int16u": BasicInteger(idl_name="int16u", byte_count=2, is_signed=False),
@@ -336,7 +334,7 @@ class TypeLookupContext:
         Handles both standard names (like enum8) as well as enumerations defined
         within the current lookup context.
         """
-        if name.lower() in ["enum8", "enum16", "enum24", "enum32"]:
+        if name.lower() in ["enum8", "enum16"]:
             return True
         return any(map(lambda e: e.name == name, self.all_enums))
 
@@ -386,7 +384,7 @@ def ParseDataType(data_type: DataType, lookup: TypeLookupContext) -> Union[Basic
         return BasicString(idl_name=lowercase_name, is_binary=False, max_length=data_type.max_length)
     elif lowercase_name in ['octet_string', 'long_octet_string']:
         return BasicString(idl_name=lowercase_name, is_binary=True, max_length=data_type.max_length)
-    elif lowercase_name in ['enum8', 'enum16', 'enum24', 'enum32']:
+    elif lowercase_name in ['enum8', 'enum16']:
         return IdlEnumType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
     elif lowercase_name in ['bitmap8', 'bitmap16', 'bitmap24', 'bitmap32', 'bitmap64']:
         return IdlBitmapType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])

--- a/scripts/py_matter_idl/matter_idl/generators/type_definitions.py
+++ b/scripts/py_matter_idl/matter_idl/generators/type_definitions.py
@@ -164,7 +164,6 @@ class IdlType:
 # Data types, held by ZAP in chip-types.xml and generally by the spec.
 __CHIP_SIZED_TYPES__ = {
     "bitmap16": BasicInteger(idl_name="bitmap16", byte_count=2, is_signed=False),
-    "bitmap24": BasicInteger(idl_name="bitmap24", byte_count=3, is_signed=False),
     "bitmap32": BasicInteger(idl_name="bitmap32", byte_count=4, is_signed=False),
     "bitmap64": BasicInteger(idl_name="bitmap64", byte_count=8, is_signed=False),
     "bitmap8": BasicInteger(idl_name="bitmap8", byte_count=1, is_signed=False),
@@ -346,7 +345,7 @@ class TypeLookupContext:
 
     def is_untyped_bitmap_type(self, name: str):
         """Determine if the given type is a untyped bitmap (just an interger size)."""
-        return name.lower() in {"bitmap8", "bitmap16", "bitmap24", "bitmap32", "bitmap64"}
+        return name.lower() in {"bitmap8", "bitmap16", "bitmap32", "bitmap64"}
 
     def is_bitmap_type(self, name: str):
         """
@@ -386,7 +385,7 @@ def ParseDataType(data_type: DataType, lookup: TypeLookupContext) -> Union[Basic
         return BasicString(idl_name=lowercase_name, is_binary=True, max_length=data_type.max_length)
     elif lowercase_name in ['enum8', 'enum16']:
         return IdlEnumType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
-    elif lowercase_name in ['bitmap8', 'bitmap16', 'bitmap24', 'bitmap32', 'bitmap64']:
+    elif lowercase_name in ['bitmap8', 'bitmap16', 'bitmap32', 'bitmap64']:
         return IdlBitmapType(idl_name=lowercase_name, base_type=__CHIP_SIZED_TYPES__[lowercase_name])
 
     int_type = __CHIP_SIZED_TYPES__.get(lowercase_name, None)

--- a/scripts/py_matter_idl/matter_idl/test_supported_types.py
+++ b/scripts/py_matter_idl/matter_idl/test_supported_types.py
@@ -72,7 +72,7 @@ class TestSupportedTypes(unittest.TestCase):
                     # handled as a non-integer type
                     "boolean", "single", "double",
                     # handled as specific bitmaps
-                    "bitmap8", "bitmap16", "bitmap24", "bitmap32", "bitmap64",
+                    "bitmap8", "bitmap16", "bitmap32", "bitmap64",
                     # handled as specific enums. Note that spec defines enumerations only for 8 and 16
                     "enum8", "enum16",
 

--- a/scripts/py_matter_idl/matter_idl/test_supported_types.py
+++ b/scripts/py_matter_idl/matter_idl/test_supported_types.py
@@ -74,7 +74,7 @@ class TestSupportedTypes(unittest.TestCase):
                     # handled as specific bitmaps
                     "bitmap8", "bitmap16", "bitmap24", "bitmap32", "bitmap64",
                     # handled as specific enums. Note that spec defines enumerations only for 8 and 16
-                    "enum8", "enum16"
+                    "enum8", "enum16",
 
                     # TODO: these may be bugs to fix
                     "unknown"

--- a/scripts/py_matter_idl/matter_idl/test_supported_types.py
+++ b/scripts/py_matter_idl/matter_idl/test_supported_types.py
@@ -73,8 +73,8 @@ class TestSupportedTypes(unittest.TestCase):
                     "boolean", "single", "double",
                     # handled as specific bitmaps
                     "bitmap8", "bitmap16", "bitmap24", "bitmap32", "bitmap64",
-                    # handled as specific enums
-                    "enum8", "enum16", "enum24", "enum32",
+                    # handled as specific enums. Note that spec defines enumerations only for 8 and 16
+                    "enum8", "enum16"
 
                     # TODO: these may be bugs to fix
                     "unknown"

--- a/src/app/tests/suites/README.md
+++ b/src/app/tests/suites/README.md
@@ -314,7 +314,6 @@ src/app/tests/suites/examples/gen_readme_example.sh
 | boolean           | 1    | BOOLEAN           | 0x10 | Boolean                  | uint8_t    |
 | bitmap8           | 1    | BITMAP8           | 0x18 | 8-bit bitmap             | uint8_t    |
 | bitmap16          | 2    | BITMAP16          | 0x19 | 16-bit bitmap            | uint16_t   |
-| bitmap24          | 3    | BITMAP24          | 0x1A | 24-bit bitmap            | uint32_t   |
 | bitmap32          | 4    | BITMAP32          | 0x1B | 32-bit bitmap            | uint32_t   |
 | bitmap64          | 8    | BITMAP64          | 0x1F | 64-bit bitmap            | uint8_t \* |
 | int8u             | 1    | INT8U             | 0x20 | Unsigned 8-bit integer   | uint8_t    |

--- a/src/app/zap-templates/zcl/data-model/chip/chip-types.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-types.xml
@@ -27,7 +27,6 @@ limitations under the License.
     <type id="0x10" description="Boolean"                  name="boolean"           size="1"  discrete="true" />
     <type id="0x18" description="8-bit bitmap"             name="bitmap8"           size="1"  discrete="true" />
     <type id="0x19" description="16-bit bitmap"            name="bitmap16"          size="2"  discrete="true" />
-    <type id="0x1A" description="24-bit bitmap"            name="bitmap24"          size="3"  discrete="true" />
     <type id="0x1B" description="32-bit bitmap"            name="bitmap32"          size="4"  discrete="true" />
     <type id="0x1F" description="64-bit bitmap"            name="bitmap64"          size="8"  discrete="true" />
     <type id="0x20" description="Unsigned 8-bit integer"   name="int8u"             size="1"  analog="true"   />

--- a/zzz_generated/app-common/app-common/zap-generated/attribute-type.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attribute-type.h
@@ -27,7 +27,6 @@ enum
     ZCL_BOOLEAN_ATTRIBUTE_TYPE           = 0x10, // Boolean
     ZCL_BITMAP8_ATTRIBUTE_TYPE           = 0x18, // 8-bit bitmap
     ZCL_BITMAP16_ATTRIBUTE_TYPE          = 0x19, // 16-bit bitmap
-    ZCL_BITMAP24_ATTRIBUTE_TYPE          = 0x1A, // 24-bit bitmap
     ZCL_BITMAP32_ATTRIBUTE_TYPE          = 0x1B, // 32-bit bitmap
     ZCL_BITMAP64_ATTRIBUTE_TYPE          = 0x1F, // 64-bit bitmap
     ZCL_INT8U_ATTRIBUTE_TYPE             = 0x20, // Unsigned 8-bit integer


### PR DESCRIPTION
Spec `7.19.2 Data Types`  says that enumerations may only go up to enum16 and chip-types.xml agrees with that.

This removes the enum24/32/64 support from various python files.

I grepped all .matter files and none use more than enum8/16.

###  Changes

- remove references of enum24/enum32/enum64 from scripts
- remove bitmap24 from types XML and script references (since type 0x1A is NOT in the spec anymore)

