### PR TITLE
DM tools scraper: Add new required flags.

### DIFF
--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -79,7 +79,7 @@ def scrape_clusters(scraper, spec_root, output_dir, dry_run):
 
     def scrape_cluster(filename: str) -> None:
         xml_path = get_xml_path(filename, clusters_output_dir)
-        cmd = [scraper, 'cluster', filename, xml_path, '-nd']
+        cmd = [scraper, 'cluster', '-i', filename, '-o', xml_path, '-nd']
         if dry_run:
             print(cmd)
         else:
@@ -109,7 +109,7 @@ def scrape_device_types(scraper, spec_root, output_dir, dry_run):
 
     def scrape_device_type(filename: str) -> None:
         xml_path = get_xml_path(filename, device_types_output_dir)
-        cmd = [scraper, 'devicetype', '-c', clusters_output_dir, '-nd', filename, xml_path]
+        cmd = [scraper, 'devicetype', '-c', clusters_output_dir, '-nd', '-i', filename, '-o', xml_path]
         if dry_run:
             print(cmd)
         else:


### PR DESCRIPTION
In 1.2.0, the scraper used positional arguments, now it uses flags. This is better, IMO. Moving the script to the new format so we can get some of the improvements from the newer scraper revisions.

