### PR TITLE
Validate InvokeRequestMessage TLV properly terminated before running commands

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -171,9 +171,8 @@ CHIP_ERROR CommandHandler::ValidateInvokeRequestMessageAndBuildRegistry(InvokeRe
     {
         err = CHIP_NO_ERROR;
     }
-    ReturnErrorOnFailure(invokeRequestMessage.ExitContainer());
-
-    return err;
+    ReturnErrorOnFailure(err);
+    return invokeRequestMessage.ExitContainer();
 }
 
 Status CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && payload, bool isTimedInvoke)

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -105,11 +105,16 @@ void CommandHandler::OnInvokeCommandRequest(Messaging::ExchangeContext * ec, con
     mGoneAsync = true;
 }
 
-CHIP_ERROR CommandHandler::ValidateInvokeRequestsAndBuildRegistry(TLV::TLVReader & invokeRequestsReader)
+CHIP_ERROR CommandHandler::ValidateInvokeRequestMessageAndBuildRegistry(InvokeRequestMessage::Parser & invokeRequestMessage)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     size_t commandCount     = 0;
     bool commandRefExpected = false;
+    InvokeRequests::Parser invokeRequests;
+
+    ReturnErrorOnFailure(invokeRequestMessage.GetInvokeRequests(&invokeRequests));
+    TLV::TLVReader invokeRequestsReader;
+    invokeRequests.GetReader(&invokeRequestsReader);
 
     ReturnErrorOnFailure(TLV::Utilities::Count(invokeRequestsReader, commandCount, false /* recurse */));
 
@@ -166,6 +171,8 @@ CHIP_ERROR CommandHandler::ValidateInvokeRequestsAndBuildRegistry(TLV::TLVReader
     {
         err = CHIP_NO_ERROR;
     }
+    ReturnErrorOnFailure(invokeRequestMessage.ExitContainer());
+
     return err;
 }
 
@@ -191,9 +198,8 @@ Status CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && payloa
     VerifyOrReturnError(mTimedRequest == isTimedInvoke, Status::UnsupportedAccess);
 
     {
-        TLV::TLVReader validationInvokeRequestsReader;
-        invokeRequests.GetReader(&validationInvokeRequestsReader);
-        VerifyOrReturnError(ValidateInvokeRequestsAndBuildRegistry(validationInvokeRequestsReader) == CHIP_NO_ERROR,
+        InvokeRequestMessage::Parser validationInvokeRequestMessage = invokeRequestMessage;
+        VerifyOrReturnError(ValidateInvokeRequestMessageAndBuildRegistry(validationInvokeRequestMessage) == CHIP_NO_ERROR,
                             Status::InvalidAction);
     }
 

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -209,12 +209,13 @@ public:
 
     /**
      * Checks that all CommandDataIB within InvokeRequests satisfy the spec's general
-     * constraints for CommandDataIB.
+     * constraints for CommandDataIB. Additionally checks that InvokeRequestMessage is
+     * properly formatted.
      *
      * This also builds a registry that to ensure that all commands can be responded
      * to with the data required as per spec.
      */
-    CHIP_ERROR ValidateInvokeRequestsAndBuildRegistry(TLV::TLVReader & invokeRequestsReader);
+    CHIP_ERROR ValidateInvokeRequestMessageAndBuildRegistry(InvokeRequestMessage::Parser & invokeRequestMessage);
 
     /**
      * Adds the given command status and returns any failures in adding statuses (e.g. out


### PR DESCRIPTION
### Problem:
If an InvokeRequestMessage was missing the final close container in the TLV payload we would execute all the provided commands but return an error indicated that arguments were invalid.

### Solution: 
Validate entire InvokeRequestMessage before processing elements.