### PR TITLE
Upgrade labeler config to v5 from v4

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,223 +16,309 @@
 #  Top Level Labels
 ############################################################
 repo:
-    - ./*
+  - changed-files:
+    - any-glob-to-any-file:
+      - './*'
 
 ############################################################
 #  Examples
 ############################################################
 examples:
-    - examples/*
-    - examples/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - examples/*
+      - examples/**/*
 
 ############################################################
 #  Documentation
 ############################################################
 documentation:
-    - docs/*
-    - docs/**/*
-    - "*.md"
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/*
+      - docs/**/*
+      - "*.md"
 
 ############################################################
 #  Tools + Development Items
 ############################################################
 scripts:
-    - scripts/*
-    - scripts/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - scripts/*
+      - scripts/**/*
 
 integrations:
-    - integrations/*
-    - integrations/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - integrations/*
+      - integrations/**/*
 
 docker:
-    - integrations/docker/*
-    - integrations/docker/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - integrations/docker/*
+      - integrations/docker/**/*
 
 vscode:
-    - .vscode/*
-    - .vscode/**/*
-    - .devcontainer/*
-    - .devcontainer/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - .vscode/*
+      - .vscode/**/*
+      - .devcontainer/*
+      - .devcontainer/**/*
 
 gn:
-    - build/*
-    - build/**/*
-    - build_overrides/*
-    - build_overrides/**/*
-    - .gn
-    - "*.gn"
-    - "*.gni"
+  - changed-files:
+    - any-glob-to-any-file:
+      - build/*
+      - build/**/*
+      - build_overrides/*
+      - build_overrides/**/*
+      - .gn
+      - "*.gn"
+      - "*.gni"
 
 github:
-    - .github
-    - .github/*
-    - .github/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github
+      - .github/*
+      - .github/**/*
 
 workflows:
-    - .github/workflows/*
-    - .github/workflows/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/*
+      - .github/workflows/**/*
 
 tools:
-    - src/tools/*
-    - src/tools/**/*
-    - tools/*
-    - tools/**/*
-    - examples/chip-tool/*
-    - examples/chip-tool/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/tools/*
+      - src/tools/**/*
+      - tools/*
+      - tools/**/*
+      - examples/chip-tool/*
+      - examples/chip-tool/**/*
 
 ############################################################
 #  Tests
 ############################################################
 tests:
-    - src/python_testing/*
-    - src/python_testing/**/*
-    - src/app/tests/*
-    - src/app/tests/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/python_testing/*
+      - src/python_testing/**/*
+      - src/app/tests/*
+      - src/app/tests/**/*
 
 test driver:
-    - src/test_driver/*
-    - src/test_driver/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/test_driver/*
+      - src/test_driver/**/*
 
 ############################################################
 #  Source Code
 ############################################################
 qr code:
-    - src/qrcode/*
-    - src/qrcode/**/*
-    - src/qrcodetool/*
-    - src/qrcodetool/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/qrcode/*
+      - src/qrcode/**/*
+      - src/qrcodetool/*
+      - src/qrcodetool/**/*
 
 lwip:
-    - src/lwip/*
-    - src/lwip/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lwip/*
+      - src/lwip/**/*
 
 inet:
-    - src/inet/*
-    - src/inet/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/inet/*
+      - src/inet/**/*
 
 config:
-    - config/*
-    - config/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - config/*
+      - config/**/*
 
 lib:
-    - src/lib/*
-    - src/lib/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lib/*
+      - src/lib/**/*
 
 core:
-    - src/lib/core/*
-    - src/lib/core/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lib/core/*
+      - src/lib/core/**/*
 
 protocols:
-    - src/lib/protocols/*
-    - src/lib/protocols/**/*
-    - src/protocols/*
-    - src/protocols/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lib/protocols/*
+      - src/lib/protocols/**/*
+      - src/protocols/*
+      - src/protocols/**/*
 
 messaging:
-    - src/messaging/*
-    - src/messaging/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/messaging/*
+      - src/messaging/**/*
 
 shell:
-    - src/lib/shell/*
-    - src/lib/shell/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lib/shell/*
+      - src/lib/shell/**/*
 
 support:
-    - src/lib/support/*
-    - src/lib/support/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/lib/support/*
+      - src/lib/support/**/*
 
 crypto:
-    - src/crypto/*
-    - src/crypto/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/crypto/*
+      - src/crypto/**/*
 
 controller:
-    - src/controller/*
-    - src/controller/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/controller/*
+      - src/controller/**/*
 
 ble:
-    - src/ble/*
-    - src/ble/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/ble/*
+      - src/ble/**/*
 
 app:
-    - src/app/*
-    - src/app/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/app/*
+      - src/app/**/*
 
 icd:
