### PR TITLE
Introduce a Status + Cluster Code abstraction

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -248,7 +248,7 @@ executable("darwin-framework-tool") {
 
       # pics is needed by tests
       "${chip_root}/src/app/tests/suites/pics",
-      "${chip_root}/src/protocols:im_status",
+      "${chip_root}/src/protocols/interaction_model",
     ]
 
     defines = []

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -60,6 +60,7 @@ if (chip_build_tests) {
       "${chip_root}/src/lib/core/tests",
       "${chip_root}/src/messaging/tests",
       "${chip_root}/src/protocols/bdx/tests",
+      "${chip_root}/src/protocols/interaction_model/tests",
       "${chip_root}/src/protocols/user_directed_commissioning/tests",
       "${chip_root}/src/transport/retransmit/tests",
     ]

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -250,8 +250,8 @@ static_library("app") {
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
-    "${chip_root}/src/protocols/secure_channel",
     "${chip_root}/src/protocols/interaction_model",
+    "${chip_root}/src/protocols/secure_channel",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -251,6 +251,7 @@ static_library("app") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/protocols/secure_channel",
+    "${chip_root}/src/protocols/interaction_model",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -27,6 +27,7 @@ static_library("cluster-objects") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/protocols/interaction_model",
   ]
 
   defines = []

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -22,6 +22,7 @@
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/UnitTestRegistration.h>
+#include <src/protocols/interaction_model/StatusCode.h>
 
 #include <nlunit-test.h>
 

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -22,7 +22,7 @@
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/UnitTestRegistration.h>
-#include <src/protocols/interaction_model/StatusCode.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 #include <nlunit-test.h>
 

--- a/src/protocols/BUILD.gn
+++ b/src/protocols/BUILD.gn
@@ -38,27 +38,12 @@ static_library("protocols") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
-    ":im_status",
     ":type_definitions",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/protocols/bdx",
+    "${chip_root}/src/protocols/interaction_model",
     "${chip_root}/src/protocols/secure_channel",
-  ]
-}
-
-static_library("im_status") {
-  sources = [
-    "interaction_model/StatusCode.cpp",
-    "interaction_model/StatusCode.h",
-  ]
-
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
-    ":type_definitions",
-    "${chip_root}/src/lib/core",
-    "${chip_root}/src/lib/support",
   ]
 }

--- a/src/protocols/interaction_model/BUILD.gn
+++ b/src/protocols/interaction_model/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 static_library("interaction_model") {
-  output_name = "libInteractionModelCommands"
+  output_name = "libInteractionModel"
 
   sources = [
-    "InteractionModel.cpp",
-    "InteractionModel.h",
+    "Constants.h",
+    "StatusCode.cpp",
+    "StatusCode.h",
+    "StatusCodeList.h",
   ]
 
   cflags = [ "-Wconversion" ]
 
   public_deps = [
-    "${chip_root}/src/app",
+    "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/lib/support:testing",
   ]
 }

--- a/src/protocols/interaction_model/BUILD.gn
+++ b/src/protocols/interaction_model/BUILD.gn
@@ -29,5 +29,6 @@ static_library("interaction_model") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/protocols:type_definitions",
   ]
 }

--- a/src/protocols/interaction_model/StatusCode.h
+++ b/src/protocols/interaction_model/StatusCode.h
@@ -64,28 +64,24 @@ const char * StatusName(Status status);
  */
 class StatusCode
 {
-  public:
+public:
     explicit StatusCode(Status status) : mStatus(status) {}
 
     // We only have simple copyable members, so we should be trivially copyable.
-    StatusCode(const StatusCode & other) = default;
+    StatusCode(const StatusCode & other)             = default;
     StatusCode & operator=(const StatusCode & other) = default;
 
-    bool operator==(const StatusCode &other)
+    bool operator==(const StatusCode & other)
     {
-        return (this->mStatus == other.mStatus)
-            && (this->HasClusterSpecificCode() == other.HasClusterSpecificCode())
-            && (this->GetClusterSpecificCode() == other.GetClusterSpecificCode());
+        return (this->mStatus == other.mStatus) && (this->HasClusterSpecificCode() == other.HasClusterSpecificCode()) &&
+            (this->GetClusterSpecificCode() == other.GetClusterSpecificCode());
     }
 
-    bool operator!=(const StatusCode &other)
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const StatusCode & other) { return !(*this == other); }
 
     StatusCode & operator=(const Status & status)
     {
-        this->mStatus = status;
+        this->mStatus              = status;
         this->mClusterSpecificCode = chip::NullOptional;
         return *this;
     }
