### PR TITLE
Introduce CommandSender::Callback::OnPathSpecificError 

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -387,7 +387,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             ConcreteCommandPath concreteCommandPath(endpointId, clusterId, commandId);
             if (statusIB.IsSuccess())
             {
-               mpCallback->OnResponseWithAdditionalData(this, concreteCommandPath, statusIB,
+                mpCallback->OnResponseWithAdditionalData(this, concreteCommandPath, statusIB,
                                                          hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);
             }
             else

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -384,14 +384,15 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
 
         if (mpCallback != nullptr)
         {
+            ConcreteCommandPath concreteCommandPath(endpointId, clusterId, commandId);
             if (statusIB.IsSuccess())
             {
-                mpCallback->OnResponseWithAdditionalData(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
+               mpCallback->OnResponseWithAdditionalData(this, concreteCommandPath, statusIB,
                                                          hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);
             }
             else
             {
-                mpCallback->OnError(this, statusIB.ToChipError());
+                mpCallback->OnPathSpecificError(this, concreteCommandPath, statusIB, additionalResponseData);
             }
         }
     }

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -133,11 +133,11 @@ public:
          * receives an OnDone call to destroy and free the object.
          *
          * Note: When implementing batch command feature for Matter 1.3, it was noticed that there was a gap for when path-specific
-         * IM Status was not successful. OnResponse contract explicitily states that IM Status needed to be success. OnError's contract
-         * specified that it only is supposed to take non-path-specific status response from the server. We were left with this gap
-         * where we needed a callback that could be called for path-specific statuses that contained an error. Ideally it would have
-         * been nice to change OnResponse's contract to not force IM status to be a success, but doing so would cause regression as
-         * code outside SDK may rely on the existing callback behavior; hence the addition of OnPathSpecificError.
+         * IM Status was not successful. OnResponse contract explicitily states that IM Status needed to be success. OnError's
+         * contract specified that it only is supposed to take non-path-specific status response from the server. We were left with
+         * this gap where we needed a callback that could be called for path-specific statuses that contained an error. Ideally it
+         * would have been nice to change OnResponse's contract to not force IM status to be a success, but doing so would cause
+         * regression as code outside SDK may rely on the existing callback behavior; hence the addition of OnPathSpecificError.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -132,9 +132,9 @@ public:
          * receives an OnDone call to destroy and free the object.
          *
          * Note: When implementing batch command feature for Matter 1.3, it was noticed that there was a gap for when IM Status was
-         * not successful for a particular path. OnResponse contract explicitily states that IM Status needed to be success. OnError's
-         * contract specified that it only is supposed to take non-path-specific status response from the server. We were left with this
-         * gap where we needed a callback that could be called for path-specific statuses.
+         * not successful for a particular path. OnResponse contract explicitily states that IM Status needed to be success.
+         * OnError's contract specified that it only is supposed to take non-path-specific status response from the server. We were
+         * left with this gap where we needed a callback that could be called for path-specific statuses.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.
@@ -143,12 +143,12 @@ public:
          * @param[in] aAdditionalResponseData
          *                            Additional response data that comes within the InvokeResponseMessage.
          */
-        virtual void OnPathSpecificError(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatusIB,
-                                         const AdditionalResponseData & aAdditionalResponseData)
+        virtual void OnPathSpecificError(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
+                                         const StatusIB & aStatusIB, const AdditionalResponseData & aAdditionalResponseData)
         {
-            // Legacy code was previously sending these path-specific error status to OnError. To not break compatibility we will continue
-            // to send these error to OnError. Clients that want granularity differentiating between path-specific, and non-path specific
-            // errors can override this method to capture path-specific error.
+            // Legacy code was previously sending these path-specific error status to OnError. To not break compatibility we will
+            // continue to send these error to OnError. Clients that want granularity differentiating between path-specific, and
+            // non-path specific errors can override this method to capture path-specific error.
             OnError(apCommandSender, aStatusIB.ToChipError());
         }
 
@@ -484,10 +484,10 @@ private:
     uint16_t mRemoteMaxPathsPerInvoke = 1;
 
     bool mSendPathSpecificErrorToOnResponseCallback = false;
-    bool mSuppressResponse     = false;
-    bool mTimedRequest         = false;
-    bool mBufferAllocated      = false;
-    bool mBatchCommandsEnabled = false;
+    bool mSuppressResponse                          = false;
+    bool mTimedRequest                              = false;
+    bool mBufferAllocated                           = false;
+    bool mBatchCommandsEnabled                      = false;
 };
 
 } // namespace app

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -126,20 +126,22 @@ public:
         {}
 
         /**
-         * OnPathSpecificError will be called when we recieved a response from server, but server had an issue processing request.
+         * OnPathSpecificError will be called when we recieved a response from server, but server had an issue processing request
+         * with the associated path.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy and free the object.
          *
-         * Note: When implementing batch command feature for Matter 1.3, it was noticed that there was a gap for when IM Status was
-         * not successful for a particular path. OnResponse contract explicitily states that IM Status needed to be success.
-         * OnError's contract specified that it only is supposed to take non-path-specific status response from the server. We were
-         * left with this gap where we needed a callback that could be called for path-specific statuses.
+         * Note: When implementing batch command feature for Matter 1.3, it was noticed that there was a gap for when path-specific
+         * IM Status was not successful. OnResponse contract explicitily states that IM Status needed to be success. OnError's contract
+         * specified that it only is supposed to take non-path-specific status response from the server. We were left with this gap
+         * where we needed a callback that could be called for path-specific statuses that contained an error. Ideally it would have
+         * been nice to change OnResponse's contract to no force IM status to be a success, but doing so would break a lot of code,
+         * hence the addition of OnPathSpecificError.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.
-         * @param[in] aStatusIB       It will always have a success status. It can be any error status,
-         *                            including possibly a cluster-specific one.
+         * @param[in] aStatusIB       It can be any IM error status, including possibly a cluster-specific one.
          * @param[in] aAdditionalResponseData
          *                            Additional response data that comes within the InvokeResponseMessage.
          */

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -136,8 +136,8 @@ public:
          * IM Status was not successful. OnResponse contract explicitily states that IM Status needed to be success. OnError's contract
          * specified that it only is supposed to take non-path-specific status response from the server. We were left with this gap
          * where we needed a callback that could be called for path-specific statuses that contained an error. Ideally it would have
