### PR TITLE
Add space after %p format specifier in attribute-table logs

### DIFF
--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -172,7 +172,7 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
     // if we dont support that attribute
     if (metadata == nullptr)
     {
-        ChipLogProgress(Zcl, "%pep %x clus " ChipLogFormatMEI " attr " ChipLogFormatMEI " not supported", "WRITE ERR: ", endpoint,
+        ChipLogProgress(Zcl, "%p ep %x clus " ChipLogFormatMEI " attr " ChipLogFormatMEI " not supported", "WRITE ERR: ", endpoint,
                         ChipLogValueMEI(cluster), ChipLogValueMEI(attributeID));
         return status;
     }
@@ -182,13 +182,13 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
     {
         if (dataType != metadata->attributeType)
         {
-            ChipLogProgress(Zcl, "%pinvalid data type", "WRITE ERR: ");
+            ChipLogProgress(Zcl, "%p invalid data type", "WRITE ERR: ");
             return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
         }
 
         if (metadata->IsReadOnly())
         {
-            ChipLogProgress(Zcl, "%pattr not writable", "WRITE ERR: ");
+            ChipLogProgress(Zcl, "%p attr not writable", "WRITE ERR: ");
             return EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
         }
     }


### PR DESCRIPTION
Without space an old log would looks like
```
I (40592) chip[ZCL]: 0x3c12939cep 1 clus 0x0000_0201 attr 0x0000_0029 not supported
```