### PR TITLE
[ICD] Add unit tests to validate Check-In message generation

### DIFF
--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -121,8 +121,8 @@ size_t CheckinMessage::GetAppDataSize(ByteSpan & payload)
     return (payload.size() <= kMinPayloadSize) ? 0 : payload.size() - kMinPayloadSize;
 }
 
-CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
-                                       Encoding::LittleEndian::BufferWriter & writer)
+CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
+                                                       Encoding::LittleEndian::BufferWriter & writer)
 {
     VerifyOrReturnError(writer.Available() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_BUFFER_TOO_SMALL);
 

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -116,11 +116,6 @@ CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(const Crypto::Aes128KeyHan
     return CHIP_NO_ERROR;
 }
 
-size_t CheckinMessage::GetAppDataSize(ByteSpan & payload)
-{
-    return (payload.size() <= kMinPayloadSize) ? 0 : payload.size() - kMinPayloadSize;
-}
-
 CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
                                                        Encoding::LittleEndian::BufferWriter & writer)
 {
@@ -141,6 +136,11 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
     VerifyOrReturnError(writer.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     return CHIP_NO_ERROR;
+}
+
+size_t CheckinMessage::GetAppDataSize(ByteSpan & payload)
+{
+    return (payload.size() <= kMinPayloadSize) ? 0 : payload.size() - kMinPayloadSize;
 }
 
 } // namespace SecureChannel

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -20,10 +20,9 @@
  *      This file implements the Matter Checkin protocol.
  */
 
-#include "CheckinMessage.h"
 #include <lib/core/CHIPCore.h>
-
 #include <lib/core/CHIPEncoding.h>
+#include <protocols/secure_channel/CheckinMessage.h>
 #include <protocols/secure_channel/Constants.h>
 
 namespace chip {
@@ -117,8 +116,13 @@ CHIP_ERROR CheckinMessage::ParseCheckinMessagePayload(const Crypto::Aes128KeyHan
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
-                                                       Encoding::LittleEndian::BufferWriter & writer)
+size_t CheckinMessage::GetAppDataSize(ByteSpan & payload)
+{
+    return (payload.size() <= kMinPayloadSize) ? 0 : payload.size() - kMinPayloadSize;
+}
+
+CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
+                                       Encoding::LittleEndian::BufferWriter & writer)
 {
     VerifyOrReturnError(writer.Available() >= CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, CHIP_ERROR_BUFFER_TOO_SMALL);
 
@@ -137,11 +141,6 @@ CHIP_ERROR CheckinMessage::GenerateCheckInMessageNonce(const Crypto::Hmac128KeyH
     VerifyOrReturnError(writer.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     return CHIP_NO_ERROR;
-}
-
-size_t CheckinMessage::GetAppDataSize(ByteSpan & payload)
-{
-    return (payload.size() <= kMinPayloadSize) ? 0 : payload.size() - kMinPayloadSize;
 }
 
 } // namespace SecureChannel

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -98,22 +98,23 @@ public:
 
     static constexpr uint16_t kMinPayloadSize =
         CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
-};
 
-/**
- * @brief Generate the Nonce for the Check-In message
- *
- * @param[in]   hmacKeyHandle Key handle to use with the HMAC algorithm
- * @param[in]   counter       Check-In Counter value to use as message of the HMAC algorithm
- * @param[out]  output        output buffer for the generated Nonce.
- *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
- *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
- *
- * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
- *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message Nonce
- */
-CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
-                                       Encoding::LittleEndian::BufferWriter & writer);
+private:
+    /**
+     * @brief Generate the Nonce for the Check-In message
+     *
+     * @param[in]   hmacKeyHandle Key handle to use with the HMAC algorithm
+     * @param[in]   counter       Check-In Counter value to use as message of the HMAC algorithm
+     * @param[out]  output        output buffer for the generated Nonce.
+     *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
+     *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
+     *
+     * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
+     *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message Nonce
+     */
+    static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
+                                                  Encoding::LittleEndian::BufferWriter & writer);
+};
 
 } // namespace SecureChannel
 } // namespace Protocols

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -98,25 +98,22 @@ public:
 
     static constexpr uint16_t kMinPayloadSize =
         CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
-
-private:
-    friend class TestCheckInMsg;
-
-    /**
-     * @brief Generate the Nonce for the Check-In message
-     *
-     * @param[in]   hmacKeyHandle Key handle to use with the HMAC algorithm
-     * @param[in]   counter       Check-In Counter value to use as message of the HMAC algorithm
-     * @param[out]  output        output buffer for the generated Nonce.
-     *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
-     *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
-     *
-     * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
-     *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message Nonce
-     */
-    static CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
-                                                  Encoding::LittleEndian::BufferWriter & writer);
 };
+
+/**
+ * @brief Generate the Nonce for the Check-In message
+ *
+ * @param[in]   hmacKeyHandle Key handle to use with the HMAC algorithm
+ * @param[in]   counter       Check-In Counter value to use as message of the HMAC algorithm
+ * @param[out]  output        output buffer for the generated Nonce.
+ *                            SUFFICIENT SPACE MUST BE ALLOCATED by the caller
+ *                            Size must be at least CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES
+ *
+ * @return CHIP_ERROR_BUFFER_TOO_SMALL if output buffer is too small
+ *         CHIP_ERROR_INVALID_ARGUMENT if the provided arguments cannot be used to generate the Check-In message Nonce
+ */
+CHIP_ERROR GenerateCheckInMessageNonce(const Crypto::Hmac128KeyHandle & hmacKeyHandle, CounterType counter,
+                                       Encoding::LittleEndian::BufferWriter & writer);
 
 } // namespace SecureChannel
 } // namespace Protocols

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -100,6 +100,8 @@ public:
         CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
 
 private:
+    friend class TestCheckInMsg;
+
     /**
      * @brief Generate the Nonce for the Check-In message
      *

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -10,16 +10,18 @@ chip_test_suite_using_nltest("tests") {
 
   test_sources = [
     "TestCASESession.cpp",
-
-    # TODO - Fix Message Counter Sync to use group key
-    #    "TestMessageCounterManager.cpp",
     "TestCheckinMsg.cpp",
     "TestDefaultSessionResumptionStorage.cpp",
     "TestPASESession.cpp",
     "TestPairingSession.cpp",
     "TestSimpleSessionResumptionStorage.cpp",
     "TestStatusReport.cpp",
+
+    # TODO - Fix Message Counter Sync to use group key
+    #    "TestMessageCounterManager.cpp",
   ]
+
+  sources = [ "CheckIn_Message_test_vectors.h" ]
 
   public_deps = [
     "${chip_root}/src/app/icd:icd_config",

--- a/src/protocols/secure_channel/tests/CheckIn_Message_test_vectors.h
+++ b/src/protocols/secure_channel/tests/CheckIn_Message_test_vectors.h
@@ -43,7 +43,7 @@ typedef struct CheckIn_Message_test_vector
 } CheckIn_Message_test_vector;
 
 /**
- * Test 3 Inputs
+ * vector 1
  */
 
 const uint8_t kKey1[] = { 0xd9, 0x0e, 0x13, 0x18, 0x0d, 0x00, 0xba, 0xad, 0xd2, 0x0c, 0xf5, 0xed, 0x49, 0x13, 0xd3, 0xff };
@@ -74,7 +74,7 @@ const CheckIn_Message_test_vector vector1 = { .key                  = kKey1,
                                               .payload_len          = sizeof(kPayload1) };
 
 /**
- * Test 3 Inputs
+ * vector 2
  */
 
 const uint8_t kKey2[] = { 0x18, 0xfd, 0xbc, 0xea, 0xef, 0x01, 0x95, 0x5b, 0x0e, 0xc8, 0x75, 0xed, 0xa3, 0xae, 0x6e, 0xe8 };
@@ -106,7 +106,7 @@ const CheckIn_Message_test_vector vector2 = { .key                  = kKey2,
                                               .payload_len          = sizeof(kPayload2) };
 
 /**
- * Test 3 Inputs
+ * vector 3
  */
 
 const uint8_t kKey3[] = { 0xd9, 0x0e, 0x13, 0x18, 0x0d, 0x00, 0xba, 0xad, 0xd2, 0x0c, 0xf5, 0xed, 0x49, 0x13, 0xd3, 0xff };
@@ -138,7 +138,7 @@ const CheckIn_Message_test_vector vector3 = { .key                  = kKey3,
                                               .payload_len          = sizeof(kPayload3) };
 
 /**
- * Test 4 Inputs
+ * vector 4
  */
 
 const uint8_t kKey4[] = { 0xca, 0x67, 0xd4, 0x1f, 0xf7, 0x11, 0x29, 0x10, 0xfd, 0xd1, 0x8a, 0x1b, 0xf9, 0x9e, 0xa9, 0x74 };
@@ -172,7 +172,7 @@ const CheckIn_Message_test_vector vector4 = { .key                  = kKey4,
                                               .payload_len          = sizeof(kPayload4) };
 
 /**
- * Test 5 Inputs
+ * vector 5
  */
 
 const uint8_t kKey5[] = { 0xca, 0x67, 0xd4, 0x1f, 0xf7, 0x11, 0x29, 0x10, 0xfd, 0xd1, 0x8a, 0x1b, 0xf9, 0x9e, 0xa9, 0x74 };

