### PR TITLE
CommandSender and CommandHandler reserves space for Finalize to succeed

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -656,8 +656,6 @@ CHIP_ERROR CommandHandler::FinishCommand(bool aStartDataStruct)
     }
 
     auto * tlvWriter = mInvokeResponseBuilder.GetWriter();
-    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetInvokeResponses().GetSizeToEndInvokeResponses()));
-    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetSizeToEndInvokeResponseMessage()));
     ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
     ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB());
     MoveToState(State::AddedCommand);
@@ -763,6 +761,8 @@ CommandHandler::Handle::Handle(CommandHandler * handle)
 CHIP_ERROR CommandHandler::Finalize(System::PacketBufferHandle & commandPacket)
 {
     VerifyOrReturnError(mState == State::AddedCommand, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetInvokeResponses().GetSizeToEndInvokeResponses()));
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetSizeToEndInvokeResponseMessage()));
     ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses());
     ReturnErrorOnFailure(mInvokeResponseBuilder.EndOfInvokeResponseMessage());
     return mCommandMessageWriter.Finalize(&commandPacket);

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR CommandHandler::AllocateBuffer()
         mInvokeResponseBuilder.SuppressResponse(mSuppressResponse);
         ReturnErrorOnFailure(mInvokeResponseBuilder.GetError());
 
-        mInvokeResponseBuilder.CreateInvokeResponses(/*aReserveEndBuffer =*/true);
+        mInvokeResponseBuilder.CreateInvokeResponses(/* aReserveEndBuffer = */ true);
         ReturnErrorOnFailure(mInvokeResponseBuilder.GetError());
 
         mBufferAllocated = true;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -655,7 +655,6 @@ CHIP_ERROR CommandHandler::FinishCommand(bool aStartDataStruct)
         ReturnErrorOnFailure(commandData.Ref(mRefForResponse.Value()));
     }
 
-    auto * tlvWriter = mInvokeResponseBuilder.GetWriter();
     ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
     ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB());
     MoveToState(State::AddedCommand);
@@ -761,6 +760,8 @@ CommandHandler::Handle::Handle(CommandHandler * handle)
 CHIP_ERROR CommandHandler::Finalize(System::PacketBufferHandle & commandPacket)
 {
     VerifyOrReturnError(mState == State::AddedCommand, CHIP_ERROR_INCORRECT_STATE);
+
+    auto * tlvWriter = mInvokeResponseBuilder.GetWriter();
     ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetInvokeResponses().GetSizeToEndInvokeResponses()));
     ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetSizeToEndInvokeResponseMessage()));
     ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().EndOfInvokeResponses());

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -69,6 +69,10 @@ CHIP_ERROR CommandHandler::AllocateBuffer()
 
         mInvokeResponseBuilder.CreateInvokeResponses();
         ReturnErrorOnFailure(mInvokeResponseBuilder.GetError());
+
+        auto * tlvWriter = mInvokeResponseBuilder.GetWriter();
+        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeResponseBuilder.GetInvokeResponses().GetSizeToEndInvokeResponses()));
+        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeResponseBuilder.GetSizeToEndInvokeResponseMessage()));
         mBufferAllocated = true;
     }
 
@@ -651,6 +655,9 @@ CHIP_ERROR CommandHandler::FinishCommand(bool aStartDataStruct)
         ReturnErrorOnFailure(commandData.Ref(mRefForResponse.Value()));
     }
 
+    auto * tlvWriter = mInvokeResponseBuilder.GetWriter();
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetInvokeResponses().GetSizeToEndInvokeResponses()));
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeResponseBuilder.GetSizeToEndInvokeResponseMessage()));
     ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
     ReturnErrorOnFailure(mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().EndOfInvokeResponseIB());
     MoveToState(State::AddedCommand);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -91,6 +91,10 @@ CHIP_ERROR CommandSender::AllocateBuffer()
         mInvokeRequestBuilder.CreateInvokeRequests();
         ReturnErrorOnFailure(mInvokeRequestBuilder.GetError());
 
+        auto * tlvWriter = mInvokeRequestBuilder.GetWriter();
+        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeRequestBuilder.GetInvokeRequests().GetSizeToEndInvokeRequests()));
+        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeRequestBuilder.GetSizeToEndInvokeRequestMessage()));
+
         mBufferAllocated = true;
     }
 
