### PR TITLE
[Silabs][Wi-Fi] Fixes for 917 platform

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -189,7 +189,8 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_CONN);
     wfx_rsi.join_retries = 0;
     retryInterval        = WLAN_MIN_RETRY_TIMER_MS;
-    if (is_wifi_disconnection_event) {
+    if (is_wifi_disconnection_event)
+    {
         is_wifi_disconnection_event = false;
     }
     callback_status = SL_STATUS_OK;
@@ -517,7 +518,7 @@ static sl_status_t wfx_rsi_do_join(void)
                            wfx_rsi.join_retries);
                 wfx_rsi.join_retries += 1;
                 wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
-                if (is_wifi_disconnection_event ||  wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT)
+                if (is_wifi_disconnection_event || wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT)
                 {
                     xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
                 }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -42,7 +42,6 @@
 #include "ble_config.h"
 
 #include "dhcp_client.h"
-#include "lwip/nd6.h"
 #include "sl_wifi.h"
 #include "wfx_host_events.h"
 #include "wfx_rsi.h"
@@ -604,14 +603,6 @@ void wfx_rsi_task(void * arg)
                     hasNotifiedIPV4 = false;
                 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-                /*
-                 * Checks if the IPv6 event has been notified, if not invoke the nd6_tmr,
-                 * which starts the duplicate address detectation.
-                 */
-                if (!hasNotifiedIPV6)
-                {
-                    nd6_tmr();
-                }
                 /* Checks if the assigned IPv6 address is preferred by evaluating
                  * the first block of IPv6 address ( block 0)
                  */

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -172,14 +172,13 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     {
         SILABS_LOG("F: Join Event received with %u bytes payload\n", result_length);
         callback_status = *(sl_status_t *) result;
-        wfx_rsi.join_retries += 1;
         wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTED);
         wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
+        is_wifi_disconnection_event = true;
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
         {
             xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
         }
-        is_wifi_disconnection_event = true;
         return SL_STATUS_FAIL;
     }
     /*
@@ -188,6 +187,11 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     SILABS_LOG("join_callback_handler: join completed.");
     SILABS_LOG("%c: Join Event received with %u bytes payload\n", *result, result_length);
     xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_CONN);
+    wfx_rsi.join_retries = 0;
+    retryInterval        = WLAN_MIN_RETRY_TIMER_MS;
+    if (is_wifi_disconnection_event) {
+        is_wifi_disconnection_event = false;
+    }
     callback_status = SL_STATUS_OK;
     return SL_STATUS_OK;
 }
@@ -392,11 +396,6 @@ sl_status_t bg_scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_
  *******************************************************************************************/
 static void wfx_rsi_save_ap_info() // translation
 {
-    if (wfx_rsi.dev_state & WFX_RSI_ST_SCANSTARTED)
-    {
-        return;
-    }
-    wfx_rsi.dev_state |= WFX_RSI_ST_SCANSTARTED;
     sl_status_t status = SL_STATUS_OK;
 #ifndef EXP_BOARD // TODO: this changes will be reverted back after the SDK team fix the scan API
     sl_wifi_scan_configuration_t wifi_scan_configuration = { 0 };
@@ -406,6 +405,7 @@ static void wfx_rsi_save_ap_info() // translation
     ssid_arg.length = strlen(wfx_rsi.sec.ssid);
     memcpy(ssid_arg.value, (int8_t *) &wfx_rsi.sec.ssid[0], ssid_arg.length);
     sl_wifi_set_scan_callback(scan_callback_handler, NULL);
+    scan_results_complete = false;
 #ifndef EXP_BOARD
     // TODO: this changes will be reverted back after the SDK team fix the scan API
     status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, &ssid_arg, &wifi_scan_configuration);
@@ -510,15 +510,18 @@ static sl_status_t wfx_rsi_do_join(void)
         }
         else
         {
-            while (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
+            if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
             {
-                SILABS_LOG("%s: Wifi connect failed with status: %x", __func__, status);
-                SILABS_LOG("%s: failed. retry: %d", __func__, wfx_rsi.join_retries);
-                wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
-                if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
-                    xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
-                SILABS_LOG("%s: starting JOIN to %s after %d tries\n", __func__, (char *) &wfx_rsi.sec.ssid[0],
+                SILABS_LOG("wfx_rsi_do_join: Wifi connect failed with status: %x", status);
+                SILABS_LOG("wfx_rsi_do_join: starting JOIN to %s after %d tries\n", (char *) &wfx_rsi.sec.ssid[0],
                            wfx_rsi.join_retries);
+                wfx_rsi.join_retries += 1;
+                wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
+                if (is_wifi_disconnection_event ||  wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT)
+                {
+                    xEventGroupSetBits(wfx_rsi.events, WFX_EVT_STA_START_JOIN);
+                }
+                wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries);
             }
         }
     }
@@ -685,11 +688,11 @@ void wfx_rsi_task(void * arg)
                     wifi_scan_configuration = default_wifi_scan_configuration;
                 }
                 sl_wifi_set_scan_callback(bg_scan_callback_handler, NULL);
