### PR TITLE
Use python3-config to get CFLAGS and LIBS for CHIP Python module

### DIFF
--- a/build/config/python/python3_config.gni
+++ b/build/config/python/python3_config.gni
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3_config = get_path_info("python3_config.py", "abspath")
+
+# Get configuration for building Python3 extension modules.
+#
+# For building targets which embed Python3 (e.g. Python code is called from
+# C++), use set invoker.embed to true.
+template("python3_config") {
+  config(target_name) {
+    result = exec_script(python3_config, [], "json")
+
+    include_dirs = result["include_dirs"]
+    lib_dirs = result["lib_dirs"]
+
+    if (invoker.embed) {
+      libs = result["libs_embed"]
+    } else {
+      libs = result["libs"]
+    }
+  }
+}

--- a/build/config/python/python3_config.py
+++ b/build/config/python/python3_config.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+import subprocess
+
+
+class Python3Config:
+
+    @staticmethod
+    def _get_config(*args):
+        return subprocess.check_output(["python3-config", *args], text=True)
+
+    def get_include_dirs(self):
+        return [re.sub(r"^-I", "", x)
+                for x in self._get_config("--includes").split()]
+
+    def get_lib_dirs(self):
+        return [re.sub(r"^-L", "", x)
+                for x in self._get_config("--ldflags").split()
+                if x.startswith("-L")]
+
+    def get_libs(self):
+        return [re.sub(r"^-l", "", x)
+                for x in self._get_config("--libs").split()]
+
+    def get_libs_embed(self):
+        return [re.sub(r"^-l", "", x)
+                for x in self._get_config("--libs", "--embed").split()]
+
+
+if __name__ == '__main__':
+    config = Python3Config()
+    print(json.dumps({
+        'include_dirs': config.get_include_dirs(),
+        'lib_dirs': config.get_lib_dirs(),
+        'libs': config.get_libs(),
+        'libs_embed': config.get_libs_embed(),
+    }))

--- a/build/config/python/python3_config.py
+++ b/build/config/python/python3_config.py
@@ -15,15 +15,68 @@
 # limitations under the License.
 
 import json
+import os
 import re
+import shutil
 import subprocess
+
+
+def is_subpath(path: str, parent: str):
+    """Check if path is a subpath of parent."""
+    try:
+        return os.path.commonpath([path, parent]) == parent
+    except ValueError:
+        return False
+
+
+def find_command(command: str, exclude: list[str]):
+    """Extended shutil.which() with exclude parameters."""
+    for path in os.getenv("PATH", os.defpath).split(os.pathsep):
+        if any(is_subpath(path, x) for x in exclude):
+            continue
+        app = shutil.which(command, path=path)
+        if app is not None:
+            return app
+    return None
 
 
 class Python3Config:
 