@@ -508,6 +512,11 @@ CHIP_ERROR CommandSender::FinishCommand(const Optional<uint16_t> & aTimedInvokeT
 CHIP_ERROR CommandSender::Finalize(System::PacketBufferHandle & commandPacket)
 {
     VerifyOrReturnError(mState == State::AddedCommand, CHIP_ERROR_INCORRECT_STATE);
+
+    auto * tlvWriter = mInvokeRequestBuilder.GetWriter();
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeRequestBuilder.GetInvokeRequests().GetSizeToEndInvokeRequests()));
+    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeRequestBuilder.GetSizeToEndInvokeRequestMessage()));
+
     ReturnErrorOnFailure(mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests());
     ReturnErrorOnFailure(mInvokeRequestBuilder.EndOfInvokeRequestMessage());
     return mCommandMessageWriter.Finalize(&commandPacket);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -83,17 +83,13 @@ CHIP_ERROR CommandSender::AllocateBuffer()
         VerifyOrReturnError(!commandPacket.IsNull(), CHIP_ERROR_NO_MEMORY);
 
         mCommandMessageWriter.Init(std::move(commandPacket));
-        ReturnErrorOnFailure(mInvokeRequestBuilder.Init(&mCommandMessageWriter));
+        ReturnErrorOnFailure(mInvokeRequestBuilder.InitWithEndBufferReserved(&mCommandMessageWriter));
 
         mInvokeRequestBuilder.SuppressResponse(mSuppressResponse).TimedRequest(mTimedRequest);
         ReturnErrorOnFailure(mInvokeRequestBuilder.GetError());
 
-        mInvokeRequestBuilder.CreateInvokeRequests();
+        mInvokeRequestBuilder.CreateInvokeRequests(/* aReserveEndBuffer = */ true);
         ReturnErrorOnFailure(mInvokeRequestBuilder.GetError());
-
-        auto * tlvWriter = mInvokeRequestBuilder.GetWriter();
-        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeRequestBuilder.GetInvokeRequests().GetSizeToEndInvokeRequests()));
-        ReturnErrorOnFailure(tlvWriter->ReserveBuffer(mInvokeRequestBuilder.GetSizeToEndInvokeRequestMessage()));
 
         mBufferAllocated = true;
     }
