### PR TITLE
[Linux] BlueZ changes to improve the use of the BluezEndpoint object

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -115,6 +115,24 @@ struct GAutoPtrDeleter<GDBusConnection>
 };
 
 template <>
+struct GAutoPtrDeleter<GDBusObjectManager>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<GDBusObjectManagerServer>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<GCancellable>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GError>
 {
     using deleter = GErrorDeleter;

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -595,7 +595,7 @@ void BLEManagerImpl::DriveBLEState()
             // Configure advertising data if it hasn't been done yet.
             if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
-                SuccessOrExit(err = mBLEAdvertisement.Init(&mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
+                SuccessOrExit(err = mBLEAdvertisement.Init(mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
                 mFlags.Set(Flags::kAdvertisingConfigured);
             }
 
@@ -668,7 +668,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     mBLEScanConfig.mBleScanState = scanType;
 
-    CHIP_ERROR err = mDeviceScanner.Init(&mEndpoint, this);
+    CHIP_ERROR err = mDeviceScanner.Init(this);
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -595,7 +595,7 @@ void BLEManagerImpl::DriveBLEState()
             // Configure advertising data if it hasn't been done yet.
             if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
-                SuccessOrExit(err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
+                SuccessOrExit(err = mBLEAdvertisement.Init(&mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
                 mFlags.Set(Flags::kAdvertisingConfigured);
             }
 
@@ -668,7 +668,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 
     mBLEScanConfig.mBleScanState = scanType;
 
-    CHIP_ERROR err = mDeviceScanner.Init(mEndpoint.GetAdapter(), this);
+    CHIP_ERROR err = mDeviceScanner.Init(&mEndpoint, this);
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -188,12 +188,12 @@ private:
     bool mIsCentral = false;
     BluezEndpoint mEndpoint;
 
-    BluezAdvertisement mBLEAdvertisement;
-    ChipAdvType mBLEAdvType    = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
-    uint16_t mBLEAdvDurationMs = 20;
-    const char * mpBLEAdvUUID  = nullptr;
+    BluezAdvertisement mBLEAdvertisement = BluezAdvertisement(mEndpoint);
+    ChipAdvType mBLEAdvType              = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
+    uint16_t mBLEAdvDurationMs           = 20;
+    const char * mpBLEAdvUUID            = nullptr;
 
-    ChipDeviceScanner mDeviceScanner;
+    ChipDeviceScanner mDeviceScanner = ChipDeviceScanner(mEndpoint);
     BLEScanConfig mBLEScanConfig;
 };
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -188,12 +188,12 @@ private:
     bool mIsCentral = false;
     BluezEndpoint mEndpoint;
 
-    BluezAdvertisement mBLEAdvertisement = BluezAdvertisement(mEndpoint);
-    ChipAdvType mBLEAdvType              = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
-    uint16_t mBLEAdvDurationMs           = 20;
-    const char * mpBLEAdvUUID            = nullptr;
+    BluezAdvertisement mBLEAdvertisement{ mEndpoint };
+    ChipAdvType mBLEAdvType    = ChipAdvType::BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE;
+    uint16_t mBLEAdvDurationMs = 20;
+    const char * mpBLEAdvUUID  = nullptr;
 
-    ChipDeviceScanner mDeviceScanner = ChipDeviceScanner(mEndpoint);
+    ChipDeviceScanner mDeviceScanner{ mEndpoint };
     BLEScanConfig mBLEScanConfig;
 };
 

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -28,20 +28,9 @@ namespace Internal {
 
 AdapterIterator::~AdapterIterator()
 {
-    if (mManager != nullptr)
-    {
-        g_object_unref(mManager);
-    }
-
     if (mObjectList != nullptr)
     {
         g_list_free_full(mObjectList, g_object_unref);
-    }
-
-    if (mCurrent.adapter != nullptr)
-    {
-        g_object_unref(mCurrent.adapter);
-        mCurrent.adapter = nullptr;
     }
 }
 
@@ -54,15 +43,16 @@ CHIP_ERROR AdapterIterator::Initialize(AdapterIterator * self)
     CHIP_ERROR err = CHIP_NO_ERROR;
     GAutoPtr<GError> error;
 
-    self->mManager = g_dbus_object_manager_client_new_for_bus_sync(
+    self->mManager = GAutoPtr<GDBusObjectManager>(g_dbus_object_manager_client_new_for_bus_sync(
         G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/",
         bluez_object_manager_client_get_proxy_type, nullptr /* unused user data in the Proxy Type Func */,
-        nullptr /*destroy notify */, nullptr /* cancellable */, &MakeUniquePointerReceiver(error).Get());
+        nullptr /*destroy notify */, nullptr /* cancellable */, &MakeUniquePointerReceiver(error).Get()));
 
-    VerifyOrExit(self->mManager != nullptr, ChipLogError(DeviceLayer, "Failed to get DBUS object manager for listing adapters.");
+    VerifyOrExit(self->mManager.get() != nullptr,
+                 ChipLogError(DeviceLayer, "Failed to get DBUS object manager for listing adapters.");
                  err = CHIP_ERROR_INTERNAL);
 
-    self->mObjectList      = g_dbus_object_manager_get_objects(self->mManager);
+    self->mObjectList      = g_dbus_object_manager_get_objects(self->mManager.get());
     self->mCurrentListItem = self->mObjectList;
 
 exit:
@@ -102,18 +92,14 @@ bool AdapterIterator::Advance()
             index = 0;
         }
 
-        if (mCurrent.adapter != nullptr)
-        {
-            g_object_unref(mCurrent.adapter);
-            mCurrent.adapter = nullptr;
-        }
+        mCurrent.adapter = nullptr;
 
         mCurrent.index   = index;
         mCurrent.address = bluez_adapter1_get_address(adapter);
         mCurrent.alias   = bluez_adapter1_get_alias(adapter);
         mCurrent.name    = bluez_adapter1_get_name(adapter);
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
-        mCurrent.adapter = adapter;
+        mCurrent.adapter = GAutoPtr<BluezAdapter1>(adapter);
 
         mCurrentListItem = mCurrentListItem->next;
 

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR AdapterIterator::Initialize(AdapterIterator * self)
     CHIP_ERROR err = CHIP_NO_ERROR;
     GAutoPtr<GError> error;
 
-    self->mManager = GAutoPtr<GDBusObjectManager>(g_dbus_object_manager_client_new_for_bus_sync(
+    self->mManager.reset(g_dbus_object_manager_client_new_for_bus_sync(
         G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/",
         bluez_object_manager_client_get_proxy_type, nullptr /* unused user data in the Proxy Type Func */,
         nullptr /*destroy notify */, nullptr /* cancellable */, &MakeUniquePointerReceiver(error).Get()));
@@ -92,14 +92,12 @@ bool AdapterIterator::Advance()
             index = 0;
         }
 
-        mCurrent.adapter = nullptr;
-
         mCurrent.index   = index;
         mCurrent.address = bluez_adapter1_get_address(adapter);
         mCurrent.alias   = bluez_adapter1_get_alias(adapter);
         mCurrent.name    = bluez_adapter1_get_name(adapter);
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
-        mCurrent.adapter = GAutoPtr<BluezAdapter1>(adapter);
+        mCurrent.adapter.reset(adapter);
 
         mCurrentListItem = mCurrentListItem->next;
 

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -61,7 +61,7 @@ public:
     const char * GetAlias() const { return mCurrent.alias.c_str(); }
     const char * GetName() const { return mCurrent.name.c_str(); }
     bool IsPowered() const { return mCurrent.powered; }
-    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter; }
+    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter.get(); }
 
 private:
     /// Sets up the DBUS manager and loads the list
@@ -76,9 +76,9 @@ private:
     static constexpr size_t kMaxAddressLength = 19; // xx:xx:xx:xx:xx:xx
     static constexpr size_t kMaxNameLength    = 64;
 
-    GDBusObjectManager * mManager = nullptr; // DBus connection
-    GList * mObjectList           = nullptr; // listing of objects on the bus
-    GList * mCurrentListItem      = nullptr; // current item viewed in the list
+    GAutoPtr<GDBusObjectManager> mManager; // DBus connection
+    GList * mObjectList      = nullptr;    // listing of objects on the bus
+    GList * mCurrentListItem = nullptr;    // current item viewed in the list
 
     // data valid only if Next() returns true
     struct
@@ -88,7 +88,7 @@ private:
         std::string alias;
         std::string name;
         bool powered;
-        BluezAdapter1 * adapter;
+        GAutoPtr<BluezAdapter1> adapter;
     } mCurrent = { 0 };
 };
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -154,7 +154,8 @@ CHIP_ERROR BluezAdvertisement::Init(ChipAdvType aAdvType, const char * aAdvUUID,
     mDeviceIdInfo.SetAdditionalDataFlag(true);
 #endif
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Init() on CHIPoBluez thread"));
 
@@ -252,8 +253,8 @@ CHIP_ERROR BluezAdvertisement::Start()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err =
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Start() on CHIPoBluez thread"));
     return err;
@@ -314,8 +315,8 @@ CHIP_ERROR BluezAdvertisement::Stop()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err =
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Stop() on CHIPoBluez thread"));
     return err;

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -62,7 +62,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
                           g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, &mDeviceIdInfo, sizeof(mDeviceIdInfo), sizeof(uint8_t)));
     g_variant_builder_add(&serviceUUIDsBuilder, "s", mpAdvUUID);
 
-    localNamePtr = mpAdapterName;
+    localNamePtr = mEndpoint->GetAdapterName();
     if (localNamePtr == nullptr)
     {
         g_snprintf(localName, sizeof(localName), "%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
@@ -107,7 +107,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
                      }),
                      this);
 