@@ -146,9 +142,11 @@ class StatusCode
     operator int() const { return static_cast<int>(mStatus); }
     operator uint8_t() const { return static_cast<uint8_t>(mStatus); }
 
-  private:
+private:
     StatusCode() = delete;
-    StatusCode(Status status, uint8_t cluster_specific_code) : mStatus(status), mClusterSpecificCode(chip::MakeOptional(cluster_specific_code)) { }
+    StatusCode(Status status, uint8_t cluster_specific_code) :
+        mStatus(status), mClusterSpecificCode(chip::MakeOptional(cluster_specific_code))
+    {}
 
     Status mStatus;
     chip::Optional<uint8_t> mClusterSpecificCode;

--- a/src/protocols/interaction_model/StatusCode.h
+++ b/src/protocols/interaction_model/StatusCode.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <limits>
 #include <stdint.h>
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/Optional.h>
 #include <lib/support/TypeTraits.h>
 
 #if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
@@ -47,6 +49,110 @@ enum class Status : uint8_t
 #if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
 const char * StatusName(Status status);
 #endif // CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
+
+/**
+ * @brief Class to encapsulate a Status code, including possibly a
+ *        cluster-specific code for generic SUCCESS/FAILURE.
+ *
+ * This can be used everywhere a `Status` is used, but it is lossy
+ * to the cluster-specific code if used in place of `Status` when
+ * the cluster-specific code is set.
+ *
+ * This class can only be directly constructed from a `Status`. To
+ * attach a cluster-specific-code, please use the `ClusterSpecificFailure`
+ * and `ClusterSpecificSuccess` factory methods.
+ */
+class StatusCode
+{
+  public:
+    explicit StatusCode(Status status) : mStatus(status) {}
+
+    // We only have simple copyable members, so we should be trivially copyable.
+    StatusCode(const StatusCode & other) = default;
+    StatusCode & operator=(const StatusCode & other) = default;
+
+    bool operator==(const StatusCode &other)
+    {
+        return (this->mStatus == other.mStatus)
+            && (this->HasClusterSpecificCode() == other.HasClusterSpecificCode())
+            && (this->GetClusterSpecificCode() == other.GetClusterSpecificCode());
+    }
+
+    bool operator!=(const StatusCode &other)
+    {
+        return !(*this == other);
+    }
+
+    StatusCode & operator=(const Status & status)
+    {
+        this->mStatus = status;
+        this->mClusterSpecificCode = chip::NullOptional;
+        return *this;
+    }
+
+    /**
+     * @brief Builder for a cluster-specific failure status code.
+     *
+     * @tparam T - enum type for the cluster-specific status code
+     *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum)
+     * @param cluster_specific_code - cluster-specific code to record with the failure
+     *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen)
+     * @return a StatusCode instance properly configured.
+     */
+    template <typename T>
+    static StatusCode ClusterSpecificFailure(T cluster_specific_code)
+    {
+        static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<uint8_t>::max(), "Type used must fit in uint8_t");
+        return StatusCode(Status::Failure, static_cast<uint8_t>(cluster_specific_code));
+    }
+
+    /**
+     * @brief Builder for a cluster-specific success status code.
+     *
+     * @tparam T - enum type for the cluster-specific status code
+     *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum)
+     * @param cluster_specific_code - cluster-specific code to record with the success
+     *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kBasicWindowOpen)
+     * @return a StatusCode instance properly configured.
+     */
+    template <typename T>
+    static StatusCode ClusterSpecificSuccess(T cluster_specific_code)
+    {
+        static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<uint8_t>::max(), "Type used must fit in uint8_t");
+        return StatusCode(Status::Success, static_cast<uint8_t>(cluster_specific_code));
+    }
+
+    /// @return true if the core Status associated with this StatusCode is the one for success.
+    bool IsSuccess() const { return mStatus == Status::Success; }
+
+    /// @return the core Status code associated withi this StatusCode.
+    Status GetStatus() const { return mStatus; }
+
+    /// @return true if a cluster-specific code is associated with the StatusCode.
+    bool HasClusterSpecificCode() const { return mClusterSpecificCode.HasValue(); }
+
+    /// @return the cluster-specific code associated with this StatusCode or chip::NullOptional if none is associated.
+    chip::Optional<uint8_t> GetClusterSpecificCode() const
+    {
+        if (!mClusterSpecificCode.HasValue() || !((mStatus == Status::Failure) || (mStatus == Status::Success)))
+        {
+            return chip::NullOptional;
+        }
+        return mClusterSpecificCode;
+    }
+
+    // Automatic conversions to common types, using the status code alone.
+    operator Status() const { return mStatus; }
+    operator int() const { return static_cast<int>(mStatus); }
+    operator uint8_t() const { return static_cast<uint8_t>(mStatus); }
+
+  private:
+    StatusCode() = delete;
+    StatusCode(Status status, uint8_t cluster_specific_code) : mStatus(status), mClusterSpecificCode(chip::MakeOptional(cluster_specific_code)) { }
+
+    Status mStatus;
+    chip::Optional<uint8_t> mClusterSpecificCode;
+};
 
 } // namespace InteractionModel
 } // namespace Protocols