--- a/src/protocols/secure_channel/tests/CheckIn_Message_test_vectors.h
+++ b/src/protocols/secure_channel/tests/CheckIn_Message_test_vectors.h
@@ -1,0 +1,209 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file - This file contains the Check-In message test vectors
+ */
+
+#pragma once
+
+#include <protocols/secure_channel/CheckinMessage.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct CheckIn_Message_test_vector
+{
+    const uint8_t * key;
+    const size_t key_len;
+    const uint8_t * application_data;
+    const size_t application_data_len;
+    const chip::Protocols::SecureChannel::CounterType counter;
+    const uint8_t * nonce;
+    const size_t nonce_len;
+    const uint8_t * ciphertext;
+    const size_t ciphertext_len;
+    const uint8_t * mic;
+    const size_t mic_len;
+    const uint8_t * payload;
+    const size_t payload_len;
+} CheckIn_Message_test_vector;
+
+/**
+ * Test 3 Inputs
+ */
+
+const uint8_t kKey1[] = { 0xd9, 0x0e, 0x13, 0x18, 0x0d, 0x00, 0xba, 0xad, 0xd2, 0x0c, 0xf5, 0xed, 0x49, 0x13, 0xd3, 0xff };
+
+const uint8_t kApplicationData1[] = {};
+
+const uint8_t kNonce1[] = { 0x45, 0x80, 0xd2, 0xc6, 0xf1, 0x31, 0x0d, 0xc4, 0xeb, 0x64, 0xf1, 0xf8, 0xe8 };
+
+const uint8_t kCiphertext1[] = { 0xbd, 0xc2, 0x1f, 0xb5 };
+
+const uint8_t kMic1[] = { 0x19, 0x5d, 0x74, 0x7d, 0xd2, 0x87, 0x9b, 0x2b, 0x0d, 0x43, 0xce, 0x5b, 0x1c, 0x56, 0x50, 0x78 };
+
+const uint8_t kPayload1[] = { 0x45, 0x80, 0xd2, 0xc6, 0xf1, 0x31, 0x0d, 0xc4, 0xeb, 0x64, 0xf1, 0xf8, 0xe8, 0xbd, 0xc2, 0x1f, 0xb5,
+                              0x19, 0x5d, 0x74, 0x7d, 0xd2, 0x87, 0x9b, 0x2b, 0x0d, 0x43, 0xce, 0x5b, 0x1c, 0x56, 0x50, 0x78 };
+
+const CheckIn_Message_test_vector vector1 = { .key                  = kKey1,
+                                              .key_len              = sizeof(kKey1),
+                                              .application_data     = kApplicationData1,
+                                              .application_data_len = sizeof(kApplicationData1),
+                                              .counter              = 12,
+                                              .nonce                = kNonce1,
+                                              .nonce_len            = sizeof(kNonce1),
+                                              .ciphertext           = kCiphertext1,
+                                              .ciphertext_len       = sizeof(kCiphertext1),
+                                              .mic                  = kMic1,
+                                              .mic_len              = sizeof(kMic1),
+                                              .payload              = kPayload1,
+                                              .payload_len          = sizeof(kPayload1) };
+
+/**
+ * Test 3 Inputs
+ */
+
+const uint8_t kKey2[] = { 0x18, 0xfd, 0xbc, 0xea, 0xef, 0x01, 0x95, 0x5b, 0x0e, 0xc8, 0x75, 0xed, 0xa3, 0xae, 0x6e, 0xe8 };
+
+const uint8_t kApplicationData2[] = { 0x54, 0x68, 0x69, 0x73 };
+
+const uint8_t kNonce2[] = { 0x9b, 0x02, 0xed, 0x21, 0xee, 0x0c, 0x7b, 0x49, 0x19, 0x85, 0x50, 0x2e, 0x37 };
+
+const uint8_t kCiphertext2[] = { 0x2d, 0xbd, 0x7b, 0x3f, 0x8b, 0x4f, 0x8e, 0x3c };
+
+const uint8_t kMic2[] = { 0x5a, 0xd9, 0x94, 0x19, 0x38, 0x9f, 0x41, 0xa8, 0xd6, 0x09, 0x93, 0x8c, 0x67, 0xa8, 0x6d, 0x65 };
+
+const uint8_t kPayload2[] = { 0x9b, 0x02, 0xed, 0x21, 0xee, 0x0c, 0x7b, 0x49, 0x19, 0x85, 0x50, 0x2e, 0x37,
+                              0x2d, 0xbd, 0x7b, 0x3f, 0x8b, 0x4f, 0x8e, 0x3c, 0x5a, 0xd9, 0x94, 0x19, 0x38,
+                              0x9f, 0x41, 0xa8, 0xd6, 0x09, 0x93, 0x8c, 0x67, 0xa8, 0x6d, 0x65 };
+
+const CheckIn_Message_test_vector vector2 = { .key                  = kKey2,
+                                              .key_len              = sizeof(kKey2),
+                                              .application_data     = kApplicationData2,
+                                              .application_data_len = sizeof(kApplicationData2),
+                                              .counter              = 15,
+                                              .nonce                = kNonce2,
+                                              .nonce_len            = sizeof(kNonce2),
+                                              .ciphertext           = kCiphertext2,
+                                              .ciphertext_len       = sizeof(kCiphertext2),
+                                              .mic                  = kMic2,
+                                              .mic_len              = sizeof(kMic2),
+                                              .payload              = kPayload2,
+                                              .payload_len          = sizeof(kPayload2) };
+
+/**
+ * Test 3 Inputs
+ */
+
+const uint8_t kKey3[] = { 0xd9, 0x0e, 0x13, 0x18, 0x0d, 0x00, 0xba, 0xad, 0xd2, 0x0c, 0xf5, 0xed, 0x49, 0x13, 0xd3, 0xff };
+
+const uint8_t kApplicationData3[] = { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61 };
+
+const uint8_t kNonce3[] = { 0xaa, 0x84, 0xbc, 0x60, 0x88, 0x6a, 0x63, 0xa8, 0x47, 0x5d, 0x5d, 0xbe, 0xb5 };
+
+const uint8_t kCiphertext3[] = { 0x6d, 0x63, 0x5f, 0xa9, 0x52, 0x85, 0xae, 0x33, 0x62, 0x66, 0x13, 0xc7, 0x63 };
+
+const uint8_t kMic3[] = { 0x6c, 0xe3, 0xe3, 0xb2, 0xa8, 0xb1, 0x3a, 0x8c, 0x89, 0xbe, 0xf7, 0x68, 0x91, 0xe8, 0xe2, 0x96 };
+
+const uint8_t kPayload3[] = { 0xaa, 0x84, 0xbc, 0x60, 0x88, 0x6a, 0x63, 0xa8, 0x47, 0x5d, 0x5d, 0xbe, 0xb5, 0x6d,
+                              0x63, 0x5f, 0xa9, 0x52, 0x85, 0xae, 0x33, 0x62, 0x66, 0x13, 0xc7, 0x63, 0x6c, 0xe3,
+                              0xe3, 0xb2, 0xa8, 0xb1, 0x3a, 0x8c, 0x89, 0xbe, 0xf7, 0x68, 0x91, 0xe8, 0xe2, 0x96 };
+
+const CheckIn_Message_test_vector vector3 = { .key                  = kKey3,
+                                              .key_len              = sizeof(kKey3),
+                                              .application_data     = kApplicationData3,
+                                              .application_data_len = sizeof(kApplicationData3),
+                                              .counter              = 11,
+                                              .nonce                = kNonce3,
+                                              .nonce_len            = sizeof(kNonce3),
+                                              .ciphertext           = kCiphertext3,
+                                              .ciphertext_len       = sizeof(kCiphertext3),
+                                              .mic                  = kMic3,
+                                              .mic_len              = sizeof(kMic3),
+                                              .payload              = kPayload3,
+                                              .payload_len          = sizeof(kPayload3) };
+
+/**
+ * Test 4 Inputs
+ */
+
+const uint8_t kKey4[] = { 0xca, 0x67, 0xd4, 0x1f, 0xf7, 0x11, 0x29, 0x10, 0xfd, 0xd1, 0x8a, 0x1b, 0xf9, 0x9e, 0xa9, 0x74 };
+
+const uint8_t kApplicationData4[] = { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61,
+                                      0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x75, 0x65, 0x72 };
+
+const uint8_t kNonce4[] = { 0x7a, 0x97, 0x72, 0x24, 0x3c, 0x97, 0xc8, 0x7d, 0x5f, 0x3a, 0x31, 0xc4, 0xe6 };
+
+const uint8_t kCiphertext4[] = { 0xdb, 0xbc, 0x1a, 0xa5, 0x66, 0xc4, 0x43, 0xc2, 0x05, 0x86, 0x06,
+                                 0x6b, 0x42, 0x7b, 0xfc, 0xaa, 0xad, 0x78, 0xca, 0x5d, 0xad };
+
+const uint8_t kMic4[] = { 0x3d, 0x79, 0x78, 0xf7, 0x04, 0xe6, 0x30, 0xac, 0x04, 0x3f, 0xbf, 0xaa, 0x81, 0x25, 0xb2, 0xac };
+
+const uint8_t kPayload4[] = { 0x7a, 0x97, 0x72, 0x24, 0x3c, 0x97, 0xc8, 0x7d, 0x5f, 0x3a, 0x31, 0xc4, 0xe6, 0xdb, 0xbc, 0x1a, 0xa5,
+                              0x66, 0xc4, 0x43, 0xc2, 0x05, 0x86, 0x06, 0x6b, 0x42, 0x7b, 0xfc, 0xaa, 0xad, 0x78, 0xca, 0x5d, 0xad,
+                              0x3d, 0x79, 0x78, 0xf7, 0x04, 0xe6, 0x30, 0xac, 0x04, 0x3f, 0xbf, 0xaa, 0x81, 0x25, 0xb2, 0xac };
+
+const CheckIn_Message_test_vector vector4 = { .key                  = kKey4,
+                                              .key_len              = sizeof(kKey4),
+                                              .application_data     = kApplicationData4,
+                                              .application_data_len = sizeof(kApplicationData4),
+                                              .counter              = 11,
+                                              .nonce                = kNonce4,
+                                              .nonce_len            = sizeof(kNonce4),
+                                              .ciphertext           = kCiphertext4,
+                                              .ciphertext_len       = sizeof(kCiphertext4),
+                                              .mic                  = kMic4,
+                                              .mic_len              = sizeof(kMic4),
+                                              .payload              = kPayload4,
+                                              .payload_len          = sizeof(kPayload4) };
+
+/**
+ * Test 5 Inputs
+ */
+
+const uint8_t kKey5[] = { 0xca, 0x67, 0xd4, 0x1f, 0xf7, 0x11, 0x29, 0x10, 0xfd, 0xd1, 0x8a, 0x1b, 0xf9, 0x9e, 0xa9, 0x74 };
+
+const uint8_t kApplicationData5[] = { 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x6c, 0x6f,
+                                      0x6e, 0x67, 0x75, 0x65, 0x72, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67 };
+
+const uint8_t kNonce5[] = { 0x06, 0x34, 0x67, 0x6e, 0xa6, 0xe0, 0x70, 0x7b, 0x7a, 0xd7, 0x81, 0x4f, 0xf8 };
+
+const uint8_t kCiphertext5[] = { 0x2e, 0x5b, 0x18, 0xd1, 0x9a, 0x23, 0xb2, 0xe4, 0xfa, 0xdf, 0x82, 0x92, 0x53, 0x51,
+                                 0x7f, 0xf3, 0xc9, 0x1d, 0x9d, 0x50, 0xd6, 0x62, 0x5d, 0x18, 0x29, 0x0f, 0xb1, 0x21 };
+
+const uint8_t kMic5[] = { 0x8b, 0x5d, 0xef, 0x99, 0x65, 0xb4, 0xdc, 0x3a, 0x87, 0x25, 0xc2, 0xeb, 0x2e, 0x18, 0x25, 0x98 };
+
+const uint8_t kPayload5[] = { 0x06, 0x34, 0x67, 0x6e, 0xa6, 0xe0, 0x70, 0x7b, 0x7a, 0xd7, 0x81, 0x4f, 0xf8, 0x2e, 0x5b,
+                              0x18, 0xd1, 0x9a, 0x23, 0xb2, 0xe4, 0xfa, 0xdf, 0x82, 0x92, 0x53, 0x51, 0x7f, 0xf3, 0xc9,
+                              0x1d, 0x9d, 0x50, 0xd6, 0x62, 0x5d, 0x18, 0x29, 0x0f, 0xb1, 0x21, 0x8b, 0x5d, 0xef, 0x99,
+                              0x65, 0xb4, 0xdc, 0x3a, 0x87, 0x25, 0xc2, 0xeb, 0x2e, 0x18, 0x25, 0x98 };
+
+const CheckIn_Message_test_vector vector5 = { .key                  = kKey5,
+                                              .key_len              = sizeof(kKey5),
+                                              .application_data     = kApplicationData5,
+                                              .application_data_len = sizeof(kApplicationData5),
+                                              .counter              = 12,
+                                              .nonce                = kNonce5,
+                                              .nonce_len            = sizeof(kNonce5),
+                                              .ciphertext           = kCiphertext5,
+                                              .ciphertext_len       = sizeof(kCiphertext5),
+                                              .mic                  = kMic5,
+                                              .mic_len              = sizeof(kMic5),
+                                              .payload              = kPayload5,
+                                              .payload_len          = sizeof(kPayload5) };
+
+const CheckIn_Message_test_vector checkIn_message_test_vectors[]{ vector1, vector2, vector3, vector4, vector5 };

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -269,7 +269,7 @@ void TestCheckInMsg::TestCheckinGenerateParse(nlTestSuite * inSuite, void * inCo
 }
 
 /**
- * @brief Test validates that the nonce generation is successful when using valid inputs
+ * @brief Test verifies that the nonce generation is successful when using valid inputs
  */
 void TestCheckInMsg::TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, void * inContext)
 {
@@ -292,11 +292,11 @@ void TestCheckInMsg::TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, vo
         // Verify that the generation succeeded
         NL_TEST_ASSERT_SUCCESS(inSuite, CheckinMessage::GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer));
 
