### PR TITLE
[Python] Call OnAttributeChangeCb for Vendor specific clusters too

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -582,7 +582,7 @@ class SubscriptionTransaction:
             self._onErrorCb = callback
 
     @property
-    def OnAttributeChangeCb(self) -> Callable[[TypedAttributePath, SubscriptionTransaction], None]:
+    def OnAttributeChangeCb(self) -> Callable[[Union[TypedAttributePath, AttributePath], SubscriptionTransaction], None]:
         return self._onAttributeChangeCb
 
     @property
@@ -791,12 +791,12 @@ class AsyncReadTransaction:
 
         if (self._subscription_handler is not None):
             for change in self._changedPathSet:
+                attribute_path = change
                 try:
                     attribute_path = TypedAttributePath(Path=change)
-                except (KeyError, ValueError) as err:
+                except KeyError as err:
                     # path could not be resolved into a TypedAttributePath
                     logging.getLogger(__name__).exception(err)
-                    continue
                 self._subscription_handler.OnAttributeChangeCb(
                     attribute_path, self._subscription_handler)
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -796,7 +796,7 @@ class AsyncReadTransaction:
                     attribute_path = TypedAttributePath(Path=change)
                 except KeyError as err:
                     # path could not be resolved into a TypedAttributePath
-                    logging.getLogger(__name__).exception(err)
+                    logging.getLogger(__name__).warning(err)
                 self._subscription_handler.OnAttributeChangeCb(
                     attribute_path, self._subscription_handler)
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -561,7 +561,7 @@ class SubscriptionTransaction:
             self._onResubscriptionSucceededCb = callback
             self._onResubscriptionSucceededCb_isAsync = isAsync
 
-    def SetAttributeUpdateCallback(self, callback: Callable[[TypedAttributePath, SubscriptionTransaction], None]):
+    def SetAttributeUpdateCallback(self, callback: Callable[[Union[TypedAttributePath, AttributePath], SubscriptionTransaction], None]):
         '''
         Sets the callback function for the attribute value change event,
         accepts a Callable accepts an attribute path and the cached data.
@@ -620,7 +620,7 @@ def DefaultResubscriptionAttemptedCallback(transaction: SubscriptionTransaction,
     print(f"Previous subscription failed with Error: {terminationError} - re-subscribing in {nextResubscribeIntervalMsec}ms...")
 
 
-def DefaultAttributeChangeCallback(path: TypedAttributePath, transaction: SubscriptionTransaction):
+def DefaultAttributeChangeCallback(path: Union[TypedAttributePath, AttributePath], transaction: SubscriptionTransaction):
     data = transaction.GetAttribute(path)
     value = {
         'Endpoint': path.Path.EndpointId,

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -377,7 +377,10 @@ class AttributeChangeAccumulator:
         self._expected_attribute = expected_attribute
         self._output_queue = output_queue
 
-    def __call__(self, path: TypedAttributePath, transaction: SubscriptionTransaction):
+    def __call__(self, path: Union[TypedAttributePath, AttributePath], transaction: SubscriptionTransaction):
+        # We are not interested in untyped (e.g. vendor specific) attributes
+        if not isinstance(path, TypedAttributePath):
+            return
         if path.AttributeType == self._expected_attribute:
             data = transaction.GetAttribute(path)
             result = _ActionResult(status=_ActionStatus.SUCCESS, response=path.AttributeType(data))


### PR DESCRIPTION
When it is not possible to resolve the type of a particular attribute, the exception is catched and logged currently. However, a user might be interested in this change even though it wasn't able to resolve the type.

This changes the callback signature to also accept the untyped AttributePath. Callback implementation which are not interested in this untyped variant will have to check the type and ignore those callbacks.