--- a/src/protocols/interaction_model/tests/BUILD.gn
+++ b/src/protocols/interaction_model/tests/BUILD.gn
@@ -21,9 +21,7 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite_using_nltest("tests") {
   output_name = "libInteractionModelTests"
 
-  test_sources = [
-    "TestStatusCode.cpp",
-  ]
+  test_sources = [ "TestStatusCode.cpp" ]
 
   public_deps = [
     "${chip_root}/src/lib/core",

--- a/src/protocols/interaction_model/tests/BUILD.gn
+++ b/src/protocols/interaction_model/tests/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2023 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,24 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/nlunit_test.gni")
 
-static_library("interaction_model") {
-  output_name = "libInteractionModelCommands"
+import("${chip_root}/build/chip/chip_test_suite.gni")
 
-  sources = [
-    "InteractionModel.cpp",
-    "InteractionModel.h",
+chip_test_suite_using_nltest("tests") {
+  output_name = "libInteractionModelTests"
+
+  test_sources = [
+    "TestStatusCode.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/lib/support:testing",
+    "${chip_root}/src/protocols/interaction_model",
+    "${nlunit_test_root}:nlunit-test",
   ]
 
   cflags = [ "-Wconversion" ]
-
-  public_deps = [
-    "${chip_root}/src/app",
-    "${chip_root}/src/lib/support",
-    "${chip_root}/src/lib/support:testing",
-  ]
 }

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -1,0 +1,136 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdint.h>
+
+#include <lib/support/UnitTestExtendedAssertions.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/core/Optional.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+#include <nlunit-test.h>
+
+using namespace ::chip;
+using namespace ::chip::Protocols::InteractionModel;
+
+namespace {
+
+void TestStatusBasicValues(nlTestSuite * inSuite, void * inContext)
+{
+    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::Success), 0);
+    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::Failure), 1);
+    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::UnsupportedEndpoint), 0x7f);
+    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::InvalidInState), 0xcb);
+}
+
+void TestStatusCode(nlTestSuite * inSuite, void * inContext)
+{
+    // Basic usage as a Status.
+    {
+        StatusCode status_code_success{Status::Success};
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetStatus(), Status::Success);
+        NL_TEST_ASSERT(inSuite, !status_code_success.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, 0);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), chip::NullOptional);
+        NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
+
+        StatusCode status_code_failure{Status::Failure};
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetStatus(), Status::Failure);
+        NL_TEST_ASSERT(inSuite, !status_code_failure.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1u);
+        NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
+
+        StatusCode status_code_unsupported_ep{Status::UnsupportedEndpoint};
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, Status::UnsupportedEndpoint);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
+        NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, static_cast<uint8_t>(0x7f));
+        NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.IsSuccess());
+
+        StatusCode status_code_invalid_in_state{Status::InvalidInState};
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, Status::InvalidInState);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
+        NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, static_cast<uint8_t>(0xcb));
+        NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.IsSuccess());
+    }
+
+    enum RobotoStatusCode : uint8_t {
+        kSandwichError = 7,
+        kSauceSuccess = 81,
+    };
+
+    // Cluster-specific usage.
+    {
+        StatusCode status_code_success = StatusCode::ClusterSpecificSuccess(RobotoStatusCode::kSauceSuccess);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
+        NL_TEST_ASSERT(inSuite, status_code_success.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, 0);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSauceSuccess));
+        NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
+
+        StatusCode status_code_failure = StatusCode::ClusterSpecificFailure(RobotoStatusCode::kSandwichError);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
+        NL_TEST_ASSERT(inSuite, status_code_failure.HasClusterSpecificCode());
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1);
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+        NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
+    }
+
+    // Copy/Assignment
+    {
+        StatusCode status_code_failure1 = StatusCode::ClusterSpecificFailure(RobotoStatusCode::kSandwichError);
+        StatusCode status_code_failure2(status_code_failure1);
+
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1, status_code_failure2);
+        NL_TEST_ASSERT(inSuite, status_code_failure1.HasClusterSpecificCode());
+        NL_TEST_ASSERT(inSuite, status_code_failure2.HasClusterSpecificCode());
+
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+
+        StatusCode status_code_failure3{Status::InvalidCommand};
+        NL_TEST_ASSERT(inSuite, status_code_failure2 != status_code_failure3);
+
+        status_code_failure3 = status_code_failure2;
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2, status_code_failure3);
+    }
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestStatusBasicValues", TestStatusBasicValues),
+    NL_TEST_DEF("TestStatusCode", TestStatusCode),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+nlTestSuite sSuite = { "Test IM Status Code abstractions", &sTests[0], nullptr, nullptr };
+} // namespace
+
+int TestStatusCode()
+{
+    nlTestRunner(&sSuite, nullptr);
+
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestStatusCode)

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -18,9 +18,9 @@
 
 #include <stdint.h>
 
