### PR TITLE
[network-commissioning] Encode SupportedWiFiBands as list

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -54,6 +54,9 @@ namespace {
 // For WiFi and Thread scan results, each item will cost ~60 bytes in TLV, thus 15 is a safe upper bound of scan results.
 constexpr size_t kMaxNetworksInScanResponse = 15;
 
+// The maximum number of Wi-Fi bands a device can support.
+constexpr size_t kMaxWiFiBands = 6;
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 constexpr size_t kPossessionNonceSize = 32;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
@@ -269,7 +272,19 @@ CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValu
     case Attributes::SupportedWiFiBands::Id:
         VerifyOrReturnError(mFeatureFlags.Has(Feature::kWiFiNetworkInterface), CHIP_NO_ERROR);
         VerifyOrReturnError(mpDriver.Valid(), CHIP_NO_ERROR);
-        return aEncoder.Encode(mpDriver.Get<WiFiDriver *>()->GetSupportedWiFiBands());
+
+        return aEncoder.EncodeList([this](const auto & encoder) -> CHIP_ERROR {
+            WiFiBand bandsBuffer[kMaxWiFiBands];
+            Span<WiFiBand> bands(bandsBuffer);
+            ReturnErrorOnFailure(mpDriver.Get<WiFiDriver *>()->GetSupportedWiFiBands(bands));
+
+            for (WiFiBand band : bands)
+            {
+                ReturnErrorOnFailure(encoder.Encode(band));
+            }
+
+            return CHIP_NO_ERROR;
+        });
 
     case Attributes::SupportedThreadFeatures::Id:
         VerifyOrReturnError(mFeatureFlags.Has(Feature::kThreadNetworkInterface), CHIP_NO_ERROR);

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -354,10 +354,23 @@ public:
     /**
      *  @brief Provide all the frequency bands supported by the Wi-Fi interface
      *
-     *  Provide a default implementation that returns the 2.4 Ghz band support.
+     *  The default implementation returns the 2.4 GHz band support.
      *  Note: WiFi platforms should implement this function in their WiFiDriver to provide their complete device capabilities
+     *
+     *  @param bands Reference to a span that is used to return the supported bands.
+     *               The span is initialized with a fixed-size buffer.
+     *               The implementation is expected to resize the span to match the number of returned results.
+     *
+     *  @return CHIP_NO_ERROR on success or a CHIP_ERROR on failure.
      */
-    virtual WiFiBand GetSupportedWiFiBands() { return WiFiBand::k2g4; }
+    virtual CHIP_ERROR GetSupportedWiFiBands(Span<WiFiBand> & bands)
+    {
+        ReturnErrorCodeIf(bands.empty(), CHIP_ERROR_BUFFER_TOO_SMALL);
+        bands.front() = WiFiBand::k2g4;
+        bands.reduce_size(1);
+
+        return CHIP_NO_ERROR;
+    }
 
     ~WiFiDriver() override = default;
 };

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -276,6 +276,22 @@ void NrfWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callb
     }
 }
 
+CHIP_ERROR NrfWiFiDriver::GetSupportedWiFiBands(Span<WiFiBand> & bands)
+{
+    static constexpr WiFiBand kBands[] = {
+        WiFiBand::k2g4,
+#ifndef CONFIG_BOARD_NRF7001
+        WiFiBand::k5g,
+#endif
+    };
+
+    VerifyOrReturnError(ArraySize(kBands) <= bands.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(bands.data(), kBands, sizeof(kBands));
+    bands.reduce_size(ArraySize(kBands));
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace NetworkCommissioning
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -86,6 +86,7 @@ public:
     Status AddOrUpdateNetwork(ByteSpan ssid, ByteSpan credentials, MutableCharSpan & outDebugText,
                               uint8_t & outNetworkIndex) override;
     void ScanNetworks(ByteSpan ssid, ScanCallback * callback) override;
+    CHIP_ERROR GetSupportedWiFiBands(Span<WiFiBand> & bands) override;
 
     static NrfWiFiDriver & Instance()
     {


### PR DESCRIPTION
SupportedWiFiBands attribute is a list according to the spec yet the implementation encoded it as a scalar.
Also, add an implementation for nRF Connect platform.

Related to #30579.