@@ -512,11 +508,6 @@ CHIP_ERROR CommandSender::FinishCommand(const Optional<uint16_t> & aTimedInvokeT
 CHIP_ERROR CommandSender::Finalize(System::PacketBufferHandle & commandPacket)
 {
     VerifyOrReturnError(mState == State::AddedCommand, CHIP_ERROR_INCORRECT_STATE);
-
-    auto * tlvWriter = mInvokeRequestBuilder.GetWriter();
-    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeRequestBuilder.GetInvokeRequests().GetSizeToEndInvokeRequests()));
-    ReturnErrorOnFailure(tlvWriter->UnreserveBuffer(mInvokeRequestBuilder.GetSizeToEndInvokeRequestMessage()));
-
     ReturnErrorOnFailure(mInvokeRequestBuilder.GetInvokeRequests().EndOfInvokeRequests());
     ReturnErrorOnFailure(mInvokeRequestBuilder.EndOfInvokeRequestMessage());
     return mCommandMessageWriter.Finalize(&commandPacket);

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -142,6 +142,9 @@ InvokeRequests::Builder & InvokeRequestMessage::Builder::CreateInvokeRequests()
 
 CHIP_ERROR InvokeRequestMessage::Builder::EndOfInvokeRequestMessage()
 {
+    // If any changes are made to how we end the invoke request message that involves how many
+    // bytes are needed, a corresponding change to GetSizeToEndInvokeRequestMessage indicating
+    // the new size that will be required.
     if (mError == CHIP_NO_ERROR)
     {
         mError = MessageBuilder::EncodeInteractionModelRevision();
@@ -155,7 +158,8 @@ CHIP_ERROR InvokeRequestMessage::Builder::EndOfInvokeRequestMessage()
 
 uint32_t InvokeRequestMessage::Builder::GetSizeToEndInvokeRequestMessage()
 {
-    // This encodes uint8_t into Tag 0xFF. This means 1 bytes for tag, 1 byte for length, 1 byte for value
+    // EncodeInteractionModelRevision() encodes a uint8_t with context tag 0xFF. This means 1 control byte,
+    // 1 byte for the tag, 1 byte for the value.
     uint32_t kEncodeInteractionModelSize = 1 + 1 + 1;
     uint32_t kEndOfContainerSize         = 1;
 

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -152,5 +152,14 @@ CHIP_ERROR InvokeRequestMessage::Builder::EndOfInvokeRequestMessage()
     }
     return GetError();
 }
+
+uint32_t InvokeRequestMessage::Builder::GetSizeToEndInvokeRequestMessage()
+{
+    // This encodes uint8_t into Tag 0xFF. This means 1 bytes for tag, 1 byte for length, 1 byte for value
+    uint32_t kEncodeInteractionModelSize = 1 + 1 + 1;
+    uint32_t kEndOfContainerSize         = 1;
+
+    return kEncodeInteractionModelSize + kEndOfContainerSize;
+}
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -76,6 +76,12 @@ class Builder : public MessageBuilder
 {
 public:
     /**
+     *  @brief Performs underlying StructBuilder::Init, but reserves memory need in
+     *  EndOfInvokeRequestMessage() with underlying TLVWriter.
+     */
+    CHIP_ERROR InitWithEndBufferReserved(TLV::TLVWriter * const apWriter);
+
+    /**
      *  @brief when sets to true, it means do not send a response to this action
      */
     InvokeRequestMessage::Builder & SuppressResponse(const bool aSuppressResponse);
@@ -90,7 +96,7 @@ public:
      *
      *  @return A reference to InvokeRequests::Builder
      */
-    InvokeRequests::Builder & CreateInvokeRequests();
+    InvokeRequests::Builder & CreateInvokeRequests(const bool aReserveEndBuffer = false);
 
     /**
      *  @brief Get reference to InvokeRequests::Builder
@@ -115,6 +121,7 @@ public:
 
 private:
     InvokeRequests::Builder mInvokeRequests;
+    bool mIsEndBufferReserved = false;
 };
 } // namespace InvokeRequestMessage
 } // namespace app

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -106,6 +106,13 @@ public:
      */
     CHIP_ERROR EndOfInvokeRequestMessage();
 
+    /**
+     *  @brief Get number of bytes required to call EndOfInvokeRequestMessage()
+     *
+     *  @return Expected number of bytes required to call EndOfInvokeRequestMessage()
+     */
+    uint32_t GetSizeToEndInvokeRequestMessage();
+
 private:
     InvokeRequests::Builder mInvokeRequests;
 };

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -107,9 +107,9 @@ public:
     CHIP_ERROR EndOfInvokeRequestMessage();
 
     /**
-     *  @brief Get number of bytes required to call EndOfInvokeRequestMessage()
+     *  @brief Get number of bytes required in the buffer by EndOfInvokeRequestMessage()
      *
-     *  @return Expected number of bytes required to call EndOfInvokeRequestMessage()
+     *  @return Expected number of bytes required in the buffer by EndOfInvokeRequestMessage()
      */
     uint32_t GetSizeToEndInvokeRequestMessage();
 

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -81,6 +81,9 @@ CommandDataIB::Builder & InvokeRequests::Builder::CreateCommandData()
 
 CHIP_ERROR InvokeRequests::Builder::EndOfInvokeRequests()
 {
+    // If any changes are made to how we end the invoke requests that involves how many bytes are
+    // needed, a corresponding change to GetSizeToEndInvokeRequests indicating the new size that
+    // will be required.
     EndOfContainer();
     return GetError();
 }

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -70,6 +70,14 @@ CHIP_ERROR InvokeRequests::Parser::PrettyPrint() const
 }
 #endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
+CHIP_ERROR InvokeRequests::Builder::InitWithEndBufferReserved(TLV::TLVWriter * const apWriter, const uint8_t aContextTagToUse)
+{
+    ReturnErrorOnFailure(Init(apWriter, aContextTagToUse));
+    ReturnErrorOnFailure(GetWriter()->ReserveBuffer(GetSizeToEndInvokeRequests()));
+    mIsEndBufferReserved = true;
+    return CHIP_NO_ERROR;
+}
+
 CommandDataIB::Builder & InvokeRequests::Builder::CreateCommandData()
 {
     if (mError == CHIP_NO_ERROR)
@@ -84,6 +92,11 @@ CHIP_ERROR InvokeRequests::Builder::EndOfInvokeRequests()
     // If any changes are made to how we end the invoke requests that involves how many bytes are
     // needed, a corresponding change to GetSizeToEndInvokeRequests indicating the new size that
     // will be required.
+    if (mIsEndBufferReserved)
+    {
+        ReturnErrorOnFailure(GetWriter()->UnreserveBuffer(GetSizeToEndInvokeRequests()));
+        mIsEndBufferReserved = false;
+    }
     EndOfContainer();
     return GetError();
 }

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -84,5 +84,11 @@ CHIP_ERROR InvokeRequests::Builder::EndOfInvokeRequests()
     EndOfContainer();
     return GetError();
 }
