### PR TITLE
Remove dead !HAVE_LWIP_UDP_BIND_NETIF configuration

### DIFF
--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -23,10 +23,6 @@
 
 #include <inet/UDPEndPointImplLwIP.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <lwip/lwip_buildconfig.h> // nogncheck
-#endif                             // CHIP_HAVE_CONFIG_H
-
 #if INET_CONFIG_ENABLE_IPV4
 #include <lwip/igmp.h>
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -121,13 +117,9 @@ CHIP_ERROR UDPEndPointImplLwIP::LwIPBindInterface(struct udp_pcb * aUDP, Interfa
 
 InterfaceId UDPEndPointImplLwIP::GetBoundInterface() const
 {
-#if HAVE_LWIP_UDP_BIND_NETIF
     struct netif * netif;
     RunOnTCPIP([this, &netif]() { netif = netif_get_by_index(mUDP->netif_idx); });
     return InterfaceId(netif);
-#else
-    return InterfaceId(mUDP->intf_filter);
-#endif
 }
 
 uint16_t UDPEndPointImplLwIP::GetBoundPort() const

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -91,10 +91,6 @@ buildconfig_header("lwip_buildconfig") {
       # Automatically enable LWIP_DEBUG for internal is_debug builds.
       defines += [ "LWIP_DEBUG=1" ]
     }
-
-    if (current_os == "android") {
-      defines += [ "LWIP_NO_STDINT_H=1" ]
-    }
   }
 }
 

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -84,7 +84,8 @@ buildconfig_header("lwip_buildconfig") {
   header = "lwip_buildconfig.h"
   header_dir = "lwip"
 
-  defines = [ "HAVE_LWIP_UDP_BIND_NETIF=1" ]
+  defines = []
+
   if (lwip_platform != "external") {
     if (lwip_debug) {
       # Automatically enable LWIP_DEBUG for internal is_debug builds.

--- a/src/platform/mt793x/lwip/BUILD.gn
+++ b/src/platform/mt793x/lwip/BUILD.gn
@@ -37,7 +37,6 @@ import("${mt793x_sdk_build_root}/mt793x_sdk.gni")
 #  header = "lwip_buildconfig.h"
 #  header_dir = "lwip"
 #
-#  defines = [ "HAVE_LWIP_UDP_BIND_NETIF=1" ]
 #  if (lwip_platform != "external") {
 #    if (current_os == "android") {
 #      defines += [ "LWIP_NO_STDINT_H=1" ]

--- a/src/platform/mt793x/lwip/BUILD.gn
+++ b/src/platform/mt793x/lwip/BUILD.gn
@@ -33,17 +33,6 @@ declare_args() {
 import("//build_overrides/mt793x_sdk.gni")
 import("${mt793x_sdk_build_root}/mt793x_sdk.gni")
 
-#buildconfig_header("lwip_buildconfig") {
-#  header = "lwip_buildconfig.h"
-#  header_dir = "lwip"
-#
-#  if (lwip_platform != "external") {
-#    if (current_os == "android") {
-#      defines += [ "LWIP_NO_STDINT_H=1" ]
-#    }
-#  }
-#}
-
 config("lwip_config") {
   include_dirs = [
     "${mt793x_sdk_root}/project/mt7933_hdk/apps/${mt793x_project_name}/inc",


### PR DESCRIPTION
This define came in with the initial import, but we never provided any way to turn it off. Remove that case as dead code.