+                scan_results_complete = false;
                 wfx_rsi.dev_state |= WFX_RSI_ST_SCANSTARTED;
                 status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, NULL, &wifi_scan_configuration);
                 if (SL_STATUS_IN_PROGRESS == status)
                 {
-                    printf("Scanning...\r\n");
                     const uint32_t start = osKernelGetTickCount();
                     while (!bg_scan_results_complete && (osKernelGetTickCount() - start) <= WIFI_SCAN_TIMEOUT_TICK)
                     {

--- a/examples/platform/silabs/SiWx917/uart.cpp
+++ b/examples/platform/silabs/SiWx917/uart.cpp
@@ -49,7 +49,7 @@ void callback_event(uint32_t event)
     case SL_USART_EVENT_RECEIVE_COMPLETE:
 #ifdef ENABLE_CHIP_SHELL
         chip::NotifyShellProcessFromISR();
-#endif;
+#endif
     case SL_USART_EVENT_TRANSFER_COMPLETE:
         break;
     }
@@ -72,28 +72,26 @@ void uartConsoleInit(void)
     usart_config.synch_mode    = DISABLE;
     sl_si91x_usart_control_config_t get_config;
 
-    // Initialized board UART
-    DEBUGINIT();
 
     // Initialize the UART
     status = sl_si91x_usart_init((usart_peripheral_t) usart_config.usart_module, &usart_handle);
     if (status != SL_STATUS_OK)
     {
-        DEBUGOUT("sl_si91x_usart_initialize: Error Code : %lu \n", status);
+        SILABS_LOG("sl_si91x_usart_initialize: Error Code : %lu \n", status);
     }
 
     // Configure the USART configurations
     status = sl_si91x_usart_set_configuration(usart_handle, &usart_config);
     if (status != SL_STATUS_OK)
     {
-        DEBUGOUT("sl_si91x_usart_set_configuration: Error Code : %lu \n", status);
+        SILABS_LOG("sl_si91x_usart_set_configuration: Error Code : %lu \n", status);
     }
 
     // Register user callback function
     status = sl_si91x_usart_register_event_callback(callback_event);
     if (status != SL_STATUS_OK)
     {
-        DEBUGOUT("sl_si91x_usart_register_event_callback: Error Code : %lu \n", status);
+        SILABS_LOG("sl_si91x_usart_register_event_callback: Error Code : %lu \n", status);
     }
 
     NVIC_EnableIRQ(USART0_IRQn);

--- a/examples/platform/silabs/SiWx917/uart.cpp
+++ b/examples/platform/silabs/SiWx917/uart.cpp
@@ -72,7 +72,6 @@ void uartConsoleInit(void)
     usart_config.synch_mode    = DISABLE;
     sl_si91x_usart_control_config_t get_config;
 
-
     // Initialize the UART
     status = sl_si91x_usart_init((usart_peripheral_t) usart_config.usart_module, &usart_handle);
     if (status != SL_STATUS_OK)

--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -25,6 +25,10 @@
 #include "glib.h"
 #include "lcd.h"
 
+#if SL_WIFI
+#include "spi_multiplex.h"
+#endif // SL_WIFI
+
 // LCD line define
 constexpr uint8_t kTempLcdInitialX = 30;
 
@@ -65,7 +69,13 @@ void ThermostatUI::DrawUI(GLIB_Context_t * glibContext)
     DrawCurrentTemp(glibContext, mCurrentTempCelsius);
     DrawFooter(glibContext, false);
 
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_pre_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
     DMD_updateDisplay();
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_post_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
 }
 
 void ThermostatUI::SetHeatingSetPoint(int8_t temp)
@@ -98,7 +108,13 @@ void ThermostatUI::DrawHeader(GLIB_Context_t * glibContext)
                     WIFI_BITMAP_HEIGHT, (UI_WIFI) ? wifiLogo : threadLogo);
     // Draw Matter Icon
     GLIB_drawBitmap(glibContext, MATTER_ICON_POSITION_X, STATUS_ICON_LINE, MATTER_LOGO_WIDTH, MATTER_LOGO_HEIGHT, matterLogoBitmap);
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_pre_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
     DMD_updateDisplay();
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_post_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
 }
 
 void ThermostatUI::DrawFooter(GLIB_Context_t * glibContext, bool autoMode)
@@ -129,7 +145,13 @@ void ThermostatUI::DrawFooter(GLIB_Context_t * glibContext, bool autoMode)
         break;
     }
 
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_pre_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
     DMD_updateDisplay();
+#if SL_LCDCTRL_MUX
+    sl_wfx_host_post_lcd_spi_transfer();
+#endif // SL_LCDCTRL_MUX
 }
 
 /**

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -157,7 +157,7 @@ private:
     enum
     {
         kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS,
-        kMaxDeviceNameLength = 27,
+        kMaxDeviceNameLength = 21,
         kUnusedIndex         = 0xFF,
     };
 

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -157,7 +157,7 @@ private:
     enum
     {
         kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS,
-        kMaxDeviceNameLength = 16,
+        kMaxDeviceNameLength = 27,
         kUnusedIndex         = 0xFF,
     };
 


### PR DESCRIPTION
This PR brings a series of small fixes for the 917 wifi platform
1. Fix For Lwip Error: before getting ipv6 link local address, the nd6 timer updated lwip state which affected the stability.
2. Fix an issue where the wifi AP was not found by the device after restarting the router.
3. Fix a hard fault in the fix for the thermostat app when the LCD was enabled.
4. Support longer BLE Names than 16 characters.
5. Fix compilation issues when enabling Matter shell on 917 SOC