### PR TITLE
Add yaml test to validate previous fix to group including multiple endpoints

### DIFF
--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -109,7 +109,7 @@ tests:
               - name: "GroupID"
                 value: 0x0101
 
-    - label: "Add Group 1 (endpoint 1)"
+    - label: "Add Group 1 (endpoint 2)"
       cluster: "Groups"
       command: "AddGroup"
       endpoint: 2
@@ -233,6 +233,14 @@ tests:
       response:
           value: 0
 
+    - label: "Check on/off attribute value is false for endpoint 1"
+      cluster: "On/Off"
+      command: "readAttribute"
+      attribute: "OnOff"
+      endpoint: 2
+      response:
+          value: 0
+
     - label: "Turn On the light to see attribute change"
       cluster: "On/Off"
       command: "On"
@@ -258,10 +266,39 @@ tests:
       response:
           value: 1
 
+    - label:
+          "Check on/off attribute value is true after on command for endpoint 2"
+      cluster: "On/Off"
+      command: "readAttribute"
+      attribute: "OnOff"
+      endpoint: 2
+      response:
+          value: 1
+
     - label: "Turn off the light to get ready for the next test"
       cluster: "On/Off"
       command: "Off"
       endpoint: 1
+
+    - label: "Turn off the light to get ready for the next test"
+      cluster: "On/Off"
+      command: "Off"
+      endpoint: 2
+    
+    - label: "Cleanup for next test remove Group 1 (endpoint 2)"
+      cluster: "Groups"
+      command: "RemoveGroup"
+      endpoint: 2
+      arguments:
+          values:
+              - name: "GroupID"
+                value: 0x0101
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: 0x0101
 
     - label: "Cleanup ACLs"
       cluster: "Access Control"

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -233,7 +233,7 @@ tests:
       response:
           value: 0
 
-    - label: "Check on/off attribute value is false for endpoint 1"
+    - label: "Check on/off attribute value is false for endpoint 2"
       cluster: "On/Off"
       command: "readAttribute"
       attribute: "OnOff"
@@ -275,12 +275,12 @@ tests:
       response:
           value: 1
 
-    - label: "Turn off the light to get ready for the next test"
+    - label: "Turn off the light to get ready for the next test for endpoint 1"
       cluster: "On/Off"
       command: "Off"
       endpoint: 1
 
-    - label: "Turn off the light to get ready for the next test"
+    - label: "Turn off the light to get ready for the next test for endpoint 2"
       cluster: "On/Off"
       command: "Off"
       endpoint: 2

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -284,7 +284,7 @@ tests:
       cluster: "On/Off"
       command: "Off"
       endpoint: 2
-    
+
     - label: "Cleanup for next test remove Group 1 (endpoint 2)"
       cluster: "Groups"
       command: "RemoveGroup"

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -109,6 +109,23 @@ tests:
               - name: "GroupID"
                 value: 0x0101
 
+    - label: "Add Group 1 (endpoint 1)"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 2
+      arguments:
+          values:
+              - name: "GroupID"
+                value: 0x0101
+              - name: "GroupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: 0x0101
+
     - label: "Add Group 2 (endpoint 0)"
       cluster: "Groups"
       command: "AddGroup"


### PR DESCRIPTION
This expands test in `TestGroupMessaging.yaml` so that two endpoints on one device on one fabric are in the same group that gets sent a command. Prior to real fix in https://github.com/project-chip/connectedhomeip/pull/30484 and https://github.com/project-chip/connectedhomeip/pull/30614 , this would.

All we are doing is adding a test that would have previously failed prior to https://github.com/project-chip/connectedhomeip/pull/30484. We are trying to have CI insures that we don't accidentally reintroduce the bug.

Fixes: https://github.com/project-chip/connectedhomeip/issues/30472
^ Comment added to auto close that issue. The issues was fixed for real for Status response in 