### PR TITLE
[Python] Explicit delete of BLE scanner object

### DIFF
--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -19,6 +19,7 @@
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Linux/bluez/AdapterIterator.h>
+#include <platform/Linux/bluez/ChipDeviceScanner.h>
 #include <platform/internal/BLEManager.h>
 
 using namespace chip::DeviceLayer::Internal;

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -112,8 +112,6 @@ public:
         {
             mCompleteCallback(mContext);
         }
-
-        delete this;
     }
 
     virtual void OnScanError(CHIP_ERROR error) override
@@ -134,10 +132,10 @@ private:
 
 } // namespace
 
-extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeoutMs,
-                                            ScannerDelegateImpl::DeviceScannedCallback scanCallback,
-                                            ScannerDelegateImpl::ScanCompleteCallback completeCallback,
-                                            ScannerDelegateImpl::ScanErrorCallback errorCallback)
+extern "C" void * pychip_ble_scanner_start(PyObject * context, void * adapter, uint32_t timeoutMs,
+                                           ScannerDelegateImpl::DeviceScannedCallback scanCallback,
+                                           ScannerDelegateImpl::ScanCompleteCallback completeCallback,
+                                           ScannerDelegateImpl::ScanErrorCallback errorCallback)
 {
     std::unique_ptr<ScannerDelegateImpl> delegate =
         std::make_unique<ScannerDelegateImpl>(context, scanCallback, completeCallback, errorCallback);
@@ -151,4 +149,10 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
     VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr);
 
     return delegate.release();
+}
+
+extern "C" void pychip_ble_scanner_delete(void * scanner)
+{
+    chip::DeviceLayer::StackLock lock;
+    delete static_cast<ScannerDelegateImpl *>(scanner);
 }

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -141,12 +141,14 @@ extern "C" void * pychip_ble_scanner_start(PyObject * context, void * adapter, u
         std::make_unique<ScannerDelegateImpl>(context, scanCallback, completeCallback, errorCallback);
 
     CHIP_ERROR err = delegate->ScannerInit(static_cast<BluezAdapter1 *>(adapter));
-    VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr,
+                        ChipLogError(Ble, "Failed to initialize BLE scanner: %" CHIP_ERROR_FORMAT, err.Format()));
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     err = delegate->ScannerStartScan(chip::System::Clock::Milliseconds32(timeoutMs));
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-    VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr,
+                        ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
 
     return delegate.release();
 }

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -131,7 +131,7 @@ using ScanErrorCallback = void (*)(PyObject * context, uint32_t error);
 
 @end
 
-extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeout,
+extern "C" void * pychip_ble_scanner_start(PyObject * context, void * adapter, uint32_t timeout,
     DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback, ScanErrorCallback errorCallback)
 {
     // NOTE: adapter is ignored as it does not apply to mac
@@ -143,4 +143,9 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
                                                                          timeoutMs:timeout];
 
     return (__bridge_retained void *) (scanner);
+}
+
+extern "C" void pychip_ble_scanner_delete(void * scanner)
+{
+    CFRelease((CFTypeRef) scanner);
 }

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -57,8 +57,10 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
         setter.Set('pychip_ble_adapter_list_get_raw_adapter',
                    VoidPointer, [VoidPointer])
 