+
+uint32_t InvokeRequests::Builder::GetSizeToEndInvokeRequests()
+{
+    uint32_t kEndOfContainerSize = 1;
+    return kEndOfContainerSize;
+}
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -61,6 +61,13 @@ public:
      */
     CHIP_ERROR EndOfInvokeRequests();
 
+    /**
+     *  @brief Get number of bytes required to call EndOfInvokeRequests()
+     *
+     *  @return Expected number of bytes required to call EndOfInvokeRequests()
+     */
+    uint32_t GetSizeToEndInvokeRequests();
+
 private:
     CommandDataIB::Builder mCommandData;
 };

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -43,6 +43,12 @@ class Builder : public ArrayBuilder
 {
 public:
     /**
+     *  @brief Performs underlying StructBuilder::Init, but reserves memory need in
+     *  EndOfInvokeRequests() with underlying TLVWriter.
+     */
+    CHIP_ERROR InitWithEndBufferReserved(TLV::TLVWriter * const apWriter, const uint8_t aContextTagToUse);
+
+    /**
      *  @brief Initialize a CommandDataIB::Builder for writing into the TLV stream
      *
      *  @return A reference to CommandDataIB::Builder
@@ -70,6 +76,7 @@ public:
 
 private:
     CommandDataIB::Builder mCommandData;
+    bool mIsEndBufferReserved = false;
 };
 } // namespace InvokeRequests
 } // namespace app

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -62,9 +62,9 @@ public:
     CHIP_ERROR EndOfInvokeRequests();
 
     /**
-     *  @brief Get number of bytes required to call EndOfInvokeRequests()
+     *  @brief Get number of bytes required in the buffer by EndOfInvokeRequests()
      *
-     *  @return Expected number of bytes required to call EndOfInvokeRequests()
+     *  @return Expected number of bytes required in the buffer by EndOfInvokeRequests()
      */
     uint32_t GetSizeToEndInvokeRequests();
 

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -70,6 +70,14 @@ CHIP_ERROR InvokeResponseIBs::Parser::PrettyPrint() const
 }
 #endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
+CHIP_ERROR InvokeResponseIBs::Builder::InitWithEndBufferReserved(TLV::TLVWriter * const apWriter, const uint8_t aContextTagToUse)
+{
+    ReturnErrorOnFailure(Init(apWriter, aContextTagToUse));
+    ReturnErrorOnFailure(GetWriter()->ReserveBuffer(GetSizeToEndInvokeResponses()));
+    mIsEndBufferReserved = true;
+    return CHIP_NO_ERROR;
+}
+
 InvokeResponseIB::Builder & InvokeResponseIBs::Builder::CreateInvokeResponse()
 {
     if (mError == CHIP_NO_ERROR)
@@ -84,6 +92,11 @@ CHIP_ERROR InvokeResponseIBs::Builder::EndOfInvokeResponses()
     // If any changes are made to how we end the invoke responses that involves how many bytes are
     // needed, a corresponding change to GetSizeToEndInvokeResponses indicating the new size that
     // will be required.
+    if (mIsEndBufferReserved)
+    {
+        ReturnErrorOnFailure(GetWriter()->UnreserveBuffer(GetSizeToEndInvokeResponses()));
+        mIsEndBufferReserved = false;
+    }
     EndOfContainer();
     return GetError();
 }

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -81,6 +81,9 @@ InvokeResponseIB::Builder & InvokeResponseIBs::Builder::CreateInvokeResponse()
 
 CHIP_ERROR InvokeResponseIBs::Builder::EndOfInvokeResponses()
 {
+    // If any changes are made to how we end the invoke responses that involves how many bytes are
+    // needed, a corresponding change to GetSizeToEndInvokeResponses indicating the new size that
+    // will be required.
     EndOfContainer();
     return GetError();
 }

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -84,5 +84,11 @@ CHIP_ERROR InvokeResponseIBs::Builder::EndOfInvokeResponses()
     EndOfContainer();
     return GetError();
 }
