### PR TITLE
Remove java_build_test from multiarch build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -146,7 +146,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
     if (chip_build_tests) {
       deps += [ "//src:tests" ]
-      if (current_os == "android") {
+      if (current_os == "android" && current_toolchain == default_toolchain) {
         deps += [ "${chip_root}/build/chip/java/tests:java_build_test" ]
       }
     }


### PR DESCRIPTION
This test doesn't work with multiple toolchains since it assumes an output directory.