-        setter.Set('pychip_ble_start_scanning', VoidPointer, [
-            py_object, VoidPointer, c_uint32, DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
+        setter.Set('pychip_ble_scanner_start', VoidPointer, [
+            py_object, VoidPointer, c_uint32, DeviceScannedCallback,
+            ScanDoneCallback, ScanErrorCallback,
         ])
+        setter.Set('pychip_ble_scanner_delete', None, [VoidPointer])
 
     return handle

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -54,8 +54,11 @@ def DiscoverAsync(timeoutMs: int, scanCallback, doneCallback, errorCallback, ada
                     a string with the adapter address. If None, the first
                     adapter on the system is used.
     """
-    if adapter and not isinstance(adapter, str):
-        adapter = adapter.address
+    if adapter:
+        if isinstance(adapter, str):
+            adapter = adapter.upper()
+        else:
+            adapter = adapter.address
 
     handle = _GetBleLibraryHandle()
 

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -137,8 +137,6 @@ def DiscoverSync(timeoutMs: int, adapter=None) -> Generator[DeviceInfo, None, No
 
     Args:
       timeoutMs:    scan will complete after this time
-      scanCallback: callback when a device is found
-      doneCallback: callback when the scan is complete
       adapter:      what adapter to choose. Either an AdapterInfo object or
                     a string with the adapter address. If None, the first
                     adapter on the system is used.

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -130,8 +130,6 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
     {
         ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format());
         mIsScanning = false;
-        // The callback is explicitly allowed to delete the scanner instance, so
-        // we must not access 'this' after this point.
         mDelegate->OnScanComplete();
         return err;
     }
@@ -140,7 +138,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed to schedule BLE scan timeout: %" CHIP_ERROR_FORMAT, err.Format());
-        StopScan(); // This will call the callback
+        StopScan(); // This will call the OnScanComplete callback
         return err;
     }
     mTimerExpired = false;
@@ -168,8 +166,6 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
         +[](ChipDeviceScanner * self) { return self->StopScanImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, ChipLogError(Ble, "Failed to stop BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    // The callback is explicitly allowed to delete the scanner instance, so
-    // we must not access 'this' after this point.
     mDelegate->OnScanComplete();
 
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -101,7 +101,7 @@ private:
     bool mIsScanning                      = false;
     bool mIsStopping                      = false;
     /// Used to track if timer has already expired and doesn't need to be canceled.
-    bool mTimerExpired = false;
+    bool mTimerExpired = true;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -40,10 +40,6 @@ public:
     virtual void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
 
     // Called when a scan was completed (stopped or timed out)
-    //
-    // NOTE: This callback is allowed to delete the scanner instance. Please
-    //       make sure to not use the scanner instance after this callback
-    //       returns.
     virtual void OnScanComplete() = 0;
 
     // Call on scan error
@@ -76,10 +72,6 @@ public:
     CHIP_ERROR StartScan(System::Clock::Timeout timeout);
 
     /// Stop any currently running scan
-    ///
-    /// This method calls OnScanComplete() on the delegate. The delegate is allowed to
-    /// delete the scanner instance. If that's the case, the scanner instance must not
-    /// be used after this method returns.
     CHIP_ERROR StopScan();
 
 private:

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -40,6 +40,10 @@ public:
     virtual void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
 
     // Called when a scan was completed (stopped or timed out)
+    //
+    // NOTE: This callback is allowed to delete the scanner instance. Please
+    //       make sure to not use the scanner instance after this callback
+    //       returns.
     virtual void OnScanComplete() = 0;
 
     // Call on scan error

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -76,16 +76,21 @@ public:
     CHIP_ERROR StartScan(System::Clock::Timeout timeout);
 
     /// Stop any currently running scan
+    ///
+    /// This method calls OnScanComplete() on the delegate. The delegate is allowed to
+    /// delete the scanner instance. If that's the case, the scanner instance must not
+    /// be used after this method returns.
     CHIP_ERROR StopScan();
 
 private:
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
-    static CHIP_ERROR MainLoopStartScan(ChipDeviceScanner * self);
-    static CHIP_ERROR MainLoopStopScan(ChipDeviceScanner * self);
     static void SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self);
     static void SignalInterfaceChanged(GDBusObjectManagerClient * manager, GDBusObjectProxy * object, GDBusProxy * aInterface,
                                        GVariant * aChangedProperties, const gchar * const * aInvalidatedProps,
                                        ChipDeviceScanner * self);
+
+    CHIP_ERROR StartScanImpl();
+    CHIP_ERROR StopScanImpl();
 
     /// Check if a given device is a CHIP device and if yes, report it as discovered
     void ReportDevice(BluezDevice1 & device);


### PR DESCRIPTION
### Problem

The Python module deletes scanner instance in the `OnScanComplete()` callback. We have to make sure that `this` will not be used after callback returns, which causes some issues in Linux platform.

### Changes

- add `pychip_ble_scanner_delete` which can be used for explicit memory management
- in python, spawn daemon thread which deletes the scanner object after being triggered by onScanComplete callback
- normalize (uppercase) BT address passed to `DiscoverAsync()`

### Testing

Locally tested scanner functionality with chip-tool on Linux