+
+uint32_t InvokeResponseIBs::Builder::GetSizeToEndInvokeResponses()
+{
+    uint32_t kEndOfContainerSize = 1;
+    return kEndOfContainerSize;
+}
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -43,6 +43,12 @@ class Builder : public ArrayBuilder
 {
 public:
     /**
+     *  @brief Performs underlying StructBuilder::Init, but reserves memory need in
+     *  EndOfInvokeResponses() with underlying TLVWriter.
+     */
+    CHIP_ERROR InitWithEndBufferReserved(TLV::TLVWriter * const apWriter, const uint8_t aContextTagToUse);
+
+    /**
      *  @brief Initialize a InvokeResponseIB::Builder for writing into the TLV stream
      *
      *  @return A reference to InvokeResponseIB::Builder
@@ -70,6 +76,7 @@ public:
 
 private:
     InvokeResponseIB::Builder mInvokeResponse;
+    bool mIsEndBufferReserved = false;
 };
 } // namespace InvokeResponseIBs
 } // namespace app

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -62,9 +62,9 @@ public:
     CHIP_ERROR EndOfInvokeResponses();
 
     /**
-     *  @brief Get number of bytes required to call EndOfInvokeResponses()
+     *  @brief Get number of bytes required in the buffer by EndOfInvokeResponses()
      *
-     *  @return Expected number of bytes required to call EndOfInvokeResponses()
+     *  @return Expected number of bytes required in the buffer by EndOfInvokeResponses()
      */
     uint32_t GetSizeToEndInvokeResponses();
 

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -61,6 +61,13 @@ public:
      */
     CHIP_ERROR EndOfInvokeResponses();
 
+    /**
+     *  @brief Get number of bytes required to call EndOfInvokeResponses()
+     *
+     *  @return Expected number of bytes required to call EndOfInvokeResponses()
+     */
+    uint32_t GetSizeToEndInvokeResponses();
+
 private:
     InvokeResponseIB::Builder mInvokeResponse;
 };

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -152,5 +152,14 @@ CHIP_ERROR InvokeResponseMessage::Builder::EndOfInvokeResponseMessage()
     }
     return GetError();
 }