-        // Verify the enough space was present in the buffer
+        // Verify that enough space was present in the buffer
         size_t written = 0;
         NL_TEST_ASSERT(inSuite, writer.Fit(written));
 
-        // Verify the number of written bytes matches the length of the generated nonce
+        // Verify the number of written bytes matches the length of the expected nonce
         NL_TEST_ASSERT_EQUALS(inSuite, vector.nonce_len, written);
 
         // Verify that generated nonce matches the expected nonce
@@ -308,7 +308,7 @@ void TestCheckInMsg::TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, vo
 }
 
 /**
- * @brief Test verifies that nonce generation returns an error if the output writer is too small to fit nonce
+ * @brief Test verifies that the nonce generation returns an error if the output writer is too small to fit the nonce
  */
 void TestCheckInMsg::TestCheckInMessageNonceGenerationTooSmallWriter(nlTestSuite * inSuite, void * inContext)
 {
@@ -351,20 +351,20 @@ void TestCheckInMsg::TestCheckInMessagePayloadSize(nlTestSuite * inSuite, void *
         ByteSpan payload(vector.payload, vector.payload_len);
         size_t calculated_size = CheckinMessage::GetAppDataSize(payload);
 
-        // Verify the AppData size matches the application data size
+        // Verify the AppData size matches the expected application data size
         NL_TEST_ASSERT_EQUALS(inSuite, vector.application_data_len, calculated_size);
     }
 }
 
 /**
- * @brief test verifies that GetAppDataSize returns 0 if a null buffer is given as input
+ * @brief test verifies that GetAppDataSize returns 0 if the payload is smaller that the minimum size
  */
 void TestCheckInMsg::TestCheckInMessagePayloadSizeNullBuffer(nlTestSuite * inSuite, void * inContext)
 {
     ByteSpan payload;
     size_t calculated_size = CheckinMessage::GetAppDataSize(payload);
 
-    // Verify the AppData size is 0
+    // Verify that the size is 0
     NL_TEST_ASSERT_EQUALS(inSuite, calculated_size, 0);
 }
 

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -175,6 +175,9 @@ void TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsTooSmallOutput(nlTest
     NL_TEST_ASSERT(inSuite, CHIP_ERROR_BUFFER_TOO_SMALL == GenerateAndVerifyPayload(inSuite, output, vector));
 }
 
