### PR TITLE
fix: remove `const` from the argument `chip::Span<chip::DataVersion>` of `emberAfSetDynamicEndpoint()` because there is internal changes

### DIFF
--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
@@ -48,7 +48,7 @@ static EndpointId gFirstDynamicEndpointId;
 static SubDevice * gSubDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT]; // number of dynamic endpoints count
 
 int AddDeviceEndpoint(SubDevice * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId)
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId)
 {
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)

--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.h
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.h
@@ -66,7 +66,7 @@ extern "C" {
 #define ZCL_ON_OFF_CLUSTER_REVISION (4u)
 
 int AddDeviceEndpoint(SubDevice * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId);
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId);
 CHIP_ERROR RemoveDeviceEndpoint(SubDevice * dev);
 EmberAfStatus HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer,
                                                     uint16_t maxReadLength);

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -158,7 +158,7 @@ DataVersion gLight4DataVersions[ArraySize(bridgedLightClusters)];
 #define ZCL_ON_OFF_CLUSTER_REVISION (4u)
 
 int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId)
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId)
 {
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -251,7 +251,7 @@ DataVersion gComposedTempSensor2DataVersions[ArraySize(bridgedTempSensorClusters
 // ---------------------------------------------------------------------------
 
 int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId = chip::kInvalidEndpointId)
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId = chip::kInvalidEndpointId)
 {
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)

--- a/examples/bridge-app/telink/src/AppTask.cpp
+++ b/examples/bridge-app/telink/src/AppTask.cpp
@@ -33,7 +33,7 @@ AppTask AppTask::sAppTask;
 #include <app/InteractionModelEngine.h>
 
 int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId);
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId);
 CHIP_ERROR RemoveDeviceEndpoint(Device * dev);
 void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSensor::Changed_t itemChangedMask);
 EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId, uint8_t * buffer,
@@ -181,7 +181,7 @@ const EmberAfDeviceType gBridgedTempSensorDeviceTypes[] = { { DEVICE_TYPE_TEMP_S
                                                             { DEVICE_TYPE_BRIDGED_NODE, DEVICE_VERSION_DEFAULT } };
 
 int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId)
+                      Span<DataVersion> && dataVersionStorage, chip::EndpointId parentEndpointId)
 {
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -107,8 +107,7 @@ AppPlatformExternalAttributeWriteCallback(EndpointId endpoint, ClusterId cluster
     return (EMBER_ZCL_STATUS_FAILURE);
 }
 
-EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep,
-                                             const Span<DataVersion> & dataVersionStorage,
+EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep, Span<DataVersion> && dataVersionStorage,
                                              const Span<const EmberAfDeviceType> & deviceTypeList)
 {
     CatalogVendorApp vendorApp = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();
@@ -165,8 +164,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
     return kNoCurrentEndpointId;
 }
 
-EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep,
-                                             const Span<DataVersion> & dataVersionStorage,
+EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep, Span<DataVersion> && dataVersionStorage,
                                              const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId)
 {
     CatalogVendorApp vendorApp = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -102,7 +102,7 @@ public:
     // returns the global endpoint for this app, or kNoCurrentEndpointId if an error occurred.
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
-    EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
+    EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, Span<DataVersion> && dataVersionStorage,
                              const Span<const EmberAfDeviceType> & deviceTypeList);
 
     // add apps to the platform.