+
+uint32_t InvokeResponseMessage::Builder::GetSizeToEndInvokeResponseMessage()
+{
+    // This encodes uint8_t into Tag 0xFF. This means 1 bytes for tag, 1 byte for length, 1 byte for value
+    uint32_t kEncodeInteractionModelSize = 1 + 1 + 1;
+    uint32_t kEndOfContainerSize         = 1;
+
+    return kEncodeInteractionModelSize + kEndOfContainerSize;
+}
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -142,6 +142,9 @@ InvokeResponseMessage::Builder & InvokeResponseMessage::Builder::MoreChunkedMess
 
 CHIP_ERROR InvokeResponseMessage::Builder::EndOfInvokeResponseMessage()
 {
+    // If any changes are made to how we end the invoke response message that involves how many
+    // bytes are needed, a corresponding change to GetSizeToEndInvokeResponseMessage indicating
+    // the new size that will be required.
     if (mError == CHIP_NO_ERROR)
     {
         mError = MessageBuilder::EncodeInteractionModelRevision();
@@ -155,7 +158,8 @@ CHIP_ERROR InvokeResponseMessage::Builder::EndOfInvokeResponseMessage()
 
 uint32_t InvokeResponseMessage::Builder::GetSizeToEndInvokeResponseMessage()
 {
-    // This encodes uint8_t into Tag 0xFF. This means 1 bytes for tag, 1 byte for length, 1 byte for value
+    // EncodeInteractionModelRevision() encodes a uint8_t with context tag 0xFF. This means 1 control byte,
+    // 1 byte for the tag, 1 byte for the value.
     uint32_t kEncodeInteractionModelSize = 1 + 1 + 1;
     uint32_t kEndOfContainerSize         = 1;
 

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -112,9 +112,9 @@ public:
     CHIP_ERROR EndOfInvokeResponseMessage();
 
     /**
-     *  @brief Get number of bytes required to call EndOfInvokeResponseMessage()
+     *  @brief Get number of bytes required in the buffer by EndOfInvokeResponseMessage()
      *
-     *  @return Expected number of bytes required to call EndOfInvokeResponseMessage()
+     *  @return Expected number of bytes required in the buffer by EndOfInvokeResponseMessage()
      */
     uint32_t GetSizeToEndInvokeResponseMessage();
 

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -111,6 +111,13 @@ public:
      */
     CHIP_ERROR EndOfInvokeResponseMessage();
 
+    /**
+     *  @brief Get number of bytes required to call EndOfInvokeResponseMessage()
+     *
+     *  @return Expected number of bytes required to call EndOfInvokeResponseMessage()
+     */
+    uint32_t GetSizeToEndInvokeResponseMessage();
+
 private:
     InvokeResponseIBs::Builder mInvokeResponses;
 };

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -78,6 +78,12 @@ class Builder : public MessageBuilder
 {
 public:
     /**
+     *  @brief Performs underlying StructBuilder::Init, but reserves memory need in
+     *  EndOfInvokeResponseMessage() with underlying TLVWriter.
+     */
+    CHIP_ERROR InitWithEndBufferReserved(TLV::TLVWriter * const apWriter);
+
+    /**
      *  @brief This is set to 'true' by the subscriber to indicate preservation of previous subscriptions. If omitted, it implies
      * 'false' as a value.
      */
@@ -88,7 +94,7 @@ public:
      *
      *  @return A reference to InvokeResponseIBs::Builder
      */
-    InvokeResponseIBs::Builder & CreateInvokeResponses();
+    InvokeResponseIBs::Builder & CreateInvokeResponses(const bool aReserveEndBuffer = false);
 
     /**
      *  @brief Get reference to InvokeResponseIBs::Builder
@@ -120,6 +126,7 @@ public:
 
 private:
     InvokeResponseIBs::Builder mInvokeResponses;
+    bool mIsEndBufferReserved = false;
 };
 } // namespace InvokeResponseMessage
 } // namespace app

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -2064,45 +2064,41 @@ void InvokeRequestMessageEndOfMessageReservationTest(nlTestSuite * apSuite, void
     InvokeRequestMessage::Builder invokeRequestMessageBuilder;
     const uint32_t kSmallBufferSize = 100;
     writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
-    err = invokeRequestMessageBuilder.Init(&writer);
+    err = invokeRequestMessageBuilder.InitWithEndBufferReserved(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t sizeToReserve = invokeRequestMessageBuilder.GetSizeToEndInvokeRequestMessage();
-    err                    = writer.ReserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
+    uint32_t remainingLengthAfterInitWithReservation = writer.GetRemainingFreeLength();
 
-    err = writer.UnreserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeRequestMessageBuilder.EndOfInvokeRequestMessage();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     uint32_t remainingLengthAfterEndingInvokeRequestMessage = writer.GetRemainingFreeLength();
-    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remainingLengthAfterEndingInvokeRequestMessage);
+    NL_TEST_ASSERT(apSuite, remainingLengthAfterInitWithReservation == remainingLengthAfterEndingInvokeRequestMessage);
 }
 
 void InvokeRequestsEndOfRequestReservationTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
-    InvokeRequests::Builder invokeRequestsBuilder;
+    InvokeRequestMessage::Builder invokeRequestMessageBuilder;
     const uint32_t kSmallBufferSize = 100;
     writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
-    err = invokeRequestsBuilder.Init(&writer);
+    err = invokeRequestMessageBuilder.InitWithEndBufferReserved(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t sizeToReserve = invokeRequestsBuilder.GetSizeToEndInvokeRequests();
-    err                    = writer.ReserveBuffer(sizeToReserve);
+    invokeRequestMessageBuilder.CreateInvokeRequests(/* aReserveEndBuffer = */ true);
+    InvokeRequests::Builder & invokeRequestsBuilder = invokeRequestMessageBuilder.GetInvokeRequests();
+    err                                             = invokeRequestsBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
 
-    err = writer.UnreserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    auto * invokeRequestsWriter                      = invokeRequestsBuilder.GetWriter();
+    uint32_t remainingLengthAfterInitWithReservation = invokeRequestsWriter->GetRemainingFreeLength();
+
     err = invokeRequestsBuilder.EndOfInvokeRequests();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t remianingLengthAfterEndingInvokeRequests = writer.GetRemainingFreeLength();
-    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeRequests);
+    uint32_t remainingLengthAfterEndingInvokeRequests = invokeRequestsWriter->GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remainingLengthAfterInitWithReservation == remainingLengthAfterEndingInvokeRequests);
 }
 
 void InvokeInvokeResponseMessageTest(nlTestSuite * apSuite, void * apContext)
