### PR TITLE
Make wholesale replacement of lwIP more straightforward

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -37,6 +37,10 @@ import("${build_root}/config/compiler/compiler.gni")
 
 import("//src/crypto/crypto.gni")
 
+if (chip_with_lwip) {
+  import("//build_overrides/lwip.gni")
+}
+
 if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   declare_args() {
     chip_enable_python_modules =
@@ -152,7 +156,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
 
     if (chip_with_lwip) {
-      deps += [ "${chip_root}/src/lwip" ]
+      deps += [ "${lwip_root}:lwip" ]
     }
 
     if (chip_build_tools) {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -19,7 +19,6 @@ import("${build_root}/config/compiler/compiler.gni")
 import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/ble/ble.gni")
-import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/src/tracing/tracing_args.gni")
 

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -20,12 +20,15 @@ import("//build_overrides/nlio.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/build/chip/tests.gni")
-import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 import("inet.gni")
 
 if (chip_system_config_use_open_thread_inet_endpoints) {
   import("//build_overrides/openthread.gni")
+}
+
+if (chip_system_config_use_lwip) {
+  import("//build_overrides/lwip.gni")
 }
 
 declare_args() {
@@ -105,7 +108,7 @@ static_library("inet") {
 
   if (chip_system_config_use_lwip) {
     sources += [ "EndPointStateLwIP.cpp" ]
-    public_deps += [ "${chip_root}/src/lwip" ]
+    public_deps += [ "${lwip_root}:lwip" ]
   }
 
   if (chip_system_config_use_open_thread_inet_endpoints) {

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -18,7 +18,6 @@ import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/build/chip/tests.gni")
-import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 
 config("tests_config") {

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -99,6 +99,11 @@ buildconfig_header("lwip_buildconfig") {
 if (current_os == "zephyr" || current_os == "mbed") {
   group("lwip") {
   }
+} else if (get_path_info(lwip_root, "abspath") != get_path_info("${chip_root}/third_party/lwip", "abspath")) {
+  # Redirect old dependencies on ${chip_root}/src/lwip onto ${lwip_root}:lwip
+  group("lwip") {
+    public_deps = ["${lwip_root}:lwip"]
+  }
 } else if (lwip_platform == "external" || lwip_platform == "mw320") {
   group("lwip") {
     public_deps = [ ":lwip_buildconfig" ]

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -99,10 +99,11 @@ buildconfig_header("lwip_buildconfig") {
 if (current_os == "zephyr" || current_os == "mbed") {
   group("lwip") {
   }
-} else if (get_path_info(lwip_root, "abspath") != get_path_info("${chip_root}/third_party/lwip", "abspath")) {
+} else if (get_path_info(lwip_root, "abspath") !=
+           get_path_info("${chip_root}/third_party/lwip", "abspath")) {
   # Redirect old dependencies on ${chip_root}/src/lwip onto ${lwip_root}:lwip
   group("lwip") {
-    public_deps = ["${lwip_root}:lwip"]
+    public_deps = [ "${lwip_root}:lwip" ]
   }
 } else if (lwip_platform == "external" || lwip_platform == "mw320") {
   group("lwip") {
@@ -147,7 +148,7 @@ if (current_os == "zephyr" || current_os == "mbed") {
   }
 
   group("lwip") {
-    public_deps = [":legacy_lwip"]
+    public_deps = [ ":legacy_lwip" ]
   }
 } else if (lwip_platform == "bl602") {
   group("lwip") {
@@ -250,6 +251,6 @@ if (current_os == "zephyr" || current_os == "mbed") {
   }
 
   group("lwip") {
-    public_deps = [":legacy_lwip"]
+    public_deps = [ ":legacy_lwip" ]
   }
 }

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -99,10 +99,6 @@ buildconfig_header("lwip_buildconfig") {
 if (current_os == "zephyr" || current_os == "mbed") {
   group("lwip") {
   }
-} else if (lwip_platform == "silabs") {
-  group("lwip") {
-    public_deps = [ "${lwip_root}:lwip" ]
-  }
 } else if (lwip_platform == "external" || lwip_platform == "mw320") {
   group("lwip") {
     public_deps = [ ":lwip_buildconfig" ]
@@ -127,7 +123,7 @@ if (current_os == "zephyr" || current_os == "mbed") {
     include_dirs = [ "freertos" ]
   }
 
-  lwip_target("lwip") {
+  lwip_target("legacy_lwip") {
     public = [
       "${qpg_sdk_root}/Components/ThirdParty/Lwip/arch/cc.h",
       "${qpg_sdk_root}/Components/ThirdParty/Lwip/arch/perf.h",
@@ -143,6 +139,10 @@ if (current_os == "zephyr" || current_os == "mbed") {
       ":lwip_config",
       "${chip_root}/src:includes",
     ]
+  }
+
+  group("lwip") {
+    public_deps = [":legacy_lwip"]
   }
 } else if (lwip_platform == "bl602") {
   group("lwip") {
@@ -191,7 +191,7 @@ if (current_os == "zephyr" || current_os == "mbed") {
     }
   }
 
-  lwip_target("lwip") {
+  lwip_target("legacy_lwip") {
     public = [
       "${lwip_platform}/arch/cc.h",
       "${lwip_platform}/arch/perf.h",
@@ -220,6 +220,8 @@ if (current_os == "zephyr" || current_os == "mbed") {
       public_deps += [ "${ti_simplelink_sdk_build_root}:ti_simplelink_sdk" ]
       sources +=
           [ "${chip_root}/third_party/lwip/repo/lwip/src/apps/mdns/mdns.c" ]
+    } else if (lwip_platform == "silabs") {
+      public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
     } else if (lwip_platform == "standalone") {
       public_deps += [ "${chip_root}/src/lib/support" ]
     } else if (lwip_platform == "k32w0") {
@@ -240,5 +242,9 @@ if (current_os == "zephyr" || current_os == "mbed") {
       ":lwip_config",
       "${chip_root}/src:includes",
     ]
+  }
+
+  group("lwip") {
+    public_deps = [":legacy_lwip"]
   }
 }

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -18,7 +18,6 @@ import("//build_overrides/lwip.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/lwip/lwip.gni")
-import("${lwip_root}/lwip.gni")
 
 assert(chip_with_lwip)
 
@@ -100,6 +99,10 @@ buildconfig_header("lwip_buildconfig") {
 if (current_os == "zephyr" || current_os == "mbed") {
   group("lwip") {
   }
+} else if (lwip_platform == "silabs") {
+  group("lwip") {
+    public_deps = [ "${lwip_root}:lwip" ]
+  }
 } else if (lwip_platform == "external" || lwip_platform == "mw320") {
   group("lwip") {
     public_deps = [ ":lwip_buildconfig" ]
@@ -118,6 +121,8 @@ if (current_os == "zephyr" || current_os == "mbed") {
     public_configs += [ "${psoc6_sdk_build_root}:psoc6_sdk_config" ]
   }
 } else if (lwip_platform == "qpg") {
+  import("${lwip_root}/lwip.gni")
+
   config("lwip_config") {
     include_dirs = [ "freertos" ]
   }
@@ -176,6 +181,8 @@ if (current_os == "zephyr" || current_os == "mbed") {
     ]
   }
 } else {
+  import("${lwip_root}/lwip.gni")
+
   config("lwip_config") {
     include_dirs = [ lwip_platform ]
 
@@ -213,8 +220,6 @@ if (current_os == "zephyr" || current_os == "mbed") {
       public_deps += [ "${ti_simplelink_sdk_build_root}:ti_simplelink_sdk" ]
       sources +=
           [ "${chip_root}/third_party/lwip/repo/lwip/src/apps/mdns/mdns.c" ]
-    } else if (lwip_platform == "silabs") {
-      public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
     } else if (lwip_platform == "standalone") {
       public_deps += [ "${chip_root}/src/lib/support" ]
     } else if (lwip_platform == "k32w0") {

--- a/src/platform/mt793x/ConnectivityManagerImpl.cpp
+++ b/src/platform/mt793x/ConnectivityManagerImpl.cpp
@@ -23,8 +23,6 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/BLEManager.h>
 
-#include <app/server/Dnssd.h>
-
 #include <lwip/dns.h>
 #include <lwip/ip_addr.h>
 #include <lwip/nd6.h>

--- a/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
@@ -33,6 +33,8 @@ namespace NetworkCommissioning {
 namespace {
 NetworkCommissioning::WiFiScanResponse * sScanResult;
 GenioScanResponseIterator<NetworkCommissioning::WiFiScanResponse> mScanResponseIter(sScanResult);
+
+using chip::app::Clusters::NetworkCommissioning::WiFiSecurityBitmap;
 } // namespace
 
 CHIP_ERROR GenioWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)

--- a/src/platform/mt793x/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/mt793x/NetworkCommissioningWiFiDriver.h
@@ -122,7 +122,7 @@ public:
 
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
 
-    chip::BitFlags<WiFiSecurityBitmap> ConvertSecuritytype(wifi_auth_mode_t auth_mode);
+    chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> ConvertSecuritytype(wifi_auth_mode_t auth_mode);
 
     void OnConnectWiFiNetwork();
     static GenioWiFiDriver & GetInstance()

--- a/src/platform/mt793x/args.gni
+++ b/src/platform/mt793x/args.gni
@@ -31,7 +31,7 @@ lwip_platform = "mt793x"
 
 # Use our porting instad of //third_party/lwip
 
-lwip_root = "${chip_root}/third_party/mt793x_sdk/lwip"
+lwip_root = "${mt793x_sdk_build_root}/mt793x_lwip"
 
 chip_mdns = "platform"
 chip_inet_config_enable_ipv4 = true

--- a/src/platform/mt793x/lwip/BUILD.gn
+++ b/src/platform/mt793x/lwip/BUILD.gn
@@ -67,5 +67,5 @@ lwip_target("mt793x_lwip") {
 }
 
 group("lwip") {
-  public_deps = [":mt793x_lwip"]
+  public_deps = [ ":mt793x_lwip" ]
 }

--- a/src/platform/mt793x/lwip/BUILD.gn
+++ b/src/platform/mt793x/lwip/BUILD.gn
@@ -51,7 +51,7 @@ config("lwip_config") {
   ]
 }
 
-lwip_target("lwip") {
+lwip_target("mt793x_lwip") {
   public = [ "${mt793x_sdk_root}/project/mt7933_hdk/apps/${mt793x_project_name}/inc/lwipopts.h" ]
 
   sources = []
@@ -64,4 +64,8 @@ lwip_target("lwip") {
     ":lwip_config",
     "${chip_root}/src:includes",
   ]
+}
+
+group("lwip") {
+  public_deps = [":mt793x_lwip"]
 }

--- a/src/platform/silabs/wifi_args.gni
+++ b/src/platform/silabs/wifi_args.gni
@@ -35,7 +35,7 @@ if (chip_crypto == "") {
 chip_use_transitional_commissionable_data_provider = false
 
 # Use GSDK lwip instead of CHIP
-lwip_root = "${efr32_sdk_build_root}"
+lwip_root = "${efr32_sdk_build_root}/silabs_lwip"
 
 #lwip_platform = "external"
 lwip_platform = "silabs"

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -23,6 +23,10 @@ import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
 import("system.gni")
 
+if (chip_system_config_use_lwip) {
+  import("//build_overrides/lwip.gni")
+}
+
 declare_args() {
   # Extra header to include in CHIPConfig.h for project.
   # TODO - This should probably be in src/core but src/system also uses it.
@@ -175,7 +179,7 @@ source_set("system_config_header") {
 
   if (target_cpu != "esp32") {
     if (chip_system_config_use_lwip) {
-      public_deps += [ "${chip_root}/src/lwip" ]
+      public_deps += [ "${lwip_root}:lwip" ]
     } else {
       if (chip_device_platform == "efr32") {
         public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]

--- a/third_party/lwip/BUILD.gn
+++ b/third_party/lwip/BUILD.gn
@@ -1,0 +1,62 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+# Re-export the Matter lwip integration as "lwip"
+#
+# To depend on lwip while keeping the implementation target
+# encapsulated:
+#
+# import("//build_overrides/lwip.gni")
+#
+# source_set("foo") {
+#   public_deps = [
+#      "${lwip_root}:lwip",
+#      ...
+#   ]
+# }
+#
+# and set up the build_overrides appropriately (a typical lwip_root
+# would be //third_party/lwip).
+#
+# To help define the library, a reusable template is provided as
+# lwip_target() in third_party/lwip/lwip.gni. Example usage:
+#
+# //example/lwip/BUILD.gn:
+#
+#  config("lwip_config") {
+#    include_dirs = [ "include" ]
+#  }
+#
+#  lwip_target("lwip") {
+#    public = [
+#      "include/lwipopts.h"
+#    ]
+#
+#    sources = [ "sys_arch.c" ]
+#
+#    public_configs = [
+#      ":lwip_config",
+#    ]
+#  }
+#
+# Then set lwip_root = "//example/lwip" in build args. Defining the
+# library directly works too.
+#
+# If there's no include paths to add, defines to set, sources to
+# compile, or libraries to link, then an empty group target suffices.
+group("lwip") {
+  public_deps = [ "${chip_root}/src/lwip:lwip" ]
+}

--- a/third_party/lwip/BUILD.gn
+++ b/third_party/lwip/BUILD.gn
@@ -52,8 +52,10 @@ import("//build_overrides/chip.gni")
 #    ]
 #  }
 #
-# Then set lwip_root = "//example/lwip" in build args. Defining the
-# library directly works too.
+# Then set lwip_root = "//example/lwip" in build_overrides (or,
+# if declared as an argument in build_overrides, via args).
+#
+# Defining the library directly works too.
 #
 # If there's no include paths to add, defines to set, sources to
 # compile, or libraries to link, then an empty group target suffices.

--- a/third_party/mt793x_sdk/mt793x_lwip/BUILD.gn
+++ b/third_party/mt793x_sdk/mt793x_lwip/BUILD.gn
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/mt793x_sdk.gni")
+
+import("${mt793x_sdk_build_root}/lwip/lwip.gni")
+
+config("lwip_config") {
+  include_dirs = [
+    "${chip_root}/src/lwip/mt793x",
+    "${chip_root}/src/lwip/freertos",
+  ]
+}
+
+lwip_target("lwip") {
+  public = [
+    "${chip_root}/src/lwip/mt793x/arch/cc.h",
+    "${chip_root}/src/lwip/mt793x/arch/perf.h",
+    "${chip_root}/src/lwip/mt793x/lwipopts.h",
+  ]
+
+  sources = []
+
+  public_deps = [
+    "${chip_root}/src/lwip:lwip_buildconfig",
+    "${mt793x_sdk_build_root}:mt793x_sdk",
+  ]
+
+  public_configs = [
+    ":lwip_config",
+    "${chip_root}/src:includes",
+  ]
+}

--- a/third_party/mt793x_sdk/mt793x_sdk.gni
+++ b/third_party/mt793x_sdk/mt793x_sdk.gni
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 import("//build_overrides/chip.gni")
+import("//build_overrides/lwip.gni")
 import("//build_overrides/mbedtls.gni")
 import("//build_overrides/mt793x_sdk.gni")
 import("${chip_root}/src/crypto/crypto.gni")
-import("${chip_root}/src/platform/mt793x/args.gni")
+import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/src/platform/mt793x/lwip/lwip.gni")
 
 #

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/jlink.gni")
 import("//build_overrides/openthread.gni")
+import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${efr32_sdk_build_root}/silabs_board.gni")
 
@@ -51,6 +52,12 @@ assert(silabs_sdk_target != "", "silabs_sdk_target must be specified")
 group("efr32_sdk") {
   public_deps = [ silabs_sdk_target ]
   public_configs = [ ":silabs_config" ]
+}
+
+if (chip_with_lwip) {
+  group("lwip") {
+    public_deps = [ "silabs_lwip:lwip" ]
+  }
 }
 
 if (wifi_soc != true) {  # CCP board

--- a/third_party/silabs/silabs_lwip/BUILD.gn
+++ b/third_party/silabs/silabs_lwip/BUILD.gn
@@ -24,7 +24,7 @@ config("lwip_config") {
   ]
 }
 
-lwip_target("lwip") {
+lwip_target("silabs_lwip") {
   public = [
     "${chip_root}/src/lwip/freertos/arch/sys_arch.h",
     "${chip_root}/src/lwip/silabs/arch/cc.h",
@@ -44,4 +44,8 @@ lwip_target("lwip") {
     ":lwip_config",
     "${chip_root}/src:includes",
   ]
+}
+
+group("lwip") {
+  public_deps = [":silabs_lwip"]
 }

--- a/third_party/silabs/silabs_lwip/BUILD.gn
+++ b/third_party/silabs/silabs_lwip/BUILD.gn
@@ -47,5 +47,5 @@ lwip_target("silabs_lwip") {
 }
 
 group("lwip") {
-  public_deps = [":silabs_lwip"]
+  public_deps = [ ":silabs_lwip" ]
 }

--- a/third_party/silabs/silabs_lwip/BUILD.gn
+++ b/third_party/silabs/silabs_lwip/BUILD.gn
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/efr32_sdk.gni")
+
+import("../lwip.gni")
+
+config("lwip_config") {
+  include_dirs = [
+    "${chip_root}/src/lwip/silabs",
+    "${chip_root}/src/lwip/freertos",
+  ]
+}
+
+lwip_target("lwip") {
+  public = [
+    "${chip_root}/src/lwip/freertos/arch/sys_arch.h",
+    "${chip_root}/src/lwip/silabs/arch/cc.h",
+    "${chip_root}/src/lwip/silabs/arch/perf.h",
+    "${chip_root}/src/lwip/silabs/lwipopts.h",
+    "${chip_root}/src/lwip/silabs/lwippools.h",
+  ]
+
+  sources = [ "${chip_root}/src/lwip/freertos/sys_arch.c" ]
+
+  public_deps = [
+    "${chip_root}/src/lwip:lwip_buildconfig",
+    "${efr32_sdk_build_root}:efr32_sdk",
+  ]
+
+  public_configs = [
+    ":lwip_config",
+    "${chip_root}/src:includes",
+  ]
+}


### PR DESCRIPTION
Instead of everyone directly adjusting the definintions in src/lwip, which only works in-tree, clean up the dependencies so that overriding lwip_root works cleanly (ie, without introducing dependencies on $chip_root/src/lwip).

See docs in third_party/lwip/BUILD.gn