-    g_dbus_object_manager_server_export(mpRoot, G_DBUS_OBJECT_SKELETON(object));
+    g_dbus_object_manager_server_export(mEndpoint->GetGattApplicationObjectManager(), G_DBUS_OBJECT_SKELETON(object));
     g_object_unref(object);
 
     return adv;
@@ -116,7 +116,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
 gboolean BluezAdvertisement::BluezLEAdvertisement1Release(BluezLEAdvertisement1 * aAdv, GDBusMethodInvocation * aInvocation)
 {
     ChipLogDetail(DeviceLayer, "Release BLE adv object in %s", __func__);
-    g_dbus_object_manager_server_unexport(mpRoot, mpAdvPath);
+    g_dbus_object_manager_server_unexport(mEndpoint->GetGattApplicationObjectManager(), mpAdvPath);
     g_object_unref(mpAdv);
     mpAdv          = nullptr;
     mIsAdvertising = false;
@@ -133,7 +133,7 @@ CHIP_ERROR BluezAdvertisement::InitImpl()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID,
+CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint * aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID,
                                     uint32_t aAdvDurationMs)
 {
     GAutoPtr<char> rootPath;
@@ -142,11 +142,10 @@ CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType
     VerifyOrExit(mpAdv == nullptr, err = CHIP_ERROR_INCORRECT_STATE;
                  ChipLogError(DeviceLayer, "FAIL: BLE advertisement already initialized in %s", __func__));
 
-    mpRoot        = reinterpret_cast<GDBusObjectManagerServer *>(g_object_ref(aEndpoint.GetGattApplicationObjectManager()));
-    mpAdapter     = reinterpret_cast<BluezAdapter1 *>(g_object_ref(aEndpoint.GetAdapter()));
-    mpAdapterName = g_strdup(aEndpoint.GetAdapterName());
+    mEndpoint = aEndpoint;
 
-    g_object_get(G_OBJECT(mpRoot), "object-path", &MakeUniquePointerReceiver(rootPath).Get(), nullptr);
+    g_object_get(G_OBJECT(mEndpoint->GetGattApplicationObjectManager()), "object-path", &MakeUniquePointerReceiver(rootPath).Get(),
+                 nullptr);
     mpAdvPath      = g_strdup_printf("%s/advertising", rootPath.get());
     mAdvType       = aAdvType;
     mpAdvUUID      = g_strdup(aAdvUUID);
@@ -159,8 +158,7 @@ CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType
     mDeviceIdInfo.SetAdditionalDataFlag(true);
 #endif
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Init() on CHIPoBluez thread"));
 
@@ -188,16 +186,6 @@ void BluezAdvertisement::Shutdown()
     // attached to the advertising object that may run on the glib thread.
     PlatformMgrImpl().GLibMatterContextInvokeSync(
         +[](BluezAdvertisement * self) {
-            if (self->mpRoot != nullptr)
-            {
-                g_object_unref(self->mpRoot);
-                self->mpRoot = nullptr;
-            }
-            if (self->mpAdapter != nullptr)
-            {
-                g_object_unref(self->mpAdapter);
-                self->mpAdapter = nullptr;
-            }
             if (self->mpAdv != nullptr)
             {
                 g_object_unref(self->mpAdv);
@@ -209,8 +197,6 @@ void BluezAdvertisement::Shutdown()
 
     g_free(mpAdvPath);
     mpAdvPath = nullptr;
-    g_free(mpAdapterName);
-    mpAdapterName = nullptr;
     g_free(mpAdvUUID);
     mpAdvUUID = nullptr;
 
@@ -227,7 +213,7 @@ void BluezAdvertisement::StartDone(GObject * aObject, GAsyncResult * aResult)
         bluez_leadvertising_manager1_call_register_advertisement_finish(advMgr, aResult, &MakeUniquePointerReceiver(error).Get());
     if (success == FALSE)
     {
-        g_dbus_object_manager_server_unexport(mpRoot, mpAdvPath);
+        g_dbus_object_manager_server_unexport(mEndpoint->GetGattApplicationObjectManager(), mpAdvPath);
     }
     VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: RegisterAdvertisement : %s", error->message));
 
@@ -247,9 +233,9 @@ CHIP_ERROR BluezAdvertisement::StartImpl()
     GVariant * options;
 
     VerifyOrExit(!mIsAdvertising, ChipLogError(DeviceLayer, "FAIL: Advertising has already been enabled in %s", __func__));
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mEndpoint->GetAdapter() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
 
-    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mpAdapter));
+    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mEndpoint->GetAdapter()));
     VerifyOrExit(adapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
@@ -273,8 +259,8 @@ CHIP_ERROR BluezAdvertisement::Start()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
+    CHIP_ERROR err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Start() on CHIPoBluez thread"));
     return err;
@@ -291,7 +277,7 @@ void BluezAdvertisement::StopDone(GObject * aObject, GAsyncResult * aResult)
 
     if (success == FALSE)
     {
-        g_dbus_object_manager_server_unexport(mpRoot, mpAdvPath);
+        g_dbus_object_manager_server_unexport(mEndpoint->GetGattApplicationObjectManager(), mpAdvPath);
     }
     else
     {
@@ -312,9 +298,9 @@ CHIP_ERROR BluezAdvertisement::StopImpl()
     BluezLEAdvertisingManager1 * advMgr = nullptr;
 
     VerifyOrExit(mIsAdvertising, ChipLogError(DeviceLayer, "FAIL: Advertising has already been disabled in %s", __func__));
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mEndpoint->GetAdapter() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
 
-    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mpAdapter));
+    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mEndpoint->GetAdapter()));
     VerifyOrExit(adapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
@@ -335,8 +321,8 @@ CHIP_ERROR BluezAdvertisement::Stop()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
+    CHIP_ERROR err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Stop() on CHIPoBluez thread"));
     return err;

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -41,7 +41,7 @@ public:
     BluezAdvertisement() = default;
     ~BluezAdvertisement() { Shutdown(); }
 
-    CHIP_ERROR Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
+    CHIP_ERROR Init(const BluezEndpoint * aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
     void Shutdown();
 
     /// Start BLE advertising.
@@ -69,9 +69,8 @@ private:
     CHIP_ERROR StopImpl();
 
     // Objects (interfaces) used by LE advertisement
-    GDBusObjectManagerServer * mpRoot = nullptr;
-    BluezAdapter1 * mpAdapter         = nullptr;
-    BluezLEAdvertisement1 * mpAdv     = nullptr;
+    const BluezEndpoint * mEndpoint = nullptr;
+    BluezLEAdvertisement1 * mpAdv   = nullptr;
 
     bool mIsInitialized = false;
     bool mIsAdvertising = false;

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -71,15 +71,14 @@ private:
 
     // Objects (interfaces) used by LE advertisement
     const BluezEndpoint & mEndpoint;
-    BluezLEAdvertisement1 * mpAdv = nullptr;
+    GAutoPtr<BluezLEAdvertisement1> mpAdv;
 
     bool mIsInitialized = false;
     bool mIsAdvertising = false;
 
     Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
-    char * mpAdvPath     = nullptr;
-    char * mpAdapterName = nullptr;
-    char * mpAdvUUID     = nullptr;
+    char * mpAdvPath = nullptr;
+    char * mpAdvUUID = nullptr;
     ChipAdvType mAdvType;
     uint16_t mAdvDurationMs = 0;
 };

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -38,7 +38,6 @@ class BluezEndpoint;
 class BluezAdvertisement
 {
 public:
-    BluezAdvertisement() = delete;
     BluezAdvertisement(const BluezEndpoint & endpoint) : mEndpoint(endpoint){};
     ~BluezAdvertisement() { Shutdown(); }
 
@@ -69,7 +68,6 @@ private:
     void StopDone(GObject * aObject, GAsyncResult * aResult);
     CHIP_ERROR StopImpl();
 
-    // Objects (interfaces) used by LE advertisement
     const BluezEndpoint & mEndpoint;
     GAutoPtr<BluezLEAdvertisement1> mpAdv;
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -38,10 +38,11 @@ class BluezEndpoint;
 class BluezAdvertisement
 {
 public:
-    BluezAdvertisement() = default;
+    BluezAdvertisement() = delete;
+    BluezAdvertisement(const BluezEndpoint & endpoint) : mEndpoint(endpoint){};
     ~BluezAdvertisement() { Shutdown(); }
 
-    CHIP_ERROR Init(const BluezEndpoint * aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
+    CHIP_ERROR Init(ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
     void Shutdown();
 
     /// Start BLE advertising.
@@ -69,8 +70,8 @@ private:
     CHIP_ERROR StopImpl();
 
     // Objects (interfaces) used by LE advertisement
-    const BluezEndpoint * mEndpoint = nullptr;
-    BluezLEAdvertisement1 * mpAdv   = nullptr;
+    const BluezEndpoint & mEndpoint;
+    BluezLEAdvertisement1 * mpAdv = nullptr;
 
     bool mIsInitialized = false;
     bool mIsAdvertising = false;

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -64,8 +64,6 @@ BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 *
     Init(aEndpoint);
 }
 
-BluezConnection::~BluezConnection() {}
-
 BluezConnection::IOChannel::~IOChannel()
 {
     if (mWatchSource != nullptr)
@@ -75,8 +73,7 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn),
-    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -75,7 +75,8 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn),
+    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -86,9 +86,9 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
     if (!aEndpoint.mIsCentral)
     {
-        mpService = GAutoPtr<BluezGattService1>(BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService.get())));
-        mpC1      = GAutoPtr<BluezGattCharacteristic1>(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1.get())));
-        mpC2      = GAutoPtr<BluezGattCharacteristic1>(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2.get())));
+        mpService.reset(BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService.get())));
+        mpC1.reset(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1.get())));
+        mpC2.reset(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2.get())));
     }
     else
     {
@@ -104,7 +104,7 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
                 if ((BluezIsServiceOnDevice(service, mpDevice.get())) == TRUE &&
                     (strcmp(bluez_gatt_service1_get_uuid(service), CHIP_BLE_UUID_SERVICE_STRING) == 0))
                 {
-                    mpService = GAutoPtr<BluezGattService1>(service);
+                    mpService.reset(service);
                     break;
                 }
                 g_object_unref(service);
@@ -123,18 +123,18 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
                 if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                     (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C1_STRING) == 0))
                 {
-                    mpC1 = GAutoPtr<BluezGattCharacteristic1>(char1);
+                    mpC1.reset(char1);
                 }
                 else if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C2_STRING) == 0))
                 {
-                    mpC2 = GAutoPtr<BluezGattCharacteristic1>(char1);
+                    mpC2.reset(char1);
                 }
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
                 else if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C3_STRING) == 0))
                 {
-                    mpC3 = GAutoPtr<BluezGattCharacteristic1>(char1);
+                    mpC3.reset(char1);
                 }
 #endif
                 else

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -34,7 +34,6 @@
 #include <system/SystemPacketBuffer.h>
 
 #include "BluezEndpoint.h"