@@ -2129,45 +2125,39 @@ void InvokeResponseMessageEndOfMessageReservationTest(nlTestSuite * apSuite, voi
     InvokeResponseMessage::Builder invokeResponseMessageBuilder;
     const uint32_t kSmallBufferSize = 100;
     writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
-    err = invokeResponseMessageBuilder.Init(&writer);
+    err = invokeResponseMessageBuilder.InitWithEndBufferReserved(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t sizeToReserve = invokeResponseMessageBuilder.GetSizeToEndInvokeResponseMessage();
-    err                    = writer.ReserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
-
-    err = writer.UnreserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    uint32_t remainingLengthAfterInitWithReservation = writer.GetRemainingFreeLength();
     err = invokeResponseMessageBuilder.EndOfInvokeResponseMessage();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t remianingLengthAfterEndingInvokeResponseMessage = writer.GetRemainingFreeLength();
-    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeResponseMessage);
+    uint32_t remainingLengthAfterEndingInvokeResponseMessage = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remainingLengthAfterInitWithReservation == remainingLengthAfterEndingInvokeResponseMessage);
 }
 
 void InvokeResponsesEndOfResponseReservationTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
-    InvokeResponseIBs::Builder invokeResponsesBuilder;
+    InvokeResponseMessage::Builder invokeResponseMessageBuilder;
     const uint32_t kSmallBufferSize = 100;
     writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
-    err = invokeResponsesBuilder.Init(&writer);
+    err = invokeResponseMessageBuilder.InitWithEndBufferReserved(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t sizeToReserve = invokeResponsesBuilder.GetSizeToEndInvokeResponses();
-    err                    = writer.ReserveBuffer(sizeToReserve);
+    invokeResponseMessageBuilder.CreateInvokeResponses(/* aReserveEndBuffer = */ true);
+    InvokeResponseIBs::Builder & invokeResponsesBuilder = invokeResponseMessageBuilder.GetInvokeResponses();
+    err                                                 = invokeResponsesBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
 
-    err = writer.UnreserveBuffer(sizeToReserve);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    auto * invokeResponsesWriter                     = invokeResponsesBuilder.GetWriter();
+    uint32_t remainingLengthAfterInitWithReservation = invokeResponsesWriter->GetRemainingFreeLength();
     err = invokeResponsesBuilder.EndOfInvokeResponses();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t remianingLengthAfterEndingInvokeResponses = writer.GetRemainingFreeLength();
-    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeResponses);
+    uint32_t remainingLengthAfterEndingInvokeResponses = invokeResponsesWriter->GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remainingLengthAfterInitWithReservation == remainingLengthAfterEndingInvokeResponses);
 }
 
 void ReportDataMessageTest(nlTestSuite * apSuite, void * apContext)

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -2077,8 +2077,8 @@ void InvokeRequestMessageEndOfMessageReservationTest(nlTestSuite * apSuite, void
     err = invokeRequestMessageBuilder.EndOfInvokeRequestMessage();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    uint32_t remianingLengthAfterEndingInvokeRequestMessage = writer.GetRemainingFreeLength();
-    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeRequestMessage);
+    uint32_t remainingLengthAfterEndingInvokeRequestMessage = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remainingLengthAfterEndingInvokeRequestMessage);
 }
 
 void InvokeRequestsEndOfRequestReservationTest(nlTestSuite * apSuite, void * apContext)

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -2057,6 +2057,54 @@ void InvokeInvokeRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     ParseInvokeRequestMessage(apSuite, reader);
 }
 
+void InvokeRequestMessageEndOfMessageReservationTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    InvokeRequestMessage::Builder invokeRequestMessageBuilder;
+    const uint32_t kSmallBufferSize = 100;
+    writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
+    err = invokeRequestMessageBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t sizeToReserve = invokeRequestMessageBuilder.GetSizeToEndInvokeRequestMessage();
+    err                    = writer.ReserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
+
+    err = writer.UnreserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeRequestMessageBuilder.EndOfInvokeRequestMessage();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remianingLengthAfterEndingInvokeRequestMessage = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeRequestMessage);
+}
+
+void InvokeRequestsEndOfRequestReservationTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    InvokeRequests::Builder invokeRequestsBuilder;
+    const uint32_t kSmallBufferSize = 100;
+    writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
+    err = invokeRequestsBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t sizeToReserve = invokeRequestsBuilder.GetSizeToEndInvokeRequests();
+    err                    = writer.ReserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
+
+    err = writer.UnreserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeRequestsBuilder.EndOfInvokeRequests();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remianingLengthAfterEndingInvokeRequests = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeRequests);
+}
+
 void InvokeInvokeResponseMessageTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2072,6 +2120,54 @@ void InvokeInvokeResponseMessageTest(nlTestSuite * apSuite, void * apContext)
 
     reader.Init(std::move(buf));
     ParseInvokeResponseMessage(apSuite, reader);
