### PR TITLE
Add way to erase matter data only and emit event for application

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -81,6 +81,16 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
             chip::app::DnssdServer::Instance().StartServer();
         }
         break;
+
+    case DeviceEventType::PublicEventTypes::kFactoryReset: {
+        ESP_LOGI(TAG, "App performing factory reset");
+    }
+    break;
+
+    case DeviceEventType::PublicEventTypes::kMatterDataReset: {
+        ESP_LOGI(TAG, "App performing Matter data reset");
+    }
+    break;
     }
 
     ESP_LOGI(TAG, "Current free heap: %u\n", static_cast<unsigned int>(heap_caps_get_free_size(MALLOC_CAP_8BIT)));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -515,8 +515,37 @@ void Server::ScheduleFactoryReset()
     PlatformMgr().ScheduleWork([](intptr_t) {
         // Delete all fabrics and emit Leave event.
         GetInstance().GetFabricTable().DeleteAllFabrics();
+        if (GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            ChipDeviceEvent event;
+            event.Type     = DeviceEventType::PublicEventTypes::kFactoryReset;
+            CHIP_ERROR err = PlatformMgr().PostEvent(&event);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Failed to post factory reset event");
+            }
+        }
         PlatformMgr().HandleServerShuttingDown();
         ConfigurationMgr().InitiateFactoryReset();
+    });
+}
+
+void Server::ScheduleMatterDataReset()
+{
+    PlatformMgr().ScheduleWork([](intptr_t) {
+        // Delete all fabrics and emit Leave event.
+        GetInstance().GetFabricTable().DeleteAllFabrics();
+        if (GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            ChipDeviceEvent event;
+            event.Type     = DeviceEventType::PublicEventTypes::kMatterDataReset;
+            CHIP_ERROR err = PlatformMgr().PostEvent(&event);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Failed to post matter data reset event");
+            }
+        }
+        ConfigurationMgr().InitiateMatterDataReset();
     });
 }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -374,6 +374,8 @@ public:
 
     void ScheduleFactoryReset();
 
+    void ScheduleMatterDataReset();
+
     System::Clock::Microseconds64 TimeSinceInit() const
     {
         return System::SystemClock().GetMonotonicMicroseconds64() - mInitTimestamp;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -258,7 +258,7 @@ enum PublicEventTypes
     kFactoryReset,
 
     /**
-     * Signals the application that device is going to reset matter data.
+     * Signals the application that device is going to reset matter data (on last fabric removed).
      */
     kMatterDataReset,
 };

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -251,6 +251,16 @@ enum PublicEventTypes
      * sending messages to other nodes.
      */
     kServerReady,