-#include "Types.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -65,20 +64,7 @@ BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 *
     Init(aEndpoint);
 }
 
-BluezConnection::~BluezConnection()
-{
-    g_object_unref(mpDevice);
-    if (mpService)
-        g_object_unref(mpService);
-    if (mpC1)
-        g_object_unref(mpC1);
-    if (mpC2)
-        g_object_unref(mpC2);
-#if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
-    if (mpC3)
-        g_object_unref(mpC2);
-#endif
-}
+BluezConnection::~BluezConnection() {}
 
 BluezConnection::IOChannel::~IOChannel()
 {
@@ -89,8 +75,7 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn),
-    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
@@ -101,13 +86,13 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
     if (!aEndpoint.mIsCentral)
     {
-        mpService = BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService));
-        mpC1      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1));
-        mpC2      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2));
+        mpService = GAutoPtr<BluezGattService1>(BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService.get())));
+        mpC1      = GAutoPtr<BluezGattCharacteristic1>(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1.get())));
+        mpC2      = GAutoPtr<BluezGattCharacteristic1>(BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2.get())));
     }
     else
     {
-        objects = g_dbus_object_manager_get_objects(aEndpoint.mpObjMgr);
+        objects = g_dbus_object_manager_get_objects(aEndpoint.mpObjMgr.get());
 
         for (l = objects; l != nullptr; l = l->next)
         {
@@ -116,17 +101,17 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
             if (service != nullptr)
             {
-                if ((BluezIsServiceOnDevice(service, mpDevice)) == TRUE &&
+                if ((BluezIsServiceOnDevice(service, mpDevice.get())) == TRUE &&
                     (strcmp(bluez_gatt_service1_get_uuid(service), CHIP_BLE_UUID_SERVICE_STRING) == 0))
                 {
-                    mpService = service;
+                    mpService = GAutoPtr<BluezGattService1>(service);
                     break;
                 }
                 g_object_unref(service);
             }
         }
 
-        VerifyOrExit(mpService != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL service in %s", __func__));
+        VerifyOrExit(mpService.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL service in %s", __func__));
 
         for (l = objects; l != nullptr; l = l->next)
         {
@@ -135,21 +120,21 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
             if (char1 != nullptr)
             {
-                if ((BluezIsCharOnService(char1, mpService) == TRUE) &&
+                if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                     (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C1_STRING) == 0))
                 {
-                    mpC1 = char1;
+                    mpC1 = GAutoPtr<BluezGattCharacteristic1>(char1);
                 }
-                else if ((BluezIsCharOnService(char1, mpService) == TRUE) &&
+                else if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C2_STRING) == 0))
                 {
-                    mpC2 = char1;
+                    mpC2 = GAutoPtr<BluezGattCharacteristic1>(char1);
                 }
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
-                else if ((BluezIsCharOnService(char1, mpService) == TRUE) &&
+                else if ((BluezIsCharOnService(char1, mpService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), CHIP_PLAT_BLE_UUID_C3_STRING) == 0))
                 {
-                    mpC3 = char1;
+                    mpC3 = GAutoPtr<BluezGattCharacteristic1>(char1);
                 }
 #endif
                 else
@@ -163,8 +148,8 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
             }
         }
 
-        VerifyOrExit(mpC1 != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL C1 in %s", __func__));
-        VerifyOrExit(mpC2 != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL C2 in %s", __func__));
+        VerifyOrExit(mpC1.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL C1 in %s", __func__));
+        VerifyOrExit(mpC2.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL C2 in %s", __func__));
     }
 
 exit:
@@ -180,7 +165,7 @@ CHIP_ERROR BluezConnection::BluezDisconnect(BluezConnection * conn)
 
     ChipLogDetail(DeviceLayer, "%s peer=%s", __func__, conn->GetPeerAddress());
 
-    success = bluez_device1_call_disconnect_sync(conn->mpDevice, nullptr, &MakeUniquePointerReceiver(error).Get());
+    success = bluez_device1_call_disconnect_sync(conn->mpDevice.get(), nullptr, &MakeUniquePointerReceiver(error).Get());
     VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: Disconnect: %s", error->message));
 
 exit:
@@ -194,7 +179,7 @@ CHIP_ERROR BluezConnection::CloseConnection()
 
 const char * BluezConnection::GetPeerAddress() const
 {
-    return bluez_device1_get_address(mpDevice);
+    return bluez_device1_get_address(mpDevice.get());
 }
 
 gboolean BluezConnection::WriteHandlerCallback(GIOChannel * aChannel, GIOCondition aCond, BluezConnection * apConn)
@@ -216,7 +201,7 @@ gboolean BluezConnection::WriteHandlerCallback(GIOChannel * aChannel, GIOConditi
     // Casting len to size_t is safe, since we ensured that it's not negative.
     newVal = g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, buf, static_cast<size_t>(len), sizeof(uint8_t));
 
-    bluez_gatt_characteristic1_set_value(apConn->mpC1, newVal);
+    bluez_gatt_characteristic1_set_value(apConn->mpC1.get(), newVal);
     BLEManagerImpl::HandleRXCharWrite(apConn, buf, static_cast<size_t>(len));
     isSuccess = true;
 
@@ -278,7 +263,7 @@ CHIP_ERROR BluezConnection::SendIndicationImpl(ConnectionDataBundle * data)
     GAutoPtr<GError> error;
     size_t len, written;
 
-    if (bluez_gatt_characteristic1_get_notify_acquired(data->mConn.mpC2) == TRUE)
+    if (bluez_gatt_characteristic1_get_notify_acquired(data->mConn.mpC2.get()) == TRUE)
     {
         auto * buf = static_cast<const char *>(g_variant_get_fixed_array(data->mData.get(), &len, sizeof(uint8_t)));
         VerifyOrExit(len <= static_cast<size_t>(std::numeric_limits<gssize>::max()),
@@ -289,7 +274,7 @@ CHIP_ERROR BluezConnection::SendIndicationImpl(ConnectionDataBundle * data)
     }
     else
     {
-        bluez_gatt_characteristic1_set_value(data->mConn.mpC2, data->mData.release());
+        bluez_gatt_characteristic1_set_value(data->mConn.mpC2.get(), data->mData.release());
     }
 
 exit:
@@ -299,7 +284,7 @@ exit:
 CHIP_ERROR BluezConnection::SendIndication(chip::System::PacketBufferHandle apBuf)
 {
     VerifyOrReturnError(!apBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT, ChipLogError(DeviceLayer, "apBuf is NULL in %s", __func__));
-    VerifyOrReturnError(mpC2 != nullptr, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
+    VerifyOrReturnError(mpC2.get() != nullptr, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
 
     ConnectionDataBundle bundle(*this, apBuf);
     return PlatformMgrImpl().GLibMatterContextInvokeSync(SendIndicationImpl, &bundle);
@@ -325,8 +310,8 @@ CHIP_ERROR BluezConnection::SendWriteRequestImpl(ConnectionDataBundle * data)
     g_variant_builder_add(&optionsBuilder, "{sv}", "type", g_variant_new_string("request"));
     auto options = g_variant_builder_end(&optionsBuilder);
 
-    bluez_gatt_characteristic1_call_write_value(data->mConn.mpC1, data->mData.release(), options, nullptr, SendWriteRequestDone,
-                                                const_cast<BluezConnection *>(&data->mConn));
+    bluez_gatt_characteristic1_call_write_value(data->mConn.mpC1.get(), data->mData.release(), options, nullptr,
+                                                SendWriteRequestDone, const_cast<BluezConnection *>(&data->mConn));
 
     return CHIP_NO_ERROR;
 }
@@ -334,7 +319,7 @@ CHIP_ERROR BluezConnection::SendWriteRequestImpl(ConnectionDataBundle * data)
 CHIP_ERROR BluezConnection::SendWriteRequest(chip::System::PacketBufferHandle apBuf)
 {
     VerifyOrReturnError(!apBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT, ChipLogError(DeviceLayer, "apBuf is NULL in %s", __func__));
-    VerifyOrReturnError(mpC1 != nullptr, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "C1 is NULL in %s", __func__));
+    VerifyOrReturnError(mpC1.get() != nullptr, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "C1 is NULL in %s", __func__));
 
     ConnectionDataBundle bundle(*this, apBuf);
     return PlatformMgrImpl().GLibMatterContextInvokeSync(SendWriteRequestImpl, &bundle);
@@ -370,12 +355,12 @@ void BluezConnection::SubscribeCharacteristicDone(GObject * aObject, GAsyncResul
 CHIP_ERROR BluezConnection::SubscribeCharacteristicImpl(BluezConnection * connection)
 {
     BluezGattCharacteristic1 * c2 = nullptr;
-    VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
-    c2 = BLUEZ_GATT_CHARACTERISTIC1(connection->mpC2);
+    VerifyOrExit(connection->mpC2.get() != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
+    c2 = BLUEZ_GATT_CHARACTERISTIC1(connection->mpC2.get());
 
     // Get notifications on the TX characteristic change (e.g. indication is received)
     g_signal_connect(c2, "g-properties-changed", G_CALLBACK(OnCharacteristicChanged), connection);
-    bluez_gatt_characteristic1_call_start_notify(connection->mpC2, nullptr, SubscribeCharacteristicDone, connection);
+    bluez_gatt_characteristic1_call_start_notify(connection->mpC2.get(), nullptr, SubscribeCharacteristicDone, connection);
 
 exit:
     return CHIP_NO_ERROR;
@@ -403,9 +388,9 @@ void BluezConnection::UnsubscribeCharacteristicDone(GObject * aObject, GAsyncRes
 
 CHIP_ERROR BluezConnection::UnsubscribeCharacteristicImpl(BluezConnection * connection)
 {
-    VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
+    VerifyOrExit(connection->mpC2.get() != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
 
-    bluez_gatt_characteristic1_call_stop_notify(connection->mpC2, nullptr, UnsubscribeCharacteristicDone, connection);
+    bluez_gatt_characteristic1_call_stop_notify(connection->mpC2.get(), nullptr, UnsubscribeCharacteristicDone, connection);
 
 exit:
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -73,7 +73,8 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn),
+    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -40,7 +40,7 @@ class BluezConnection
 {
 public:
     BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice);
-    ~BluezConnection();
+    ~BluezConnection() = default;
 
     const char * GetPeerAddress() const;
 

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -28,6 +28,8 @@
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 #include <system/SystemPacketBuffer.h>
 
+#include "Types.h"
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -115,20 +117,20 @@ private:
     static void UnsubscribeCharacteristicDone(GObject * aObject, GAsyncResult * aResult, gpointer apConn);
     static CHIP_ERROR UnsubscribeCharacteristicImpl(BluezConnection * apConn);
 
-    BluezDevice1 * mpDevice;
+    GAutoPtr<BluezDevice1> mpDevice;
 
     bool mNotifyAcquired = false;
     uint16_t mMtu        = 0;
 
-    BluezGattService1 * mpService = nullptr;
+    GAutoPtr<BluezGattService1> mpService;
 
-    BluezGattCharacteristic1 * mpC1 = nullptr;
-    IOChannel mC1Channel            = { 0 };
-    BluezGattCharacteristic1 * mpC2 = nullptr;
-    IOChannel mC2Channel            = { 0 };
+    GAutoPtr<BluezGattCharacteristic1> mpC1;
+    IOChannel mC1Channel = { 0 };
+    GAutoPtr<BluezGattCharacteristic1> mpC2;
+    IOChannel mC2Channel = { 0 };
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
-    BluezGattCharacteristic1 * mpC3 = nullptr;
-    IOChannel mC3Channel            = { 0 };
+    GAutoPtr<BluezGattCharacteristic1> mpC3;
+    IOChannel mC3Channel = { 0 };
 #endif
 };
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -682,8 +682,8 @@ CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char 
         mpConnectCancellable.reset(g_cancellable_new());
     }
 
-    err =
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization"));
 
     ChipLogDetail(DeviceLayer, "BlueZ integration init success");

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -252,7 +252,7 @@ BluezGattCharacteristic1 * BluezEndpoint::CreateGattCharacteristic(BluezGattServ
     bluez_gatt_characteristic1_set_value(characteristic, value);
 
     bluez_object_skeleton_set_gatt_characteristic1(object, characteristic);
-    g_dbus_object_manager_server_export(mpRoot, G_DBUS_OBJECT_SKELETON(object));
+    g_dbus_object_manager_server_export(mpRoot.get(), G_DBUS_OBJECT_SKELETON(object));
     g_object_unref(object);
 
     return characteristic;
@@ -282,9 +282,9 @@ CHIP_ERROR BluezEndpoint::RegisterGattApplicationImpl()
     GVariantBuilder optionsBuilder;
     GVariant * options;
 
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mpAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
 
-    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mpAdapter));
+    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mpAdapter.get()));
     VerifyOrExit(adapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
 
     gattMgr = bluez_object_get_gatt_manager1(BLUEZ_OBJECT(adapter));
@@ -344,11 +344,11 @@ void BluezEndpoint::BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClie
                                                           GDBusProxy * aInterface, GVariant * aChangedProperties,
                                                           const char * const * aInvalidatedProps)
 {
-    VerifyOrReturn(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrReturn(mpAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
     VerifyOrReturn(strcmp(g_dbus_proxy_get_interface_name(aInterface), DEVICE_INTERFACE) == 0, );
 
     BluezDevice1 * device = BLUEZ_DEVICE1(aInterface);
-    VerifyOrReturn(BluezIsDeviceOnAdapter(device, mpAdapter));
+    VerifyOrReturn(BluezIsDeviceOnAdapter(device, mpAdapter.get()));
 
     UpdateConnectionTable(device);
 }
@@ -386,7 +386,7 @@ void BluezEndpoint::BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBu
     GAutoPtr<BluezDevice1> device(bluez_object_get_device1(BLUEZ_OBJECT(aObject)));
     VerifyOrReturn(device.get() != nullptr);
 
-    if (BluezIsDeviceOnAdapter(device.get(), mpAdapter) == TRUE)
+    if (BluezIsDeviceOnAdapter(device.get(), mpAdapter.get()) == TRUE)
     {
         HandleNewDevice(device.get());
     }
@@ -395,7 +395,7 @@ void BluezEndpoint::BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBu
 void BluezEndpoint::BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject)
 {
     // TODO: for Device1, lookup connection, and call otPlatTobleHandleDisconnected
-    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mpAdapter.
+    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mpAdapter.get().
     // for Characteristic1, or GattService -- handle here via calling otPlatTobleHandleDisconnected, or ignore.
 }
 
@@ -415,7 +415,7 @@ BluezGattService1 * BluezEndpoint::CreateGattService(const char * aUUID)
 
     // includes -- unclear whether required.  Might be filled in later
     bluez_object_skeleton_set_gatt_service1(object, service);
-    g_dbus_object_manager_server_export(mpRoot, G_DBUS_OBJECT_SKELETON(object));
+    g_dbus_object_manager_server_export(mpRoot.get(), G_DBUS_OBJECT_SKELETON(object));
     g_object_unref(object);
 
     return service;
@@ -426,8 +426,8 @@ void BluezEndpoint::SetupAdapter()
     char expectedPath[32];
     snprintf(expectedPath, sizeof(expectedPath), BLUEZ_PATH "/hci%u", mAdapterId);
 
-    GList * objects = g_dbus_object_manager_get_objects(mpObjMgr);
-    for (auto l = objects; l != nullptr && mpAdapter == nullptr; l = l->next)
+    GList * objects = g_dbus_object_manager_get_objects(mpObjMgr.get());
+    for (auto l = objects; l != nullptr && mpAdapter.get() == nullptr; l = l->next)
     {
         BluezObject * object = BLUEZ_OBJECT(l->data);
 
@@ -441,14 +441,14 @@ void BluezEndpoint::SetupAdapter()
                 {
                     if (strcmp(g_dbus_proxy_get_object_path(G_DBUS_PROXY(adapter)), expectedPath) == 0)
                     {
-                        mpAdapter = static_cast<BluezAdapter1 *>(g_object_ref(adapter));
+                        mpAdapter = GAutoPtr<BluezAdapter1>(g_object_ref(adapter));
                     }
                 }
                 else
                 {
                     if (strcmp(bluez_adapter1_get_address(adapter), mpAdapterAddr) == 0)
                     {
-                        mpAdapter = static_cast<BluezAdapter1 *>(g_object_ref(adapter));
+                        mpAdapter = GAutoPtr<BluezAdapter1>(g_object_ref(adapter));
                     }
                 }
             }
@@ -456,14 +456,14 @@ void BluezEndpoint::SetupAdapter()
         g_list_free_full(interfaces, g_object_unref);
     }
 
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mpAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
 
-    bluez_adapter1_set_powered(mpAdapter, TRUE);
+    bluez_adapter1_set_powered(mpAdapter.get(), TRUE);
 
     // Setting "Discoverable" to False on the adapter and to True on the advertisement convinces
     // Bluez to set "BR/EDR Not Supported" flag. Bluez doesn't provide API to do that explicitly
     // and the flag is necessary to force using LE transport.
-    bluez_adapter1_set_discoverable(mpAdapter, FALSE);
+    bluez_adapter1_set_discoverable(mpAdapter.get(), FALSE);
 
 exit:
     g_list_free_full(objects, g_object_unref);
@@ -534,63 +534,66 @@ void BluezEndpoint::SetupGattService()
     static const char * const c3_flags[] = { "read", nullptr };
 #endif
 
-    mpService = CreateGattService(CHIP_BLE_UUID_SERVICE_SHORT_STRING);
+    mpService = GAutoPtr<BluezGattService1>(CreateGattService(CHIP_BLE_UUID_SERVICE_SHORT_STRING));
 
     // C1 characteristic
-    mpC1 = CreateGattCharacteristic(mpService, "c1", CHIP_PLAT_BLE_UUID_C1_STRING, c1_flags);
-    g_signal_connect(mpC1, "handle-read-value",
+    mpC1 =
+        GAutoPtr<BluezGattCharacteristic1>(CreateGattCharacteristic(mpService.get(), "c1", CHIP_PLAT_BLE_UUID_C1_STRING, c1_flags));
+    g_signal_connect(mpC1.get(), "handle-read-value",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicReadValue(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC1, "handle-acquire-write",
+    g_signal_connect(mpC1.get(), "handle-acquire-write",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicAcquireWrite(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC1, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotifyError), nullptr);
-    g_signal_connect(mpC1, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirmError), nullptr);
+    g_signal_connect(mpC1.get(), "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotifyError), nullptr);
+    g_signal_connect(mpC1.get(), "handle-confirm", G_CALLBACK(BluezCharacteristicConfirmError), nullptr);
 
     // C2 characteristic
-    mpC2 = CreateGattCharacteristic(mpService, "c2", CHIP_PLAT_BLE_UUID_C2_STRING, c2_flags);
-    g_signal_connect(mpC2, "handle-read-value",
+    mpC2 =
+        GAutoPtr<BluezGattCharacteristic1>(CreateGattCharacteristic(mpService.get(), "c2", CHIP_PLAT_BLE_UUID_C2_STRING, c2_flags));
+    g_signal_connect(mpC2.get(), "handle-read-value",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicReadValue(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC2, "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
-    g_signal_connect(mpC2, "handle-acquire-notify",
+    g_signal_connect(mpC2.get(), "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
+    g_signal_connect(mpC2.get(), "handle-acquire-notify",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicAcquireNotify(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC2, "handle-confirm",
+    g_signal_connect(mpC2.get(), "handle-confirm",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, BluezEndpoint * self) {
                          return self->BluezCharacteristicConfirm(aChar, aInv);
                      }),
                      this);
 
-    ChipLogDetail(DeviceLayer, "CHIP BTP C1 %s", bluez_gatt_characteristic1_get_service(mpC1));
-    ChipLogDetail(DeviceLayer, "CHIP BTP C2 %s", bluez_gatt_characteristic1_get_service(mpC2));
+    ChipLogDetail(DeviceLayer, "CHIP BTP C1 %s", bluez_gatt_characteristic1_get_service(mpC1.get()));
+    ChipLogDetail(DeviceLayer, "CHIP BTP C2 %s", bluez_gatt_characteristic1_get_service(mpC2.get()));
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     ChipLogDetail(DeviceLayer, "CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING is TRUE");
     // Additional data characteristics
-    mpC3 = CreateGattCharacteristic(mpService, "c3", CHIP_PLAT_BLE_UUID_C3_STRING, c3_flags);
-    g_signal_connect(mpC3, "handle-read-value",
+    mpC3 =
+        GAutoPtr<BluezGattCharacteristic1>(CreateGattCharacteristic(mpService.get(), "c3", CHIP_PLAT_BLE_UUID_C3_STRING, c3_flags));
+    g_signal_connect(mpC3.get(), "handle-read-value",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicReadValue(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC3, "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
-    g_signal_connect(mpC3, "handle-acquire-notify",
+    g_signal_connect(mpC3.get(), "handle-acquire-write", G_CALLBACK(BluezCharacteristicAcquireWriteError), nullptr);
+    g_signal_connect(mpC3.get(), "handle-acquire-notify",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOpt,
                                     BluezEndpoint * self) { return self->BluezCharacteristicAcquireNotify(aChar, aInv, aOpt); }),
                      this);
-    g_signal_connect(mpC3, "handle-confirm",
+    g_signal_connect(mpC3.get(), "handle-confirm",
                      G_CALLBACK(+[](BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, BluezEndpoint * self) {
                          return self->BluezCharacteristicConfirm(aChar, aInv);
                      }),
                      this);
 
     // update the characteristic value
-    UpdateAdditionalDataCharacteristic(mpC3);
-    ChipLogDetail(DeviceLayer, "CHIP BTP C3 %s", bluez_gatt_characteristic1_get_service(mpC3));
+    UpdateAdditionalDataCharacteristic(mpC3.get());
+    ChipLogDetail(DeviceLayer, "CHIP BTP C3 %s", bluez_gatt_characteristic1_get_service(mpC3.get()));
 #else
     ChipLogDetail(DeviceLayer, "CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING is FALSE");
 #endif
@@ -601,13 +604,13 @@ void BluezEndpoint::SetupGattServer(GDBusConnection * aConn)
     VerifyOrReturn(!mIsCentral);
 
     mpRootPath = g_strdup_printf("/chipoble/%04x", getpid() & 0xffff);
-    mpRoot     = g_dbus_object_manager_server_new(mpRootPath);
+    mpRoot     = GAutoPtr<GDBusObjectManagerServer>(g_dbus_object_manager_server_new(mpRootPath));
 
     SetupGattService();
 
     // Set connection after the service is set up in order to reduce the number
     // of signals sent on the bus.
-    g_dbus_object_manager_server_set_connection(mpRoot, aConn);
+    g_dbus_object_manager_server_set_connection(mpRoot.get(), aConn);
 }
 
 CHIP_ERROR BluezEndpoint::StartupEndpointBindings()
@@ -625,23 +628,24 @@ CHIP_ERROR BluezEndpoint::StartupEndpointBindings()
 
     SetupGattServer(conn.get());
 
-    mpObjMgr = g_dbus_object_manager_client_new_sync(
+    mpObjMgr = GAutoPtr<GDBusObjectManager>(g_dbus_object_manager_client_new_sync(
         conn.get(), G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/", bluez_object_manager_client_get_proxy_type,
         nullptr /* unused user data in the Proxy Type Func */, nullptr /*destroy notify */, nullptr /* cancellable */,
-        &MakeUniquePointerReceiver(err).Get());
-    VerifyOrReturnError(mpObjMgr != nullptr, CHIP_ERROR_INTERNAL,
+        &MakeUniquePointerReceiver(err).Get()));
+    VerifyOrReturnError(mpObjMgr.get() != nullptr, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "FAIL: Error getting object manager client: %s", err->message));
 
-    g_signal_connect(mpObjMgr, "object-added", G_CALLBACK(+[](GDBusObjectManager * aMgr, GDBusObject * aObj, BluezEndpoint * self) {
+    g_signal_connect(mpObjMgr.get(), "object-added",
+                     G_CALLBACK(+[](GDBusObjectManager * aMgr, GDBusObject * aObj, BluezEndpoint * self) {
                          return self->BluezSignalOnObjectAdded(aMgr, aObj);
                      }),
                      this);
-    g_signal_connect(mpObjMgr, "object-removed",
+    g_signal_connect(mpObjMgr.get(), "object-removed",
                      G_CALLBACK(+[](GDBusObjectManager * aMgr, GDBusObject * aObj, BluezEndpoint * self) {
                          return self->BluezSignalOnObjectRemoved(aMgr, aObj);
                      }),
                      this);
-    g_signal_connect(mpObjMgr, "interface-proxy-properties-changed",
+    g_signal_connect(mpObjMgr.get(), "interface-proxy-properties-changed",
                      G_CALLBACK(+[](GDBusObjectManagerClient * aMgr, GDBusObjectProxy * aObj, GDBusProxy * aIface,
                                     GVariant * aChangedProps, const char * const * aInvalidatedProps, BluezEndpoint * self) {
                          return self->BluezSignalInterfacePropertiesChanged(aMgr, aObj, aIface, aChangedProps, aInvalidatedProps);
@@ -678,11 +682,11 @@ CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char 
     }
     else
     {
-        mpConnectCancellable = g_cancellable_new();
+        mpConnectCancellable = GAutoPtr<GCancellable>(g_cancellable_new());
     }
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
+    err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization"));
 
     ChipLogDetail(DeviceLayer, "BlueZ integration init success");
@@ -695,33 +699,15 @@ void BluezEndpoint::Shutdown()
 {
     VerifyOrReturn(mIsInitialized);
 
-    // Run endpoint cleanup on the CHIPoBluez thread. This is necessary because the
-    // cleanup function releases the D-Bus manager client object, which handles D-Bus
-    // signals. Otherwise, we will face race condition when the D-Bus signal is in
-    // the middle of being processed when the cleanup function is called.
-    PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezEndpoint * self) {
-            if (self->mpObjMgr != nullptr)
-                g_object_unref(self->mpObjMgr);
-            if (self->mpAdapter != nullptr)
-                g_object_unref(self->mpAdapter);
-            if (self->mpDevice != nullptr)
-                g_object_unref(self->mpDevice);
-            if (self->mpRoot != nullptr)
-                g_object_unref(self->mpRoot);
-            if (self->mpService != nullptr)
-                g_object_unref(self->mpService);
-            if (self->mpC1 != nullptr)
-                g_object_unref(self->mpC1);
-            if (self->mpC2 != nullptr)
-                g_object_unref(self->mpC2);
-            if (self->mpC3 != nullptr)
-                g_object_unref(self->mpC3);
-            if (self->mpConnectCancellable != nullptr)
-                g_object_unref(self->mpConnectCancellable);
-            return CHIP_NO_ERROR;
-        },
-        this);
+    mpObjMgr             = nullptr;
+    mpAdapter            = nullptr;
+    mpDevice             = nullptr;
+    mpRoot               = nullptr;
+    mpService            = nullptr;
+    mpC1                 = nullptr;
+    mpC2                 = nullptr;
+    mpC3                 = nullptr;
+    mpConnectCancellable = nullptr;
 
     g_free(mpOwningName);
     g_free(mpAdapterName);
@@ -756,7 +742,7 @@ void BluezEndpoint::ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult,
             g_clear_error(&MakeUniquePointerReceiver(error).Get());
 
             bluez_device1_call_disconnect_sync(device, nullptr, &MakeUniquePointerReceiver(error).Get());
-            bluez_device1_call_connect(device, params->mEndpoint.mpConnectCancellable, ConnectDeviceDone, params);
+            bluez_device1_call_connect(device, params->mEndpoint.mpConnectCancellable.get(), ConnectDeviceDone, params);
             return;
         }
 
@@ -772,8 +758,8 @@ void BluezEndpoint::ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult,
 
 CHIP_ERROR BluezEndpoint::ConnectDeviceImpl(ConnectParams * apParams)
 {
-    g_cancellable_reset(apParams->mEndpoint.mpConnectCancellable);
-    bluez_device1_call_connect(apParams->mpDevice, apParams->mEndpoint.mpConnectCancellable, ConnectDeviceDone, apParams);
+    g_cancellable_reset(apParams->mEndpoint.mpConnectCancellable.get());
+    bluez_device1_call_connect(apParams->mpDevice, apParams->mEndpoint.mpConnectCancellable.get(), ConnectDeviceDone, apParams);
     return CHIP_NO_ERROR;
 }
 
@@ -794,8 +780,8 @@ CHIP_ERROR BluezEndpoint::ConnectDevice(BluezDevice1 & aDevice)
 
 void BluezEndpoint::CancelConnect()
 {
-    VerifyOrDie(mpConnectCancellable != nullptr);
-    g_cancellable_cancel(mpConnectCancellable);
+    VerifyOrDie(mpConnectCancellable.get() != nullptr);
+    g_cancellable_cancel(mpConnectCancellable.get());
 }
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -395,7 +395,7 @@ void BluezEndpoint::BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBu
 void BluezEndpoint::BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject)
 {
     // TODO: for Device1, lookup connection, and call otPlatTobleHandleDisconnected
-    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mpAdapter.get().
+    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mpAdapter.
     // for Characteristic1, or GattService -- handle here via calling otPlatTobleHandleDisconnected, or ignore.
 }
 
@@ -685,8 +685,8 @@ CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char 
         mpConnectCancellable.reset(g_cancellable_new());
     }
 
-    err =
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->StartupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization"));
 
     ChipLogDetail(DeviceLayer, "BlueZ integration init success");
@@ -705,15 +705,15 @@ void BluezEndpoint::Shutdown()
     // the middle of being processed when the cleanup function is called.
     PlatformMgrImpl().GLibMatterContextInvokeSync(
         +[](BluezEndpoint * self) {
-            mpObjMgr.reset();
-            mpAdapter.reset();
-            mpDevice.reset();
-            mpRoot.reset();
-            mpService.reset();
-            mpC1.reset();
-            mpC2.reset();
-            mpC3.reset();
-            mpConnectCancellable.reset();
+            self->mpObjMgr.reset();
+            self->mpAdapter.reset();
+            self->mpDevice.reset();
+            self->mpRoot.reset();
+            self->mpService.reset();
+            self->mpC1.reset();
+            self->mpC2.reset();
+            self->mpC3.reset();
+            self->mpConnectCancellable.reset();
             return CHIP_NO_ERROR;
         },
         this);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -77,7 +77,7 @@ public:
 
     CHIP_ERROR RegisterGattApplication();
     GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot.get(); }
-    GDBusObjectManager * GetObjectManager() const { return mpObjMgr.get(); }
+    GDBusObjectManager * GetBluezObjectManager() const { return mpObjMgr.get(); }
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -72,6 +72,7 @@ public:
     CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
+    void SetAdapter(BluezAdapter1 * apAdapter) { mpAdapter.reset(apAdapter); };
     BluezAdapter1 * GetAdapter() const { return mpAdapter.get(); }
     const char * GetAdapterName() const { return mpAdapterName; }
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -77,6 +77,7 @@ public:
 
     CHIP_ERROR RegisterGattApplication();
     GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot; }
+    GDBusObjectManager * GetObjectManager() const { return mpObjMgr; }
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -72,12 +72,12 @@ public:
     CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
     void Shutdown();
 
-    BluezAdapter1 * GetAdapter() const { return mpAdapter; }
+    BluezAdapter1 * GetAdapter() const { return mpAdapter.get(); }
     const char * GetAdapterName() const { return mpAdapterName; }
 
     CHIP_ERROR RegisterGattApplication();
-    GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot; }
-    GDBusObjectManager * GetObjectManager() const { return mpObjMgr; }
+    GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot.get(); }
+    GDBusObjectManager * GetObjectManager() const { return mpObjMgr.get(); }
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();
@@ -141,21 +141,21 @@ private:
     char * mpServicePath = nullptr;
 
     // Objects (interfaces) subscribed to by this service
-    GDBusObjectManager * mpObjMgr = nullptr;
-    BluezAdapter1 * mpAdapter     = nullptr;
-    BluezDevice1 * mpDevice       = nullptr;
+    GAutoPtr<GDBusObjectManager> mpObjMgr;
+    GAutoPtr<BluezAdapter1> mpAdapter;
+    GAutoPtr<BluezDevice1> mpDevice;
 
     // Objects (interfaces) published by this service
-    GDBusObjectManagerServer * mpRoot = nullptr;
-    BluezGattService1 * mpService     = nullptr;
-    BluezGattCharacteristic1 * mpC1   = nullptr;
-    BluezGattCharacteristic1 * mpC2   = nullptr;
+    GAutoPtr<GDBusObjectManagerServer> mpRoot;
+    GAutoPtr<BluezGattService1> mpService;
+    GAutoPtr<BluezGattCharacteristic1> mpC1;
+    GAutoPtr<BluezGattCharacteristic1> mpC2;
     // additional data characteristics
-    BluezGattCharacteristic1 * mpC3 = nullptr;
+    GAutoPtr<BluezGattCharacteristic1> mpC3;
 
     std::unordered_map<std::string, BluezConnection *> mConnMap;
-    GCancellable * mpConnectCancellable = nullptr;
-    char * mpPeerDevicePath             = nullptr;
+    GAutoPtr<GCancellable> mpConnectCancellable;
+    char * mpPeerDevicePath = nullptr;
 
     // Allow BluezConnection to access our private members
     friend class BluezConnection;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -83,7 +83,7 @@ void ChipDeviceScanner::Shutdown()
     // released during a D-Bus signal being processed.
     PlatformMgrImpl().GLibMatterContextInvokeSync(
         +[](ChipDeviceScanner * self) {
-            mCancellable.reset();
+            self->mCancellable.reset();
             return CHIP_NO_ERROR;
         },
         this);

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -52,33 +52,21 @@ bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIden
 
 } // namespace
 
-CHIP_ERROR ChipDeviceScanner::Init(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate)
+CHIP_ERROR ChipDeviceScanner::Init(const BluezEndpoint * aEndpoint, ChipDeviceScannerDelegate * delegate)
 {
 
     // Make this function idempotent by shutting down previously initialized state if any.
     Shutdown();
 
-    mAdapter     = BLUEZ_ADAPTER1(g_object_ref(adapter));
+    mEndpoint    = aEndpoint;
     mCancellable = g_cancellable_new();
     mDelegate    = delegate;
 
-    // Create the D-Bus object manager client object on the glib thread, so that all D-Bus signals
-    // will be delivered to the glib thread.
-    ReturnErrorOnFailure(PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) {
-            // When creating D-Bus proxy object, the thread default context must be initialized.
-            VerifyOrDie(g_main_context_get_thread_default() != nullptr);
+    g_cancellable_cancel(mCancellable);
 
-            GAutoPtr<GError> err;
-            self->mManager = g_dbus_object_manager_client_new_for_bus_sync(
-                G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/",
-                bluez_object_manager_client_get_proxy_type, nullptr /* unused user data in the Proxy Type Func */,
-                nullptr /* destroy notify */, self->mCancellable, &MakeUniquePointerReceiver(err).Get());
-            VerifyOrReturnError(self->mManager != nullptr, CHIP_ERROR_INTERNAL,
-                                ChipLogError(Ble, "Failed to get D-Bus object manager for device scanning: %s", err->message));
-            return CHIP_NO_ERROR;
-        },
-        this));
+    GAutoPtr<GError> err;
+    VerifyOrReturnError(mEndpoint->GetObjectManager() != nullptr, CHIP_ERROR_INTERNAL,
+                        ChipLogError(Ble, "Failed to get D-Bus object manager for device scanning: %s", err->message));
 
     mIsInitialized = true;
     return CHIP_NO_ERROR;
@@ -97,20 +85,8 @@ void ChipDeviceScanner::Shutdown()
         chip::DeviceLayer::SystemLayer().CancelTimer(TimerExpiredCallback, this);
     }
 
-    // Release resources on the glib thread. This is necessary because the D-Bus manager client
-    // object handles D-Bus signals. Otherwise, we might face a race when the manager object is
-    // released during a D-Bus signal being processed.
-    PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) {
-            if (self->mManager != nullptr)
-                g_object_unref(self->mManager);
-            if (self->mAdapter != nullptr)
-                g_object_unref(self->mAdapter);
-            if (self->mCancellable != nullptr)
-                g_object_unref(self->mCancellable);
-            return CHIP_NO_ERROR;
-        },
-        this);
+    if (mCancellable != nullptr)
+        g_object_unref(mCancellable);
 
     mIsInitialized = false;
 }
@@ -166,13 +142,13 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
 
     if (mObjectAddedSignal)
     {
-        g_signal_handler_disconnect(mManager, mObjectAddedSignal);
+        g_signal_handler_disconnect(mEndpoint->GetObjectManager(), mObjectAddedSignal);
         mObjectAddedSignal = 0;
     }
 
     if (mInterfaceChangedSignal)
     {
-        g_signal_handler_disconnect(mManager, mInterfaceChangedSignal);
+        g_signal_handler_disconnect(mEndpoint->GetObjectManager(), mInterfaceChangedSignal);
         mInterfaceChangedSignal = 0;
     }
 
@@ -194,7 +170,7 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
 {
     GAutoPtr<GError> error;
 
-    if (!bluez_adapter1_call_stop_discovery_sync(self->mAdapter, nullptr /* not cancellable */,
+    if (!bluez_adapter1_call_stop_discovery_sync(self->mEndpoint->GetAdapter(), nullptr /* not cancellable */,
                                                  &MakeUniquePointerReceiver(error).Get()))
     {
         ChipLogError(Ble, "Failed to stop discovery %s", error->message);
@@ -224,7 +200,7 @@ void ChipDeviceScanner::SignalInterfaceChanged(GDBusObjectManagerClient * manage
 
 void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
 {
-    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter))) != 0)
+    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mEndpoint->GetAdapter()))) != 0)
     {
         return;
     }
@@ -242,7 +218,7 @@ void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
 
 void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
 {
-    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter))) != 0)
+    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mEndpoint->GetAdapter()))) != 0)
     {
         return;
     }
