### PR TITLE
[ICD] Skip Get RegistrationInfo when parameter is already added

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -403,13 +403,6 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
     SetCommandExitStatus(err);
 }
 
-void PairingCommand::OnICDRegistrationInfoRequired()
-{
-    // Since we compute our ICD Registration info up front, we can call ICDRegistrationInfoReady() directly.
-    CurrentCommissioner().ICDRegistrationInfoReady();
-    mDeviceIsICD = true;
-}
-
 void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounter)
 {
     char icdSymmetricKeyHex[chip::Crypto::kAES_CCM128_Key_Length * 2 + 1];
@@ -436,6 +429,8 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
         SetCommandExitStatus(err);
         return;
     }
+
+    mDeviceIsICD = true;
 
     ChipLogProgress(chipTool, "Saved ICD Symmetric key for " ChipLogFormatX64, ChipLogValueX64(nodeId));
     ChipLogProgress(chipTool,

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -195,7 +195,6 @@ public:
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
-    void OnICDRegistrationInfoRequired() override;
     void OnICDRegistrationComplete(NodeId deviceId, uint32_t icdCounter) override;
 
     /////////// DeviceDiscoveryDelegate Interface /////////

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -409,7 +409,8 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
     case CommissioningStage::kConfigureTrustedTimeSource:
         if (mNeedIcdRegistration)
         {
-            if (mParams.GetICDCheckInNodeId().HasValue() && mParams.GetICDMonitoredSubject().HasValue() && mParams.GetICDSymmetricKey().HasValue())
+            if (mParams.GetICDCheckInNodeId().HasValue() && mParams.GetICDMonitoredSubject().HasValue() &&
+                mParams.GetICDSymmetricKey().HasValue())
             {
                 return CommissioningStage::kICDRegistration;
             }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -409,6 +409,10 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
     case CommissioningStage::kConfigureTrustedTimeSource:
         if (mNeedIcdRegistration)
         {
+            if (mParams.GetICDCheckInNodeId().HasValue() && mParams.GetICDMonitoredSubject().HasValue() && mParams.GetICDSymmetricKey().HasValue())
+            {
+                return CommissioningStage::kICDRegistration;
+            }
             return CommissioningStage::kICDGetRegistrationInfo;
         }
         return GetNextCommissioningStageInternal(CommissioningStage::kICDSendStayActive, lastErr);

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -124,6 +124,8 @@ public:
      * The implementation should set the ICD registration info on the CommissioningParameters of the CommissioningDelegate
      * using CommissioningDelegate.SetCommissioningParameters(), and then call DeviceCommissioner.ICDRegistrationInfoReady()
      * in order to resume the commissioning process.
+     * 
+     * Not called if the ICD registration info is provided up front.
      */
     virtual void OnICDRegistrationInfoRequired() {}
 

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -124,8 +124,6 @@ public:
      * The implementation should set the ICD registration info on the CommissioningParameters of the CommissioningDelegate
      * using CommissioningDelegate.SetCommissioningParameters(), and then call DeviceCommissioner.ICDRegistrationInfoReady()
      * in order to resume the commissioning process.
-     *
-     * The implementation may set the credentials before start commissioning, and call ICDRegistrationInfoReady() directly.
      */
     virtual void OnICDRegistrationInfoRequired() {}
 

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -124,7 +124,7 @@ public:
      * The implementation should set the ICD registration info on the CommissioningParameters of the CommissioningDelegate
      * using CommissioningDelegate.SetCommissioningParameters(), and then call DeviceCommissioner.ICDRegistrationInfoReady()
      * in order to resume the commissioning process.
-     * 
+     *
      * Not called if the ICD registration info is provided up front.
      */
     virtual void OnICDRegistrationInfoRequired() {}


### PR DESCRIPTION
If commissioner set the credentials before start commissioning, ICDGetRegistrationInfo step can skip.
(OnICDRegistrationInfoRequired callback doesn't need when parameter is set.)