+
+    /**
+     * Signals the application that device is going to factory reset.
+     */
+    kFactoryReset,
+
+    /**
+     * Signals the application that device is going to reset matter data.
+     */
+    kMatterDataReset,
 };
 
 /**

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -129,8 +129,9 @@ public:
     virtual void RunUnitTests() = 0;
 #endif
 
-    virtual bool IsFullyProvisioned()   = 0;
-    virtual void InitiateFactoryReset() = 0;
+    virtual bool IsFullyProvisioned()      = 0;
+    virtual void InitiateFactoryReset()    = 0;
+    virtual void InitiateMatterDataReset() = 0;
 
     // Gets called when starting BLE/DNS-SD advertisement
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING

--- a/src/platform/ASR/ConfigurationManagerImpl.h
+++ b/src/platform/ASR/ConfigurationManagerImpl.h
@@ -47,7 +47,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/ASR/ConfigurationManagerImpl.h
+++ b/src/platform/ASR/ConfigurationManagerImpl.h
@@ -47,6 +47,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -54,6 +54,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -54,7 +54,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.

--- a/src/platform/Beken/ConfigurationManagerImpl.h
+++ b/src/platform/Beken/ConfigurationManagerImpl.h
@@ -45,7 +45,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf);
     bool CanFactoryReset(void);
     void InitiateFactoryReset(void);
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount);

--- a/src/platform/Beken/ConfigurationManagerImpl.h
+++ b/src/platform/Beken/ConfigurationManagerImpl.h
@@ -45,6 +45,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf);
     bool CanFactoryReset(void);
     void InitiateFactoryReset(void);
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount);

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -62,7 +62,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -62,6 +62,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -330,7 +330,7 @@ void ConfigurationManagerImpl::DoMatterDataReset(intptr_t arg)
 {
     CHIP_ERROR err;
 
-    ChipLogProgress(DeviceLayer, "Performing factory reset without erasing network credentials");
+    ChipLogProgress(DeviceLayer, "Performing matter data reset");
 
     // Erase all values in the chip-config NVS namespace.
     err = ESP32Config::ClearNamespace(ESP32Config::kConfigNamespace_ChipConfig);
@@ -383,25 +383,11 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 void ConfigurationManagerImpl::InitiateMatterDataReset()
 {
-    ChipDeviceEvent event;
-    event.Type     = DeviceEventType::PublicEventTypes::kMatterDataReset;
-    CHIP_ERROR err = PlatformMgr().PostEvent(&event);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to post matter data reset event");
-    }
     PlatformMgr().ScheduleWork(DoMatterDataReset);
 }
 
 void ConfigurationManagerImpl::InitiateFactoryReset()
 {
-    ChipDeviceEvent event;
-    event.Type     = DeviceEventType::PublicEventTypes::kFactoryReset;
-    CHIP_ERROR err = PlatformMgr().PostEvent(&event);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to post factory reset event");
-    }
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -72,7 +72,14 @@ private:
 #endif
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
+
+    // InitiateFactoryReset erases matter data (chip config, counters, kvs) along with wifi credentials
+    // and complete nvs erase.
     void InitiateFactoryReset(void) override;
+
+    // InitiateMatterDataReset erases matter data only (chip config, counters, kvs namespaces).
+    void InitiateMatterDataReset(void);
+
     CHIP_ERROR MapConfigError(esp_err_t error);
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
@@ -96,6 +103,7 @@ private:
     // ===== Private members reserved for use by this class only.
 
     static void DoFactoryReset(intptr_t arg);
+    static void DoMatterDataReset(intptr_t arg);
 };
 
 /**

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -78,7 +78,7 @@ private:
     void InitiateFactoryReset(void) override;
 
     // InitiateMatterDataReset erases matter data only (chip config, counters, kvs namespaces).
-    void InitiateMatterDataReset(void);
+    void InitiateMatterDataReset(void) override;
 
     CHIP_ERROR MapConfigError(esp_err_t error);
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;

--- a/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
@@ -50,7 +50,7 @@ private:
     CHIP_ERROR Init(void) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.h
@@ -50,6 +50,7 @@ private:
     CHIP_ERROR Init(void) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
@@ -54,6 +54,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
+++ b/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.h
@@ -54,7 +54,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -57,7 +57,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -57,6 +57,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -61,6 +61,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -61,7 +61,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -50,6 +50,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -50,7 +50,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -51,7 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -51,6 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
@@ -45,6 +45,7 @@ private:
 
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
@@ -45,7 +45,7 @@ private:
 
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -51,7 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -51,6 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
@@ -50,6 +50,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ConfigurationManagerImpl.h
@@ -50,7 +50,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc32xx/ConfigurationManagerImpl.h
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.h
@@ -45,7 +45,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/cc32xx/ConfigurationManagerImpl.h
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.h
@@ -45,6 +45,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -92,6 +92,7 @@ private:
     void LogDeviceConfig() override {}
     bool CanFactoryReset() override { return true; }
     void InitiateFactoryReset() override {}
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -92,7 +92,7 @@ private:
     void LogDeviceConfig() override {}
     bool CanFactoryReset() override { return true; }
     void InitiateFactoryReset() override {}
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -51,7 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -51,6 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/mt793x/ConfigurationManagerImpl.h
+++ b/src/platform/mt793x/ConfigurationManagerImpl.h
@@ -53,7 +53,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/mt793x/ConfigurationManagerImpl.h
+++ b/src/platform/mt793x/ConfigurationManagerImpl.h
@@ -53,6 +53,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/nxp/common/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.h
@@ -47,6 +47,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;

--- a/src/platform/nxp/common/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.h
@@ -47,7 +47,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -46,6 +46,7 @@ public:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -46,7 +46,7 @@ public:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
@@ -48,7 +48,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w1/ConfigurationManagerImpl.h
@@ -48,6 +48,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.h
@@ -72,7 +72,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.h
@@ -72,6 +72,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;

--- a/src/platform/openiotsdk/ConfigurationManagerImpl.h
+++ b/src/platform/openiotsdk/ConfigurationManagerImpl.h
@@ -46,7 +46,7 @@ private:
     CHIP_ERROR Init(void) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/openiotsdk/ConfigurationManagerImpl.h
+++ b/src/platform/openiotsdk/ConfigurationManagerImpl.h
@@ -46,6 +46,7 @@ private:
     CHIP_ERROR Init(void) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -51,7 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -51,6 +51,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/silabs/ConfigurationManagerImpl.h
+++ b/src/platform/silabs/ConfigurationManagerImpl.h
@@ -53,7 +53,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/silabs/ConfigurationManagerImpl.h
+++ b/src/platform/silabs/ConfigurationManagerImpl.h
@@ -53,6 +53,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/stm32/ConfigurationManagerImpl.h
+++ b/src/platform/stm32/ConfigurationManagerImpl.h
@@ -48,6 +48,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/stm32/ConfigurationManagerImpl.h
+++ b/src/platform/stm32/ConfigurationManagerImpl.h
@@ -48,7 +48,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;
     void InitiateFactoryReset(void) override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/webos/ConfigurationManagerImpl.h
+++ b/src/platform/webos/ConfigurationManagerImpl.h
@@ -57,7 +57,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
-    void InitiateMatterDataReset() override {};
+    void InitiateMatterDataReset() override{};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 

--- a/src/platform/webos/ConfigurationManagerImpl.h
+++ b/src/platform/webos/ConfigurationManagerImpl.h
@@ -57,6 +57,7 @@ private:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;
+    void InitiateMatterDataReset() override {};
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 


### PR DESCRIPTION
- Problem
> We need a API to reset matter data ( chip config, counters and kvs)
> And event for the application about factory reset

- Changes
> Add events for factory reset and matter data reset
> Add InitiateMatterDataReset API to erase matter data

- Testing
> Tested factory reset and matter data reset with esp32