### PR TITLE
TC-ACL-2.2: Implement in python

### DIFF
--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -1,0 +1,55 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+
+import chip.clusters as Clusters
+from chip.interaction_model import Status
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_ACL_2_2(MatterBaseTest):
+
+    def desc_TC_ACL_2_2(self) -> str:
+        return "[TC-ACL-2.2] Cluster endpoint"
+
+    def steps_TC_ACE_1_3(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "TH1 reads DUT Descriptor cluster ServerList attribute from Endpoint 0"),
+            TestStep(3, "TH1 reads DUT Descriptor cluster ServerList attribute from every Endpoint except 0"),
+        ]
+        return steps
+
+    @async_test_body
+    async def test_TC_ACE_1_3(self):
+        self.step(1)
+        self.step(2)
+        data = await self.default_controller.ReadAttribute(nodeid=self.dut_node_id, attributes=[(Clusters.Descriptor.Attributes.ServerList)])
+        asserts.assert_true(Clusters.AccessControl.id in data[0][Clusters.Descriptor]
+                            [Clusters.Descriptor.Attributes.ServerList], "ACL cluster not on EP0")
+        self.step(3)
+        for endpoint, ep_data in data.items():
+            if endpoint == 0:
+                continue
+            asserts.assert_false(Clusters.AccessControl.id in ep_data[Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList],
+                                 f"ACL cluster incorrectly present on endpoint {endpoint}")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -14,11 +14,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-
-import logging
-
 import chip.clusters as Clusters
-from chip.interaction_model import Status
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 

--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2022 Project CHIP Authors
+#    Copyright (c) 2023 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ class TC_ACL_2_2(MatterBaseTest):
     def desc_TC_ACL_2_2(self) -> str:
         return "[TC-ACL-2.2] Cluster endpoint"
 
-    def steps_TC_ACE_1_3(self) -> list[TestStep]:
+    def steps_TC_ACE_2_2(self) -> list[TestStep]:
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH1 reads DUT Descriptor cluster ServerList attribute from Endpoint 0"),
@@ -33,7 +33,7 @@ class TC_ACL_2_2(MatterBaseTest):
         return steps
 
     @async_test_body
-    async def test_TC_ACE_1_3(self):
+    async def test_TC_ACE_2_2(self):
         self.step(1)
         self.step(2)
         data = await self.default_controller.ReadAttribute(nodeid=self.dut_node_id, attributes=[(Clusters.Descriptor.Attributes.ServerList)])


### PR DESCRIPTION
Lets us do the all endpoint check in a sane way.

Fixes: https://github.com/project-chip/matter-test-scripts/issues/92