+#include <lib/core/Optional.h>
 #include <lib/support/UnitTestExtendedAssertions.h>
 #include <lib/support/UnitTestRegistration.h>
-#include <lib/core/Optional.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <nlunit-test.h>
@@ -42,7 +42,7 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
 {
     // Basic usage as a Status.
     {
-        StatusCode status_code_success{Status::Success};
+        StatusCode status_code_success{ Status::Success };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetStatus(), Status::Success);
         NL_TEST_ASSERT(inSuite, !status_code_success.HasClusterSpecificCode());
@@ -50,21 +50,21 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), chip::NullOptional);
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
-        StatusCode status_code_failure{Status::Failure};
+        StatusCode status_code_failure{ Status::Failure };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetStatus(), Status::Failure);
         NL_TEST_ASSERT(inSuite, !status_code_failure.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1u);
         NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
 
-        StatusCode status_code_unsupported_ep{Status::UnsupportedEndpoint};
+        StatusCode status_code_unsupported_ep{ Status::UnsupportedEndpoint };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, Status::UnsupportedEndpoint);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, static_cast<uint8_t>(0x7f));
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.IsSuccess());
 
-        StatusCode status_code_invalid_in_state{Status::InvalidInState};
+        StatusCode status_code_invalid_in_state{ Status::InvalidInState };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, Status::InvalidInState);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
         NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.HasClusterSpecificCode());
@@ -72,9 +72,10 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.IsSuccess());
     }
 
-    enum RobotoStatusCode : uint8_t {
+    enum RobotoStatusCode : uint8_t
+    {
         kSandwichError = 7,
-        kSauceSuccess = 81,
+        kSauceSuccess  = 81,
     };
 
     // Cluster-specific usage.
@@ -83,14 +84,16 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT(inSuite, status_code_success.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, 0);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSauceSuccess));
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(),
+                              static_cast<uint8_t>(RobotoStatusCode::kSauceSuccess));
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
         StatusCode status_code_failure = StatusCode::ClusterSpecificFailure(RobotoStatusCode::kSandwichError);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT(inSuite, status_code_failure.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(),
+                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
         NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
     }
 
@@ -103,10 +106,12 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, status_code_failure1.HasClusterSpecificCode());
         NL_TEST_ASSERT(inSuite, status_code_failure2.HasClusterSpecificCode());
 
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1.GetClusterSpecificCode(),
+                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(),
+                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
 
-        StatusCode status_code_failure3{Status::InvalidCommand};
+        StatusCode status_code_failure3{ Status::InvalidCommand };
         NL_TEST_ASSERT(inSuite, status_code_failure2 != status_code_failure3);
 
         status_code_failure3 = status_code_failure2;

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -38,30 +38,30 @@ void TestStatusBasicValues(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::InvalidInState), 0xcb);
 }
 
