### PR TITLE
[ESP32] fix the unsafe access to chip stack in lock-app

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -99,7 +99,7 @@ CHIP_ERROR AppTask::Init()
 
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
 
-    chip::DeviceLayer::SystemLayer().ScheduleWork(UpdateClusterState, nullptr);
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(UpdateClusterState, reinterpret_cast<intptr_t>(nullptr));
 
     ConfigurationMgr().LogDeviceConfig();
 
@@ -424,7 +424,7 @@ void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
     }
     if (sAppTask.mSyncClusterToButtonAction)
     {
-        chip::DeviceLayer::SystemLayer().ScheduleWork(UpdateClusterState, nullptr);
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(UpdateClusterState, reinterpret_cast<intptr_t>(nullptr));
         sAppTask.mSyncClusterToButtonAction = false;
     }
 }
@@ -463,7 +463,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 }
 
 /* if unlocked then it locked it first*/
-void AppTask::UpdateClusterState(chip::System::Layer *, void * context)
+void AppTask::UpdateClusterState(intptr_t context)
 {
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
 

--- a/examples/lock-app/esp32/main/include/AppTask.h
+++ b/examples/lock-app/esp32/main/include/AppTask.h
@@ -66,7 +66,7 @@ private:
     static void LockActionEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
-    static void UpdateClusterState(chip::System::Layer *, void * context);
+    static void UpdateClusterState(intptr_t context);
 
     void StartTimer(uint32_t aTimeoutMs);
 


### PR DESCRIPTION
Fixes #31126

`SystemLayer::ScheduleWork()` must be called from chip thread and `PlatformMgr::ScheduleWork()` can be called from any thread.

Replaced the `SystemLayer::ScheduleWork()` with `PlatformMgr::ScheduleWork()` for thread safety.