### PR TITLE
Redefine CommandSender::Callback::OnResponse API contract to take path-specific errors

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -384,15 +384,8 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
 
         if (mpCallback != nullptr)
         {
-            if (statusIB.IsSuccess())
-            {
-                mpCallback->OnResponseWithAdditionalData(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
-                                                         hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);
-            }
-            else
-            {
-                mpCallback->OnError(this, statusIB.ToChipError());
-            }
+            mpCallback->OnResponse(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
+                                   hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);
         }
     }
     return CHIP_NO_ERROR;

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -69,22 +69,15 @@ public:
         virtual ~Callback() = default;
 
         /**
-         * OnResponseWithAdditionalData will be called when a successful response from the server has been received and processed.
+         * OnResponse will be called when an InvokeResponse from the server has been received and processed.
          * Specifically:
-         *  - When a status code is received and it is IM::Success, aData will be nullptr.
-         *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
+         *  - When a CommandStatusIB response is received, aData will be nullptr. The command specific status itself can be an error such as
+         *    UnsupportedCluster.
+         *  - When a CommandDataIB response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
-         *
-         * This OnResponseWithAdditionalData is similar to OnResponse mentioned below, except it contains an additional parameter
-         * `AdditionalResponseData`. This was added in Matter 1.3 to not break backward compatibility, but is extendable in the
-         * future to provide additional response data by only making changes to `AdditionalResponseData`, and not all the potential
-         * callees.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
-         *
-         * It is advised that subclass should only override this or `OnResponse`. But, it shouldn't actually matter if both are
-         * overridden, just that `OnResponse` will never be called by CommandSender directly.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.
@@ -95,35 +88,10 @@ public:
          * @param[in] aAdditionalResponseData
          *                            Additional response data that comes within the InvokeResponseMessage.
          */
-        virtual void OnResponseWithAdditionalData(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
-                                                  const StatusIB & aStatusIB, TLV::TLVReader * apData,
-                                                  const AdditionalResponseData & aAdditionalResponseData)
-        {
-            OnResponse(apCommandSender, aPath, aStatusIB, apData);
-        }
+        virtual void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
+                                const StatusIB & aStatusIB, TLV::TLVReader * apData,
+                                const AdditionalResponseData & aAdditionalResponseData) {}
 
-        /**
-         * OnResponse will be called when a successful response from server has been received and processed. Specifically:
-         *  - When a status code is received and it is IM::Success, aData will be nullptr.
-         *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
-         *    that contains the data payload (callee will still need to open and process the container).
-         *
-         * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
-         * receives an OnDone call to destroy the object.
-         *
-         * It is advised that subclasses should only override this or `OnResponseWithAdditionalData`. But, it shouldn't actually
-         * matter if both are overridden, just that `OnResponse` will never be called by CommandSender directly.
-         *
-         * @param[in] apCommandSender The command sender object that initiated the command transaction.
-         * @param[in] aPath           The command path field in invoke command response.
-         * @param[in] aStatusIB       It will always have a success status. If apData is null, it can be any success status,
-         *                            including possibly a cluster-specific one. If apData is not null it aStatusIB will always
-         *                            be a generic SUCCESS status with no-cluster specific information.
-         * @param[in] apData          The command data, will be nullptr if the server returns a StatusIB.
-         */
-        virtual void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatusIB,
-                                TLV::TLVReader * apData)
-        {}
 
         /**
          * OnError will be called when an error occur *after* a successful call to SendCommandRequest(). The following

--- a/src/controller/TypedCommandCallback.h
+++ b/src/controller/TypedCommandCallback.h
@@ -59,7 +59,7 @@ public:
 
 private:
     void OnResponse(app::CommandSender * apCommandSender, const app::ConcreteCommandPath & aCommandPath,
-                    const app::StatusIB & aStatus, TLV::TLVReader * aReader) override;
+                    const app::StatusIB & aStatus, TLV::TLVReader * aReader, const app::CommandSender::AdditionalResponseData & aAdditionalResponseData) override;
 
     void OnError(const app::CommandSender * apCommandSender, CHIP_ERROR aError) override
     {
@@ -102,8 +102,15 @@ private:
 template <typename CommandResponseObjectT>
 void TypedCommandCallback<CommandResponseObjectT>::OnResponse(app::CommandSender * apCommandSender,
                                                               const app::ConcreteCommandPath & aCommandPath,
-                                                              const app::StatusIB & aStatus, TLV::TLVReader * aReader)
+                                                              const app::StatusIB & aStatus, TLV::TLVReader * aReader,
+                                                              const app::CommandSender::AdditionalResponseData & aAdditionalResponseData)
 {
+    if (!aStatus.IsSuccess())
+    {
+        OnError(apCommandSender, aStatus.ToChipError());
+        return;
+    }
+
     if (mCalledCallback)
     {
         return;
@@ -148,8 +155,16 @@ template <>
 inline void TypedCommandCallback<app::DataModel::NullObjectType>::OnResponse(app::CommandSender * apCommandSender,
                                                                              const app::ConcreteCommandPath & aCommandPath,
                                                                              const app::StatusIB & aStatus,
-                                                                             TLV::TLVReader * aReader)
+                                                                             TLV::TLVReader * aReader,
+                                                                             const app::CommandSender::AdditionalResponseData & aAdditionalResponseData
+                                                                             )
 {
+    if (!aStatus.IsSuccess())
+    {
+        OnError(apCommandSender, aStatus.ToChipError());
+        return;
+    }
+
     if (mCalledCallback)
     {
         return;

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -82,9 +82,9 @@ public:
         mAppContext(appContext), mIsBatchedCommands(isBatchedCommands)
     {}
 
-    void OnResponseWithAdditionalData(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
-                                      const app::StatusIB & aStatus, TLV::TLVReader * aData,
-                                      const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
+    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
+                    const app::StatusIB & aStatus, TLV::TLVReader * aData,
+                    const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
         uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];


### PR DESCRIPTION
Fixes: https://github.com/project-chip/connectedhomeip/issues/30991

This solution leverages fact that with batched commands we already have the need for new API arguments so we use this as an opportunity to update the API contract to what it should have always been originally. This introduces a compile time breaking change. All clients that implement `CommandSender::Callbacks` will be forced to reconcile how path specific error should be handled at this time.

Advantage:
* This is how that API contract should have been all along.

Drawback:
* We introduce a breaking change for all. Everyone will be forced to spend time on how they should handle path specific status errors.
* Take for instance the chip-repl method of fixing this. We still need to not break existing uses so for non-batch commands we are still calling the error handler. So there is still some left over ugliness. Although this is still the case even with https://github.com/project-chip/connectedhomeip/pull/30998 (see https://github.com/project-chip/connectedhomeip/pull/31001)

Test:
  * Confirmed that chip-repl behaves as expected
