### PR TITLE
Simplify CertificationDeclaration EncodeSignerInfo

### DIFF
--- a/src/credentials/CertificationDeclaration.cpp
+++ b/src/credentials/CertificationDeclaration.cpp
@@ -473,12 +473,12 @@ CHIP_ERROR EncodeSignerInfo(const ByteSpan & signerKeyId, const P256ECDSASignatu
             }
             ASN1_END_SEQUENCE;
 
-            uint8_t asn1SignatureBuf[kMax_ECDSA_Signature_Length_Der];
-            MutableByteSpan asn1Signature(asn1SignatureBuf);
-            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, signature.Span(), asn1Signature));
-
             // signature OCTET STRING
-            ReturnErrorOnFailure(writer.PutOctetString(asn1Signature.data(), static_cast<uint16_t>(asn1Signature.size())));
+            ASN1_START_OCTET_STRING_ENCAPSULATED
+            {
+                ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan(signature.ConstBytes()), writer));
+            }
+            ASN1_END_ENCAPSULATED;
         }
         ASN1_END_SEQUENCE;
     }

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -1000,7 +1000,7 @@ CHIP_ERROR EncodeSignerInfo_Ignor_Error(const ByteSpan & signerKeyId, const P256
 
             uint8_t asn1SignatureBuf[kMax_ECDSA_Signature_Length_Der];
             MutableByteSpan asn1Signature(asn1SignatureBuf);
-            ReturnErrorOnFailure(EcdsaRawSignatureToAsn1(kP256_FE_Length, signature.Span(), asn1Signature));
+            ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan(signature.ConstBytes()), asn1Signature));
 
             if (!cdConfig.IsCMSSignatureCorrect())
             {


### PR DESCRIPTION
... by using `ConvertECDSASignatureRawToDER` which directly integrates with the ASN.1 writer rather than `EcdsaRawSignatureToAsn1` from CHIPCryptoPAL. Also make the same change in the chip-cert gen-cd command.
