### PR TITLE
small fixes to the minimal configure script

### DIFF
--- a/scripts/configure
+++ b/scripts/configure
@@ -47,9 +47,9 @@ function usage() { # status
     info "Project options (mapped to GN build args):"
     info "  --enable-<ARG>[=no]   Enables (or disables with '=no') a bool build arg"
     info "  --<ARG>=<VALUE>       Sets a (non-bool) build arg to the given value"
-    info "  GN argument names can be specified with '-' instead of '_' and prefixes"
-    info "  like 'chip_' can be ommitted from names. For the full list of available"
-    info "  build arguments, see the generated args.configured file."
+    info "  GN argument names must be specified with '-' instead of '_'."
+    info "  Prefixes like 'chip_' can be ommitted from names. For the full list of"
+    info "  available build arguments, see the generated args.configured file."
     info ""
     info "  By default, the toolchain for the GN build will be configured from the usual"
     info "  environment variables (CC, CXX, AR, CFLAGS, CXXFLAGS, ...), falling back to"
@@ -216,9 +216,11 @@ function gn_generate() { # [project options]
     } >"${BUILD_DIR}/args.gn"
     "${gn[@]}" -q gen "$BUILD_DIR"
 
+    # Generate args.configured first
+    "${gn[@]}" args "$BUILD_DIR" --list >"${BUILD_DIR}/args.configured"
+
     # Use the argument list to drive the mapping of our command line options to GN args
     call_impl process_project_args <("${gn[@]}" args "$BUILD_DIR" --list --json) "$@" >>"${BUILD_DIR}/args.gn"
-    "${gn[@]}" args "$BUILD_DIR" --list >"${BUILD_DIR}/args.configured"
 
     # Now gn gen with the arguments we have configured.
     info "Running gn gen to generate ninja files"

--- a/scripts/configure
+++ b/scripts/configure
@@ -216,7 +216,8 @@ function gn_generate() { # [project options]
     } >"${BUILD_DIR}/args.gn"
     "${gn[@]}" -q gen "$BUILD_DIR"
 
-    # Generate args.configured first
+    # Generate args.configured before populating args.gn because process_project_args may fail
+    # and we want to make sure, that args.configured is available as stated above in the info message
     "${gn[@]}" args "$BUILD_DIR" --list >"${BUILD_DIR}/args.configured"
 
     # Use the argument list to drive the mapping of our command line options to GN args


### PR DESCRIPTION
This PR fixes two small issues.

1) The description was misleading to allow configure parameters mit underscores. Looking at the regex of the implementation (https://github.com/project-chip/connectedhomeip/blob/master/scripts/configure.impl.py#L149) suggests that they are not allowed. Therefore i propose to correct the documentation.

2) If you fell for 1) you will the the message `see out/configured/args.configured for full list`, but this file is not created until the real arglist was processed. Move the generation of the `args.configured` file up to have it generated before the failure can happen.