-    @staticmethod
-    def _get_config(*args):
-        return subprocess.check_output(["python3-config", *args], text=True)
+    # List of python3-config commands to try in order. This is needed because
+    # not all environments have python3-config symlinked in the PATH.
+    COMMANDS = [
+        "python3-config",
+        "python3.12-config",
+        "python3.11-config",
+        "python3.10-config",
+        "python3.9-config",
+    ]
+
+    def __init__(self):
+
+        exclude = []
+
+        # Exclude directory with python3 installed by CIPD manager in Matter
+        # build environment. The python3-config provided by CIPD is broken - it
+        # returns wrong include/link paths and does not provide python shared
+        # library.
+        if os.getenv("PW_PYTHON_CIPD_INSTALL_DIR"):
+            exclude.append(os.getenv("PW_PYTHON_CIPD_INSTALL_DIR"))
+
+        for command in self.COMMANDS:
+            command = find_command(command, exclude=exclude)
+            if command is not None:
+                self._python_config_exe = command
+                break
+        else:
+            raise RuntimeError("Could not find python3-config in PATH")
+
+    def _get_config(self, *args):
+        return subprocess.check_output([self._python_config_exe, *args], text=True)
+
+    def get_cflags(self):
+        return [x for x in self._get_config("--cflags").split()
+                if not x.startswith("-I")]
 
     def get_include_dirs(self):
         return [re.sub(r"^-I", "", x)
@@ -36,16 +89,19 @@ class Python3Config:
 
     def get_libs(self):
         return [re.sub(r"^-l", "", x)
-                for x in self._get_config("--libs").split()]
+                for x in self._get_config("--libs").split()
+                if x.startswith("-l")]
 
     def get_libs_embed(self):
         return [re.sub(r"^-l", "", x)
-                for x in self._get_config("--libs", "--embed").split()]
+                for x in self._get_config("--libs", "--embed").split()
+                if x.startswith("-l")]
 
 
 if __name__ == '__main__':
     config = Python3Config()
     print(json.dumps({
+        'cflags': config.get_cflags(),
         'include_dirs': config.get_include_dirs(),
         'lib_dirs': config.get_lib_dirs(),
         'libs': config.get_libs(),

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -18,7 +18,8 @@ import("//build_overrides/pigweed.gni")
 
 import("$dir_pw_build/python.gni")
 
-import("${chip_root}/build/chip/tools.gni")
+import("${build_root}/chip/tools.gni")
+import("${build_root}/config/python/python3_config.gni")
 import("${chip_root}/src/platform/python.gni")
 import("${chip_root}/src/system/system.gni")
 import("${dir_pw_unit_test}/test.gni")
@@ -35,6 +36,12 @@ declare_args() {
   chip_python_version = "0.0"
   chip_python_package_prefix = "chip"
   chip_python_supports_stack_locking = chip_system_config_locking != "none"
+}
+
+# Matter Python API supports callbacks registration which then are called
+# from C++ code. This requires the "embed" version of Python library.
+python3_config("python3-embed-config") {
+  embed = true
 }
 
 shared_library("ChipDeviceCtrl") {
@@ -144,7 +151,10 @@ shared_library("ChipDeviceCtrl") {
     public_deps += [ "$chip_data_model" ]
   }
 
-  configs += [ ":controller_wno_deprecate" ]
+  configs += [
+    ":controller_wno_deprecate",
+    ":python3-embed-config",
+  ]
 }
 
 template("chip_python_wheel_action") {

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -60,7 +60,8 @@ shared_library("ChipDeviceCtrl") {
 
   sources += [ "chip/native/CommonStackInit.cpp" ]
 
-  defines = []
+  # Ensure that the module will be compatible with the Python >= 3.7 API.
+  defines = [ "Py_LIMITED_API=0x03070000" ]
 
   if (chip_controller) {
     sources += [

--- a/src/controller/python/ChipDeviceController-IssueNocChain.cpp
+++ b/src/controller/python/ChipDeviceController-IssueNocChain.cpp
@@ -19,6 +19,8 @@
 #include <map>
 #include <string>
 
+#include <Python.h>
+
 #include <controller/CHIPDeviceController.h>
 #include <controller/python/chip/native/PyChipError.h>
 #include <lib/core/CHIPError.h>
@@ -26,8 +28,6 @@
 
 using namespace chip;
 using namespace chip::Credentials;
-
-typedef void PyObject;
 
 using namespace chip;
 
@@ -58,6 +58,7 @@ void pychip_DeviceController_IssueNOCChainCallback(void * context, CHIP_ERROR st
         return;
     }
 
+    auto pythonContext = reinterpret_cast<PyObject *>(context);
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipNoc;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipIcac;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipRcac;
@@ -87,13 +88,13 @@ exit:
     if (err == CHIP_NO_ERROR)
     {
         pychip_DeviceController_IssueNOCChainCallbackPythonCallbackFunct(
-            context, ToPyChipError(err), chipNocSpan.data(), chipNocSpan.size(), chipIcacSpan.data(), chipIcacSpan.size(),
+            pythonContext, ToPyChipError(err), chipNocSpan.data(), chipNocSpan.size(), chipIcacSpan.data(), chipIcacSpan.size(),
             chipRcacSpan.data(), chipRcacSpan.size(), ipk.HasValue() ? ipk.Value().data() : nullptr,
             ipk.HasValue() ? ipk.Value().size() : 0, adminSubject.ValueOr(kUndefinedNodeId));
     }
     else
     {
-        pychip_DeviceController_IssueNOCChainCallbackPythonCallbackFunct(context, ToPyChipError(err), nullptr, 0, nullptr, 0,
+        pychip_DeviceController_IssueNOCChainCallbackPythonCallbackFunct(pythonContext, ToPyChipError(err), nullptr, 0, nullptr, 0,
                                                                          nullptr, 0, nullptr, 0, 0);
     }
 }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -89,7 +89,7 @@ using namespace chip::DeviceLayer;
 extern "C" {
 typedef void (*ConstructBytesArrayFunct)(const uint8_t * dataBuf, uint32_t dataLen);
 typedef void (*LogMessageFunct)(uint64_t time, uint64_t timeUS, const char * moduleName, uint8_t category, const char * msg);
-typedef void (*DeviceAvailableFunc)(chip::Controller::Python::PyObject * context, DeviceProxy * device, PyChipError err);
+typedef void (*DeviceAvailableFunc)(PyObject * context, DeviceProxy * device, PyChipError err);
 typedef void (*ChipThreadTaskRunnerFunct)(intptr_t context);
 typedef void (*DeviceUnpairingCompleteFunct)(uint64_t nodeId, PyChipError error);
 }
@@ -208,7 +208,7 @@ const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t stat
 void pychip_Stack_SetLogFunct(LogMessageFunct logFunct);
 
 PyChipError pychip_GetConnectedDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
-                                              chip::Controller::Python::PyObject * context, DeviceAvailableFunc callback);
+                                              PyObject * context, DeviceAvailableFunc callback);
 PyChipError pychip_FreeOperationalDeviceProxy(chip::OperationalDeviceProxy * deviceProxy);
 PyChipError pychip_GetLocalSessionId(chip::OperationalDeviceProxy * deviceProxy, uint16_t * localSessionId);
 PyChipError pychip_GetNumSessionsToPeer(chip::OperationalDeviceProxy * deviceProxy, uint32_t * numSessions);
@@ -224,15 +224,13 @@ PyChipError pychip_InteractionModel_ShutdownSubscription(SubscriptionId subscrip
 //
 // Storage
 //
-void * pychip_Storage_InitializeStorageAdapter(chip::Controller::Python::PyObject * context,
-                                               chip::Controller::Python::SyncSetKeyValueCb setCb,
+void * pychip_Storage_InitializeStorageAdapter(PyObject * context, chip::Controller::Python::SyncSetKeyValueCb setCb,
                                                chip::Controller::Python::SetGetKeyValueCb getCb,
                                                chip::Controller::Python::SyncDeleteKeyValueCb deleteCb);
 void pychip_Storage_ShutdownAdapter(chip::Controller::Python::StorageAdapter * storageAdapter);
 }
 
-void * pychip_Storage_InitializeStorageAdapter(chip::Controller::Python::PyObject * context,
-                                               chip::Controller::Python::SyncSetKeyValueCb setCb,
+void * pychip_Storage_InitializeStorageAdapter(PyObject * context, chip::Controller::Python::SyncSetKeyValueCb setCb,
                                                chip::Controller::Python::SetGetKeyValueCb getCb,
                                                chip::Controller::Python::SyncDeleteKeyValueCb deleteCb)
 {
@@ -745,7 +743,7 @@ namespace {
 
 struct GetDeviceCallbacks
 {
-    GetDeviceCallbacks(chip::Controller::Python::PyObject * context, DeviceAvailableFunc callback) :
+    GetDeviceCallbacks(PyObject * context, DeviceAvailableFunc callback) :
         mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnConnectionFailureFn, this), mContext(context), mCallback(callback)
     {}
 
@@ -766,13 +764,13 @@ struct GetDeviceCallbacks
 
     Callback::Callback<OnDeviceConnected> mOnSuccess;
     Callback::Callback<OnDeviceConnectionFailure> mOnFailure;
-    chip::Controller::Python::PyObject * const mContext;
+    PyObject * const mContext;
     DeviceAvailableFunc mCallback;
 };
 } // anonymous namespace
 
 PyChipError pychip_GetConnectedDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
-                                              chip::Controller::Python::PyObject * context, DeviceAvailableFunc callback)
+                                              PyObject * context, DeviceAvailableFunc callback)
 {
     VerifyOrReturnError(devCtrl != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
     auto * callbacks = new GetDeviceCallbacks(context, callback);

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -21,6 +21,8 @@
 #include <map>
 #include <string>
 
+#include <Python.h>
+
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 
 class PythonPersistentStorageDelegate;
@@ -41,8 +43,6 @@ private:
 };
 
 namespace Python {
-
-using PyObject = void;
 
 using SyncSetKeyValueCb    = void (*)(PyObject * appContext, const char * key, const void * value, uint16_t size);
 using SetGetKeyValueCb     = void (*)(PyObject * appContext, const char * key, char * value, uint16_t * size, bool * isFound);

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -133,6 +133,8 @@ try:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         python_requires=">=3.7",
         packages=packages,

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -16,6 +16,10 @@
  *    limitations under the License.
  */
 
+#include <memory>
+
+#include <Python.h>
+
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Linux/bluez/AdapterIterator.h>
@@ -77,7 +81,6 @@ namespace {
 // To avoid python compatibility issues on inc/dec references,
 // code assumes an abstract type and leaves it up to python to keep track of
 // reference counts
-struct PyObject;
 
 class ScannerDelegateImpl : public ChipDeviceScannerDelegate
 {

--- a/src/controller/python/chip/ble/darwin/AdapterListing.mm
+++ b/src/controller/python/chip/ble/darwin/AdapterListing.mm
@@ -1,3 +1,20 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -1,3 +1,22 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
 #include <ble/BleUUID.h>
 #include <ble/CHIPBleServiceData.h>
 #include <lib/support/CHIPMem.h>
@@ -7,7 +26,6 @@
 #import <CoreBluetooth/CoreBluetooth.h>
 
 namespace {
-struct PyObject;
 using DeviceScannedCallback
     = void (*)(PyObject * context, const char * address, uint16_t discriminator, uint16_t vendorId, uint16_t productId);
 using ScanCompleteCallback = void (*)(PyObject * context);

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -17,8 +17,11 @@
 
 #include "system/SystemClock.h"
 #include <cstdarg>
+#include <cstdio>
 #include <memory>
 #include <type_traits>
+
+#include <Python.h>
 
 #include <app/BufferedReadCallback.h>
 #include <app/ChunkedWriteCallback.h>
@@ -29,17 +32,12 @@
 #include <controller/CHIPDeviceController.h>
 #include <controller/python/chip/interaction_model/Delegate.h>
 #include <controller/python/chip/native/PyChipError.h>
-#include <lib/support/CodeUtils.h>
-
-#include <cstdio>
-#include <lib/support/logging/CHIPLogging.h>
-
 #include <lib/core/Optional.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
 using namespace chip::app;
-
-using PyObject = void;
 
 namespace chip {
 namespace python {
@@ -257,7 +255,7 @@ struct __attribute__((packed)) PyReadAttributeParams
     bool autoResubscribe;
 };
 
-PyChipError pychip_WriteClient_WriteAttributes(void * appContext, DeviceProxy * device, size_t timedWriteTimeoutMsSizeT,
+PyChipError pychip_WriteClient_WriteAttributes(PyObject * appContext, DeviceProxy * device, size_t timedWriteTimeoutMsSizeT,
                                                size_t interactionTimeoutMsSizeT, size_t busyWaitMsSizeT,
                                                chip::python::PyWriteAttributeData * writeAttributesData,
                                                size_t attributeDataLength);
@@ -338,7 +336,7 @@ void pychip_ReadClient_InitCallbacks(OnReadAttributeDataCallback onReadAttribute
     gOnReportEndCallback               = onReportEndCallback;
 }
 
-PyChipError pychip_WriteClient_WriteAttributes(void * appContext, DeviceProxy * device, size_t timedWriteTimeoutMsSizeT,
+PyChipError pychip_WriteClient_WriteAttributes(PyObject * appContext, DeviceProxy * device, size_t timedWriteTimeoutMsSizeT,
                                                size_t interactionTimeoutMsSizeT, size_t busyWaitMsSizeT,
                                                python::PyWriteAttributeData * writeAttributesData, size_t attributeDataLength)
 {
@@ -472,7 +470,7 @@ PyChipError pychip_ReadClient_GetReportingIntervals(ReadClient * pReadClient, ui
     return ToPyChipError(err);
 }
 
-PyChipError pychip_ReadClient_Read(void * appContext, ReadClient ** pReadClient, ReadClientCallback ** pCallback,
+PyChipError pychip_ReadClient_Read(PyObject * appContext, ReadClient ** pReadClient, ReadClientCallback ** pCallback,
                                    DeviceProxy * device, uint8_t * readParamsBuf, void ** attributePathsFromPython,
                                    size_t numAttributePaths, void ** dataversionFiltersFromPython, size_t numDataversionFilters,
                                    void ** eventPathsFromPython, size_t numEventPaths, uint64_t * eventNumberFilter)

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -180,7 +180,7 @@ private:
     bool mIsBatchedCommands;
 };
 
-PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
+PyChipError SendBatchCommandsInternal(PyObject * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
                                       uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
                                       python::TestOnlyPyBatchCommandsOverrides * testOnlyOverrides,
                                       python::PyInvokeRequestData * batchCommandData, size_t length)
@@ -381,9 +381,9 @@ PyChipError pychip_CommandSender_SendBatchCommands(PyObject * appContext, Device
                                      testOnlyOverrides, batchCommandData, length);
 }
 
-PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                                           uint16_t interactionTimeoutMs, uint16_t busyWaitMs,
-                                                           bool suppressResponse,
+PyChipError pychip_CommandSender_TestOnlySendBatchCommands(PyObject * appContext, DeviceProxy * device,
+                                                           uint16_t timedRequestTimeoutMs, uint16_t interactionTimeoutMs,
+                                                           uint16_t busyWaitMs, bool suppressResponse,
                                                            python::TestOnlyPyBatchCommandsOverrides testOnlyOverrides,
                                                            python::PyInvokeRequestData * batchCommandData, size_t length)
 {

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -111,15 +111,15 @@ buildconfig_header("system_buildconfig") {
     "CHIP_SYSTEM_CONFIG_ZEPHYR_LOCKING=${chip_system_config_zephyr_locking}",
     "CHIP_SYSTEM_CONFIG_NO_LOCKING=${chip_system_config_no_locking}",
     "CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS=${chip_system_config_provide_statistics}",
-    "HAVE_CLOCK_GETTIME=${have_clock_gettime}",
-    "HAVE_CLOCK_SETTIME=${have_clock_settime}",
-    "HAVE_GETTIMEOFDAY=${have_gettimeofday}",
-    "HAVE_SYS_TIME_H=true",
-    "HAVE_NETINET_ICMP6_H=true",
-    "HAVE_ICMP6_FILTER=true",
     "CONFIG_HAVE_VCBPRINTF=false",
     "CONFIG_HAVE_VSNPRINTF_EX=false",
-    "HAVE_SYS_SOCKET_H=${chip_system_config_use_sockets}",
+    "ifndef:HAVE_CLOCK_GETTIME=${have_clock_gettime}",
+    "ifndef:HAVE_CLOCK_SETTIME=${have_clock_settime}",
+    "ifndef:HAVE_GETTIMEOFDAY=${have_gettimeofday}",
+    "ifndef:HAVE_ICMP6_FILTER=true",
+    "ifndef:HAVE_NETINET_ICMP6_H=true",
+    "ifndef:HAVE_SYS_SOCKET_H=${chip_system_config_use_sockets}",
+    "ifndef:HAVE_SYS_TIME_H=true",
   ]
 
   if (chip_project_config_include != "") {


### PR DESCRIPTION
### Problem

When building Python C module which calls Python code (e.g. via registered callbacks), it is required to link .so library in the "embed" mode (e.g. in order to call `PyGILState_Ensure()` in multi-threaded application). To do that we need to get proper cflags and libraries. We can use `pkg-config` or `python-config` for that. In order to simplify things on platforms which do not support `pkg-config`, this PR proposes the usage of `python3-config` for that purpose.

### Changes

- use `python3-config` outside of our `.environment` to get proper libs and cflags
- add `#include <Python.h>` where appropriate and fix `PyObject` usage
- extend `buildconfig_header` to allow wrapping defines with `#ifndef` (our config clashes with `python3.x/pyconfig.h`)

### Testing

Locally tested on Linux that python-bindings works as expected in case where CPython functions are used by CHIP Python module (that's not the case yet in the current master - there will be a followup). CI will verify other platforms.