-    - src/app/icd/*
-    - src/app/icd/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/app/icd/*
+      - src/app/icd/**/*
 
 transport:
-    - src/transport/*
-    - src/transport/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/transport/*
+      - src/transport/**/*
 
 system:
-    - src/system/*
-    - src/system/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/system/*
+      - src/system/**/*
 
 setup payload:
-    - src/setup_payload/*
-    - src/setup_payload/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/setup_payload/*
+      - src/setup_payload/**/*
 
 ############################################################
 #  Platforms
 ############################################################
 platform:
-    - src/platform/*
-    - src/platform/**/*
-    - config/tizen/chip-gn/platform/*
-    - config/tizen/chip-gn/platform/**/*
-    - examples/platform/*
-    - examples/platform/**/*
-    - scripts/tools/memory/platform/*
-    - scripts/tools/memory/platform/**/*
-    - src/include/platform/*
-    - src/include/platform/**/*
-    - src/lib/dnssd/platform/*
-    - src/lib/dnssd/platform/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/*
+      - src/platform/**/*
+      - config/tizen/chip-gn/platform/*
+      - config/tizen/chip-gn/platform/**/*
+      - examples/platform/*
+      - examples/platform/**/*
+      - scripts/tools/memory/platform/*
+      - scripts/tools/memory/platform/**/*
+      - src/include/platform/*
+      - src/include/platform/**/*
+      - src/lib/dnssd/platform/*
+      - src/lib/dnssd/platform/**/*
 
 darwin:
-    - src/platform/Darwin/*
-    - src/platform/Darwin/**/*
-    - src/darwin/*
-    - src/darwin/**/*
-    - examples/darwin-framework-tool/*
-    - examples/darwin-framework-tool/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/Darwin/*
+      - src/platform/Darwin/**/*
+      - src/darwin/*
+      - src/darwin/**/*
+      - examples/darwin-framework-tool/*
+      - examples/darwin-framework-tool/**/*
 
 silabs:
-    - src/platform/silabs/*
-    - src/platform/silabs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/silabs/*
+      - src/platform/silabs/**/*
 
 esp32:
-    - src/platform/ESP32/*
-    - src/platform/ESP32/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/ESP32/*
+      - src/platform/ESP32/**/*
 
 freeRTOS:
-    - src/platform/FreeRTOS/*
-    - src/platform/FreeRTOS/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/FreeRTOS/*
+      - src/platform/FreeRTOS/**/*
 
 k32w:
-    - src/platform/K32W/*
-    - src/platform/K32W/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/K32W/*
+      - src/platform/K32W/**/*
 
 linux:
-    - src/platform/Linux/*
-    - src/platform/Linux/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/Linux/*
+      - src/platform/Linux/**/*
 
 nrf connect:
-    - src/platform/nrfconnect/*
-    - src/platform/nrfconnect/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/nrfconnect/*
+      - src/platform/nrfconnect/**/*
 
 openthread:
-    - src/platform/openthread/*
-    - src/platform/openthread/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/openthread/*
+      - src/platform/openthread/**/*
 
 zephyr:
-    - src/platform/Zephyr/*
-    - src/platform/Zephyr/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/Zephyr/*
+      - src/platform/Zephyr/**/*
 
 telink:
-    - src/platform/telink/*
-    - src/platform/telink/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/telink/*
+      - src/platform/telink/**/*
 
 tizen:
-    - src/platform/Tizen/*
-    - src/platform/Tizen/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/platform/Tizen/*
+      - src/platform/Tizen/**/*

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    name: Label Triage
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Fixes #30930

Following work to the PR #30996  after the merge still showing the error.

Currently https://github.com/project-chip/connectedhomeip/blob/master/.github/workflows/labeler.yaml our labeler yaml is pointing to the version v4.

Seems to have broken label CI actions (which is ugly because the CI itself passed, it just fails on other PRs like https://github.com/project-chip/connectedhomeip/actions/runs/7169114229/job/19518884500?pr=30921)

1. Currently because of the fail it has been reverted back to v4 
2. Modified the labeler correctly in order to use version 5 (v5.0.0) 
3. Config file has been updated. File -> .github/labeler.yaml. Ref Links for the upgrade as below,
 - https://github.com/actions/labeler?tab=readme-ov-file#breaking-changes-in-v5
https://github.com/flutter/flutter/pull/139564/files#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR23
   - Follow-Up work required after last merge on PR #30996 -> https://github.com/flutter/flutter/pull/139596  
4. Workflow Labeler has been to updated. File -> .github/workflows/labeler.yaml. Ref link for upgrade as below,
 - https://github.com/actions/labeler/issues/712
5. Will need to carry the testing operation to check it's working.