-         * been nice to change OnResponse's contract to no force IM status to be a success, but doing so would break a lot of code,
-         * hence the addition of OnPathSpecificError.
+         * been nice to change OnResponse's contract to not force IM status to be a success, but doing so would cause regression as
+         * code outside SDK may rely on the existing callback behavior; hence the addition of OnPathSpecificError.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.
@@ -163,8 +163,8 @@ public:
          * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific status response
          *     from the server. In that case, StatusIB::InitFromChipError can be used to extract
          *     the status.
-         *       Note: If client does not override OnPathSpecificError they will also get path-specific status response
-         *             from server this way. This is done for backwards compatibility.
+         *       Note: If client does not override OnPathSpecificError they will also get path-specific error status
+         *             response(s) from server this way. This is done for backwards compatibility.
          * - CHIP_ERROR*: All other cases.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -483,11 +483,10 @@ private:
     uint16_t mFinishedCommandCount    = 0;
     uint16_t mRemoteMaxPathsPerInvoke = 1;
 
-    bool mSendPathSpecificErrorToOnResponseCallback = false;
-    bool mSuppressResponse                          = false;
-    bool mTimedRequest                              = false;
-    bool mBufferAllocated                           = false;
-    bool mBatchCommandsEnabled                      = false;
+    bool mSuppressResponse     = false;
+    bool mTimedRequest         = false;
+    bool mBufferAllocated      = false;
+    bool mBatchCommandsEnabled = false;
 };
 
 } // namespace app

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -126,14 +126,43 @@ public:
         {}
 
         /**
+         * OnPathSpecificError will be called when we recieved a response from server, but server had an issue processing request.
+         *
+         * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
+         * receives an OnDone call to destroy and free the object.
+         *
+         * Note: When implementing batch command feature for Matter 1.3, it was noticed that there was a gap for when IM Status was
+         * not successful for a particular path. OnResponse contract explicitily states that IM Status needed to be success. OnError's
+         * contract specified that it only is supposed to take non-path-specific status response from the server. We were left with this
+         * gap where we needed a callback that could be called for path-specific statuses.
+         *
+         * @param[in] apCommandSender The command sender object that initiated the command transaction.
+         * @param[in] aPath           The command path field in invoke command response.
+         * @param[in] aStatusIB       It will always have a success status. It can be any error status,
+         *                            including possibly a cluster-specific one.
+         * @param[in] aAdditionalResponseData
+         *                            Additional response data that comes within the InvokeResponseMessage.
+         */
+        virtual void OnPathSpecificError(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatusIB,
+                                         const AdditionalResponseData & aAdditionalResponseData)
+        {
+            // Legacy code was previously sending these path-specific error status to OnError. To not break compatibility we will continue
+            // to send these error to OnError. Clients that want granularity differentiating between path-specific, and non-path specific
+            // errors can override this method to capture path-specific error.
+            OnError(apCommandSender, aStatusIB.ToChipError());
+        }
+
+        /**
          * OnError will be called when an error occur *after* a successful call to SendCommandRequest(). The following
          * errors will be delivered through this call in the aError field:
          *
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
          * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
-         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
+         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific status response
+         *     from the server. In that case, StatusIB::InitFromChipError can be used to extract
+         *     the status.
+         *       Note: If client does not override OnPathSpecificError they will also get path-specific status response
+         *             from server this way. This is done for backwards compatibility.
          * - CHIP_ERROR*: All other cases.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
@@ -454,6 +483,7 @@ private:
     uint16_t mFinishedCommandCount    = 0;
     uint16_t mRemoteMaxPathsPerInvoke = 1;
 
+    bool mSendPathSpecificErrorToOnResponseCallback = false;
     bool mSuppressResponse     = false;
     bool mTimedRequest         = false;
     bool mBufferAllocated      = false;


### PR DESCRIPTION
Fixes: https://github.com/project-chip/connectedhomeip/issues/30991

This solution introduces a new virtual function to `CommandSender::Callback` called `OnPathSpecificError`

Advantage:
* This puts the burden on implementer that want batch commands to explicitly make the required fixes so that they get the path specific errors in the manner that they want

Drawback:
* Should platforms not properly implement this, they will start getting multiple calls to the `OnError` callback which was never the intention
* APIs Contract to `CommandSender::Callback` continue to look ugly going into the future

Test:
* CI Passes
* With local changes confirmed that I am able to differentiate errors from the InvokeRequests Action and the individual command errors