+/**
+ * @brief Test verifies that the Check-In Message generations returns an error if the AesKeyHandle is empty
+ */
 void TestCheckInMsg::TestCheckInMessageGenerate_EmptyAesKeyHandle(nlTestSuite * inSuite, void * inContexT)
 {
     TestSessionKeystoreImpl keystore;
@@ -215,6 +218,9 @@ void TestCheckInMsg::TestCheckInMessageGenerate_EmptyAesKeyHandle(nlTestSuite * 
     keystore.DestroyKey(hmac128KeyHandle);
 }
 
+/**
+ * @brief Test verifies that the Check-In Message generations returns an error if the HmacKeyHandle is empty
+ */
 void TestCheckInMsg::TestCheckInMessageGenerate_EmptyHmacKeyHandle(nlTestSuite * inSuite, void * inContexT)
 {
     TestSessionKeystoreImpl keystore;

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -290,7 +290,7 @@ void TestCheckInMsg::TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, vo
         NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
         // Verify that the generation succeeded
-        NL_TEST_ASSERT_SUCCESS(inSuite, CheckinMessage::GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer));
+        NL_TEST_ASSERT_SUCCESS(inSuite, GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer));
 
         // Verify that enough space was present in the buffer
         size_t written = 0;
@@ -326,7 +326,7 @@ void TestCheckInMsg::TestCheckInMessageNonceGenerationTooSmallWriter(nlTestSuite
     NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
 
     // Verify that the generation succeeded
-    CHIP_ERROR err = CheckinMessage::GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer);
+    CHIP_ERROR err = GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer);
     NL_TEST_ASSERT_EQUALS(inSuite, err, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Verify that nothing was written

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -46,112 +46,212 @@ namespace SecureChannel {
 class TestCheckInMsg
 {
 public:
-    static void TestCheckinGenerate(nlTestSuite * inSuite, void * inContext);
-    static void TestCheckinParse(nlTestSuite * inSuite, void * inContext);
-    static void TestCheckinGenerateParse(nlTestSuite * inSuite, void * inContext);
-    static void TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, void * inContext);
-    static void TestCheckInMessageNonceGenerationTooSmallWriter(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckinMessageGenerate_ValidInputsSameSizeOutputAsPayload(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckinMessageGenerate_ValidInputsBiggerSizeOutput(nlTestSuite * inSuite, void * inContext);
     static void TestCheckInMessagePayloadSize(nlTestSuite * inSuite, void * inContext);
     static void TestCheckInMessagePayloadSizeNullBuffer(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckinMessageGenerate_ValidInputsTooSmallOutput(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckInMessageGenerate_EmptyAesKeyHandle(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckInMessageGenerate_EmptyHmacKeyHandle(nlTestSuite * inSuite, void * inContext);
+
+    static void TestCheckinParse(nlTestSuite * inSuite, void * inContext);
+    static void TestCheckinGenerateParse(nlTestSuite * inSuite, void * inContext);
+
+private:
+    static CHIP_ERROR GenerateAndVerifyPayload(nlTestSuite * inSuite, MutableByteSpan & output,
+                                               const CheckIn_Message_test_vector & vector);
 };
 
-void TestCheckInMsg::TestCheckinGenerate(nlTestSuite * inSuite, void * inContext)
+/**
+ * @brief Helper function that generates the Check-In message based on the test vector
+ *        and verifies the generated Check-In message
+ *        Helper is to avoid having the same code three times in different tests
+ *
+ * @return CHIP_NO_ERROR if the generation was successful
+ *         error code if the generation failed - see GenerateCheckinMessagePayload
+ */
+CHIP_ERROR TestCheckInMsg::GenerateAndVerifyPayload(nlTestSuite * inSuite, MutableByteSpan & output,
+                                                    const CheckIn_Message_test_vector & vector)
 {
-    uint8_t a[300] = { 0 };
-    uint8_t b[300] = { 0 };
-    MutableByteSpan outputBuffer{ a };
-    MutableByteSpan oldOutputBuffer{ b };
-    uint32_t counter = 0;
-    ByteSpan userData;
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TestSessionKeystoreImpl keystore;
 
-    // Verify that keys imported to the keystore behave as expected.
-    for (const ccm_128_test_vector * testPtr : ccm_128_test_vectors)
+    // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
+    Symmetric128BitsKeyByteArray aesKeyMaterial;
+    memcpy(aesKeyMaterial, vector.key, vector.key_len);
+
+    Symmetric128BitsKeyByteArray hmacKeyMaterial;
+    memcpy(hmacKeyMaterial, vector.key, vector.key_len);
+
+    Aes128KeyHandle aes128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+    Hmac128KeyHandle hmac128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
+
+    // Create application data ByteSpan
+    ByteSpan applicationData(vector.application_data, vector.application_data_len);
+
+    // Verify that the generation succeeded
+    ReturnErrorOnFailure(
+        CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, vector.counter, applicationData, output));
+
+    // Validate Full payload
+    NL_TEST_ASSERT_EQUALS(inSuite, output.size(), vector.payload_len);
+    NL_TEST_ASSERT(inSuite, (memcmp(vector.payload, output.data(), output.size()) == 0));
+
+    size_t cursorIndex = 0;
+
+    // Validate Nonce
+    MutableByteSpan nonce = output.SubSpan(cursorIndex, vector.nonce_len);
+    NL_TEST_ASSERT(inSuite, (memcmp(vector.nonce, nonce.data(), nonce.size()) == 0));
+    cursorIndex += nonce.size();
+
+    // Validate ciphertext
+    MutableByteSpan ciphertext = output.SubSpan(cursorIndex, vector.ciphertext_len);
+    NL_TEST_ASSERT(inSuite, (memcmp(vector.ciphertext, ciphertext.data(), ciphertext.size()) == 0));
+    cursorIndex += ciphertext.size();
+
+    // Validate MIC
+    MutableByteSpan mic = output.SubSpan(cursorIndex, vector.mic_len);
+    NL_TEST_ASSERT(inSuite, (memcmp(vector.mic, mic.data(), mic.size()) == 0));
+    cursorIndex += mic.size();
+
+    // Clean up
+    keystore.DestroyKey(aes128KeyHandle);
+    keystore.DestroyKey(hmac128KeyHandle);
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ * @brief Test verifies that the Check-In message generation is successful when using an output size equal to the payload size
+ */
+void TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsSameSizeOutputAsPayload(nlTestSuite * inSuite, void * inContext)
+{
+    int numOfTestCases = ArraySize(checkIn_message_test_vectors);
+    for (int numOfTestsExecuted = 0; numOfTestsExecuted < numOfTestCases; numOfTestsExecuted++)
     {
-        const ccm_128_test_vector & test = *testPtr;
+        CheckIn_Message_test_vector vector = checkIn_message_test_vectors[numOfTestsExecuted];
 
-        // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
-        Symmetric128BitsKeyByteArray aesKeyMaterial;
-        memcpy(aesKeyMaterial, test.key, test.key_len);
+        // Create output buffer
+        uint8_t buffer[300] = { 0 };
+        MutableByteSpan output(buffer, sizeof(buffer));
 
-        Symmetric128BitsKeyByteArray hmacKeyMaterial;
-        memcpy(hmacKeyMaterial, test.key, test.key_len);
+        // Force output buffer to the payload size
+        output.reduce_size(vector.payload_len);
 
-        Aes128KeyHandle aes128KeyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
-
-        Hmac128KeyHandle hmac128KeyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
-
-        // Validate that counter change, indeed changes the output buffer content
-        counter = 0;
-        for (uint8_t j = 0; j < 5; j++)
-        {
-            err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
-            NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
-
-            // Verifiy that the output buffer changed
-            NL_TEST_ASSERT(inSuite, !outputBuffer.data_equal(oldOutputBuffer));
-            CopySpanToMutableSpan(outputBuffer, oldOutputBuffer);
-
-            // Increment by a random count. On the slim changes the increment is 0 add 1 to change output buffer
-            counter += chip::Crypto::GetRandU32() + 1;
-            outputBuffer = MutableByteSpan(a);
-        }
-
-        keystore.DestroyKey(aes128KeyHandle);
-        keystore.DestroyKey(hmac128KeyHandle);
+        NL_TEST_ASSERT_SUCCESS(inSuite, GenerateAndVerifyPayload(inSuite, output, vector));
     }
+}
 
-    // Parameter check
+/**
+ * @brief Test verifies that the Check-In message generation is successful when using an output size greater than the payload size
+ */
+void TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsBiggerSizeOutput(nlTestSuite * inSuite, void * inContext)
+{
+    int numOfTestCases = ArraySize(checkIn_message_test_vectors);
+    for (int numOfTestsExecuted = 0; numOfTestsExecuted < numOfTestCases; numOfTestsExecuted++)
     {
-        uint8_t data[]                   = { "This is some user Data. It should be encrypted" };
-        userData                         = chip::ByteSpan(data);
-        const ccm_128_test_vector & test = *ccm_128_test_vectors[0];
-        uint8_t veryLargeBuffer[2048]    = { 0 };
+        CheckIn_Message_test_vector vector = checkIn_message_test_vectors[numOfTestsExecuted];
 
-        // Two distinct key material buffers to ensure crypto-hardware-assist with single-usage keys create two different handles.
-        Symmetric128BitsKeyByteArray aesKeyMaterial;
-        memcpy(aesKeyMaterial, test.key, test.key_len);
+        // Create output buffer
+        uint8_t buffer[300] = { 0 };
+        MutableByteSpan output(buffer, sizeof(buffer));
 
-        Symmetric128BitsKeyByteArray hmacKeyMaterial;
-        memcpy(hmacKeyMaterial, test.key, test.key_len);
-
-        Aes128KeyHandle aes128KeyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
-
-        Hmac128KeyHandle hmac128KeyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
-
-        // As of now passing an empty key handle while using PSA crypto will result in a failure.
-        // However when using OpenSSL this same test result in a success.
-        // Issue #28986
-
-        // Aes128KeyHandle emptyKeyHandle;
-        // err = CheckinMessage::GenerateCheckinMessagePayload(emptyKeyHandle, counter, userData, outputBuffer);
-        // ChipLogError(Inet, "%s", err.AsString());
-        // NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
-
-        // Testing empty application data
-        ByteSpan emptyData;
-        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, emptyData, outputBuffer);
-        NL_TEST_ASSERT(inSuite, (CHIP_NO_ERROR == err));
-
-        // Testing empty output buffer
-        MutableByteSpan empty;
-        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, emptyData, empty);
-        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
-
-        // Test output buffer smaller than the ApplicationData
-        userData = chip::ByteSpan(veryLargeBuffer, sizeof(veryLargeBuffer));
-        err = CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, counter, userData, outputBuffer);
-        NL_TEST_ASSERT(inSuite, (CHIP_ERROR_BUFFER_TOO_SMALL == err));
-
-        // Cleanup
-        keystore.DestroyKey(aes128KeyHandle);
-        keystore.DestroyKey(hmac128KeyHandle);
+        NL_TEST_ASSERT_SUCCESS(inSuite, GenerateAndVerifyPayload(inSuite, output, vector));
     }
+}
+
+/**
+ * @brief Test verifies that the Check-In message generation returns an error if the output buffer is too small
+ */
+void TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsTooSmallOutput(nlTestSuite * inSuite, void * inContext)
+{
+    CheckIn_Message_test_vector vector = checkIn_message_test_vectors[0];
+
+    // Create output buffer with 0 size
+    MutableByteSpan output;
+
+    NL_TEST_ASSERT(inSuite, CHIP_ERROR_BUFFER_TOO_SMALL == GenerateAndVerifyPayload(inSuite, output, vector));
+}
+
+void TestCheckInMsg::TestCheckInMessageGenerate_EmptyAesKeyHandle(nlTestSuite * inSuite, void * inContexT)
+{
+    TestSessionKeystoreImpl keystore;
+    CheckIn_Message_test_vector vector = checkIn_message_test_vectors[0];
+
+    // Create output buffer
+    uint8_t buffer[300] = { 0 };
+    MutableByteSpan output(buffer, sizeof(buffer));
+
+    // Force output buffer to the payload size
+    output.reduce_size(vector.payload_len);
+
+    // Empty AES Key handle
+    Aes128KeyHandle aes128KeyHandle;
+
+    Symmetric128BitsKeyByteArray hmacKeyMaterial;
+    memcpy(hmacKeyMaterial, vector.key, vector.key_len);
+
+    Hmac128KeyHandle hmac128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
+
+    // Create application data ByteSpan
+    ByteSpan applicationData(vector.application_data, vector.application_data_len);
+
+    /*
+        Passing an empty key handle while using PSA crypto will result in a failure.
+        When using OpenSSL this same test result in a success.
+        Issue #28986
+
+    Verify that the generation fails with an empty key handle
+    NL_TEST_ASSERT_(inSuite,
+                    CHIP_NO_ERROR !=
+                        CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, vector.counter,
+                                                                      applicationData, output));
+    */
+
+    // Clean up
+    keystore.DestroyKey(hmac128KeyHandle);
+}
+
+void TestCheckInMsg::TestCheckInMessageGenerate_EmptyHmacKeyHandle(nlTestSuite * inSuite, void * inContexT)
+{
+    TestSessionKeystoreImpl keystore;
+    CheckIn_Message_test_vector vector = checkIn_message_test_vectors[0];
+
+    // Create output buffer
+    uint8_t buffer[300] = { 0 };
+    MutableByteSpan output(buffer, sizeof(buffer));
+
+    // Force output buffer to the payload size
+    output.reduce_size(vector.payload_len);
+
+    Symmetric128BitsKeyByteArray aesKeyMaterial;
+    memcpy(aesKeyMaterial, vector.key, vector.key_len);
+
+    Aes128KeyHandle aes128KeyHandle;
+    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(aesKeyMaterial, aes128KeyHandle));
+
+    Hmac128KeyHandle hmac128KeyHandle;
+
+    // Create application data ByteSpan
+    ByteSpan applicationData(vector.application_data, vector.application_data_len);
+
+    /*
+        Passing an empty key handle while using PSA crypto will result in a failure.
+        When using OpenSSL this same test result in a success.
+        Issue #28986
+
+    Verify that the generation fails with an empty key handle
+    NL_TEST_ASSERT_(inSuite,
+                    CHIP_NO_ERROR !=
+                        CheckinMessage::GenerateCheckinMessagePayload(aes128KeyHandle, hmac128KeyHandle, vector.counter,
+                                                                      applicationData, output));
+    */
+
+    // Clean up
+    keystore.DestroyKey(aes128KeyHandle);
 }
 
 void TestCheckInMsg::TestCheckinParse(nlTestSuite * inSuite, void * inContext)
@@ -269,76 +369,6 @@ void TestCheckInMsg::TestCheckinGenerateParse(nlTestSuite * inSuite, void * inCo
 }
 
 /**
- * @brief Test verifies that the nonce generation is successful when using valid inputs
- */
-void TestCheckInMsg::TestCheckInMessageNonceGeneration(nlTestSuite * inSuite, void * inContext)
-{
-    TestSessionKeystoreImpl keystore;
-
-    int numOfTestCases = ArraySize(checkIn_message_test_vectors);
-    for (int numOfTestsExecuted = 0; numOfTestsExecuted < numOfTestCases; numOfTestsExecuted++)
-    {
-        CheckIn_Message_test_vector vector = checkIn_message_test_vectors[numOfTestsExecuted];
-
-        uint8_t buffer[300] = { 0 };
-        Encoding::LittleEndian::BufferWriter writer(buffer, sizeof(buffer));
-
-        Symmetric128BitsKeyByteArray hmacKeyMaterial;
-        memcpy(hmacKeyMaterial, vector.key, vector.key_len);
-
-        Hmac128KeyHandle hmac128KeyHandle;
-        NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
-
-        // Verify that the generation succeeded
-        NL_TEST_ASSERT_SUCCESS(inSuite, GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer));
-
-        // Verify that enough space was present in the buffer
-        size_t written = 0;
-        NL_TEST_ASSERT(inSuite, writer.Fit(written));
-
-        // Verify the number of written bytes matches the length of the expected nonce
-        NL_TEST_ASSERT_EQUALS(inSuite, vector.nonce_len, written);
-
-        // Verify that generated nonce matches the expected nonce
-        NL_TEST_ASSERT(inSuite, memcmp(vector.nonce, writer.Buffer(), written) == 0);
-
-        // Clean up
-        keystore.DestroyKey(hmac128KeyHandle);
-    }
-}
-
-/**
- * @brief Test verifies that the nonce generation returns an error if the output writer is too small to fit the nonce
- */
-void TestCheckInMsg::TestCheckInMessageNonceGenerationTooSmallWriter(nlTestSuite * inSuite, void * inContext)
-{
-    TestSessionKeystoreImpl keystore;
-
-    CheckIn_Message_test_vector vector = checkIn_message_test_vectors[0];
-
-    uint8_t buffer[10] = { 0 };
-    Encoding::LittleEndian::BufferWriter writer(buffer, sizeof(buffer));
-
-    Symmetric128BitsKeyByteArray hmacKeyMaterial;
-    memcpy(hmacKeyMaterial, vector.key, vector.key_len);
-
-    Hmac128KeyHandle hmac128KeyHandle;
-    NL_TEST_ASSERT_SUCCESS(inSuite, keystore.CreateKey(hmacKeyMaterial, hmac128KeyHandle));
-
-    // Verify that the generation succeeded
-    CHIP_ERROR err = GenerateCheckInMessageNonce(hmac128KeyHandle, vector.counter, writer);
-    NL_TEST_ASSERT_EQUALS(inSuite, err, CHIP_ERROR_BUFFER_TOO_SMALL);
-
-    // Verify that nothing was written
-    size_t written = 0;
-    NL_TEST_ASSERT(inSuite, writer.Fit(written));
-    NL_TEST_ASSERT_EQUALS(inSuite, written, 0);
-
-    // Clean up
-    keystore.DestroyKey(hmac128KeyHandle);
-}
-
-/**
  * @brief test verifies that GetAppDataSize returns the correct application data size
  */
 void TestCheckInMsg::TestCheckInMessagePayloadSize(nlTestSuite * inSuite, void * inContext)
@@ -380,11 +410,13 @@ void TestCheckInMsg::TestCheckInMessagePayloadSizeNullBuffer(nlTestSuite * inSui
 // clang-format off
 static const nlTest sTests[] =
 {
-    NL_TEST_DEF("TestCheckinGenerate", TestCheckInMsg::TestCheckinGenerate),
+    NL_TEST_DEF("TestCheckinMessageGenerate_ValidInputsSameSizeOutputAsPayload", TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsSameSizeOutputAsPayload),
+    NL_TEST_DEF("TestCheckinMessageGenerate_ValidInputsBiggerSizeOutput", TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsBiggerSizeOutput),
+    NL_TEST_DEF("TestCheckinMessageGenerate_ValidInputsTooSmallOutput", TestCheckInMsg::TestCheckinMessageGenerate_ValidInputsTooSmallOutput),
+    NL_TEST_DEF("TestCheckinMessageGenerate_ValidInputsTooSmallOutput", TestCheckInMsg::TestCheckInMessageGenerate_EmptyAesKeyHandle),
+    NL_TEST_DEF("TestCheckinMessageGenerate_ValidInputsTooSmallOutput", TestCheckInMsg::TestCheckInMessageGenerate_EmptyHmacKeyHandle),
     NL_TEST_DEF("TestCheckinParse", TestCheckInMsg::TestCheckinParse),
     NL_TEST_DEF("TestCheckinGenerateParse", TestCheckInMsg::TestCheckinGenerateParse),
-    NL_TEST_DEF("TestCheckInMessageNonceGeneration", TestCheckInMsg::TestCheckInMessageNonceGeneration),
-    NL_TEST_DEF("TestCheckInMessageNonceGenerationTooSmallWriter", TestCheckInMsg::TestCheckInMessageNonceGenerationTooSmallWriter),
     NL_TEST_DEF("TestCheckInMessagePayloadSize", TestCheckInMsg::TestCheckInMessagePayloadSize),
     NL_TEST_DEF("TestCheckInMessagePayloadSizeNullBuffer", TestCheckInMsg::TestCheckInMessagePayloadSizeNullBuffer),
 


### PR DESCRIPTION
### Description
PR Adds unit tests to validate the Check-In message generation and payload size functions.

- Adds test vectors for Check-In message tests that were generated from the Spec Check-In message python script
- Adds Check-In message generation tests (valid and invalid inputs)
- Adds Payload size tests (differents payload sizes and empty payload)

#### Note to reviewers
PR only adds tests for generation and payload size. 
Tests for the Check-In parsing will be in a follow up

#### Tests
CI run with new unit tests
