### PR TITLE
Add Mapping and GoHome Mode tags to the RvcRunMode cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2985,6 +2985,8 @@ cluster RvcRunMode = 84 {
   enum ModeTag : enum16 {
     kIdle = 16384;
     kCleaning = 16385;
+    kMapping = 16386;
+    kGoHome = 16387;
   }
 
   enum StatusCode : enum8 {

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -1005,6 +1005,8 @@ cluster RvcRunMode = 84 {
   enum ModeTag : enum16 {
     kIdle = 16384;
     kCleaning = 16385;
+    kMapping = 16386;
+    kGoHome = 16387;
   }
 
   enum StatusCode : enum8 {

--- a/examples/rvc-app/rvc-common/rvc-app.matter
+++ b/examples/rvc-app/rvc-common/rvc-app.matter
@@ -928,6 +928,8 @@ cluster RvcRunMode = 84 {
   enum ModeTag : enum16 {
     kIdle = 16384;
     kCleaning = 16385;
+    kMapping = 16386;
+    kGoHome = 16387;
   }
 
   enum StatusCode : enum8 {

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -33,6 +33,8 @@ limitations under the License.
     <cluster code="0x0054"/>
     <item value="0x4000" name="Idle"/>
     <item value="0x4001" name="Cleaning"/>
+    <item value="0x4002" name="Mapping"/>
+    <item value="0x4003" name="GoHome"/>
   </enum>
 
   <cluster>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3289,6 +3289,8 @@ cluster RvcRunMode = 84 {
   enum ModeTag : enum16 {
     kIdle = 16384;
     kCleaning = 16385;
+    kMapping = 16386;
+    kGoHome = 16387;
   }
 
   enum StatusCode : enum8 {

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -17370,6 +17370,8 @@ class RvcRunMode(Cluster):
         class ModeTag(MatterIntEnum):
             kIdle = 0x4000
             kCleaning = 0x4001
+            kMapping = 0x4002
+            kGoHome = 0x4003
             # kUnknownEnumValue intentionally not defined. This enum never goes
             # through DataModel::Decode, likely because it is a part of a derived
             # cluster. As a result having kUnknownEnumValue in this enum is error

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -16743,6 +16743,8 @@ typedef NS_OPTIONS(uint32_t, MTRLaundryWasherControlsFeature) {
 typedef NS_ENUM(uint16_t, MTRRVCRunModeModeTag) {
     MTRRVCRunModeModeTagIdle MTR_NEWLY_AVAILABLE = 0x4000,
     MTRRVCRunModeModeTagCleaning MTR_NEWLY_AVAILABLE = 0x4001,
+    MTRRVCRunModeModeTagMapping MTR_PROVISIONALLY_AVAILABLE = 0x4002,
+    MTRRVCRunModeModeTagGoHome MTR_PROVISIONALLY_AVAILABLE = 0x4003,
 } MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTRRVCRunModeStatusCode) {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -1686,6 +1686,8 @@ enum class ModeTag : uint16_t
 {
     kIdle     = 0x4000,
     kCleaning = 0x4001,
+    kMapping  = 0x4002,
+    kGoHome   = 0x4003,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error


### PR DESCRIPTION
Fixes #30738.

- Adds the Mapping and GoHome mode tags to the RvcRunMode cluster's XML.
- Regenerates files based on the XML changes.