@@ -257,7 +233,8 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
     const auto devicePath = g_dbus_proxy_get_object_path(G_DBUS_PROXY(&device));
     GAutoPtr<GError> error;
 
-    if (!bluez_adapter1_call_remove_device_sync(mAdapter, devicePath, nullptr, &MakeUniquePointerReceiver(error).Get()))
+    if (!bluez_adapter1_call_remove_device_sync(mEndpoint->GetAdapter(), devicePath, nullptr,
+                                                &MakeUniquePointerReceiver(error).Get()))
     {
         ChipLogDetail(Ble, "Failed to remove device %s: %s", StringOrNullMarker(devicePath), error->message);
     }
@@ -267,12 +244,13 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
 {
     GAutoPtr<GError> error;
 
-    self->mObjectAddedSignal = g_signal_connect(self->mManager, "object-added", G_CALLBACK(SignalObjectAdded), self);
-    self->mInterfaceChangedSignal =
-        g_signal_connect(self->mManager, "interface-proxy-properties-changed", G_CALLBACK(SignalInterfaceChanged), self);
+    self->mObjectAddedSignal =
+        g_signal_connect(self->mEndpoint->GetObjectManager(), "object-added", G_CALLBACK(SignalObjectAdded), self);
+    self->mInterfaceChangedSignal = g_signal_connect(self->mEndpoint->GetObjectManager(), "interface-proxy-properties-changed",
+                                                     G_CALLBACK(SignalInterfaceChanged), self);
 
     ChipLogProgress(Ble, "BLE removing known devices.");
-    for (BluezObject & object : BluezObjectList(self->mManager))
+    for (BluezObject & object : BluezObjectList(self->mEndpoint->GetObjectManager()))
     {
         GAutoPtr<BluezDevice1> device(bluez_object_get_device1(&object));
         if (device.get() != nullptr)
@@ -292,7 +270,7 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     g_variant_builder_add(&filterBuilder, "{sv}", "Transport", g_variant_new_string("le"));
     GVariant * filter = g_variant_builder_end(&filterBuilder);
 
-    if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter, filter, self->mCancellable,
+    if (!bluez_adapter1_call_set_discovery_filter_sync(self->mEndpoint->GetAdapter(), filter, self->mCancellable,
                                                        &MakeUniquePointerReceiver(error).Get()))
     {
         // Not critical: ignore if fails
@@ -301,7 +279,8 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     }
 
     ChipLogProgress(Ble, "BLE initiating scan.");
-    if (!bluez_adapter1_call_start_discovery_sync(self->mAdapter, self->mCancellable, &MakeUniquePointerReceiver(error).Get()))
+    if (!bluez_adapter1_call_start_discovery_sync(self->mEndpoint->GetAdapter(), self->mCancellable,
+                                                  &MakeUniquePointerReceiver(error).Get()))
     {
         ChipLogError(Ble, "Failed to start discovery: %s", error->message);
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -142,13 +142,13 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
 
     if (mObjectAddedSignal)
     {
-        g_signal_handler_disconnect(mEndpoint.GetObjectManager(), mObjectAddedSignal);
+        g_signal_handler_disconnect(mEndpoint.GetBluezObjectManager(), mObjectAddedSignal);
         mObjectAddedSignal = 0;
     }
 
     if (mInterfaceChangedSignal)
     {
-        g_signal_handler_disconnect(mEndpoint.GetObjectManager(), mInterfaceChangedSignal);
+        g_signal_handler_disconnect(mEndpoint.GetBluezObjectManager(), mInterfaceChangedSignal);
         mInterfaceChangedSignal = 0;
     }
 
@@ -245,12 +245,12 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     GAutoPtr<GError> error;
 
     self->mObjectAddedSignal =
-        g_signal_connect(self->mEndpoint.GetObjectManager(), "object-added", G_CALLBACK(SignalObjectAdded), self);
-    self->mInterfaceChangedSignal = g_signal_connect(self->mEndpoint.GetObjectManager(), "interface-proxy-properties-changed",
+        g_signal_connect(self->mEndpoint.GetBluezObjectManager(), "object-added", G_CALLBACK(SignalObjectAdded), self);
+    self->mInterfaceChangedSignal = g_signal_connect(self->mEndpoint.GetBluezObjectManager(), "interface-proxy-properties-changed",
                                                      G_CALLBACK(SignalInterfaceChanged), self);
 
     ChipLogProgress(Ble, "BLE removing known devices.");
-    for (BluezObject & object : BluezObjectList(self->mEndpoint.GetObjectManager()))
+    for (BluezObject & object : BluezObjectList(self->mEndpoint.GetBluezObjectManager()))
     {
         GAutoPtr<BluezDevice1> device(bluez_object_get_device1(&object));
         if (device.get() != nullptr)

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -54,7 +54,8 @@ public:
 class ChipDeviceScanner
 {
 public:
-    ChipDeviceScanner()                                      = default;
+    ChipDeviceScanner() = delete;
+    ChipDeviceScanner(const BluezEndpoint & endpoint) : mEndpoint(endpoint){};
     ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
     ChipDeviceScanner(const ChipDeviceScanner &)             = delete;
     ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
@@ -62,7 +63,7 @@ public:
     ~ChipDeviceScanner() { Shutdown(); }
 
     /// Initialize the scanner.
-    CHIP_ERROR Init(const BluezEndpoint * aEndpoint, ChipDeviceScannerDelegate * delegate);
+    CHIP_ERROR Init(ChipDeviceScannerDelegate * delegate);
 
     /// Release any resources associated with the scanner.
     void Shutdown();
@@ -92,7 +93,7 @@ private:
     /// so that it can be re-discovered if it's still advertising.
     void RemoveDevice(BluezDevice1 & device);
 
-    const BluezEndpoint * mEndpoint       = nullptr;
+    const BluezEndpoint & mEndpoint;
     GCancellable * mCancellable           = nullptr;
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -30,6 +30,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
+class BluezEndpoint;
+
 /// Receives callbacks when chip devices are being scanned
 class ChipDeviceScannerDelegate
 {
@@ -60,7 +62,7 @@ public:
     ~ChipDeviceScanner() { Shutdown(); }
 
     /// Initialize the scanner.
-    CHIP_ERROR Init(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate);
+    CHIP_ERROR Init(const BluezEndpoint * aEndpoint, ChipDeviceScannerDelegate * delegate);
 
     /// Release any resources associated with the scanner.
     void Shutdown();
@@ -90,8 +92,7 @@ private:
     /// so that it can be re-discovered if it's still advertising.
     void RemoveDevice(BluezDevice1 & device);
 
-    GDBusObjectManager * mManager         = nullptr;
-    BluezAdapter1 * mAdapter              = nullptr;
+    const BluezEndpoint * mEndpoint       = nullptr;
     GCancellable * mCancellable           = nullptr;
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -56,7 +56,6 @@ public:
 class ChipDeviceScanner
 {
 public:
-    ChipDeviceScanner() = delete;
     ChipDeviceScanner(const BluezEndpoint & endpoint) : mEndpoint(endpoint){};
     ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
     ChipDeviceScanner(const ChipDeviceScanner &)             = delete;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -26,6 +26,8 @@
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 #include <system/SystemLayer.h>
 
+#include "Types.h"
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -94,7 +96,7 @@ private:
     void RemoveDevice(BluezDevice1 & device);
 
     const BluezEndpoint & mEndpoint;
-    GCancellable * mCancellable           = nullptr;
+    GAutoPtr<GCancellable> mCancellable;
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -59,6 +59,29 @@ struct GAutoPtrDeleter<BluezDevice1>
 {
     using deleter = GObjectDeleter;
 };
+template <>
+struct GAutoPtrDeleter<BluezAdapter1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<BluezGattCharacteristic1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<BluezGattService1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<BluezLEAdvertisement1>
+{
+    using deleter = GObjectDeleter;
+};
 
 namespace DeviceLayer {
 namespace Internal {


### PR DESCRIPTION
### Problem

BLE advertising and scanner classes cache adapter object as a private member. In case of D-Bus service restart (in that case BlueZ), the D-Bus connection ID changes, however, these cached objects will not be updated. This PR is a preliminary change required to fix issue #30792

### Changes

- Always get adapter object from the BluezEndpoint class as a source of trust

- Reuse D-Bus object manager client object

- Ensure the existence of the object in the compilation process.

- Convert glib Objects (interfaces) to GAutoPtr<>

### Testing

CI will test for potential build breaks.