-void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
+void TestClusterStatusCode(nlTestSuite * inSuite, void * inContext)
 {
     // Basic usage as a Status.
     {
-        ClusterStatus status_code_success{ Status::Success };
+        ClusterStatusCode status_code_success{ Status::Success };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetStatus(), Status::Success);
         NL_TEST_ASSERT(inSuite, !status_code_success.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), chip::NullOptional);
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
-        ClusterStatus status_code_failure{ Status::Failure };
+        ClusterStatusCode status_code_failure{ Status::Failure };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetStatus(), Status::Failure);
         NL_TEST_ASSERT(inSuite, !status_code_failure.HasClusterSpecificCode());
         NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
 
-        ClusterStatus status_code_unsupported_ep{ Status::UnsupportedEndpoint };
+        ClusterStatusCode status_code_unsupported_ep{ Status::UnsupportedEndpoint };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, Status::UnsupportedEndpoint);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.HasClusterSpecificCode());
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.IsSuccess());
 
-        ClusterStatus status_code_invalid_in_state{ Status::InvalidInState };
+        ClusterStatusCode status_code_invalid_in_state{ Status::InvalidInState };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, Status::InvalidInState);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
         NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.HasClusterSpecificCode());
@@ -76,14 +76,14 @@ void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
 
     // Cluster-specific usage.
     {
-        ClusterStatus status_code_success = ClusterStatus::ClusterSpecificSuccess(RobotoClusterStatus::kSauceSuccess);
+        ClusterStatusCode status_code_success = ClusterStatusCode::ClusterSpecificSuccess(RobotoClusterStatus::kSauceSuccess);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT(inSuite, status_code_success.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(),
                               static_cast<uint8_t>(RobotoClusterStatus::kSauceSuccess));
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
-        ClusterStatus status_code_failure = ClusterStatus::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
+        ClusterStatusCode status_code_failure = ClusterStatusCode::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT(inSuite, status_code_failure.HasClusterSpecificCode());
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(),
@@ -93,8 +93,8 @@ void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
 
     // Copy/Assignment
     {
-        ClusterStatus status_code_failure1 = ClusterStatus::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
-        ClusterStatus status_code_failure2(status_code_failure1);
+        ClusterStatusCode status_code_failure1 = ClusterStatusCode::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
+        ClusterStatusCode status_code_failure2(status_code_failure1);
 
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1, status_code_failure2);
         NL_TEST_ASSERT(inSuite, status_code_failure1.HasClusterSpecificCode());
@@ -105,7 +105,7 @@ void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(),
                               static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
 
-        ClusterStatus status_code_failure3{ Status::InvalidCommand };
+        ClusterStatusCode status_code_failure3{ Status::InvalidCommand };
         NL_TEST_ASSERT(inSuite, status_code_failure2 != status_code_failure3);
 
         status_code_failure3 = status_code_failure2;
@@ -117,7 +117,7 @@ void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
 const nlTest sTests[] =
 {
     NL_TEST_DEF("TestStatusBasicValues", TestStatusBasicValues),
-    NL_TEST_DEF("TestClusterStatus", TestClusterStatus),
+    NL_TEST_DEF("TestClusterStatusCode", TestClusterStatusCode),
     NL_TEST_SENTINEL()
 };
 // clang-format on
@@ -125,11 +125,11 @@ const nlTest sTests[] =
 nlTestSuite sSuite = { "Test IM Status Code abstractions", &sTests[0], nullptr, nullptr };
 } // namespace
 
-int TestClusterStatus()
+int TestClusterStatusCode()
 {
     nlTestRunner(&sSuite, nullptr);
 
     return (nlTestRunnerStats(&sSuite));
 }
 
-CHIP_REGISTER_TEST_SUITE(TestClusterStatus)
+CHIP_REGISTER_TEST_SUITE(TestClusterStatusCode)

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -38,41 +38,37 @@ void TestStatusBasicValues(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::InvalidInState), 0xcb);
 }
 
-void TestStatusCode(nlTestSuite * inSuite, void * inContext)
+void TestClusterStatus(nlTestSuite * inSuite, void * inContext)
 {
     // Basic usage as a Status.
     {
-        StatusCode status_code_success{ Status::Success };
+        ClusterStatus status_code_success{ Status::Success };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetStatus(), Status::Success);
         NL_TEST_ASSERT(inSuite, !status_code_success.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, 0);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), chip::NullOptional);
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
-        StatusCode status_code_failure{ Status::Failure };
+        ClusterStatus status_code_failure{ Status::Failure };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetStatus(), Status::Failure);
         NL_TEST_ASSERT(inSuite, !status_code_failure.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1u);
         NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
 