@@ -111,7 +111,7 @@ public:
     // , or kNoCurrentEndpointId if an error occurred. desiredEndpointId cannot be less that Fixed endpoint count
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
-    EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
+    EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, Span<DataVersion> && dataVersionStorage,
                              const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId);
 
     // remove app from the platform.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -240,7 +240,7 @@ uint16_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
 }
 
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberAfEndpointType * ep,
-                                        const chip::Span<chip::DataVersion> & dataVersionStorage,
+                                        chip::Span<chip::DataVersion> & dataVersionStorage,
                                         chip::Span<const EmberAfDeviceType> deviceTypeList, EndpointId parentEndpointId)
 {
     auto realIndex = index + FIXED_ENDPOINT_COUNT;

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -249,7 +249,7 @@ CHIP_ERROR SetTagList(chip::EndpointId endpoint,
 // An optional parent endpoint id should be passed for child endpoints of composed device.
 //
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep,
-                                        const chip::Span<chip::DataVersion> & dataVersionStorage,
+                                        chip::Span<chip::DataVersion> & dataVersionStorage,
                                         chip::Span<const EmberAfDeviceType> deviceTypeList = {},
                                         chip::EndpointId parentEndpointId                  = chip::kInvalidEndpointId);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -176,7 +176,8 @@ void TestReadEvents::TestBasicCaching(nlTestSuite * apSuite, void * apContext)
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     chip::EventNumber firstEventNumber;
     chip::EventNumber lastEventNumber;

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -317,7 +317,8 @@ void TestReadEvents::TestEventChunking(nlTestSuite * apSuite, void * apContext)
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     chip::EventNumber firstEventNumber;
     chip::EventNumber lastEventNumber;
@@ -384,7 +385,8 @@ void TestReadEvents::TestMixedEventsAndAttributesChunking(nlTestSuite * apSuite,
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     chip::EventNumber firstEventNumber;
     chip::EventNumber lastEventNumber;
@@ -461,7 +463,8 @@ void TestReadEvents::TestMixedEventsAndLargeAttributesChunking(nlTestSuite * apS
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint4, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint4, dataVersionSpan);
 
     chip::EventNumber firstEventNumber;
     chip::EventNumber lastEventNumber;

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -173,7 +173,8 @@ void TestReadEvents::TestEventNumberCaching(nlTestSuite * apSuite, void * apCont
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     chip::EventNumber firstEventNumber;
     chip::EventNumber lastEventNumber;

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -497,7 +497,8 @@ void TestReadChunking::TestChunking(nlTestSuite * apSuite, void * apContext)
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     app::AttributePathParams attributePath(kTestEndpointId, app::Clusters::UnitTesting::Id);
     app::ReadPrepareParams readParams(sessionHandle);
@@ -560,7 +561,8 @@ void TestReadChunking::TestListChunking(nlTestSuite * apSuite, void * apContext)
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpoint3Clusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId3, &testEndpoint3, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId3, &testEndpoint3, dataVersionSpan);
 
     app::AttributePathParams attributePath(kTestEndpointId3, app::Clusters::UnitTesting::Id, kTestListAttribute);
     app::ReadPrepareParams readParams(sessionHandle);
@@ -665,7 +667,8 @@ void TestReadChunking::TestBadChunking(nlTestSuite * apSuite, void * apContext)
 
     // Register our fake dynamic endpoint.
     DataVersion dataVersionStorage[ArraySize(testEndpoint3Clusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId3, &testEndpoint3, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId3, &testEndpoint3, dataVersionSpan);
 
     app::AttributePathParams attributePath(kTestEndpointId3, app::Clusters::UnitTesting::Id, kTestBadAttribute);
     app::ReadPrepareParams readParams(sessionHandle);
@@ -730,7 +733,8 @@ void TestReadChunking::TestDynamicEndpoint(nlTestSuite * apSuite, void * apConte
         app::ReadClient readClient(engine, &ctx.GetExchangeManager(), readCallback.mBufferedCallback,
                                    app::ReadClient::InteractionType::Subscribe);
         // Enable the new endpoint
-        emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+        Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+        emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
         NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
 
@@ -739,7 +743,7 @@ void TestReadChunking::TestDynamicEndpoint(nlTestSuite * apSuite, void * apConte
         NL_TEST_ASSERT(apSuite, readCallback.mOnSubscriptionEstablished);
         readCallback.mAttributeCount = 0;
 
-        emberAfSetDynamicEndpoint(0, kTestEndpointId4, &testEndpoint4, Span<DataVersion>(dataVersionStorage));
+        emberAfSetDynamicEndpoint(0, kTestEndpointId4, &testEndpoint4, dataVersionSpan);
 
         ctx.DrainAndServiceIO();
 
@@ -924,8 +928,10 @@ void TestReadChunking::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void * a
     gMutableAttrAccess.Reset();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage1));
-    emberAfSetDynamicEndpoint(1, kTestEndpointId5, &testEndpoint5, Span<DataVersion>(dataVersionStorage5));
+    Span<DataVersion> dataVersionSpan1 = Span<DataVersion>(dataVersionStorage1);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan1);
+    Span<DataVersion> dataVersionSpan5 = Span<DataVersion>(dataVersionStorage5);
+    emberAfSetDynamicEndpoint(1, kTestEndpointId5, &testEndpoint5, dataVersionSpan5);
 
     {
         app::AttributePathParams attributePath;

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -260,7 +260,8 @@ void TestCommandInteraction::TestDataResponseHelper(nlTestSuite * apSuite, void 
     // All our endpoints have the same number of clusters, so just pick one.
     //
     DataVersion dataVersionStorage[ArraySize(testEndpointClusters1)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, aEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, aEndpoint, dataVersionSpan);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -197,7 +197,8 @@ void TestWriteChunking::TestListChunking(nlTestSuite * apSuite, void * apContext
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     // Register our fake attribute access interface.
     registerAttributeAccessOverride(&testServer);
@@ -272,7 +273,8 @@ void TestWriteChunking::TestBadChunking(nlTestSuite * apSuite, void * apContext)
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     // Register our fake attribute access interface.
     registerAttributeAccessOverride(&testServer);
@@ -353,7 +355,8 @@ void TestWriteChunking::TestConflictWrite(nlTestSuite * apSuite, void * apContex
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     // Register our fake attribute access interface.
     registerAttributeAccessOverride(&testServer);
@@ -430,7 +433,8 @@ void TestWriteChunking::TestNonConflictWrite(nlTestSuite * apSuite, void * apCon
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     // Register our fake attribute access interface.
     registerAttributeAccessOverride(&testServer);
@@ -613,7 +617,8 @@ void TestWriteChunking::TestTransactionalList(nlTestSuite * apSuite, void * apCo
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, Span<DataVersion>(dataVersionStorage));
+    Span<DataVersion> dataVersionSpan = Span<DataVersion>(dataVersionStorage);
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, dataVersionSpan);
 
     // Register our fake attribute access interface.
     registerAttributeAccessOverride(&testServer);


### PR DESCRIPTION
In the arguments of `emberAfSetDynamicEndpoint()`,

https://github.com/project-chip/connectedhomeip/blob/4855f580034348e98a4c4259c6d50f784a432c36/src/app/util/attribute-storage.cpp#L242-L244

`chip::Span<chip::DataVersion>` is marked as `const`, but internal changes exist here.

https://github.com/project-chip/connectedhomeip/blob/4855f580034348e98a4c4259c6d50f784a432c36/src/app/util/attribute-storage.cpp#L286

So the argument `const chip::Span<chip::DataVersion> & dataVersionStorage` should not be `const`.
