### PR TITLE
[ReportScheduler] Renaming mTestNextReportTimestamp 

### DIFF
--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -48,8 +48,8 @@ void SynchronizedReportSchedulerImpl::OnTransitionToIdle()
 {
     Timestamp now               = mTimerDelegate->GetCurrentMonotonicTimestamp();
     uint32_t targetIdleInterval = static_cast<uint32_t>(ICD_SLEEP_TIME_JITTER_MS);
-    VerifyOrReturn(now >= mTestNextReportTimestamp);
-    if (((mTestNextReportTimestamp - now) < Seconds16(targetIdleInterval)) && (now > mNextMinTimestamp))
+    VerifyOrReturn(now >= mNextReportTimestamp);
+    if (((mNextReportTimestamp - now) < Seconds16(targetIdleInterval)) && (now > mNextMinTimestamp))
     {
         // If the next report is due in less than the idle mode interval and we are past the min interval, we can just send it now
         CancelReport();
@@ -67,7 +67,7 @@ CHIP_ERROR SynchronizedReportSchedulerImpl::ScheduleReport(Timeout timeout, Read
         return CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(mTimerDelegate->StartTimer(this, timeout));
-    mTestNextReportTimestamp = now + timeout;
+    mNextReportTimestamp = now + timeout;
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -58,8 +58,8 @@ private:
     Timestamp mNextMaxTimestamp = Milliseconds64(0);
     Timestamp mNextMinTimestamp = Milliseconds64(0);
 
-    // Timestamp of the next report to be scheduled, used by OnTransitionToIdle to determine if we should emit a report before the
-    // device goes to iddle mode
+    // Timestamp of the next report to be scheduled, used by OnTransitionToIdle to determine whether we should emit a report before the
+    // device goes to idle mode
     Timestamp mNextReportTimestamp = Milliseconds64(0);
 };
 

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -58,7 +58,8 @@ private:
     Timestamp mNextMaxTimestamp = Milliseconds64(0);
     Timestamp mNextMinTimestamp = Milliseconds64(0);
 
-    // Timestamp of the next report to be scheduled, only used for testing
+    // Timestamp of the next report to be scheduled, used by OnTransitionToIdle to determine if we should emit a report before the
+    // device goes to iddle mode
     Timestamp mNextReportTimestamp = Milliseconds64(0);
 };
 

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -58,8 +58,8 @@ private:
     Timestamp mNextMaxTimestamp = Milliseconds64(0);
     Timestamp mNextMinTimestamp = Milliseconds64(0);
 
-    // Timestamp of the next report to be scheduled, used by OnTransitionToIdle to determine whether we should emit a report before the
-    // device goes to idle mode
+    // Timestamp of the next report to be scheduled, used by OnTransitionToIdle to determine whether we should emit a report before
+    // the device goes to idle mode
     Timestamp mNextReportTimestamp = Milliseconds64(0);
 };
 

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.h
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.h
@@ -59,7 +59,7 @@ private:
     Timestamp mNextMinTimestamp = Milliseconds64(0);
 
     // Timestamp of the next report to be scheduled, only used for testing
-    Timestamp mTestNextReportTimestamp = Milliseconds64(0);
+    Timestamp mNextReportTimestamp = Milliseconds64(0);
 };
 
 } // namespace reporting

--- a/src/app/tests/TestReportScheduler.cpp
+++ b/src/app/tests/TestReportScheduler.cpp
@@ -494,7 +494,7 @@ public:
         // Validates that the highest reportable min is selected as the common min interval (0 here)
         NL_TEST_ASSERT(aSuite, syncScheduler.mNextMinTimestamp == node1->GetMinTimestamp());
         // Validates that the next report emission is scheduled on the common max timestamp
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == syncScheduler.mNextMaxTimestamp);
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == syncScheduler.mNextMaxTimestamp);
 
         // Simulate waiting for the max interval to expire (2s)
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(2000));
@@ -515,7 +515,7 @@ public:
         // Validate that the max timestamp for both readhandlers got updated and that the next report emission is scheduled on
         //  the new max timestamp for readhandler1
         NL_TEST_ASSERT(aSuite, node1->GetMaxTimestamp() > sTestTimerSynchronizedDelegate.GetCurrentMonotonicTimestamp());
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
 
         // Confirm behavior when a read handler becomes dirty
         readHandler2->ForceDirtyState();
