### PR TITLE
tv-casting-app: simplified Android discovery API

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chip.casting.app">
+    package="com">
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
@@ -19,9 +19,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:name=".ChipTvCastingApplication"
+        android:name=".chip.casting.app.ChipTvCastingApplication"
         android:theme="@style/Theme.CHIPTVCastingApp">
-        <activity android:name=".MainActivity"
+        <activity android:name=".chip.casting.app.MainActivity"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CastingContext.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CastingContext.java
@@ -3,6 +3,7 @@ package com.chip.casting.app;
 import android.content.Context;
 import android.widget.LinearLayout;
 import androidx.fragment.app.FragmentActivity;
+import com.R;
 
 public class CastingContext {
   private FragmentActivity fragmentActivity;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CertTestFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CertTestFragment.java
@@ -10,6 +10,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.R;
 import com.chip.casting.ContentApp;
 import com.chip.casting.ContentLauncherTypes;
 import com.chip.casting.FailureCallback;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -14,6 +14,7 @@ import android.widget.ListView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.R;
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.FailureCallback;
 import com.chip.casting.MatterError;
@@ -67,6 +68,7 @@ public class CommissionerDiscoveryFragment extends Fragment {
 
   @Override
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    Log.d(TAG, "onViewCreated() called");
     super.onViewCreated(view, savedInstanceState);
 
     Button manualCommissioningButton = getView().findViewById(R.id.manualCommissioningButton);
@@ -103,7 +105,10 @@ public class CommissionerDiscoveryFragment extends Fragment {
         new SuccessCallback<DiscoveredNodeData>() {
           @Override
           public void handle(DiscoveredNodeData discoveredNodeData) {
-            Log.d(TAG, "Discovered a Video Player Commissioner: " + discoveredNodeData);
+            Log.d(
+                TAG,
+                "SuccessCallback handle() Discovered a Video Player Commissioner: "
+                    + discoveredNodeData);
             new Handler(Looper.getMainLooper())
                 .post(
                     () -> {
@@ -129,7 +134,10 @@ public class CommissionerDiscoveryFragment extends Fragment {
         new FailureCallback() {
           @Override
           public void handle(MatterError matterError) {
-            Log.e(TAG, "Error occurred during video player commissioner discovery: " + matterError);
+            Log.e(
+                TAG,
+                "FailureCallback handle() Error occurred during video player commissioner discovery: "
+                    + matterError);
             if (MatterError.DISCOVERY_SERVICE_LOST == matterError) {
               Log.d(TAG, "Attempting to restart service");
               tvCastingApp.discoverVideoPlayerCommissioners(successCallback, this);
@@ -148,7 +156,7 @@ public class CommissionerDiscoveryFragment extends Fragment {
   @Override
   public void onResume() {
     super.onResume();
-    Log.d(TAG, "Auto discovering");
+    Log.d(TAG, "onResume() called. Auto discovering");
 
     poller =
         executor.scheduleAtFixedRate(

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ConnectionFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ConnectionFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.R;
 import com.chip.casting.CommissioningCallbacks;
 import com.chip.casting.ContentApp;
 import com.chip.casting.DiscoveredNodeData;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
@@ -9,6 +9,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.R;
 import com.chip.casting.ContentApp;
 import com.chip.casting.MatterCallbackHandler;
 import com.chip.casting.MatterError;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -5,18 +5,22 @@ import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
+import com.R;
 import com.chip.casting.AppParameters;
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.TvCastingApp;
 import com.chip.casting.util.GlobalCastingConstants;
 import com.chip.casting.util.PreferencesConfigurationManager;
+import com.matter.casting.DiscoveryExampleFragment;
 import com.matter.casting.InitializationExample;
+import com.matter.casting.core.CastingPlayer;
 import java.util.Random;
 
 public class MainActivity extends AppCompatActivity
     implements CommissionerDiscoveryFragment.Callback,
         ConnectionFragment.Callback,
-        SelectClusterFragment.Callback {
+        SelectClusterFragment.Callback,
+        DiscoveryExampleFragment.Callback {
 
   private static final String TAG = MainActivity.class.getSimpleName();
 
@@ -36,7 +40,12 @@ public class MainActivity extends AppCompatActivity
       return;
     }
 
-    Fragment fragment = CommissionerDiscoveryFragment.newInstance(tvCastingApp);
+    Fragment fragment = null;
+    if (GlobalCastingConstants.ChipCastingSimplified) {
+      fragment = DiscoveryExampleFragment.newInstance();
+    } else {
+      fragment = CommissionerDiscoveryFragment.newInstance(tvCastingApp);
+    }
     getSupportFragmentManager()
         .beginTransaction()
         .add(R.id.main_fragment_container, fragment, fragment.getClass().getSimpleName())
@@ -46,6 +55,13 @@ public class MainActivity extends AppCompatActivity
   @Override
   public void handleCommissioningButtonClicked(DiscoveredNodeData commissioner) {
     showFragment(ConnectionFragment.newInstance(tvCastingApp, commissioner));
+  }
+
+  @Override
+  public void handleConnectionButtonClicked(CastingPlayer player) {
+    Log.i(TAG, "MainActivity.handleConnectionButtonClicked() called");
+    // TODO: In future PR, show fragment that connects to the player.
+    // showFragment(ConnectionFragment.newInstance(CastingPlayer player));
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import com.R;
 import com.chip.casting.ContentApp;
 import com.chip.casting.FailureCallback;
 import com.chip.casting.MatterError;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/SelectClusterFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/SelectClusterFragment.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.R;
 import com.chip.casting.TvCastingApp;
 
 /** An interstitial {@link Fragment} to select one of the supported media actions to perform */

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -1,0 +1,390 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.R;
+import com.chip.casting.SuccessCallback;
+import com.matter.casting.core.CastingPlayer;
+import com.matter.casting.core.CastingPlayerDiscovery;
+import com.matter.casting.core.MatterCastingPlayerDiscovery;
+import com.matter.casting.support.MatterError;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class DiscoveryExampleFragment extends Fragment {
+  private static final String TAG = DiscoveryExampleFragment.class.getSimpleName();
+  private boolean discovering = false;
+  private TextView matterDiscoveryMessageTextView;
+  private int discoveryAttempt = 0;
+  private static final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor();
+  private ScheduledFuture scheduledFutureTask;
+  private static final List<CastingPlayer> castingPlayerList = new ArrayList<>();
+  // private FailureCallback failureCallback;
+  private static SuccessCallback<CastingPlayer> discoverySuccessCallback;
+
+  // Get a singleton instance of the MatterCastingPlayerDiscovery
+  private static final CastingPlayerDiscovery matterCastingPlayerDiscovery =
+      MatterCastingPlayerDiscovery.getInstance();
+
+  /**
+   * Implementation of a CastingPlayerChangeListener used to listen to changes in the discovered
+   * CastingPlayers
+   */
+  private static final CastingPlayerDiscovery.CastingPlayerChangeListener
+      castingPlayerChangeListener =
+          new CastingPlayerDiscovery.CastingPlayerChangeListener() {
+            private final String TAG =
+                CastingPlayerDiscovery.CastingPlayerChangeListener.class.getSimpleName();
+
+            @Override
+            public void onAdded(CastingPlayer castingPlayer) {
+              if (castingPlayer != null) {
+                Log.i(
+                    TAG,
+                    "onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
+                // Display CastingPlayer info on the screen
+                if (discoverySuccessCallback != null) {
+                  discoverySuccessCallback.handle(castingPlayer);
+                } else {
+                  Log.e(
+                      TAG,
+                      "onAdded() Warning: DiscoveryExampleFragment UX discoverySuccessCallback not set");
+                }
+              } else {
+                Log.d(TAG, "onAdded()");
+                // Attempt to invoke interface method on a null object reference will throw an error
+                Log.d(
+                    TAG,
+                    "onAdded() Discovered CastingPlayer with deviceId: "
+                        + castingPlayer.getDeviceId());
+              }
+            }
+
+            @Override
+            public void onChanged(CastingPlayer castingPlayer) {
+              Log.i(
+                  TAG,
+                  "onChanged() Discovered changes to CastingPlayer with deviceId: "
+                      + castingPlayer.getDeviceId());
+              // TODO: In following PRs. Consume changes to the provided CastingPlayer.
+            }
+
+            @Override
+            public void onRemoved(CastingPlayer castingPlayer) {
+              Log.i(
+                  TAG,
+                  "onRemoved() Removed CastingPlayer with deviceId: "
+                      + castingPlayer.getDeviceId());
+              // TODO: In following PRs. Consume CastingPlayer removed or lost from the network.
+            }
+          };
+
+  public static DiscoveryExampleFragment newInstance() {
+    Log.i(TAG, "newInstance() called");
+    return new DiscoveryExampleFragment();
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Log.i(TAG, "onCreate() called");
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    Log.i(TAG, "onCreateView() called");
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.fragment_matter_discovery_example, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Log.i(TAG, "onViewCreated() called");
+
+    matterDiscoveryMessageTextView =
+        getActivity().findViewById(R.id.matterDiscoveryMessageTextView);
+    matterDiscoveryMessageTextView.setText(
+        getString(R.string.matter_discovery_message_initializing_text));
+
+    ArrayAdapter<CastingPlayer> arrayAdapter =
+        new CastingPlayerCommissionerAdapter(getActivity(), castingPlayerList);
+    final ListView list = getActivity().findViewById(R.id.castingPlayerList);
+    list.setAdapter(arrayAdapter);
+
+    Log.d(TAG, "onViewCreated() creating callbacks");
+
+    this.discoverySuccessCallback =
+        new SuccessCallback<CastingPlayer>() {
+          @Override
+          public void handle(CastingPlayer castingPlayer) {
+            Log.d(
+                TAG,
+                "SuccessCallback handle() CastingPlayer deviceId: " + castingPlayer.getDeviceId());
+            new Handler(Looper.getMainLooper())
+                .post(
+                    () -> {
+                      final Optional<CastingPlayer> playerInList =
+                          castingPlayerList
+                              .stream()
+                              .filter(
+                                  node -> castingPlayer.discoveredCastingPlayerHasSameSource(node))
+                              .findFirst();
+                      if (playerInList.isPresent()) {
+                        Log.d(
+                            TAG,
+                            "Replacing existing CastingPlayer entry "
+                                + playerInList.get().getDeviceId()
+                                + " in castingPlayerList list");
+                        arrayAdapter.remove(playerInList.get());
+                      }
+                      arrayAdapter.add(castingPlayer);
+                    });
+          }
+        };
+
+    Button startDiscoveryButton = getView().findViewById(R.id.startDiscoveryButton);
+    startDiscoveryButton.setOnClickListener(
+        v -> {
+          Log.i(
+              TAG, "onViewCreated() startDiscoveryButton button clicked. Calling startDiscovery()");
+          arrayAdapter.clear();
+          if (!startDiscovery(15)) {
+            Log.e(TAG, "onViewCreated() startDiscovery() call Failed");
+          }
+        });
+
+    Button stopDiscoveryButton = getView().findViewById(R.id.stopDiscoveryButton);
+    stopDiscoveryButton.setOnClickListener(
+        v -> {
+          Log.i(TAG, "onViewCreated() stopDiscoveryButton button clicked. Calling stopDiscovery()");
+          stopDiscovery();
+          Log.i(TAG, "onViewCreated() stopDiscoveryButton button clicked. Canceling future task");
+          scheduledFutureTask.cancel(true);
+        });
+
+    Button clearDiscoveryResultsButton = getView().findViewById(R.id.clearDiscoveryResultsButton);
+    clearDiscoveryResultsButton.setOnClickListener(
+        v -> {
+          Log.i(
+              TAG, "onViewCreated() clearDiscoveryResultsButton button clicked. Clearing results");
+          arrayAdapter.clear();
+        });
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    Log.i(TAG, "onResume() called. Calling startDiscovery()");
+    if (!startDiscovery(15)) {
+      Log.e(TAG, "onResume() Warning: startDiscovery() call Failed");
+    }
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    Log.i(TAG, "onPause() called");
+    stopDiscovery();
+    scheduledFutureTask.cancel(true);
+  }
+
+  /** Interface for notifying the host. */
+  public interface Callback {
+    /** Notifies listener of Connection Button click. */
+    // TODO: In following PRs. Implement CastingPlayer connection
+    void handleConnectionButtonClicked(CastingPlayer castingPlayer);
+  }
+
+  private boolean startDiscovery(int discoveryDuration) {
+    Log.i(TAG, "startDiscovery() called, discoveryDuration: " + discoveryDuration + " seconds");
+    if (discovering) {
+      Log.e(TAG, "startDiscovery() Warning: already discovering, stop before starting");
+      return false;
+    }
+    // Add the implemented CastingPlayerChangeListener to listen to changes in the discovered
+    // CastingPlayers
+    MatterError errAdd =
+        matterCastingPlayerDiscovery.addCastingPlayerChangeListener(castingPlayerChangeListener);
+    if (errAdd.hasError()) {
+      Log.e(TAG, "startDiscovery() addCastingPlayerChangeListener() called, errAdd: " + errAdd);
+      return false;
+    }
+    // Start discovery
+    Log.i(TAG, "startDiscovery() calling startDiscovery()");
+    MatterError errStart = matterCastingPlayerDiscovery.startDiscovery();
+    if (errStart.hasError()) {
+      Log.e(TAG, "startDiscovery() startDiscovery() called, errStart: " + errStart);
+      return false;
+    }
+
+    discovering = true;
+    discoveryAttempt++;
+    Log.i(TAG, "startDiscovery() started discovery attempt #" + discoveryAttempt);
+
+    matterDiscoveryMessageTextView.setText(
+        getString(R.string.matter_discovery_message_discovering_text));
+    Log.d(
+        TAG,
+        "startDiscovery() text set to: "
+            + getString(R.string.matter_discovery_message_discovering_text));
+
+    // Schedule a service to stop discovery and remove the CastingPlayerChangeListener
+    // Safe to call if discovery is not running
+    scheduledFutureTask =
+        executorService.schedule(
+            () -> {
+              Log.i(
+                  TAG,
+                  "startDiscovery() executorService "
+                      + discoveryDuration
+                      + " seconds timer expired. Calling stopDiscovery() on attempt #"
+                      + discoveryAttempt);
+              stopDiscovery();
+            },
+            discoveryDuration,
+            TimeUnit.SECONDS);
+
+    return true;
+  }
+
+  private void stopDiscovery() {
+    Log.i(TAG, "stopDiscovery() called on attempt #" + discoveryAttempt);
+    boolean stopDiscoverySuccess = true;
+    if (!discovering) {
+      Log.e(TAG, "stopDiscovery() not discovering");
+      return;
+    }
+
+    // Stop discovery
+    MatterError errStop = matterCastingPlayerDiscovery.stopDiscovery();
+    if (errStop.hasError()) {
+      Log.e(
+          TAG,
+          "stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() called, errStop: "
+              + errStop);
+      stopDiscoverySuccess = false;
+    } else {
+      // TODO: In following PRs. Implement stop discovery in the Android core API.
+      Log.d(TAG, "stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() success");
+      discovering = false;
+    }
+
+    matterDiscoveryMessageTextView.setText(
+        getString(R.string.matter_discovery_message_stopped_text));
+    Log.d(
+        TAG,
+        "stopDiscovery() text set to: "
+            + getString(R.string.matter_discovery_message_stopped_text));
+
+    // Remove the CastingPlayerChangeListener
+    Log.i(TAG, "stopDiscovery() removing CastingPlayerChangeListener");
+    MatterError errRemove =
+        matterCastingPlayerDiscovery.removeCastingPlayerChangeListener(castingPlayerChangeListener);
+    if (errRemove.hasError()) {
+      Log.e(
+          TAG,
+          "stopDiscovery() matterCastingPlayerDiscovery.removeCastingPlayerChangeListener() called, errRemove: "
+              + errRemove);
+      stopDiscoverySuccess = false;
+    }
+
+    if (!stopDiscoverySuccess) {
+      Log.e(TAG, "stopDiscovery() Warning: complete with errors! Discovering: " + discovering);
+    }
+  }
+}
+
+class CastingPlayerCommissionerAdapter extends ArrayAdapter<CastingPlayer> {
+  private final List<CastingPlayer> playerList;
+  private final Context context;
+  private LayoutInflater inflater;
+  private static final String TAG = CastingPlayerCommissionerAdapter.class.getSimpleName();
+
+  public CastingPlayerCommissionerAdapter(Context context, List<CastingPlayer> playerList) {
+    super(context, 0, playerList);
+    Log.i(TAG, "CastingPlayerCommissionerAdapter() constructor called");
+    this.context = context;
+    this.playerList = playerList;
+    inflater = (LayoutInflater.from(context));
+  }
+
+  @Override
+  public View getView(int i, View view, ViewGroup viewGroup) {
+    view = inflater.inflate(R.layout.commissionable_player_list_item, null);
+    String buttonText = getCastingPlayerButtonText(playerList.get(i));
+    Button playerDescription = view.findViewById(R.id.commissionable_player_description);
+    playerDescription.setText(buttonText);
+
+    View.OnClickListener clickListener =
+        v -> {
+          CastingPlayer castingPlayer = playerList.get(i);
+          Log.d(
+              TAG,
+              "OnItemClickListener.onClick() called for castingPlayer with deviceId: "
+                  + castingPlayer.getDeviceId());
+          DiscoveryExampleFragment.Callback callback1 = (DiscoveryExampleFragment.Callback) context;
+          // TODO: In following PRs. Implement CastingPlayer connection
+          // callback1.handleCommissioningButtonClicked(castingPlayer);
+        };
+    playerDescription.setOnClickListener(clickListener);
+    return view;
+  }
+
+  private String getCastingPlayerButtonText(CastingPlayer player) {
+    String main = player.getDeviceName() != null ? player.getDeviceName() : "";
+    String aux = "" + (player.getDeviceId() != null ? "Device ID: " + player.getDeviceId() : "");
+    aux +=
+        player.getProductId() > 0
+            ? (aux.isEmpty() ? "" : ", ") + "Product ID: " + player.getProductId()
+            : "";
+    aux +=
+        player.getVendorId() > 0
+            ? (aux.isEmpty() ? "" : ", ") + "Vendor ID: " + player.getVendorId()
+            : "";
+    aux +=
+        player.getDeviceType() > 0
+            ? (aux.isEmpty() ? "" : ", ") + "Device Type: " + player.getDeviceType()
+            : "";
+    aux = aux.isEmpty() ? aux : "\n" + aux;
+
+    // String preCommissioned = commissioner.isPreCommissioned() ? " (Pre-commissioned)" : "";
+    // return main + aux + preCommissioned;
+    return main + aux;
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ScheduledFuture;
 public class DiscoveryExampleFragment extends Fragment {
   private static final String TAG = DiscoveryExampleFragment.class.getSimpleName();
   // 35 represents device type of Matter Casting Player
-  private static final int DISCOVERY_TARGET_DEVICE_TYPE = 35;
+  private static final Long DISCOVERY_TARGET_DEVICE_TYPE = 35L;
   private static final int DISCOVERY_RUNTIME_SEC = 15;
   private TextView matterDiscoveryMessageTextView;
   private static final ScheduledExecutorService executorService =
@@ -70,98 +70,68 @@ public class DiscoveryExampleFragment extends Fragment {
 
             @Override
             public void onAdded(CastingPlayer castingPlayer) {
-              if (castingPlayer != null) {
-                Log.i(
-                    TAG,
-                    "onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
-                // Display CastingPlayer info on the screen
-                new Handler(Looper.getMainLooper())
-                    .post(
-                        () -> {
-                          final Optional<CastingPlayer> playerInList =
-                              castingPlayerList
-                                  .stream()
-                                  .filter(node -> castingPlayer.equals(node))
-                                  .findFirst();
-                          if (playerInList.isPresent()) {
-                            Log.d(
-                                TAG,
-                                "onAdded() Replacing existing CastingPlayer entry "
-                                    + playerInList.get().getDeviceId()
-                                    + " in castingPlayerList list");
-                            arrayAdapter.remove(playerInList.get());
-                          }
-                          arrayAdapter.add(castingPlayer);
-                        });
-              } else {
-                Log.d(TAG, "onAdded() CastingPlayer is null");
-                // Attempt to invoke interface method on a null object reference will throw an error
-                Log.d(
-                    TAG,
-                    "onAdded() Discovered CastingPlayer with deviceId: "
-                        + castingPlayer.getDeviceId());
-              }
+              Log.i(
+                  TAG,
+                  "onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
+              // Display CastingPlayer info on the screen
+              new Handler(Looper.getMainLooper())
+                  .post(
+                      () -> {
+                        arrayAdapter.add(castingPlayer);
+                      });
             }
 
             @Override
             public void onChanged(CastingPlayer castingPlayer) {
-              if (castingPlayer != null) {
-                Log.i(
-                    TAG,
-                    "onChanged() Discovered changes to CastingPlayer with deviceId: "
-                        + castingPlayer.getDeviceId());
-                // Update the CastingPlayer on the screen
-                new Handler(Looper.getMainLooper())
-                    .post(
-                        () -> {
-                          final Optional<CastingPlayer> playerInList =
-                              castingPlayerList
-                                  .stream()
-                                  .filter(node -> castingPlayer.equals(node))
-                                  .findFirst();
-                          if (playerInList.isPresent()) {
-                            Log.d(
-                                TAG,
-                                "onChanged() Updating existing CastingPlayer entry "
-                                    + playerInList.get().getDeviceId()
-                                    + " in castingPlayerList list");
-                            arrayAdapter.remove(playerInList.get());
-                          }
-                          arrayAdapter.add(castingPlayer);
-                        });
-              } else {
-                Log.d(TAG, "onChanged() CastingPlayer is null");
-              }
+              Log.i(
+                  TAG,
+                  "onChanged() Discovered changes to CastingPlayer with deviceId: "
+                      + castingPlayer.getDeviceId());
+              // Update the CastingPlayer on the screen
+              new Handler(Looper.getMainLooper())
+                  .post(
+                      () -> {
+                        final Optional<CastingPlayer> playerInList =
+                            castingPlayerList
+                                .stream()
+                                .filter(node -> castingPlayer.equals(node))
+                                .findFirst();
+                        if (playerInList.isPresent()) {
+                          Log.d(
+                              TAG,
+                              "onChanged() Updating existing CastingPlayer entry "
+                                  + playerInList.get().getDeviceId()
+                                  + " in castingPlayerList list");
+                          arrayAdapter.remove(playerInList.get());
+                        }
+                        arrayAdapter.add(castingPlayer);
+                      });
             }
 
             @Override
             public void onRemoved(CastingPlayer castingPlayer) {
-              if (castingPlayer != null) {
-                Log.i(
-                    TAG,
-                    "onRemoved() Removed CastingPlayer with deviceId: "
-                        + castingPlayer.getDeviceId());
-                // Remove CastingPlayer from the screen
-                new Handler(Looper.getMainLooper())
-                    .post(
-                        () -> {
-                          final Optional<CastingPlayer> playerInList =
-                              castingPlayerList
-                                  .stream()
-                                  .filter(node -> castingPlayer.equals(node))
-                                  .findFirst();
-                          if (playerInList.isPresent()) {
-                            Log.d(
-                                TAG,
-                                "onRemoved() Removing existing CastingPlayer entry "
-                                    + playerInList.get().getDeviceId()
-                                    + " in castingPlayerList list");
-                            arrayAdapter.remove(playerInList.get());
-                          }
-                        });
-              } else {
-                Log.d(TAG, "onRemoved() CastingPlayer is null");
-              }
+              Log.i(
+                  TAG,
+                  "onRemoved() Removed CastingPlayer with deviceId: "
+                      + castingPlayer.getDeviceId());
+              // Remove CastingPlayer from the screen
+              new Handler(Looper.getMainLooper())
+                  .post(
+                      () -> {
+                        final Optional<CastingPlayer> playerInList =
+                            castingPlayerList
+                                .stream()
+                                .filter(node -> castingPlayer.equals(node))
+                                .findFirst();
+                        if (playerInList.isPresent()) {
+                          Log.d(
+                              TAG,
+                              "onRemoved() Removing existing CastingPlayer entry "
+                                  + playerInList.get().getDeviceId()
+                                  + " in castingPlayerList list");
+                          arrayAdapter.remove(playerInList.get());
+                        }
+                      });
             }
           };
 
@@ -201,14 +171,13 @@ public class DiscoveryExampleFragment extends Fragment {
     Log.d(TAG, "onViewCreated() creating callbacks");
 
     // TODO: In following PRs. Enable startDiscoveryButton and stopDiscoveryButton when
-    //  stopDiscovery is implemented in the core Matter SKD DNS-SD API. Enable in
+    //  stopDiscovery is implemented in the core Matter SDK DNS-SD API. Enable in
     //  fragment_matter_discovery_example.xml
     Button startDiscoveryButton = getView().findViewById(R.id.startDiscoveryButton);
     startDiscoveryButton.setOnClickListener(
         v -> {
           Log.i(
               TAG, "onViewCreated() startDiscoveryButton button clicked. Calling startDiscovery()");
-          // arrayAdapter.clear();
           if (!startDiscovery()) {
             Log.e(TAG, "onViewCreated() startDiscovery() call Failed");
           }
@@ -262,6 +231,8 @@ public class DiscoveryExampleFragment extends Fragment {
   private boolean startDiscovery() {
     Log.i(TAG, "startDiscovery() called");
 
+    arrayAdapter.clear();
+
     // Add the implemented CastingPlayerChangeListener to listen to changes in the discovered
     // CastingPlayers
     MatterError err =
@@ -271,7 +242,7 @@ public class DiscoveryExampleFragment extends Fragment {
       return false;
     }
     // Start discovery
-    Log.i(TAG, "startDiscovery() calling startDiscovery()");
+    Log.i(TAG, "startDiscovery() calling CastingPlayerDiscovery.startDiscovery()");
     err = matterCastingPlayerDiscovery.startDiscovery(DISCOVERY_TARGET_DEVICE_TYPE);
     if (err.hasError()) {
       Log.e(TAG, "startDiscovery() startDiscovery() called, err Start: " + err);
@@ -392,7 +363,7 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
         player.getDeviceType() > 0
             ? (aux.isEmpty() ? "" : ", ") + "Device Type: " + player.getDeviceType()
             : "";
-    aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP: " + (player.getNumberIPs() > 0);
+    aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP?: " + (player.getIpAddresses().size() > 0);
 
     aux = aux.isEmpty() ? aux : "\n" + aux;
     return main + aux;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -36,8 +36,6 @@ public interface CastingPlayer {
 
   String getInstanceName();
 
-  int getNumberIPs();
-
   List<InetAddress> getIpAddresses();
 
   int getPort();
@@ -46,12 +44,15 @@ public interface CastingPlayer {
 
   int getProductId();
 
-  int getDeviceType();
+  long getDeviceType();
 
+  @Override
   String toString();
 
+  @Override
   boolean equals(Object o);
 
+  @Override
   int hashCode();
 
   // TODO: Implement in following PRs. Related to player connection implementation.

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -19,6 +19,12 @@ package com.matter.casting.core;
 import java.net.InetAddress;
 import java.util.List;
 
+/**
+ * The CastingPlayer interface defines a Matter commissioner that is able to play media to a
+ * physical output or to a display screen which is part of the device (e.g. TV). It is discovered on
+ * the local network using Matter Commissioner discovery over DNS. It contains all the information
+ * about the service discovered/resolved.
+ */
 public interface CastingPlayer {
   boolean isConnected();
 
@@ -42,7 +48,11 @@ public interface CastingPlayer {
 
   int getDeviceType();
 
-  boolean discoveredCastingPlayerHasSameSource(Object o);
+  String toString();
+
+  boolean equals(Object o);
+
+  int hashCode();
 
   // TODO: Implement in following PRs. Related to player connection implementation.
   //    List<Endpoint> getEndpoints();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -1,0 +1,67 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.core;
+
+import java.net.InetAddress;
+import java.util.List;
+
+public interface CastingPlayer {
+  boolean isConnected();
+
+  String getDeviceId();
+
+  String getHostName();
+
+  String getDeviceName();
+
+  String getInstanceName();
+
+  int getNumberIPs();
+
+  List<InetAddress> getIpAddresses();
+
+  int getPort();
+
+  int getVendorId();
+
+  int getProductId();
+
+  int getDeviceType();
+
+  boolean discoveredCastingPlayerHasSameSource(Object o);
+
+  // TODO: Implement in following PRs. Related to player connection implementation.
+  //    List<Endpoint> getEndpoints();
+  //
+  //    ConnectionState getConnectionState();
+  //
+  //    CompletableFuture<Void> connect(long timeout);
+  //
+  //    static class ConnectionState extends Observable {
+  //        private boolean connected;
+  //
+  //        void setConnected(boolean connected) {
+  //            this.connected = connected;
+  //            setChanged();
+  //            notifyObservers(this.connected);
+  //        }
+  //
+  //        boolean isConnected() {
+  //            return connected;
+  //        }
+  //    }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
@@ -17,35 +17,94 @@
 package com.matter.casting.core;
 
 import android.util.Log;
+import com.matter.casting.support.MatterError;
 import java.util.List;
 
+/**
+ * The CastingPlayerDiscovery interface defines the API to control Matter Casting Player discovery
+ * over DNS-SD, and to collect discovery results. Discovery is centrally managed by the native C++
+ * layer in the Matter SDK. This class exposes native functions to add and remove a
+ * CastingPlayerChangeListener, which contains the C++ to Java callbacks for when Casting Players
+ * are discovered, updated, or lost from the network. This class is a singleton.
+ */
 public interface CastingPlayerDiscovery {
 
+  /**
+   * @return a list of Casting Players discovered during the current discovery session. This list is
+   *     cleared when discovery stops.
+   */
   List<CastingPlayer> getCastingPlayers();
 
-  com.matter.casting.support.MatterError startDiscovery();
-
-  com.matter.casting.support.MatterError stopDiscovery();
-
-  com.matter.casting.support.MatterError addCastingPlayerChangeListener(
-      CastingPlayerChangeListener listener);
-
-  com.matter.casting.support.MatterError removeCastingPlayerChangeListener(
-      CastingPlayerChangeListener listener);
+  /**
+   * Starts Casting Players discovery or returns an error.
+   *
+   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. 35
+   *     represents device type of Matter Casting Player.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
+  MatterError startDiscovery(int discoveryTargetDeviceType);
 
   /**
-   * The Casting Client discovers CastingPlayers using Matter Commissioner discovery over DNS-SD by
-   * listening for CastingPlayer events as they are discovered, updated, or lost from the network.
+   * Stops Casting Players discovery or returns an error.
+   *
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
+  MatterError stopDiscovery();
+
+  /**
+   * Adds a CastingPlayerChangeListener instance to be used during discovery. The
+   * CastingPlayerChangeListener contains the C++ to Java callbacks for when Casting Players are
+   * discovered, updated, or lost from the network. Should be called prior to calling
+   * MatterCastingPlayerDiscovery.startDiscovery().
+   *
+   * @param listener an instance of the CastingPlayerChangeListener to be implemented by the APIs
+   *     consumer.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
+  MatterError addCastingPlayerChangeListener(CastingPlayerChangeListener listener);
+
+  /**
+   * Removes CastingPlayerChangeListener from the native layer.
+   *
+   * @param listener the specific instance of CastingPlayerChangeListener to be removed.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
+  MatterError removeCastingPlayerChangeListener(CastingPlayerChangeListener listener);
+
+  /**
+   * The CastingPlayerChangeListener can discover CastingPlayers by implementing the onAdded,
+   * onChanged and onRemoved callbacks which are called as CastingPlayers, are discovered, updated,
+   * or lost from the network. The onAdded(), onChanged() and onRemoved() callbacks must be
+   * implemented by the APIs client.
    */
   abstract class CastingPlayerChangeListener {
     static final String TAG = CastingPlayerChangeListener.class.getSimpleName();
 
+    /**
+     * Called by the native C++ layer when a Casting Player is added to the local network.
+     *
+     * @param castingPlayer the Casting Player added.
+     */
     public abstract void onAdded(CastingPlayer castingPlayer);
 
+    /**
+     * Called by the native C++ layer when a Casting Player on the local network is changed.
+     *
+     * @param castingPlayer the Casting Player changed.
+     */
     public abstract void onChanged(CastingPlayer castingPlayer);
 
+    /**
+     * Called by the native C++ layer when a Casting Player is removed from the local network.
+     *
+     * @param castingPlayer the Casting Player removed.
+     */
     public abstract void onRemoved(CastingPlayer castingPlayer);
 
+    /**
+     * The following methods are used to catch possible exceptions thrown by the methods above, when
+     * not implemented correctly.
+     */
     protected final void _onAdded(CastingPlayer castingPlayer) {
       try {
         onAdded(castingPlayer);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.core;
+
+import android.util.Log;
+import java.util.List;
+
+public interface CastingPlayerDiscovery {
+
+  List<CastingPlayer> getCastingPlayers();
+
+  com.matter.casting.support.MatterError startDiscovery();
+
+  com.matter.casting.support.MatterError stopDiscovery();
+
+  com.matter.casting.support.MatterError addCastingPlayerChangeListener(
+      CastingPlayerChangeListener listener);
+
+  com.matter.casting.support.MatterError removeCastingPlayerChangeListener(
+      CastingPlayerChangeListener listener);
+
+  /**
+   * The Casting Client discovers CastingPlayers using Matter Commissioner discovery over DNS-SD by
+   * listening for CastingPlayer events as they are discovered, updated, or lost from the network.
+   */
+  abstract class CastingPlayerChangeListener {
+    static final String TAG = CastingPlayerChangeListener.class.getSimpleName();
+
+    public abstract void onAdded(CastingPlayer castingPlayer);
+
+    public abstract void onChanged(CastingPlayer castingPlayer);
+
+    public abstract void onRemoved(CastingPlayer castingPlayer);
+
+    protected final void _onAdded(CastingPlayer castingPlayer) {
+      try {
+        onAdded(castingPlayer);
+      } catch (Throwable t) {
+        Log.e(TAG, "_onAdded() Caught an unhandled Throwable from the client: " + t);
+      }
+    };
+
+    protected final void _onChanged(CastingPlayer castingPlayer) {
+      try {
+        onChanged(castingPlayer);
+      } catch (Throwable t) {
+        Log.e(TAG, "_onChanged() Caught an unhandled Throwable from the client: " + t);
+      }
+    };
+
+    protected final void _onRemoved(CastingPlayer castingPlayer) {
+      try {
+        onRemoved(castingPlayer);
+      } catch (Throwable t) {
+        Log.e(TAG, "_onRemoved() Caught an unhandled Throwable from the client: " + t);
+      }
+    };
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
@@ -75,8 +75,8 @@ public interface CastingPlayerDiscovery {
   /**
    * The CastingPlayerChangeListener can discover CastingPlayers by implementing the onAdded(),
    * onChanged() and onRemoved() callbacks which are called as CastingPlayers, are discovered,
-   * updated, or lost from the network. The onAdded(), onChanged() and onRemoved() handlers must
-   * be implemented by the API client.
+   * updated, or lost from the network. The onAdded(), onChanged() and onRemoved() handlers must be
+   * implemented by the API client.
    */
   abstract class CastingPlayerChangeListener {
     static final String TAG = CastingPlayerChangeListener.class.getSimpleName();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java
@@ -21,11 +21,11 @@ import com.matter.casting.support.MatterError;
 import java.util.List;
 
 /**
- * The CastingPlayerDiscovery interface defines the API to control Matter Casting Player discovery
- * over DNS-SD, and to collect discovery results. Discovery is centrally managed by the native C++
- * layer in the Matter SDK. This class exposes native functions to add and remove a
- * CastingPlayerChangeListener, which contains the C++ to Java callbacks for when Casting Players
- * are discovered, updated, or lost from the network. This class is a singleton.
+ * The CastingPlayerDiscovery interface defines the client API to control Matter Casting Player
+ * discovery over DNS-SD, and to collect discovery results. This interface defines the methods to
+ * add and remove a CastingPlayerChangeListener. It also defines the CastingPlayerChangeListener
+ * handler class which must be implemented by the API client. The handler contains the methods
+ * called when Casting Players are discovered, updated, or lost from the network.
  */
 public interface CastingPlayerDiscovery {
 
@@ -38,11 +38,12 @@ public interface CastingPlayerDiscovery {
   /**
    * Starts Casting Players discovery or returns an error.
    *
-   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. 35
-   *     represents device type of Matter Casting Player.
+   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. For
+   *     example: 35 represents device type of Matter Casting Video Player. If "null" is passed in,
+   *     discovery will default to all "_matterd._udp" device types.
    * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
    */
-  MatterError startDiscovery(int discoveryTargetDeviceType);
+  MatterError startDiscovery(Long discoveryTargetDeviceType);
 
   /**
    * Stops Casting Players discovery or returns an error.
@@ -53,7 +54,7 @@ public interface CastingPlayerDiscovery {
 
   /**
    * Adds a CastingPlayerChangeListener instance to be used during discovery. The
-   * CastingPlayerChangeListener contains the C++ to Java callbacks for when Casting Players are
+   * CastingPlayerChangeListener defines the handler methods for when Casting Players are
    * discovered, updated, or lost from the network. Should be called prior to calling
    * MatterCastingPlayerDiscovery.startDiscovery().
    *
@@ -64,7 +65,7 @@ public interface CastingPlayerDiscovery {
   MatterError addCastingPlayerChangeListener(CastingPlayerChangeListener listener);
 
   /**
-   * Removes CastingPlayerChangeListener from the native layer.
+   * Removes CastingPlayerChangeListener added by addCastingPlayerChangeListener().
    *
    * @param listener the specific instance of CastingPlayerChangeListener to be removed.
    * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
@@ -72,38 +73,38 @@ public interface CastingPlayerDiscovery {
   MatterError removeCastingPlayerChangeListener(CastingPlayerChangeListener listener);
 
   /**
-   * The CastingPlayerChangeListener can discover CastingPlayers by implementing the onAdded,
-   * onChanged and onRemoved callbacks which are called as CastingPlayers, are discovered, updated,
-   * or lost from the network. The onAdded(), onChanged() and onRemoved() callbacks must be
-   * implemented by the APIs client.
+   * The CastingPlayerChangeListener can discover CastingPlayers by implementing the onAdded(),
+   * onChanged() and onRemoved() callbacks which are called as CastingPlayers, are discovered,
+   * updated, or lost from the network. The onAdded(), onChanged() and onRemoved() handlers must
+   * be implemented by the API client.
    */
   abstract class CastingPlayerChangeListener {
     static final String TAG = CastingPlayerChangeListener.class.getSimpleName();
 
     /**
-     * Called by the native C++ layer when a Casting Player is added to the local network.
+     * This handler is called when a Casting Player is added to the network.
      *
      * @param castingPlayer the Casting Player added.
      */
     public abstract void onAdded(CastingPlayer castingPlayer);
 
     /**
-     * Called by the native C++ layer when a Casting Player on the local network is changed.
+     * This handler is called when a Casting Player previously detected on the network is changed.
      *
      * @param castingPlayer the Casting Player changed.
      */
     public abstract void onChanged(CastingPlayer castingPlayer);
 
     /**
-     * Called by the native C++ layer when a Casting Player is removed from the local network.
+     * This handler is called when a Casting Player previously detected on the network is removed.
      *
      * @param castingPlayer the Casting Player removed.
      */
     public abstract void onRemoved(CastingPlayer castingPlayer);
 
     /**
-     * The following methods are used to catch possible exceptions thrown by the methods above, when
-     * not implemented correctly.
+     * The following methods are used to catch possible exceptions thrown by the methods above
+     * (onAdded(), onChanged() and onRemoved()), when not implemented correctly by the client.
      */
     protected final void _onAdded(CastingPlayer castingPlayer) {
       try {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -32,12 +32,11 @@ public class MatterCastingPlayer implements CastingPlayer {
   private String deviceName;
   private String hostName;
   private String instanceName;
-  private int numberIPs;
   private List<InetAddress> ipAddresses;
   private int port;
   private int productId;
   private int vendorId;
-  private int deviceType;
+  private long deviceType;
 
   public MatterCastingPlayer(
       boolean connected,
@@ -45,18 +44,16 @@ public class MatterCastingPlayer implements CastingPlayer {
       String hostName,
       String deviceName,
       String instanceName,
-      int numberIPs,
       List<InetAddress> ipAddresses,
       int port,
       int productId,
       int vendorId,
-      int deviceType) {
+      long deviceType) {
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
     this.deviceName = deviceName;
     this.instanceName = instanceName;
-    this.numberIPs = numberIPs;
     this.ipAddresses = ipAddresses;
     this.port = port;
     this.productId = productId;
@@ -97,12 +94,6 @@ public class MatterCastingPlayer implements CastingPlayer {
     return this.instanceName;
   }
 
-  /** @return an int, corresponding to the number of valid IP addresses for this Casting PLayer. */
-  @Override
-  public int getNumberIPs() {
-    return this.numberIPs;
-  }
-
   /** @return a list of valid IP addresses for this Casting PLayer. */
   @Override
   public List<InetAddress> getIpAddresses() {
@@ -125,7 +116,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   @Override
-  public int getDeviceType() {
+  public long getDeviceType() {
     return this.deviceType;
   }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -16,14 +16,17 @@
  */
 package com.matter.casting.core;
 
-import android.util.Log;
 import java.net.InetAddress;
 import java.util.List;
 import java.util.Objects;
 
-/** The Matter Commissioner (e.g. TV) discovered using Matter Commissioner discovery. */
+/**
+ * A Matter Casting Player represents a Matter commissioner that is able to play media to a physical
+ * output or to a display screen which is part of the device (e.g. TV). It is discovered on the
+ * local network using Matter Commissioner discovery over DNS. It contains all the information about
+ * the service discovered/resolved.
+ */
 public class MatterCastingPlayer implements CastingPlayer {
-  private static final String TAG = MatterCastingPlayer.class.getSimpleName();
   private boolean connected;
   private String deviceId;
   private String deviceName;
@@ -48,8 +51,6 @@ public class MatterCastingPlayer implements CastingPlayer {
       int productId,
       int vendorId,
       int deviceType) {
-    Log.d(TAG, "MatterCastingPlayer() constructor, building player with deviceId: " + deviceId);
-    Log.d(TAG, "MatterCastingPlayer() constructor, building player with deviceName: " + deviceName);
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
@@ -63,11 +64,19 @@ public class MatterCastingPlayer implements CastingPlayer {
     this.deviceType = deviceType;
   }
 
+  /**
+   * @return a boolean indicating whether a Casting Player instance is connected to the TV Casting
+   *     App.
+   */
   @Override
   public boolean isConnected() {
     return this.connected;
   }
 
+  /**
+   * @return a String representing the Casting Player device ID which is a concatenation of the
+   *     device's IP address and port number.
+   */
   @Override
   public String getDeviceId() {
     return this.deviceId;
@@ -88,11 +97,13 @@ public class MatterCastingPlayer implements CastingPlayer {
     return this.instanceName;
   }
 
+  /** @return an int, corresponding to the number of valid IP addresses for this Casting PLayer. */
   @Override
   public int getNumberIPs() {
     return this.numberIPs;
   }
 
+  /** @return a list of valid IP addresses for this Casting PLayer. */
   @Override
   public List<InetAddress> getIpAddresses() {
     return this.ipAddresses;
@@ -119,10 +130,20 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   @Override
-  public boolean discoveredCastingPlayerHasSameSource(Object o) {
+  public String toString() {
+    return this.deviceId;
+  }
+
+  @Override
+  public int hashCode() {
+    return this.deviceId.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     MatterCastingPlayer that = (MatterCastingPlayer) o;
-    return Objects.equals(deviceId, that.deviceId) && vendorId == that.vendorId;
+    return Objects.equals(this.deviceId, that.deviceId);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -1,0 +1,128 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.core;
+
+import android.util.Log;
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Objects;
+
+/** The Matter Commissioner (e.g. TV) discovered using Matter Commissioner discovery. */
+public class MatterCastingPlayer implements CastingPlayer {
+  private static final String TAG = MatterCastingPlayer.class.getSimpleName();
+  private boolean connected;
+  private String deviceId;
+  private String deviceName;
+  private String hostName;
+  private String instanceName;
+  private int numberIPs;
+  private List<InetAddress> ipAddresses;
+  private int port;
+  private int productId;
+  private int vendorId;
+  private int deviceType;
+
+  public MatterCastingPlayer(
+      boolean connected,
+      String deviceId,
+      String hostName,
+      String deviceName,
+      String instanceName,
+      int numberIPs,
+      List<InetAddress> ipAddresses,
+      int port,
+      int productId,
+      int vendorId,
+      int deviceType) {
+    Log.d(TAG, "MatterCastingPlayer() constructor, building player with deviceId: " + deviceId);
+    Log.d(TAG, "MatterCastingPlayer() constructor, building player with deviceName: " + deviceName);
+    this.connected = connected;
+    this.deviceId = deviceId;
+    this.hostName = hostName;
+    this.deviceName = deviceName;
+    this.instanceName = instanceName;
+    this.numberIPs = numberIPs;
+    this.ipAddresses = ipAddresses;
+    this.port = port;
+    this.productId = productId;
+    this.vendorId = vendorId;
+    this.deviceType = deviceType;
+  }
+
+  @Override
+  public boolean isConnected() {
+    return this.connected;
+  }
+
+  @Override
+  public String getDeviceId() {
+    return this.deviceId;
+  }
+
+  @Override
+  public String getHostName() {
+    return this.hostName;
+  }
+
+  @Override
+  public String getDeviceName() {
+    return this.deviceName;
+  }
+
+  @Override
+  public String getInstanceName() {
+    return this.instanceName;
+  }
+
+  @Override
+  public int getNumberIPs() {
+    return this.numberIPs;
+  }
+
+  @Override
+  public List<InetAddress> getIpAddresses() {
+    return this.ipAddresses;
+  }
+
+  @Override
+  public int getPort() {
+    return this.port;
+  }
+
+  @Override
+  public int getVendorId() {
+    return this.vendorId;
+  }
+
+  @Override
+  public int getProductId() {
+    return this.productId;
+  }
+
+  @Override
+  public int getDeviceType() {
+    return this.deviceType;
+  }
+
+  @Override
+  public boolean discoveredCastingPlayerHasSameSource(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MatterCastingPlayer that = (MatterCastingPlayer) o;
+    return Objects.equals(deviceId, that.deviceId) && vendorId == that.vendorId;
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
@@ -16,36 +16,72 @@
  */
 package com.matter.casting.core;
 
-import android.util.Log;
+import com.matter.casting.support.MatterError;
 import java.util.List;
 
+/**
+ * MatterCastingPlayerDiscovery provides an API to control Matter Casting Player discovery over
+ * DNS-SD, and to collect discovery results. Discovery is centrally managed by the native C++ layer
+ * in the Matter SDK. This class exposes native functions to add and remove a
+ * CastingPlayerChangeListener, which contains the C++ to Java callbacks for when Casting Players
+ * are discovered, updated, or lost from the network. This class is a singleton.
+ */
 public final class MatterCastingPlayerDiscovery implements CastingPlayerDiscovery {
   private static final String TAG = MatterCastingPlayerDiscovery.class.getSimpleName();
   private static MatterCastingPlayerDiscovery matterCastingPlayerDiscoveryInstance;
 
   // Methods:
   public static MatterCastingPlayerDiscovery getInstance() {
-    Log.d(TAG, "MatterCastingPlayerDiscovery.getInstance() called");
     if (matterCastingPlayerDiscoveryInstance == null) {
       matterCastingPlayerDiscoveryInstance = new MatterCastingPlayerDiscovery();
     }
     return matterCastingPlayerDiscoveryInstance;
   };
 
+  /**
+   * @return a list of Casting Players discovered during the current discovery session. This list is
+   *     cleared when discovery stops.
+   */
   @Override
   public native List<CastingPlayer> getCastingPlayers();
 
+  /**
+   * Starts Casting Players discovery or returns an error.
+   *
+   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. 35
+   *     represents device type of Matter Casting Player.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
   @Override
-  public native com.matter.casting.support.MatterError startDiscovery();
+  public native MatterError startDiscovery(int discoveryTargetDeviceType);
 
+  /**
+   * Stops Casting Players discovery or returns an error.
+   *
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
   @Override
-  public native com.matter.casting.support.MatterError stopDiscovery();
+  public native MatterError stopDiscovery();
 
+  /**
+   * Adds a CastingPlayerChangeListener instance to be used during discovery. The
+   * CastingPlayerChangeListener contains the C++ to Java callbacks for when Casting Players are
+   * discovered, updated, or lost from the network. Should be called prior to calling
+   * MatterCastingPlayerDiscovery.startDiscovery().
+   *
+   * @param listener an instance of the CastingPlayerChangeListener to be implemented by the APIs
+   *     consumer.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
   @Override
-  public native com.matter.casting.support.MatterError addCastingPlayerChangeListener(
-      CastingPlayerChangeListener listener);
+  public native MatterError addCastingPlayerChangeListener(CastingPlayerChangeListener listener);
 
+  /**
+   * Removes CastingPlayerChangeListener from the native layer.
+   *
+   * @param listener the specific instance of CastingPlayerChangeListener to be removed.
+   * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
+   */
   @Override
-  public native com.matter.casting.support.MatterError removeCastingPlayerChangeListener(
-      CastingPlayerChangeListener listener);
+  public native MatterError removeCastingPlayerChangeListener(CastingPlayerChangeListener listener);
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
@@ -21,10 +21,9 @@ import java.util.List;
 
 /**
  * MatterCastingPlayerDiscovery provides an API to control Matter Casting Player discovery over
- * DNS-SD, and to collect discovery results. Discovery is centrally managed by the native C++ layer
- * in the Matter SDK. This class exposes native functions to add and remove a
- * CastingPlayerChangeListener, which contains the C++ to Java callbacks for when Casting Players
- * are discovered, updated, or lost from the network. This class is a singleton.
+ * DNS-SD, and to collect discovery results. This class provides methods to add and remove a
+ * CastingPlayerChangeListener, which contains the handlers for when Casting Players are discovered,
+ * updated, or lost from the network. This class is a singleton.
  */
 public final class MatterCastingPlayerDiscovery implements CastingPlayerDiscovery {
   private static final String TAG = MatterCastingPlayerDiscovery.class.getSimpleName();
@@ -48,12 +47,13 @@ public final class MatterCastingPlayerDiscovery implements CastingPlayerDiscover
   /**
    * Starts Casting Players discovery or returns an error.
    *
-   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. 35
-   *     represents device type of Matter Casting Player.
+   * @param discoveryTargetDeviceType the target device type to be discovered using DNS-SD. For
+   *     example: 35 represents device type of Matter Casting Video Player. If "null" is passed in,
+   *     discovery will default to all "_matterd._udp" device types.
    * @return a specific MatterError if the the operation failed or NO_ERROR if succeeded.
    */
   @Override
-  public native MatterError startDiscovery(int discoveryTargetDeviceType);
+  public native MatterError startDiscovery(Long discoveryTargetDeviceType);
 
   /**
    * Stops Casting Players discovery or returns an error.
@@ -65,7 +65,7 @@ public final class MatterCastingPlayerDiscovery implements CastingPlayerDiscover
 
   /**
    * Adds a CastingPlayerChangeListener instance to be used during discovery. The
-   * CastingPlayerChangeListener contains the C++ to Java callbacks for when Casting Players are
+   * CastingPlayerChangeListener defines the handler methods for when Casting Players are
    * discovered, updated, or lost from the network. Should be called prior to calling
    * MatterCastingPlayerDiscovery.startDiscovery().
    *

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.core;
+
+import android.util.Log;
+import java.util.List;
+
+public final class MatterCastingPlayerDiscovery implements CastingPlayerDiscovery {
+  private static final String TAG = MatterCastingPlayerDiscovery.class.getSimpleName();
+  private static MatterCastingPlayerDiscovery matterCastingPlayerDiscoveryInstance;
+
+  // Methods:
+  public static MatterCastingPlayerDiscovery getInstance() {
+    Log.d(TAG, "MatterCastingPlayerDiscovery.getInstance() called");
+    if (matterCastingPlayerDiscoveryInstance == null) {
+      matterCastingPlayerDiscoveryInstance = new MatterCastingPlayerDiscovery();
+    }
+    return matterCastingPlayerDiscoveryInstance;
+  };
+
+  @Override
+  public native List<CastingPlayer> getCastingPlayers();
+
+  @Override
+  public native com.matter.casting.support.MatterError startDiscovery();
+
+  @Override
+  public native com.matter.casting.support.MatterError stopDiscovery();
+
+  @Override
+  public native com.matter.casting.support.MatterError addCastingPlayerChangeListener(
+      CastingPlayerChangeListener listener);
+
+  @Override
+  public native com.matter.casting.support.MatterError removeCastingPlayerChangeListener(
+      CastingPlayerChangeListener listener);
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -47,7 +47,7 @@ jobject extractJAppParameter(jobject jAppParameters, const char * methodName, co
 JNI_METHOD(jobject, finishInitialization)(JNIEnv *, jobject, jobject jAppParameters)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "JNI_METHOD CastingAppJNI.finishInitialization called");
+    ChipLogProgress(AppServer, "JNI_METHOD CastingApp-JNI::finishInitialization() called");
     VerifyOrReturnValue(jAppParameters != nullptr, support::createJMatterError(CHIP_ERROR_INVALID_ARGUMENT));
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -81,7 +81,7 @@ JNI_METHOD(jobject, finishInitialization)(JNIEnv *, jobject, jobject jAppParamet
 JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "JNI_METHOD CastingAppJNI.finishStartup called");
+    ChipLogProgress(AppServer, "JNI_METHOD CastingAppJNI::finishStartup() called");
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     auto & server  = chip::Server::GetInstance();
@@ -107,7 +107,7 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
 
 jobject extractJAppParameter(jobject jAppParameters, const char * methodName, const char * methodSig)
 {
-    ChipLogProgress(AppServer, "JNI_METHOD extractJAppParameter called");
+    ChipLogProgress(AppServer, "JNI_METHOD CastingApp-JNI::extractJAppParameter() called");
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jclass jAppParametersClass;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
@@ -1,0 +1,289 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CastingPlayerDiscovery-JNI.h"
+
+#include "../JNIDACProvider.h"
+#include "../support/CastingPlayerConverter-JNI.h"
+#include "../support/ErrorConverter-JNI.h"
+#include "../support/RotatingDeviceIdUniqueIdProvider-JNI.h"
+#include "core/CastingApp.h"             // from tv-casting-common
+#include "core/CastingPlayerDiscovery.h" // from tv-casting-common
+
+#include <app/clusters/bindings/BindingManager.h>
+#include <app/server/Server.h>
+#include <jni.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+using namespace chip;
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_casting_core_MatterCastingPlayerDiscovery_##METHOD_NAME
+
+namespace matter {
+namespace casting {
+namespace core {
+
+/**
+ * @brief React to CastingPlayer discovery results with this sigleton
+ */
+class DiscoveryDelegateImpl : public DiscoveryDelegate
+{
+private:
+    DiscoveryDelegateImpl() {}
+    static DiscoveryDelegateImpl * discoveryDelegateImplSingletonInstance;
+    DiscoveryDelegateImpl(DiscoveryDelegateImpl & other) = delete;
+    void operator=(const DiscoveryDelegateImpl &)        = delete;
+
+public:
+    jobject castingPlayerChangeListenerJavaObject = nullptr;
+    jmethodID onAddedCallbackJavaMethodID         = nullptr;
+    jmethodID onChangedCallbackJavaMethodID       = nullptr;
+    // jmethodID onRemovedCallbackJavaMethodID = nullptr;
+
+    static DiscoveryDelegateImpl * GetInstance()
+    {
+        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::GetInstance() called");
+        if (DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance == nullptr)
+        {
+            ChipLogProgress(AppServer,
+                            "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::GetInstance() creating new singleton instance");
+            DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance = new DiscoveryDelegateImpl();
+        }
+        return DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance;
+    }
+
+    void HandleOnAdded(matter::casting::memory::Strong<CastingPlayer> player) override
+    {
+        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() called with CastingPlayer:");
+        player->LogDetail();
+
+        if (castingPlayerChangeListenerJavaObject == nullptr || onAddedCallbackJavaMethodID == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Not specified, "
+                         "CastingPlayerChangeListener == nullptr");
+        }
+        else
+        {
+            JNIEnv * env                          = JniReferences::GetInstance().GetEnvForCurrentThread();
+            jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
+            if (matterCastingPlayerJavaObject == nullptr)
+            {
+                ChipLogError(AppServer,
+                             "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Could not create "
+                             "CastingPlayer jobject");
+            }
+            else
+            {
+                env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onAddedCallbackJavaMethodID,
+                                    matterCastingPlayerJavaObject);
+            }
+        }
+    }
+
+    void HandleOnUpdated(matter::casting::memory::Strong<CastingPlayer> player) override
+    {
+        ChipLogProgress(AppServer,
+                        "CastingPlayerDiscovery-JNI DiscoveryDelegateImpl::HandleOnUpdated() called with CastingPlayer:");
+        player->LogDetail();
+
+        if (castingPlayerChangeListenerJavaObject == nullptr || onChangedCallbackJavaMethodID == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Not specified, "
+                         "CastingPlayerChangeListener == nullptr");
+        }
+        else
+        {
+            JNIEnv * env                          = JniReferences::GetInstance().GetEnvForCurrentThread();
+            jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
+            if (matterCastingPlayerJavaObject == nullptr)
+            {
+                ChipLogError(AppServer,
+                             "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Could not create "
+                             "CastingPlayer jobject");
+            }
+            else
+            {
+                env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onChangedCallbackJavaMethodID,
+                                    matterCastingPlayerJavaObject);
+            }
+        }
+    }
+
+    // TODO: In following PRs. Implement HandleOnRemoved after implemented in tv-casting-commom CastingPlayerDiscovery.h/cpp
+    // void HandleOnRemoved(matter::casting::memory::Strong<CastingPlayer> player) override
+    // {
+    //     ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI DiscoveryDelegateImpl::HandleOnRemoved() called with
+    //     CastingPlayer:"); player->LogDetail();
+    // }
+};
+
+// Initialize the static instance to nullptr
+DiscoveryDelegateImpl * DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance = nullptr;
+
+JNI_METHOD(jobject, startDiscovery)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::startDiscovery() called");
+    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
+    CastingPlayerDiscovery::GetInstance()->SetDelegate(delegate);
+
+    // Start CastingPlayer discovery
+    const uint64_t kTargetPlayerDeviceType = 35; // 35 represents device type of Matter Video Player
+    CHIP_ERROR err                         = CastingPlayerDiscovery::GetInstance()->StartDiscovery(kTargetPlayerDeviceType);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingPlayerDiscovery-JNI startDiscovery() err: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
+    // TODO: Verify error returned?
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+    return support::createJMatterError(CHIP_NO_ERROR);
+}
+
+JNI_METHOD(jobject, stopDiscovery)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::stopDiscovery() called");
+
+    // Stop CastingPlayer discovery
+    CHIP_ERROR err = CastingPlayerDiscovery::GetInstance()->StopDiscovery();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingPlayerDiscovery-JNI::StopDiscovery() err: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+    return support::createJMatterError(CHIP_NO_ERROR);
+}
+
+JNI_METHOD(jobject, addCastingPlayerChangeListener)(JNIEnv * env, jobject, jobject castingPlayerChangeListenerJavaObject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::addCastingPlayerChangeListener() called");
+    VerifyOrReturnValue(castingPlayerChangeListenerJavaObject != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+
+    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
+    if (delegate->castingPlayerChangeListenerJavaObject != nullptr)
+    {
+        ChipLogError(AppServer,
+                     "CastingPlayerDiscovery-JNI::addCastingPlayerChangeListener() Warning: Call removeCastingPlayerChangeListener "
+                     "before adding a new one");
+        return support::createJMatterError(CHIP_ERROR_INCORRECT_STATE);
+    }
+
+    // Get the class and method IDs for the CastingPlayerChangeListener Java class
+    jclass castingPlayerChangeListenerJavaClass = env->GetObjectClass(castingPlayerChangeListenerJavaObject);
+    VerifyOrReturnValue(castingPlayerChangeListenerJavaClass != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+
+    jmethodID onAddedJavaMethodID =
+        env->GetMethodID(castingPlayerChangeListenerJavaClass, "_onAdded", "(Lcom/matter/casting/core/CastingPlayer;)V");
+    VerifyOrReturnValue(onAddedJavaMethodID != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+    jmethodID onChangedJavaMethodID =
+        env->GetMethodID(castingPlayerChangeListenerJavaClass, "_onChanged", "(Lcom/matter/casting/core/CastingPlayer;)V");
+    VerifyOrReturnValue(onChangedJavaMethodID != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+    // jmethodID onRemovedJavaMethodID = env->GetMethodID(castingPlayerChangeListenerJavaClass, "_onRemoved",
+    // "(Lcom/matter/casting/core/CastingPlayer;)V"); VerifyOrReturnValue(onRemovedJavaMethodID != nullptr,
+    // support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
+
+    // Set Java callbacks in the DiscoveryDelegateImpl Singleton
+    delegate->castingPlayerChangeListenerJavaObject = env->NewGlobalRef(castingPlayerChangeListenerJavaObject);
+    delegate->onAddedCallbackJavaMethodID           = onAddedJavaMethodID;
+    delegate->onChangedCallbackJavaMethodID         = onChangedJavaMethodID;
+    // delegate->onRemovedCallbackJavaMethodID = onRemovedJavaMethodID;
+
+    return support::createJMatterError(CHIP_NO_ERROR);
+}
+
+JNI_METHOD(jobject, removeCastingPlayerChangeListener)(JNIEnv * env, jobject, jobject castingPlayerChangeListenerJavaObject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::removeCastingPlayerChangeListener() called");
+
+    // Remove the Java callbacks in the DiscoveryDelegateImpl Singleton
+    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
+
+    // Check if the passed object is the same as the one added in addCastingPlayerChangeListener() JNI method
+    jboolean isSameObject =
+        env->IsSameObject(castingPlayerChangeListenerJavaObject, delegate->castingPlayerChangeListenerJavaObject);
+
+    if ((bool) isSameObject)
+    {
+        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::removeCastingPlayerChangeListener() removing listener");
+
+        // Delete the global reference to the Java object
+        env->DeleteGlobalRef(delegate->castingPlayerChangeListenerJavaObject);
+        delegate->castingPlayerChangeListenerJavaObject = nullptr;
+        // No explicit cleanup required
+        delegate->onAddedCallbackJavaMethodID   = nullptr;
+        delegate->onChangedCallbackJavaMethodID = nullptr;
+        // delegate->onRemovedCallbackJavaMethodID = nullptr;
+
+        return support::createJMatterError(CHIP_NO_ERROR);
+    }
+    else
+    {
+        ChipLogError(AppServer,
+                     "CastingPlayerDiscovery-JNI::removeCastingPlayerChangeListener() Warning: Cannot remove listener. Received a "
+                     "different CastingPlayerChangeListener object");
+        return support::createJMatterError(CHIP_ERROR_INCORRECT_STATE);
+    }
+}
+
+JNI_METHOD(jobject, getCastingPlayers)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::getCastingPlayers() called");
+
+    // Create a new ArrayList
+    jclass arrayListClass          = env->FindClass("java/util/ArrayList");
+    jmethodID arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
+    jobject arrayList              = env->NewObject(arrayListClass, arrayListConstructor);
+    jmethodID addMethod            = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
+
+    std::vector<memory::Strong<CastingPlayer>> castingPlayersList = CastingPlayerDiscovery::GetInstance()->GetCastingPlayers();
+
+    for (const auto & player : castingPlayersList)
+    {
+        jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
+        if (matterCastingPlayerJavaObject != nullptr)
+        {
+            jboolean added = env->CallBooleanMethod(arrayList, addMethod, matterCastingPlayerJavaObject);
+            if ((bool) added)
+            {
+                ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::getCastingPlayers() added CastingPlayer with ID: %s",
+                                player->GetId());
+            }
+            else
+            {
+                ChipLogError(AppServer,
+                             "CastingPlayerDiscovery-JNI::getCastingPlayers() Warning: Unable to add CastingPlayer with ID: %s",
+                             player->GetId());
+            }
+        }
+    }
+
+    return arrayList;
+}
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
@@ -41,7 +41,7 @@ namespace casting {
 namespace core {
 
 /**
- * @brief React to CastingPlayer discovery results with this sigleton
+ * @brief React to CastingPlayer discovery results with this singleton
  */
 class DiscoveryDelegateImpl : public DiscoveryDelegate
 {
@@ -59,11 +59,8 @@ public:
 
     static DiscoveryDelegateImpl * GetInstance()
     {
-        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::GetInstance() called");
         if (DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance == nullptr)
         {
-            ChipLogProgress(AppServer,
-                            "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::GetInstance() creating new singleton instance");
             DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance = new DiscoveryDelegateImpl();
         }
         return DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance;
@@ -71,91 +68,80 @@ public:
 
     void HandleOnAdded(matter::casting::memory::Strong<CastingPlayer> player) override
     {
-        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() called with CastingPlayer:");
-        player->LogDetail();
+        ChipLogProgress(AppServer,
+                        "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() called with CastingPlayer, ID: %s",
+                        player->GetId());
 
-        if (castingPlayerChangeListenerJavaObject == nullptr || onAddedCallbackJavaMethodID == nullptr)
-        {
-            ChipLogError(AppServer,
-                         "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Not specified, "
-                         "CastingPlayerChangeListener == nullptr");
-        }
-        else
-        {
-            JNIEnv * env                          = JniReferences::GetInstance().GetEnvForCurrentThread();
-            jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
-            if (matterCastingPlayerJavaObject == nullptr)
-            {
-                ChipLogError(AppServer,
-                             "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Could not create "
-                             "CastingPlayer jobject");
-            }
-            else
-            {
-                env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onAddedCallbackJavaMethodID,
-                                    matterCastingPlayerJavaObject);
-            }
-        }
+        VerifyOrReturn(castingPlayerChangeListenerJavaObject != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Not set, "
+                                    "CastingPlayerChangeListener == nullptr"));
+        VerifyOrReturn(onAddedCallbackJavaMethodID != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Not set, "
+                                    "onAddedCallbackJavaMethodID == nullptr"));
+
+        jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
+        VerifyOrReturn(matterCastingPlayerJavaObject != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnAdded() Warning: Could not create "
+                                    "CastingPlayer jobject"));
+
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onAddedCallbackJavaMethodID, matterCastingPlayerJavaObject);
     }
 
     void HandleOnUpdated(matter::casting::memory::Strong<CastingPlayer> player) override
     {
         ChipLogProgress(AppServer,
-                        "CastingPlayerDiscovery-JNI DiscoveryDelegateImpl::HandleOnUpdated() called with CastingPlayer:");
-        player->LogDetail();
+                        "CastingPlayerDiscovery-JNI DiscoveryDelegateImpl::HandleOnUpdated() called with CastingPlayer, ID: %s",
+                        player->GetId());
 
-        if (castingPlayerChangeListenerJavaObject == nullptr || onChangedCallbackJavaMethodID == nullptr)
-        {
-            ChipLogError(AppServer,
-                         "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Not specified, "
-                         "CastingPlayerChangeListener == nullptr");
-        }
-        else
-        {
-            JNIEnv * env                          = JniReferences::GetInstance().GetEnvForCurrentThread();
-            jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
-            if (matterCastingPlayerJavaObject == nullptr)
-            {
-                ChipLogError(AppServer,
-                             "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Could not create "
-                             "CastingPlayer jobject");
-            }
-            else
-            {
-                env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onChangedCallbackJavaMethodID,
-                                    matterCastingPlayerJavaObject);
-            }
-        }
+        VerifyOrReturn(castingPlayerChangeListenerJavaObject != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Not set, "
+                                    "CastingPlayerChangeListener == nullptr"));
+        VerifyOrReturn(onChangedCallbackJavaMethodID != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Not set, "
+                                    "onChangedCallbackJavaMethodID == nullptr"));
+
+        jobject matterCastingPlayerJavaObject = support::createJCastingPlayer(player);
+        VerifyOrReturn(matterCastingPlayerJavaObject != nullptr,
+                       ChipLogError(AppServer,
+                                    "CastingPlayerDiscovery-JNI::DiscoveryDelegateImpl::HandleOnUpdated() Warning: Could not "
+                                    "create CastingPlayer jobject"));
+
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onChangedCallbackJavaMethodID, matterCastingPlayerJavaObject);
     }
 
     // TODO: In following PRs. Implement HandleOnRemoved after implemented in tv-casting-commom CastingPlayerDiscovery.h/cpp
     // void HandleOnRemoved(matter::casting::memory::Strong<CastingPlayer> player) override
     // {
     //     ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI DiscoveryDelegateImpl::HandleOnRemoved() called with
-    //     CastingPlayer:"); player->LogDetail();
+    //     CastingPlayer, ID: %s", player->GetId());
     // }
 };
 
 // Initialize the static instance to nullptr
 DiscoveryDelegateImpl * DiscoveryDelegateImpl::discoveryDelegateImplSingletonInstance = nullptr;
 
-JNI_METHOD(jobject, startDiscovery)(JNIEnv * env, jobject)
+JNI_METHOD(jobject, startDiscovery)(JNIEnv * env, jobject, jint discoveryTargetDeviceType)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::startDiscovery() called");
-    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
-    CastingPlayerDiscovery::GetInstance()->SetDelegate(delegate);
+    ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::startDiscovery() called with discoveryTargetDeviceType: %lu",
+                    (uint64_t) discoveryTargetDeviceType);
+    CastingPlayerDiscovery::GetInstance()->SetDelegate(DiscoveryDelegateImpl::GetInstance());
 
-    // Start CastingPlayer discovery
-    const uint64_t kTargetPlayerDeviceType = 35; // 35 represents device type of Matter Video Player
-    CHIP_ERROR err                         = CastingPlayerDiscovery::GetInstance()->StartDiscovery(kTargetPlayerDeviceType);
+    // Start CastingPlayer discovery, 35 represents device type of Matter Casting Player
+    CHIP_ERROR err = CastingPlayerDiscovery::GetInstance()->StartDiscovery((uint64_t) discoveryTargetDeviceType);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "CastingPlayerDiscovery-JNI startDiscovery() err: %" CHIP_ERROR_FORMAT, err.Format());
+        return support::createJMatterError(err);
     }
 
-    // TODO: Verify error returned?
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
     return support::createJMatterError(CHIP_NO_ERROR);
 }
 
@@ -169,9 +155,9 @@ JNI_METHOD(jobject, stopDiscovery)(JNIEnv * env, jobject)
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "CastingPlayerDiscovery-JNI::StopDiscovery() err: %" CHIP_ERROR_FORMAT, err.Format());
+        return support::createJMatterError(err);
     }
 
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
     return support::createJMatterError(CHIP_NO_ERROR);
 }
 
@@ -181,8 +167,7 @@ JNI_METHOD(jobject, addCastingPlayerChangeListener)(JNIEnv * env, jobject, jobje
     ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::addCastingPlayerChangeListener() called");
     VerifyOrReturnValue(castingPlayerChangeListenerJavaObject != nullptr, support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
 
-    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
-    if (delegate->castingPlayerChangeListenerJavaObject != nullptr)
+    if (DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject != nullptr)
     {
         ChipLogError(AppServer,
                      "CastingPlayerDiscovery-JNI::addCastingPlayerChangeListener() Warning: Call removeCastingPlayerChangeListener "
@@ -205,10 +190,11 @@ JNI_METHOD(jobject, addCastingPlayerChangeListener)(JNIEnv * env, jobject, jobje
     // support::createJMatterError(CHIP_ERROR_INCORRECT_STATE));
 
     // Set Java callbacks in the DiscoveryDelegateImpl Singleton
-    delegate->castingPlayerChangeListenerJavaObject = env->NewGlobalRef(castingPlayerChangeListenerJavaObject);
-    delegate->onAddedCallbackJavaMethodID           = onAddedJavaMethodID;
-    delegate->onChangedCallbackJavaMethodID         = onChangedJavaMethodID;
-    // delegate->onRemovedCallbackJavaMethodID = onRemovedJavaMethodID;
+    DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject =
+        env->NewGlobalRef(castingPlayerChangeListenerJavaObject);
+    DiscoveryDelegateImpl::GetInstance()->onAddedCallbackJavaMethodID   = onAddedJavaMethodID;
+    DiscoveryDelegateImpl::GetInstance()->onChangedCallbackJavaMethodID = onChangedJavaMethodID;
+    // DiscoveryDelegateImpl::GetInstance()->onRemovedCallbackJavaMethodID = onRemovedJavaMethodID;
 
     return support::createJMatterError(CHIP_NO_ERROR);
 }
@@ -218,24 +204,20 @@ JNI_METHOD(jobject, removeCastingPlayerChangeListener)(JNIEnv * env, jobject, jo
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::removeCastingPlayerChangeListener() called");
 
-    // Remove the Java callbacks in the DiscoveryDelegateImpl Singleton
-    DiscoveryDelegateImpl * delegate = DiscoveryDelegateImpl::GetInstance();
-
     // Check if the passed object is the same as the one added in addCastingPlayerChangeListener() JNI method
-    jboolean isSameObject =
-        env->IsSameObject(castingPlayerChangeListenerJavaObject, delegate->castingPlayerChangeListenerJavaObject);
+    jboolean isSameObject = env->IsSameObject(castingPlayerChangeListenerJavaObject,
+                                              DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject);
 
     if ((bool) isSameObject)
     {
-        ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::removeCastingPlayerChangeListener() removing listener");
-
         // Delete the global reference to the Java object
-        env->DeleteGlobalRef(delegate->castingPlayerChangeListenerJavaObject);
-        delegate->castingPlayerChangeListenerJavaObject = nullptr;
+        env->DeleteGlobalRef(DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject);
+        // Remove the Java callbacks in the DiscoveryDelegateImpl Singleton
+        DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject = nullptr;
         // No explicit cleanup required
-        delegate->onAddedCallbackJavaMethodID   = nullptr;
-        delegate->onChangedCallbackJavaMethodID = nullptr;
-        // delegate->onRemovedCallbackJavaMethodID = nullptr;
+        DiscoveryDelegateImpl::GetInstance()->onAddedCallbackJavaMethodID   = nullptr;
+        DiscoveryDelegateImpl::GetInstance()->onChangedCallbackJavaMethodID = nullptr;
+        // DiscoveryDelegateImpl::GetInstance()->onRemovedCallbackJavaMethodID = nullptr;
 
         return support::createJMatterError(CHIP_NO_ERROR);
     }
@@ -267,12 +249,7 @@ JNI_METHOD(jobject, getCastingPlayers)(JNIEnv * env, jobject)
         if (matterCastingPlayerJavaObject != nullptr)
         {
             jboolean added = env->CallBooleanMethod(arrayList, addMethod, matterCastingPlayerJavaObject);
-            if ((bool) added)
-            {
-                ChipLogProgress(AppServer, "CastingPlayerDiscovery-JNI::getCastingPlayers() added CastingPlayer with ID: %s",
-                                player->GetId());
-            }
-            else
+            if (!((bool) added))
             {
                 ChipLogError(AppServer,
                              "CastingPlayerDiscovery-JNI::getCastingPlayers() Warning: Unable to add CastingPlayer with ID: %s",

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+
+namespace matter {
+namespace casting {
+namespace core {
+
+class CastingPlayerDiscoveryJNI
+{
+public:
+private:
+    friend CastingPlayerDiscoveryJNI & CastingAppJNIMgr();
+    static CastingPlayerDiscoveryJNI sInstance;
+};
+
+inline class CastingPlayerDiscoveryJNI & CastingAppJNIMgr()
+{
+    return CastingPlayerDiscoveryJNI::sInstance;
+}
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
@@ -52,17 +52,7 @@ jobject createJCastingPlayer(matter::casting::memory::Strong<core::CastingPlayer
     }
 
     // Convert the CastingPlayer fields to MatterCastingPlayer Java types
-    bool connected = false;
-    if (player->IsConnected())
-    {
-        connected = true;
-    }
-    jboolean connectedJavaBoolean  = static_cast<jboolean>(connected);
-    jstring idJavaString           = env->NewStringUTF(player->GetId());
-    jstring deviceNameJavaString   = env->NewStringUTF(player->GetDeviceName());
-    jstring hostNameJavaString     = env->NewStringUTF(player->GetHostName());
-    jstring instanceNameJavaString = env->NewStringUTF(player->GetInstanceName());
-    jint numIPsJavaInt             = (jint) (player->GetNumIPs());
+    bool connected = player->IsConnected() ? true : false;
 
     jobject ipAddressListJavaObject           = nullptr;
     const chip::Inet::IPAddress * ipAddresses = player->GetIPAddresses();
@@ -84,17 +74,14 @@ jobject createJCastingPlayer(matter::casting::memory::Strong<core::CastingPlayer
         }
     }
 
-    jint portJavaInt       = (jint) (player->GetPort());
-    jint productIdJavaInt  = (jint) (player->GetProductId());
-    jint vendorIdJavaInt   = (jint) (player->GetVendorId());
-    jint deviceTypeJavaInt = (jint) (player->GetDeviceType());
-
     // Create a new instance of the MatterCastingPlayer Java class
     jobject matterCastingPlayerJavaObject = nullptr;
     matterCastingPlayerJavaObject =
-        env->NewObject(matterCastingPlayerJavaClass, constructor, connectedJavaBoolean, idJavaString, hostNameJavaString,
-                       deviceNameJavaString, instanceNameJavaString, numIPsJavaInt, ipAddressListJavaObject, portJavaInt,
-                       productIdJavaInt, vendorIdJavaInt, deviceTypeJavaInt);
+        env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(connected),
+                       env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
+                       env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()),
+                       (jint) (player->GetNumIPs()), ipAddressListJavaObject, (jint) (player->GetPort()),
+                       (jint) (player->GetProductId()), (jint) (player->GetVendorId()), (jint) (player->GetDeviceType()));
     if (matterCastingPlayerJavaObject == nullptr)
     {
         ChipLogError(AppServer,

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
@@ -1,0 +1,108 @@
+/*
+ *   Copyright (c) 2023 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CastingPlayerConverter-JNI.h"
+#include <lib/support/JniReferences.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+using namespace chip;
+
+jobject createJCastingPlayer(matter::casting::memory::Strong<core::CastingPlayer> player)
+{
+    ChipLogProgress(AppServer, "CastingPlayerConverter-JNI.createJCastingPlayer() called");
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+    // Get a reference to the MatterCastingPlayer Java class
+    jclass matterCastingPlayerJavaClass = env->FindClass("com/matter/casting/core/MatterCastingPlayer");
+    if (matterCastingPlayerJavaClass == nullptr)
+    {
+        ChipLogError(AppServer,
+                     "CastingPlayerConverter-JNI.createJCastingPlayer() could not locate MatterCastingPlayer Java class");
+        return nullptr;
+    }
+
+    // Get the constructor for the com/matter/casting/core/MatterCastingPlayer Java class
+    jmethodID constructor =
+        env->GetMethodID(matterCastingPlayerJavaClass, "<init>",
+                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;IIII)V");
+    if (constructor == nullptr)
+    {
+        ChipLogError(
+            AppServer,
+            "CastingPlayerConverter-JNI.createJCastingPlayer() could not locate MatterCastingPlayer Java class constructor");
+        return nullptr;
+    }
+
+    // Convert the CastingPlayer fields to MatterCastingPlayer Java types
+    bool connected = false;
+    if (player->IsConnected())
+    {
+        connected = true;
+    }
+    jboolean connectedJavaBoolean  = static_cast<jboolean>(connected);
+    jstring idJavaString           = env->NewStringUTF(player->GetId());
+    jstring deviceNameJavaString   = env->NewStringUTF(player->GetDeviceName());
+    jstring hostNameJavaString     = env->NewStringUTF(player->GetHostName());
+    jstring instanceNameJavaString = env->NewStringUTF(player->GetInstanceName());
+    jint numIPsJavaInt             = (jint) (player->GetNumIPs());
+
+    jobject ipAddressListJavaObject           = nullptr;
+    const chip::Inet::IPAddress * ipAddresses = player->GetIPAddresses();
+    if (ipAddresses != nullptr)
+    {
+        chip::JniReferences::GetInstance().CreateArrayList(ipAddressListJavaObject);
+        for (size_t i = 0; i < player->GetNumIPs() && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
+        {
+            char addrCString[chip::Inet::IPAddress::kMaxStringLength];
+            ipAddresses[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+            jstring jIPAddressStr = env->NewStringUTF(addrCString);
+
+            jclass jIPAddressClass = env->FindClass("java/net/InetAddress");
+            jmethodID jGetByNameMid =
+                env->GetStaticMethodID(jIPAddressClass, "getByName", "(Ljava/lang/String;)Ljava/net/InetAddress;");
+            jobject jIPAddress = env->CallStaticObjectMethod(jIPAddressClass, jGetByNameMid, jIPAddressStr);
+
+            chip::JniReferences::GetInstance().AddToList(ipAddressListJavaObject, jIPAddress);
+        }
+    }
+
+    jint portJavaInt       = (jint) (player->GetPort());
+    jint productIdJavaInt  = (jint) (player->GetProductId());
+    jint vendorIdJavaInt   = (jint) (player->GetVendorId());
+    jint deviceTypeJavaInt = (jint) (player->GetDeviceType());
+
+    // Create a new instance of the MatterCastingPlayer Java class
+    jobject matterCastingPlayerJavaObject = nullptr;
+    matterCastingPlayerJavaObject =
+        env->NewObject(matterCastingPlayerJavaClass, constructor, connectedJavaBoolean, idJavaString, hostNameJavaString,
+                       deviceNameJavaString, instanceNameJavaString, numIPsJavaInt, ipAddressListJavaObject, portJavaInt,
+                       productIdJavaInt, vendorIdJavaInt, deviceTypeJavaInt);
+    if (matterCastingPlayerJavaObject == nullptr)
+    {
+        ChipLogError(AppServer,
+                     "CastingPlayerConverter-JNI.createJCastingPlayer() Warning: Could not create MatterCastingPlayer Java object");
+    }
+    return matterCastingPlayerJavaObject;
+}
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2023-2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include "core/CastingPlayer.h"
+
+#include <lib/core/CHIPError.h>
+
+#include <jni.h>
+
+namespace matter {
+namespace casting {
+namespace support {
+
+/**
+ * @brief Convertes a native CastingPlayer into a MatterCastingPlayer jobject
+ *
+ * @param CastingPlayer represents a Matter commissioner that is able to play media to a physical
+ * output or to a display screen which is part of the device.
+ *
+ * @return pointer to the CastingPlayer jobject if created successfully, nullptr otherwise.
+ */
+jobject createJCastingPlayer(matter::casting::memory::Strong<core::CastingPlayer> player);
+
+}; // namespace support
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
@@ -35,7 +35,7 @@ jobject createJMatterError(CHIP_ERROR inErr)
 
     jmethodID jMatterErrorConstructor = env->GetMethodID(jMatterErrorClass, "<init>", "(JLjava/lang/String;)V");
 
-    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, err.AsInteger(), nullptr);
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, inErr.AsInteger(), nullptr);
 }
 
 }; // namespace support

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/activity_main.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="MainActivity">
+    tools:context=".chip.casting.app.MainActivity">
 
     <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/main_fragment_container"

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_cert_test_launcher.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_cert_test_launcher.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".CertTestFragment">
+    tools:context=".chip.casting.app.CertTestFragment">
 
 
     <LinearLayout

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_connection.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_connection.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ConnectionFragment"
+    tools:context=".chip.casting.app.ConnectionFragment"
     android:padding="10sp">
 
     <TextView

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_content_launcher.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_content_launcher.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ContentLauncherFragment">
+    tools:context=".chip.casting.app.ContentLauncherFragment">
 
 
     <LinearLayout

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_discovery_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_discovery_example.xml
@@ -3,10 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".chip.casting.app.CommissionerDiscoveryFragment">
+    tools:context=".matter.casting.DiscoveryExampleFragment">
 
     <LinearLayout
-        android:id="@+id/castingCommissioners"
+        android:id="@+id/castingPlayers"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -15,31 +15,33 @@
         android:padding="10sp">
 
         <Button
-            android:id="@+id/purgeCacheButton"
+            android:id="@+id/startDiscoveryButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Purge Cache" />
+            android:text="@string/matter_start_discovery_button_text" />
 
         <Button
-            android:id="@+id/manualCommissioningButton"
+            android:id="@+id/stopDiscoveryButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Skip to manual commissioning >>" />
+            android:text="@string/matter_stop_discovery_button_text" />
 
         <Button
-            android:id="@+id/discoverButton"
+            android:id="@+id/clearDiscoveryResultsButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Discover>" />
+            android:text="@string/matter_clear_results_button_text" />
 
         <TextView
+            android:id="@+id/matterDiscoveryMessageTextView"
+            android:text="string/matter_discovery_message_default_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/discovery_message_text"
+            android:textAlignment="center"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
         <ListView
-            android:id = "@+id/commissionerList"
+            android:id = "@+id/castingPlayerList"
             android:layout_width = "match_parent"
             android:layout_height = "wrap_content"
             android:fadeScrollbars = "false" />

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_discovery_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_discovery_example.xml
@@ -15,12 +15,14 @@
         android:padding="10sp">
 
         <Button
+            android:enabled="false"
             android:id="@+id/startDiscoveryButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/matter_start_discovery_button_text" />
 
         <Button
+            android:enabled="false"
             android:id="@+id/stopDiscoveryButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_media_playback.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_media_playback.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MediaPlaybackFragment">
+    tools:context=".chip.casting.app.MediaPlaybackFragment">
 
 
     <LinearLayout

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_select_cluster.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_select_cluster.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".SelectClusterFragment">
+    tools:context=".chip.casting.app.SelectClusterFragment">
 
     <RelativeLayout
         android:layout_width="wrap_content"

--- a/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
@@ -31,6 +31,6 @@
     <string name="matter_stop_discovery_button_text">Stop Discovery"</string>
     <string name="matter_clear_results_button_text">Clear Results"</string>
     <string name="matter_discovery_message_initializing_text">Initializing</string>
-    <string name="matter_discovery_message_discovering_text">Discovering Casting Players on-network</string>
+    <string name="matter_discovery_message_discovering_text">Casting Players on-network:</string>
     <string name="matter_discovery_message_stopped_text">Discovery Stopped</string>
 </resources>

--- a/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
@@ -26,4 +26,11 @@
     <string name="endpoint_prompt_text">Endpoint ID</string>
     <string name="shutdown_all_subscriptions_button_text">Shutdown all Subscriptions</string>
     <string name="disconnect_button_text">Disconnect from Video Player</string>
+
+    <string name="matter_start_discovery_button_text">Start Discovery"</string>
+    <string name="matter_stop_discovery_button_text">Stop Discovery"</string>
+    <string name="matter_clear_results_button_text">Clear Results"</string>
+    <string name="matter_discovery_message_initializing_text">Initializing</string>
+    <string name="matter_discovery_message_discovering_text">Discovering Casting Players on-network</string>
+    <string name="matter_discovery_message_stopped_text">Discovery Stopped</string>
 </resources>

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -38,6 +38,10 @@ shared_library("jni") {
   sources += [
     "App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp",
     "App/app/src/main/jni/cpp/core/CastingApp-JNI.h",
+    "App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp",
+    "App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.h",
+    "App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp",
+    "App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.h",
     "App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp",
     "App/app/src/main/jni/cpp/support/ErrorConverter-JNI.h",
     "App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp",
@@ -97,6 +101,10 @@ android_library("java") {
   sources += [
     "App/app/src/main/jni/com/matter/casting/core/CastingApp.java",
     "App/app/src/main/jni/com/matter/casting/core/CastingAppState.java",
+    "App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java",
+    "App/app/src/main/jni/com/matter/casting/core/CastingPlayerDiscovery.java",
+    "App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java",
+    "App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java",
     "App/app/src/main/jni/com/matter/casting/support/AppParameters.java",
     "App/app/src/main/jni/com/matter/casting/support/CommissionableData.java",
     "App/app/src/main/jni/com/matter/casting/support/DACProvider.java",

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -46,6 +46,7 @@ CastingApp * CastingApp::GetInstance()
 
 CHIP_ERROR CastingApp::Initialize(const AppParameters & appParameters)
 {
+    ChipLogProgress(Discovery, "CastingApp::Initialize() called");
     VerifyOrReturnError(mState == CASTING_APP_UNINITIALIZED, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(appParameters.GetCommissionableDataProvider() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(appParameters.GetDeviceAttestationCredentialsProvider() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -83,6 +84,7 @@ CHIP_ERROR CastingApp::Initialize(const AppParameters & appParameters)
 
 CHIP_ERROR CastingApp::Start()
 {
+    ChipLogProgress(Discovery, "CastingApp::Start() called");
     VerifyOrReturnError(mState == CASTING_APP_NOT_RUNNING, CHIP_ERROR_INCORRECT_STATE);
 
     // start Matter server
@@ -98,6 +100,7 @@ CHIP_ERROR CastingApp::Start()
 
 CHIP_ERROR CastingApp::PostStartRegistrations()
 {
+    ChipLogProgress(Discovery, "CastingApp::PostStartRegistrations() called");
     VerifyOrReturnError(mState == CASTING_APP_NOT_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     auto & server = chip::Server::GetInstance();
 
@@ -120,6 +123,7 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
 
 CHIP_ERROR CastingApp::Stop()
 {
+    ChipLogProgress(Discovery, "CastingApp::Stop() called");
     VerifyOrReturnError(mState == CASTING_APP_RUNNING, CHIP_ERROR_INCORRECT_STATE);
 
     // TODO: add logic to capture CastingPlayers that we are currently connected to, so we can automatically reconnect with them on

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -221,7 +221,7 @@ void CastingPlayer::LogDetail() const
     }
     if (strlen(mAttributes.deviceName) != 0)
     {
-        ChipLogDetail(AppServer, "\tName: %s", mAttributes.deviceName);
+        ChipLogDetail(AppServer, "\tDevice Name: %s", mAttributes.deviceName);
     }
     if (strlen(mAttributes.hostName) != 0)
     {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -40,7 +40,7 @@ CastingPlayerDiscovery * CastingPlayerDiscovery::GetInstance()
     return _castingPlayerDiscovery;
 }
 
-CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint64_t deviceTypeFilter)
+CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::StartDiscovery() called");
     VerifyOrReturnError(mState == DISCOVERY_READY, CHIP_ERROR_INCORRECT_STATE);

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -42,7 +42,7 @@ CastingPlayerDiscovery * CastingPlayerDiscovery::GetInstance()
 
 CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint64_t deviceTypeFilter)
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StartDiscovery called");
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StartDiscovery() called");
     VerifyOrReturnError(mState == DISCOVERY_READY, CHIP_ERROR_INCORRECT_STATE);
 
     mCommissionableNodeController.RegisterDeviceDiscoveryDelegate(&mDelegate);
@@ -63,9 +63,11 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint64_t deviceTypeFilter)
 
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() called");
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
+    mCastingPlayers.clear();
     mState = DISCOVERY_READY;
 
     return CHIP_NO_ERROR;
@@ -73,7 +75,7 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 
 void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
-    ChipLogProgress(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice called");
+    ChipLogProgress(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice() called");
     VerifyOrReturn(mClientDelegate != nullptr,
                    ChipLogError(NotSpecified, "CastingPlayerDeviceDiscoveryDelegate, mClientDelegate is a nullptr"));
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -101,7 +101,7 @@ public:
      * with CastingPlayers whose deviceType matches filterBydeviceType
      * @return CHIP_ERROR - CHIP_NO_ERROR if discovery for CastingPlayers started successfully, specific error code otherwise.
      */
-    CHIP_ERROR StartDiscovery(uint64_t filterBydeviceType = 0);
+    CHIP_ERROR StartDiscovery(uint32_t filterBydeviceType = 0);
 
     /**
      * @brief Stop the discovery for CastingPlayers

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -112,6 +112,7 @@ public:
 
     void SetDelegate(DiscoveryDelegate * clientDelegate)
     {
+        ChipLogProgress(Discovery, "CastingPlayerDiscovery::SetDelegate() called");
         if (clientDelegate == nullptr)
         {
             mState = DISCOVERY_NOT_READY;


### PR DESCRIPTION
This change implements and demonstrates the use of a simplified Casting Player discovery API on Android. This simplified API delegates the work to the common discovery implantation in Native. 

**Change summary**
1.	CastingPlayerDiscovery.java and its inner class CastingPlayerChangeListener are now responsible for controlling discovery and passing the callbacks to the Native layer. The CastingPlayerChangeListener interface provides the onAdded(), onChanged() and onRemoved() callbacks, which are called from the Native layer. These callbacks provide the Casting Players to be consumed by the UX/CX.
2.	Implemented the corresponding JNI functions defined in CastingPlayerDiscovery.java. These delegate to the common implementation.
3.	Provided an example of how to use the simplified discovery API in DiscoveryExampleFragment.java

**Testing**
Verified and tested locally with the Android tv-casting-app example app. The example app is able to discover and display the Casting Players on screen.
