### PR TITLE
Cleanup and fix batch command tests in TestCommandInteraction

### DIFF
--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -85,6 +85,10 @@ constexpr CommandId kTestCommandIdCommandSpecificResponse = 6;
 constexpr CommandId kTestNonExistCommandId                = 0;
 
 const app::CommandHandler::TestOnlyMarker kThisIsForTestOnly;
+#if !CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
+// This is only used in tests that support sending batch commands.
+(void) kThisIsForTestOnly;
+#endif
 } // namespace
 
 namespace app {

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -253,10 +253,12 @@ public:
     static void TestCommandHandlerWithSendEmptyResponse(nlTestSuite * apSuite, void * apContext);
 
     static void TestCommandHandlerWithProcessReceivedEmptyDataMsg(nlTestSuite * apSuite, void * apContext);
+#if CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
     static void TestCommandHandlerRejectMultipleIdenticalCommands(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerRejectsMultipleCommandsWithIdenticalCommandRef(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerRejectMultipleCommandsWhenHandlerOnlySupportsOne(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerAcceptMultipleCommands(nlTestSuite * apSuite, void * apContext);
+#endif
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     static void TestCommandHandlerReleaseWithExchangeClosed(nlTestSuite * apSuite, void * apContext);
@@ -1379,6 +1381,7 @@ void TestCommandInteraction::TestCommandSenderAbruptDestruction(nlTestSuite * ap
     NL_TEST_ASSERT(apSuite, GetNumActiveHandlerObjects() == 0);
 }
 
+#if CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
 void TestCommandInteraction::TestCommandHandlerRejectMultipleIdenticalCommands(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
@@ -1614,6 +1617,7 @@ void TestCommandInteraction::TestCommandHandlerAcceptMultipleCommands(nlTestSuit
     //
     exchange->Close();
 }
+#endif
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
 //
@@ -1671,10 +1675,13 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestCommandHandlerWithSendSimpleStatusCode", chip::app::TestCommandInteraction::TestCommandHandlerWithSendSimpleStatusCode),
     NL_TEST_DEF("TestCommandHandlerWithProcessReceivedNotExistCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistCommand),
     NL_TEST_DEF("TestCommandHandlerWithProcessReceivedEmptyDataMsg", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg),
+
+#if CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
     NL_TEST_DEF("TestCommandHandlerRejectMultipleIdenticalCommands", chip::app::TestCommandInteraction::TestCommandHandlerRejectMultipleIdenticalCommands),
     NL_TEST_DEF("TestCommandHandlerRejectsMultipleCommandsWithIdenticalCommandRef", chip::app::TestCommandInteraction::TestCommandHandlerRejectsMultipleCommandsWithIdenticalCommandRef),
     NL_TEST_DEF("TestCommandHandlerRejectMultipleCommandsWhenHandlerOnlySupportsOne", chip::app::TestCommandInteraction::TestCommandHandlerRejectMultipleCommandsWhenHandlerOnlySupportsOne),
     NL_TEST_DEF("TestCommandHandlerAcceptMultipleCommands", chip::app::TestCommandInteraction::TestCommandHandlerAcceptMultipleCommands),
+#endif
 
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1400,7 +1400,8 @@ void TestCommandInteraction::TestCommandHandlerRejectMultipleIdenticalCommands(n
         additionalParams.SetStartOrEndDataStruct(true);
 
         NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.PrepareCommand(commandPathParams, additionalParams));
-        NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
+        NL_TEST_ASSERT(apSuite,
+                       CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
         NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.FinishCommand(additionalParams));
     }
 
@@ -1449,7 +1450,8 @@ void TestCommandInteraction::TestCommandHandlerRejectsMultipleCommandsWithIdenti
             additionalParams.SetStartOrEndDataStruct(true);
 
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.PrepareCommand(requestCommandPaths[i], additionalParams));
-            NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
+            NL_TEST_ASSERT(apSuite,
+                           CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
             // We are taking advantage of the fact that the commandRef was set into additionalParams during PrepareCommand
             // But setting it to a different value here, we are overriding what it was supposed to be.
             additionalParams.mCommandRef.SetValue(hardcodedCommandRef);
@@ -1515,7 +1517,8 @@ void TestCommandInteraction::TestCommandHandlerRejectMultipleCommandsWhenHandler
             additionalParams.SetStartOrEndDataStruct(true);
 
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.PrepareCommand(requestCommandPaths[i], additionalParams));
-            NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
+            NL_TEST_ASSERT(apSuite,
+                           CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.FinishCommand(additionalParams));
         }
     }
@@ -1576,7 +1579,8 @@ void TestCommandInteraction::TestCommandHandlerAcceptMultipleCommands(nlTestSuit
             additionalParams.SetStartOrEndDataStruct(true);
 
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.PrepareCommand(requestCommandPaths[i], additionalParams));
-            NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
+            NL_TEST_ASSERT(apSuite,
+                           CHIP_NO_ERROR == commandSender.GetCommandDataIBTLVWriter()->PutBoolean(chip::TLV::ContextTag(1), true));
             NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == commandSender.FinishCommand(additionalParams));
         }
     }
@@ -1592,7 +1596,7 @@ void TestCommandInteraction::TestCommandHandlerAcceptMultipleCommands(nlTestSuit
     err = commandSender.Finalize(commandDatabuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    sendResponse           = true;
+    sendResponse = true;
     mockCommandHandlerDelegate.ResetCounter();
     commandDispatchedCount = 0;
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -84,10 +84,8 @@ constexpr CommandId kTestCommandIdNoData                  = 5;
 constexpr CommandId kTestCommandIdCommandSpecificResponse = 6;
 constexpr CommandId kTestNonExistCommandId                = 0;
 
+#if CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
 const app::CommandHandler::TestOnlyMarker kThisIsForTestOnly;
-#if !CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
-// This is only used in tests that support sending batch commands.
-(void) kThisIsForTestOnly;
 #endif
 } // namespace
 


### PR DESCRIPTION
While addressing TODO comments to use CommandSender to build multiple commands instead manually building TLV payload ourselves, it was realized that test `TestCommandHandlerRejectMultipleCommandsWhenHandlerOnlySupportsOne` was not written correctly. Fixing this test to perform what name suggests is what was done.
