### PR TITLE
[ReportScheduler] Empty node pool handling

### DIFF
--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -182,6 +182,9 @@ void SynchronizedReportSchedulerImpl::TimerFired()
     Timestamp now   = mTimerDelegate->GetCurrentMonotonicTimestamp();
     bool firedEarly = true;
 
+    // If there are no handlers registers, no need to take actions
+    VerifyOrReturn(mNodesPool.Allocated());
+
     mNodesPool.ForEachActiveObject([now, &firedEarly](ReadHandlerNode * node) {
         if (node->GetMinTimestamp() <= now)
         {
@@ -201,8 +204,7 @@ void SynchronizedReportSchedulerImpl::TimerFired()
         return Loop::Continue;
     });
 
-    // If there are no handlers registers, no need to schedule the next report
-    if (mNodesPool.Allocated() && firedEarly)
+    if (firedEarly)
     {
         Timeout timeout = Milliseconds32(0);
         ReturnOnFailure(CalculateNextReportTimeout(timeout, nullptr, now));

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -182,7 +182,7 @@ void SynchronizedReportSchedulerImpl::TimerFired()
     Timestamp now   = mTimerDelegate->GetCurrentMonotonicTimestamp();
     bool firedEarly = true;
 
-    // If there are no handlers registers, no need to take actions
+    // If there are no handlers registered, no need to do anything.
     VerifyOrReturn(mNodesPool.Allocated());
 
     mNodesPool.ForEachActiveObject([now, &firedEarly](ReadHandlerNode * node) {


### PR DESCRIPTION
The current implementation led to scheduling an engine run when an empty node pool was encountered.

It didn't make sense so instead we just return on an empty pool in the TimerFired callback.