### PR TITLE
ASN.1 null writer check should not bypass reading from TLVReader

### DIFF
--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -234,12 +234,12 @@ CHIP_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, const uint8_t * enco
 
 CHIP_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, chip::TLV::TLVReader & tlvReader)
 {
-    ReturnErrorCodeIf(IsNullWriter(), CHIP_NO_ERROR);
-
     ByteSpan encodedBits;
     ReturnErrorOnFailure(tlvReader.Get(encodedBits));
 
     VerifyOrReturnError(CanCastTo<int32_t>(encodedBits.size() + 1), ASN1_ERROR_LENGTH_OVERFLOW);
+
+    ReturnErrorCodeIf(IsNullWriter(), CHIP_NO_ERROR);
 
     ReturnErrorOnFailure(
         EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, static_cast<int32_t>(encodedBits.size() + 1)));
@@ -335,12 +335,12 @@ CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint8_t tag, bool isConstructed, co
 
 CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint8_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader)
 {
-    ReturnErrorCodeIf(IsNullWriter(), CHIP_NO_ERROR);
-
     ByteSpan val;
     ReturnErrorOnFailure(tlvReader.Get(val));
 
     VerifyOrReturnError(CanCastTo<int32_t>(val.size()), ASN1_ERROR_LENGTH_OVERFLOW);
+
+    ReturnErrorCodeIf(IsNullWriter(), CHIP_NO_ERROR);
 
     ReturnErrorOnFailure(EncodeHead(cls, tag, isConstructed, static_cast<int32_t>(val.size())));
 

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -304,6 +304,17 @@ static void TestASN1_NullWriter(nlTestSuite * inSuite, void * inContext)
 
     encodedLen = writer.GetLengthWritten();
     NL_TEST_ASSERT(inSuite, encodedLen == 0);
+
+    // Methods that take a reader should still read from it,
+    // even if the output is suppressed by the null writer.
+    TLVReader emptyTlvReader;
+    emptyTlvReader.Init(ByteSpan());
+    err = writer.PutBitString(0, emptyTlvReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
+
+    emptyTlvReader.Init(ByteSpan());
+    err = writer.PutOctetString(kASN1TagClass_ContextSpecific, 123, emptyTlvReader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
 }
 
 static void TestASN1_ASN1UniversalTime(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
... since it is just intended to be an optimization.
