### PR TITLE
Fix typo in XML for Content Launcher cluster

### DIFF
--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -4935,7 +4935,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -7215,7 +7215,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;
@@ -7369,7 +7369,7 @@ cluster ContentLauncher = 1290 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -7172,7 +7172,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;
@@ -7326,7 +7326,7 @@ cluster ContentLauncher = 1290 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2612,7 +2612,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -2074,7 +2074,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
-    <globalAttribure side="either" code="0xFFFD" value="1"/>
+    <globalAttribute side="either" code="0xFFFD" value="1"/>
 
     <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">AcceptHeader</attribute>
     <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">SupportedStreamingProtocols</attribute>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -7700,7 +7700,7 @@ cluster KeypadInput = 1289 {
 
 /** This cluster provides an interface for launching content on a media player device such as a TV or Speaker. */
 cluster ContentLauncher = 1290 {
-  revision 1; // NOTE: Default/not specifically set
+  revision 1;
 
   enum CharacteristicEnum : enum8 {
     kForcedSubtitles = 0;


### PR DESCRIPTION
globalAttribute was misspelled.