-        StatusCode status_code_unsupported_ep{ Status::UnsupportedEndpoint };
+        ClusterStatus status_code_unsupported_ep{ Status::UnsupportedEndpoint };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, Status::UnsupportedEndpoint);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, static_cast<uint8_t>(0x7f));
         NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.IsSuccess());
 
-        StatusCode status_code_invalid_in_state{ Status::InvalidInState };
+        ClusterStatus status_code_invalid_in_state{ Status::InvalidInState };
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, Status::InvalidInState);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
         NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, static_cast<uint8_t>(0xcb));
         NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.IsSuccess());
     }
 
-    enum RobotoStatusCode : uint8_t
+    enum RobotoClusterStatus : uint8_t
     {
         kSandwichError = 7,
         kSauceSuccess  = 81,
@@ -80,38 +76,36 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
 
     // Cluster-specific usage.
     {
-        StatusCode status_code_success = StatusCode::ClusterSpecificSuccess(RobotoStatusCode::kSauceSuccess);
+        ClusterStatus status_code_success = ClusterStatus::ClusterSpecificSuccess(RobotoClusterStatus::kSauceSuccess);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
         NL_TEST_ASSERT(inSuite, status_code_success.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, 0);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoStatusCode::kSauceSuccess));
+                              static_cast<uint8_t>(RobotoClusterStatus::kSauceSuccess));
         NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
 
-        StatusCode status_code_failure = StatusCode::ClusterSpecificFailure(RobotoStatusCode::kSandwichError);
+        ClusterStatus status_code_failure = ClusterStatus::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
         NL_TEST_ASSERT(inSuite, status_code_failure.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, 1);
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
         NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
     }
 
     // Copy/Assignment
     {
-        StatusCode status_code_failure1 = StatusCode::ClusterSpecificFailure(RobotoStatusCode::kSandwichError);
-        StatusCode status_code_failure2(status_code_failure1);
+        ClusterStatus status_code_failure1 = ClusterStatus::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
+        ClusterStatus status_code_failure2(status_code_failure1);
 
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1, status_code_failure2);
         NL_TEST_ASSERT(inSuite, status_code_failure1.HasClusterSpecificCode());
         NL_TEST_ASSERT(inSuite, status_code_failure2.HasClusterSpecificCode());
 
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
         NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoStatusCode::kSandwichError));
+                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
 
-        StatusCode status_code_failure3{ Status::InvalidCommand };
+        ClusterStatus status_code_failure3{ Status::InvalidCommand };
         NL_TEST_ASSERT(inSuite, status_code_failure2 != status_code_failure3);
 
         status_code_failure3 = status_code_failure2;
@@ -123,7 +117,7 @@ void TestStatusCode(nlTestSuite * inSuite, void * inContext)
 const nlTest sTests[] =
 {
     NL_TEST_DEF("TestStatusBasicValues", TestStatusBasicValues),
-    NL_TEST_DEF("TestStatusCode", TestStatusCode),
+    NL_TEST_DEF("TestClusterStatus", TestClusterStatus),
     NL_TEST_SENTINEL()
 };
 // clang-format on
@@ -131,11 +125,11 @@ const nlTest sTests[] =
 nlTestSuite sSuite = { "Test IM Status Code abstractions", &sTests[0], nullptr, nullptr };
 } // namespace
 
-int TestStatusCode()
+int TestClusterStatus()
 {
     nlTestRunner(&sSuite, nullptr);
 
     return (nlTestRunnerStats(&sSuite));
 }
 
-CHIP_REGISTER_TEST_SUITE(TestStatusCode)
+CHIP_REGISTER_TEST_SUITE(TestClusterStatus)


### PR DESCRIPTION
- Existing code always has to split IM status and cluster-specific status codes, which causes clumsy implementation of clusters (see issue #31120).
- This PR introduces a value that encapsulates both the IM status and cluster-specific status, in an easy-to-pass-around abstraction, which can be directly used in place of Status.
- Subsequent PR will implement usage in IM with overloads for common cases, such as for AddStatus.

Issue #31120

Testing done:
- Added unit tests
- Other tests still pass