@@ -530,7 +530,7 @@ public:
 
         // Confirm that the next report emission is scheduled on the min timestamp of readHandler2 (now) as it is the highest
         // reportable
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node2->GetMinTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node2->GetMinTimestamp());
         NL_TEST_ASSERT(aSuite, node1->CanBeSynced() == true);
 
         // Simulate a report emission for readHandler1
@@ -570,7 +570,7 @@ public:
 
         // Validate next report scheduled on the max timestamp of readHandler1
         NL_TEST_ASSERT(aSuite, node1->GetMaxTimestamp() > sTestTimerSynchronizedDelegate.GetCurrentMonotonicTimestamp());
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
 
         // Simulate readHandler1 becoming dirty after less than 1 seconds, since it is reportable now, this will Schedule an Engine
         // run immediately
@@ -586,7 +586,7 @@ public:
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
         // The next report should be scheduler on the max timestamp of readHandler1
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
 
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(2000));
         // Confirm node 2 can now be synced since the scheduler timer has fired on the max timestamp of readHandler1
@@ -598,7 +598,7 @@ public:
         readHandler2->mObserver->OnSubscriptionReportSent(readHandler2);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
 
         // Simulate a new ReadHandler being added with a min timestamp that will force a conflict
 
@@ -615,7 +615,7 @@ public:
 
         // Since the min interval on readHandler3 is 2, it should be above the current max timestamp, therefore the next report
         // should still happen on the max timestamp of readHandler1 and the sync should be done on future reports
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
         // The min timestamp should also not have changed since the min of readhandler3 is higher than the current max
         NL_TEST_ASSERT(aSuite, syncScheduler.mNextMinTimestamp == node2->GetMinTimestamp());
 
@@ -635,7 +635,7 @@ public:
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
         // Confirm that next report is scheduled on the max timestamp of readHandler3 and other 2 readHandlers are synced
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node3->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node3->GetMaxTimestamp());
 
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(2000));
         // Confirm nodes 1 and 2 can now be synced since the scheduler timer has fired on the max timestamp of readHandler1
@@ -655,7 +655,7 @@ public:
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler3));
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
 
         // Now simulate a new readHandler being added with a max forcing a conflict
         ReadHandler * readHandler4 =
@@ -667,7 +667,7 @@ public:
         NL_TEST_ASSERT(aSuite, syncScheduler.GetNumReadHandlers() == 4);
 
         // Confirm next report is scheduled on the max timestamp of readHandler4
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node4->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node4->GetMaxTimestamp());
 
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(1100));
         // Confirm node 1 and 2 can now be synced since the scheduler timer has fired on the max timestamp of readHandler4
@@ -714,7 +714,7 @@ public:
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler4));
 
         // Next emission should be scheduled on the max timestamp of readHandler4 as it is the most restrictive
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node4->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node4->GetMaxTimestamp());
 
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(1000));
         // Confirm node 1 and 2 can now be synced since the scheduler timer has fired on the max timestamp of readHandler4
@@ -761,7 +761,7 @@ public:
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
 
         // Confirm next report is scheduled on the max timestamp of readHandler1 and readhandler2 is not synced
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
         // Node 2's sync timestamp should have remained unaffected since its min is higher
         NL_TEST_ASSERT(aSuite, node2->CanBeSynced() == false);
 
@@ -775,7 +775,7 @@ public:
         syncScheduler.OnSubscriptionReportSent(readHandler1);
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler1));
         NL_TEST_ASSERT(aSuite, !syncScheduler.IsReportableNow(readHandler2));
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node2->GetMinTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node2->GetMinTimestamp());
 
         sTestTimerSynchronizedDelegate.IncrementMockTimestamp(System::Clock::Milliseconds64(1000));
         NL_TEST_ASSERT(aSuite, node1->CanBeSynced() == true);
@@ -786,7 +786,7 @@ public:
         syncScheduler.OnSubscriptionReportSent(readHandler1);
         syncScheduler.OnSubscriptionReportSent(readHandler2);
 
-        NL_TEST_ASSERT(aSuite, syncScheduler.mTestNextReportTimestamp == node1->GetMaxTimestamp());
+        NL_TEST_ASSERT(aSuite, syncScheduler.mNextReportTimestamp == node1->GetMaxTimestamp());
         NL_TEST_ASSERT(aSuite, node2->CanBeSynced() == false);
 
         syncScheduler.UnregisterAllHandlers();


### PR DESCRIPTION
Since we now use it outside of tests, renamed to mNextReportTimestamp