+}
+
+void InvokeResponseMessageEndOfMessageReservationTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    InvokeResponseMessage::Builder invokeResponseMessageBuilder;
+    const uint32_t kSmallBufferSize = 100;
+    writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
+    err = invokeResponseMessageBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t sizeToReserve = invokeResponseMessageBuilder.GetSizeToEndInvokeResponseMessage();
+    err                    = writer.ReserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
+
+    err = writer.UnreserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeResponseMessageBuilder.EndOfInvokeResponseMessage();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remianingLengthAfterEndingInvokeResponseMessage = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeResponseMessage);
+}
+
+void InvokeResponsesEndOfResponseReservationTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    InvokeResponseIBs::Builder invokeResponsesBuilder;
+    const uint32_t kSmallBufferSize = 100;
+    writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
+    err = invokeResponsesBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t sizeToReserve = invokeResponsesBuilder.GetSizeToEndInvokeResponses();
+    err                    = writer.ReserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    uint32_t remianingLengthAfterReservation = writer.GetRemainingFreeLength();
+
+    err = writer.UnreserveBuffer(sizeToReserve);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeResponsesBuilder.EndOfInvokeResponses();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remianingLengthAfterEndingInvokeResponses = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remianingLengthAfterReservation == remianingLengthAfterEndingInvokeResponses);
 }
 
 void ReportDataMessageTest(nlTestSuite * apSuite, void * apContext)
@@ -2283,7 +2379,11 @@ const nlTest sTests[] =
                 NL_TEST_DEF("InvokeRequestsTest", InvokeRequestsTest),
                 NL_TEST_DEF("InvokeResponsesTest", InvokeResponsesTest),
                 NL_TEST_DEF("InvokeInvokeRequestMessageTest", InvokeInvokeRequestMessageTest),
+                NL_TEST_DEF("InvokeRequestMessageEndOfMessageReservationTest", InvokeRequestMessageEndOfMessageReservationTest),
+                NL_TEST_DEF("InvokeRequestsEndOfRequestReservationTest", InvokeRequestsEndOfRequestReservationTest),
                 NL_TEST_DEF("InvokeInvokeResponseMessageTest", InvokeInvokeResponseMessageTest),
+                NL_TEST_DEF("InvokeResponseMessageEndOfMessageReservationTest", InvokeResponseMessageEndOfMessageReservationTest),
+                NL_TEST_DEF("InvokeResponsesEndOfResponseReservationTest", InvokeResponsesEndOfResponseReservationTest),
                 NL_TEST_DEF("ReportDataMessageTest", ReportDataMessageTest),
                 NL_TEST_DEF("ReadRequestMessageTest", ReadRequestMessageTest),
                 NL_TEST_DEF("WriteRequestMessageTest", WriteRequestMessageTest),

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -2129,7 +2129,7 @@ void InvokeResponseMessageEndOfMessageReservationTest(nlTestSuite * apSuite, voi
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     uint32_t remainingLengthAfterInitWithReservation = writer.GetRemainingFreeLength();
-    err = invokeResponseMessageBuilder.EndOfInvokeResponseMessage();
+    err                                              = invokeResponseMessageBuilder.EndOfInvokeResponseMessage();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     uint32_t remainingLengthAfterEndingInvokeResponseMessage = writer.GetRemainingFreeLength();
@@ -2153,7 +2153,7 @@ void InvokeResponsesEndOfResponseReservationTest(nlTestSuite * apSuite, void * a
 
     auto * invokeResponsesWriter                     = invokeResponsesBuilder.GetWriter();
     uint32_t remainingLengthAfterInitWithReservation = invokeResponsesWriter->GetRemainingFreeLength();
-    err = invokeResponsesBuilder.EndOfInvokeResponses();
+    err                                              = invokeResponsesBuilder.EndOfInvokeResponses();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     uint32_t remainingLengthAfterEndingInvokeResponses = invokeResponsesWriter->GetRemainingFreeLength();


### PR DESCRIPTION
Problem:
* Finalize can fail if there is not enough space in the buffer to end the IM messages

Solution:
* Reserve enough space for the end of the message

Now that https://github.com/project-chip/connectedhomeip/pull/30714 has landed, I feel more comfortable about setting precedent in using `ReserveBuffer`

Tests:
* Added unit test to make sure that `GetSizeToEnd...` matches how much we end up using in `EndOf...` when using the `Init...` that performs reservation in `TLVWriter` for the various IM structures. This will be ongoing in CI to ensure they match
