### PR TITLE
Minor typo fixes at Directory Structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,18 +210,18 @@ The Matter repository is structured as follows:
 | credentials        | Development and test credentials                                                                                                                      |
 | docs               | Documentation, including guides. Visit the [Matter SDK documentation page](https://project-chip.github.io/connectedhomeip-doc/index.html) to read it. |
 | examples           | Example firmware applications that demonstrate use of Matter                                                                                          |
-| integrations       | 3rd Party integrations                                                                                                                                |
+| integrations       | 3rd party integrations                                                                                                                                |
 | scripts            | Scripts needed to work with the Matter repository                                                                                                     |
 | src                | Implementation of Matter                                                                                                                              |
 | third_party        | 3rd party code used by Matter                                                                                                                         |
-| zzz_generated      | zap generated template code - Revolving around cluster information                                                                                    |
-| BUILD.gn           | Build file for the gn build system                                                                                                                    |
+| zzz_generated      | ZAP generated template code - Revolving around cluster information                                                                                    |
+| BUILD.gn           | Build file for the GN build system                                                                                                                    |
 | CODE_OF_CONDUCT.md | Code of conduct for Matter and contribution to it                                                                                                     |
 | CONTRIBUTING.md    | Guidelines for contributing to Matter                                                                                                                 |
 | LICENSE            | Matter license file                                                                                                                                   |
 | REVIEWERS.md       | PR reviewers                                                                                                                                          |
 | gn_build.sh        | Build script for specific projects such as Android, EFR32, etc.                                                                                       |
-| README.md          | This File                                                                                                                                             |
+| README.md          | This file                                                                                                                                             |
 
 # License
 


### PR DESCRIPTION
This PR proposes to fix several typos at Directory Structure in `README.md` mainly to be consistent within this file about capitalization, and use uppercases for ZAP and GN.