### PR TITLE
[Android] Replace GetMethodID with FindMethod for method retrieval

### DIFF
--- a/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
+++ b/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
@@ -60,9 +60,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         ChipLogError(Zcl, "Could not find class ChipEventStructs${{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event");
                         return nullptr;
                     }
-                    jmethodID {{asLowerCamelCase name}}StructCtor = env->GetMethodID({{asLowerCamelCase name}}StructClass, "<init>"
-                        , "({{#zcl_event_fields}}{{asJniSignature type null (asUpperCamelCase parent.parent.name) true}}{{/zcl_event_fields}})V");
-                    if ({{asLowerCamelCase name}}StructCtor == nullptr) {
+
+                    jmethodID {{asLowerCamelCase name}}StructCtor;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                       env, {{asLowerCamelCase name}}StructClass, "<init>",
+                       "({{#zcl_event_fields}}{{asJniSignature type null (asUpperCamelCase parent.parent.name) true}}{{/zcl_event_fields}})V",
+                       &{{asLowerCamelCase name}}StructCtor);
+                    if (err != CHIP_NO_ERROR || {{asLowerCamelCase name}}StructCtor == nullptr) {
                         ChipLogError(Zcl, "Could not find ChipEventStructs${{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event constructor");
                         return nullptr;
                     }

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -37,9 +37,13 @@ if ({{source}}.IsNull()) {
       ChipLogError(Zcl, "Could not find class ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}");
       return {{earlyReturn}};
     }
-    jmethodID {{asLowerCamelCase type}}StructCtor_{{depth}} = env->GetMethodID({{asLowerCamelCase type}}StructClass_{{depth}}, "<init>"
-        , "({{#zcl_struct_items_by_struct_and_cluster_name type cluster}}{{asJniSignature type null (asUpperCamelCase ../cluster) true}}{{/zcl_struct_items_by_struct_and_cluster_name}})V");
-    if ({{asLowerCamelCase type}}StructCtor_{{depth}} == nullptr) {
+
+    jmethodID {{asLowerCamelCase type}}StructCtor_{{depth}};
+    err = chip::JniReferences::GetInstance().FindMethod(
+        env, {{asLowerCamelCase type}}StructClass_{{depth}}, "<init>",
+        "({{#zcl_struct_items_by_struct_and_cluster_name type cluster}}{{asJniSignature type null (asUpperCamelCase ../cluster) true}}{{/zcl_struct_items_by_struct_and_cluster_name}})V",
+        &{{asLowerCamelCase type}}StructCtor_{{depth}});
+    if (err != CHIP_NO_ERROR || {{asLowerCamelCase type}}StructCtor_{{depth}} == nullptr) {
       ChipLogError(Zcl, "Could not find ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}} constructor");
       return {{earlyReturn}};
     }

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -559,11 +559,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterSceneInfoStruct");
                     return nullptr;
                 }
-                jmethodID sceneInfoStructStructCtor_1 =
-                    env->GetMethodID(sceneInfoStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/"
-                                     "Integer;Ljava/lang/Integer;)V");
-                if (sceneInfoStructStructCtor_1 == nullptr)
+
+                jmethodID sceneInfoStructStructCtor_1;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, sceneInfoStructStructClass_1, "<init>",
+                                                                  "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
+                                                                  "lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                  &sceneInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || sceneInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterSceneInfoStruct constructor");
                     return nullptr;
@@ -1984,9 +1987,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterDeviceTypeStruct");
                     return nullptr;
                 }
-                jmethodID deviceTypeStructStructCtor_1 =
-                    env->GetMethodID(deviceTypeStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
-                if (deviceTypeStructStructCtor_1 == nullptr)
+
+                jmethodID deviceTypeStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, deviceTypeStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Integer;)V",
+                                                                    &deviceTypeStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || deviceTypeStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$DescriptorClusterDeviceTypeStruct constructor");
                     return nullptr;
@@ -2145,10 +2151,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterSemanticTagStruct");
                     return nullptr;
                 }
-                jmethodID semanticTagStructStructCtor_1 =
-                    env->GetMethodID(semanticTagStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (semanticTagStructStructCtor_1 == nullptr)
+
+                jmethodID semanticTagStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, semanticTagStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;)V",
+                    &semanticTagStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || semanticTagStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$DescriptorClusterSemanticTagStruct constructor");
                     return nullptr;
@@ -2400,10 +2409,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$BindingClusterTargetStruct");
                     return nullptr;
                 }
-                jmethodID targetStructStructCtor_1 = env->GetMethodID(
-                    targetStructStructClass_1, "<init>",
-                    "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V");
-                if (targetStructStructCtor_1 == nullptr)
+
+                jmethodID targetStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, targetStructStructClass_1, "<init>",
+                    "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V",
+                    &targetStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || targetStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$BindingClusterTargetStruct constructor");
                     return nullptr;
@@ -2676,10 +2688,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlTargetStruct");
                             return nullptr;
                         }
-                        jmethodID accessControlTargetStructStructCtor_4 =
-                            env->GetMethodID(accessControlTargetStructStructClass_4, "<init>",
-                                             "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
-                        if (accessControlTargetStructStructCtor_4 == nullptr)
+
+                        jmethodID accessControlTargetStructStructCtor_4;
+                        err = chip::JniReferences::GetInstance().FindMethod(
+                            env, accessControlTargetStructStructClass_4, "<init>",
+                            "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V", &accessControlTargetStructStructCtor_4);
+                        if (err != CHIP_NO_ERROR || accessControlTargetStructStructCtor_4 == nullptr)
                         {
                             ChipLogError(Zcl,
                                          "Could not find ChipStructs$AccessControlClusterAccessControlTargetStruct constructor");
@@ -2708,10 +2722,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlEntryStruct");
                     return nullptr;
                 }
-                jmethodID accessControlEntryStructStructCtor_1 = env->GetMethodID(
-                    accessControlEntryStructStructClass_1, "<init>",
-                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-                if (accessControlEntryStructStructCtor_1 == nullptr)
+
+                jmethodID accessControlEntryStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, accessControlEntryStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V",
+                    &accessControlEntryStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || accessControlEntryStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlEntryStruct constructor");
                     return nullptr;
@@ -2762,9 +2779,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlExtensionStruct");
                     return nullptr;
                 }
-                jmethodID accessControlExtensionStructStructCtor_1 =
-                    env->GetMethodID(accessControlExtensionStructStructClass_1, "<init>", "([BLjava/lang/Integer;)V");
-                if (accessControlExtensionStructStructCtor_1 == nullptr)
+
+                jmethodID accessControlExtensionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, accessControlExtensionStructStructClass_1, "<init>",
+                                                                    "([BLjava/lang/Integer;)V",
+                                                                    &accessControlExtensionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || accessControlExtensionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlExtensionStruct constructor");
                     return nullptr;
@@ -3028,11 +3048,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ActionsClusterActionStruct");
                     return nullptr;
                 }
-                jmethodID actionStructStructCtor_1 =
-                    env->GetMethodID(actionStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                                     "Integer;Ljava/lang/Integer;)V");
-                if (actionStructStructCtor_1 == nullptr)
+
+                jmethodID actionStructStructCtor_1;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, actionStructStructClass_1, "<init>",
+                                                                  "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/"
+                                                                  "lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                  &actionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || actionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ActionsClusterActionStruct constructor");
                     return nullptr;
@@ -3101,10 +3124,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ActionsClusterEndpointListStruct");
                     return nullptr;
                 }
-                jmethodID endpointListStructStructCtor_1 =
-                    env->GetMethodID(endpointListStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (endpointListStructStructCtor_1 == nullptr)
+
+                jmethodID endpointListStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, endpointListStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                    &endpointListStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || endpointListStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ActionsClusterEndpointListStruct constructor");
                     return nullptr;
@@ -3560,9 +3586,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$BasicInformationClusterCapabilityMinimaStruct");
                 return nullptr;
             }
-            jmethodID capabilityMinimaStructStructCtor_0 =
-                env->GetMethodID(capabilityMinimaStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (capabilityMinimaStructStructCtor_0 == nullptr)
+
+            jmethodID capabilityMinimaStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, capabilityMinimaStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &capabilityMinimaStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || capabilityMinimaStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$BasicInformationClusterCapabilityMinimaStruct constructor");
                 return nullptr;
@@ -3611,9 +3640,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$BasicInformationClusterProductAppearanceStruct");
                 return nullptr;
             }
-            jmethodID productAppearanceStructStructCtor_0 =
-                env->GetMethodID(productAppearanceStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (productAppearanceStructStructCtor_0 == nullptr)
+
+            jmethodID productAppearanceStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, productAppearanceStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &productAppearanceStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || productAppearanceStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$BasicInformationClusterProductAppearanceStruct constructor");
                 return nullptr;
@@ -3986,9 +4018,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation");
                     return nullptr;
                 }
-                jmethodID providerLocationStructCtor_1 = env->GetMethodID(
-                    providerLocationStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                if (providerLocationStructCtor_1 == nullptr)
+
+                jmethodID providerLocationStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, providerLocationStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                    &providerLocationStructCtor_1);
+                if (err != CHIP_NO_ERROR || providerLocationStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation constructor");
                     return nullptr;
@@ -5675,9 +5710,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$GeneralCommissioningClusterBasicCommissioningInfo");
                 return nullptr;
             }
-            jmethodID basicCommissioningInfoStructCtor_0 =
-                env->GetMethodID(basicCommissioningInfoStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (basicCommissioningInfoStructCtor_0 == nullptr)
+
+            jmethodID basicCommissioningInfoStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, basicCommissioningInfoStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &basicCommissioningInfoStructCtor_0);
+            if (err != CHIP_NO_ERROR || basicCommissioningInfoStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$GeneralCommissioningClusterBasicCommissioningInfo constructor");
                 return nullptr;
@@ -5979,9 +6017,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterNetworkInfoStruct");
                     return nullptr;
                 }
-                jmethodID networkInfoStructStructCtor_1 = env->GetMethodID(
-                    networkInfoStructStructClass_1, "<init>", "([BLjava/lang/Boolean;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (networkInfoStructStructCtor_1 == nullptr)
+
+                jmethodID networkInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, networkInfoStructStructClass_1, "<init>",
+                    "([BLjava/lang/Boolean;Ljava/util/Optional;Ljava/util/Optional;)V", &networkInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || networkInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$NetworkCommissioningClusterNetworkInfoStruct constructor");
                     return nullptr;
@@ -6560,11 +6601,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GeneralDiagnosticsClusterNetworkInterface");
                     return nullptr;
                 }
-                jmethodID networkInterfaceStructCtor_1 =
-                    env->GetMethodID(networkInterfaceStructClass_1, "<init>",
-                                     "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/"
-                                     "ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-                if (networkInterfaceStructCtor_1 == nullptr)
+
+                jmethodID networkInterfaceStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, networkInterfaceStructClass_1, "<init>",
+                    "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/ArrayList;Ljava/util/"
+                    "ArrayList;Ljava/lang/Integer;)V",
+                    &networkInterfaceStructCtor_1);
+                if (err != CHIP_NO_ERROR || networkInterfaceStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$GeneralDiagnosticsClusterNetworkInterface constructor");
                     return nullptr;
@@ -6972,10 +7016,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$SoftwareDiagnosticsClusterThreadMetricsStruct");
                     return nullptr;
                 }
-                jmethodID threadMetricsStructStructCtor_1 = env->GetMethodID(
-                    threadMetricsStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (threadMetricsStructStructCtor_1 == nullptr)
+
+                jmethodID threadMetricsStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, threadMetricsStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &threadMetricsStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || threadMetricsStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$SoftwareDiagnosticsClusterThreadMetricsStruct constructor");
                     return nullptr;
@@ -7465,12 +7512,15 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTableStruct");
                     return nullptr;
                 }
-                jmethodID neighborTableStructStructCtor_1 =
-                    env->GetMethodID(neighborTableStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/"
-                                     "lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                                     "Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
-                if (neighborTableStructStructCtor_1 == nullptr)
+
+                jmethodID neighborTableStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, neighborTableStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/"
+                    "lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/"
+                    "Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V",
+                    &neighborTableStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || neighborTableStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTableStruct constructor");
                     return nullptr;
@@ -7581,11 +7631,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterRouteTableStruct");
                     return nullptr;
                 }
-                jmethodID routeTableStructStructCtor_1 = env->GetMethodID(
-                    routeTableStructStructClass_1, "<init>",
+
+                jmethodID routeTableStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, routeTableStructStructClass_1, "<init>",
                     "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                    "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
-                if (routeTableStructStructCtor_1 == nullptr)
+                    "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V",
+                    &routeTableStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || routeTableStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterRouteTableStruct constructor");
                     return nullptr;
@@ -8493,9 +8546,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterSecurityPolicy");
                     return nullptr;
                 }
-                jmethodID securityPolicyStructCtor_1 =
-                    env->GetMethodID(securityPolicyStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                if (securityPolicyStructCtor_1 == nullptr)
+
+                jmethodID securityPolicyStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, securityPolicyStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                    &securityPolicyStructCtor_1);
+                if (err != CHIP_NO_ERROR || securityPolicyStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterSecurityPolicy constructor");
                     return nullptr;
@@ -8637,12 +8693,15 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                  "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterOperationalDatasetComponents");
                     return nullptr;
                 }
-                jmethodID operationalDatasetComponentsStructCtor_1 =
-                    env->GetMethodID(operationalDatasetComponentsStructClass_1, "<init>",
-                                     "(Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/"
-                                     "Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/"
-                                     "lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
-                if (operationalDatasetComponentsStructCtor_1 == nullptr)
+
+                jmethodID operationalDatasetComponentsStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, operationalDatasetComponentsStructClass_1, "<init>",
+                    "(Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/"
+                    "Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/"
+                    "lang/Boolean;)V",
+                    &operationalDatasetComponentsStructCtor_1);
+                if (err != CHIP_NO_ERROR || operationalDatasetComponentsStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterOperationalDatasetComponents constructor");
@@ -9670,9 +9729,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TimeSynchronizationClusterTrustedTimeSourceStruct");
                     return nullptr;
                 }
-                jmethodID trustedTimeSourceStructStructCtor_1 = env->GetMethodID(
-                    trustedTimeSourceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V");
-                if (trustedTimeSourceStructStructCtor_1 == nullptr)
+
+                jmethodID trustedTimeSourceStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, trustedTimeSourceStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V",
+                                                                    &trustedTimeSourceStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || trustedTimeSourceStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$TimeSynchronizationClusterTrustedTimeSourceStruct constructor");
                     return nullptr;
@@ -9753,9 +9815,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TimeSynchronizationClusterTimeZoneStruct");
                     return nullptr;
                 }
-                jmethodID timeZoneStructStructCtor_1 = env->GetMethodID(timeZoneStructStructClass_1, "<init>",
-                                                                        "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V");
-                if (timeZoneStructStructCtor_1 == nullptr)
+
+                jmethodID timeZoneStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, timeZoneStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V",
+                                                                    &timeZoneStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || timeZoneStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$TimeSynchronizationClusterTimeZoneStruct constructor");
                     return nullptr;
@@ -9821,9 +9886,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TimeSynchronizationClusterDSTOffsetStruct");
                     return nullptr;
                 }
-                jmethodID DSTOffsetStructStructCtor_1 =
-                    env->GetMethodID(DSTOffsetStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-                if (DSTOffsetStructStructCtor_1 == nullptr)
+
+                jmethodID DSTOffsetStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, DSTOffsetStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                    &DSTOffsetStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || DSTOffsetStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$TimeSynchronizationClusterDSTOffsetStruct constructor");
                     return nullptr;
@@ -10315,9 +10383,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$BridgedDeviceBasicInformationClusterProductAppearanceStruct");
                 return nullptr;
             }
-            jmethodID productAppearanceStructStructCtor_0 =
-                env->GetMethodID(productAppearanceStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (productAppearanceStructStructCtor_0 == nullptr)
+
+            jmethodID productAppearanceStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, productAppearanceStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &productAppearanceStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || productAppearanceStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipStructs$BridgedDeviceBasicInformationClusterProductAppearanceStruct constructor");
@@ -10913,8 +10984,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterNOCStruct");
                     return nullptr;
                 }
-                jmethodID NOCStructStructCtor_1 = env->GetMethodID(NOCStructStructClass_1, "<init>", "([B[BLjava/lang/Integer;)V");
-                if (NOCStructStructCtor_1 == nullptr)
+
+                jmethodID NOCStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, NOCStructStructClass_1, "<init>",
+                                                                    "([B[BLjava/lang/Integer;)V", &NOCStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || NOCStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$OperationalCredentialsClusterNOCStruct constructor");
                     return nullptr;
@@ -10988,10 +11062,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterFabricDescriptorStruct");
                     return nullptr;
                 }
-                jmethodID fabricDescriptorStructStructCtor_1 = env->GetMethodID(
-                    fabricDescriptorStructStructClass_1, "<init>",
-                    "([BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;)V");
-                if (fabricDescriptorStructStructCtor_1 == nullptr)
+
+                jmethodID fabricDescriptorStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, fabricDescriptorStructStructClass_1, "<init>",
+                    "([BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;)V",
+                    &fabricDescriptorStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || fabricDescriptorStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$OperationalCredentialsClusterFabricDescriptorStruct constructor");
                     return nullptr;
@@ -11265,9 +11342,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct");
                     return nullptr;
                 }
-                jmethodID groupKeyMapStructStructCtor_1 = env->GetMethodID(
-                    groupKeyMapStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                if (groupKeyMapStructStructCtor_1 == nullptr)
+
+                jmethodID groupKeyMapStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, groupKeyMapStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                    &groupKeyMapStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || groupKeyMapStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct constructor");
                     return nullptr;
@@ -11346,10 +11426,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct");
                     return nullptr;
                 }
-                jmethodID groupInfoMapStructStructCtor_1 =
-                    env->GetMethodID(groupInfoMapStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/lang/Integer;)V");
-                if (groupInfoMapStructStructCtor_1 == nullptr)
+
+                jmethodID groupInfoMapStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, groupInfoMapStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/lang/Integer;)V",
+                    &groupInfoMapStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || groupInfoMapStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct constructor");
                     return nullptr;
@@ -11564,9 +11647,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$FixedLabelClusterLabelStruct");
                     return nullptr;
                 }
-                jmethodID labelStructStructCtor_1 =
-                    env->GetMethodID(labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-                if (labelStructStructCtor_1 == nullptr)
+
+                jmethodID labelStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", &labelStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || labelStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$FixedLabelClusterLabelStruct constructor");
                     return nullptr;
@@ -11749,9 +11834,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UserLabelClusterLabelStruct");
                     return nullptr;
                 }
-                jmethodID labelStructStructCtor_1 =
-                    env->GetMethodID(labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-                if (labelStructStructCtor_1 == nullptr)
+
+                jmethodID labelStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", &labelStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || labelStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UserLabelClusterLabelStruct constructor");
                     return nullptr;
@@ -12584,9 +12671,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$IcdManagementClusterMonitoringRegistrationStruct");
                     return nullptr;
                 }
-                jmethodID monitoringRegistrationStructStructCtor_1 = env->GetMethodID(
-                    monitoringRegistrationStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;)V");
-                if (monitoringRegistrationStructStructCtor_1 == nullptr)
+
+                jmethodID monitoringRegistrationStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, monitoringRegistrationStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;)V",
+                                                                    &monitoringRegistrationStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || monitoringRegistrationStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$IcdManagementClusterMonitoringRegistrationStruct constructor");
                     return nullptr;
@@ -13110,9 +13200,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OvenCavityOperationalStateClusterOperationalStateStruct");
                     return nullptr;
                 }
-                jmethodID operationalStateStructStructCtor_1 =
-                    env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (operationalStateStructStructCtor_1 == nullptr)
+
+                jmethodID operationalStateStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                    &operationalStateStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$OvenCavityOperationalStateClusterOperationalStateStruct constructor");
@@ -13191,9 +13284,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -13411,9 +13507,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$OvenModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$OvenModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -13432,9 +13531,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OvenModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$OvenModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -13932,9 +14034,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterSemanticTagStruct");
                         return nullptr;
                     }
-                    jmethodID semanticTagStructStructCtor_3 =
-                        env->GetMethodID(semanticTagStructStructClass_3, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                    if (semanticTagStructStructCtor_3 == nullptr)
+
+                    jmethodID semanticTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, semanticTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                        &semanticTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || semanticTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$ModeSelectClusterSemanticTagStruct constructor");
                         return nullptr;
@@ -13953,9 +14058,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ModeSelectClusterModeOptionStruct constructor");
                     return nullptr;
@@ -14237,9 +14345,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$LaundryWasherModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$LaundryWasherModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -14259,9 +14370,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$LaundryWasherModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$LaundryWasherModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -14547,9 +14661,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             "Could not find class ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl,
                                      "Could not find "
@@ -14573,9 +14690,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         "Could not find class ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find "
@@ -15086,9 +15206,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$RvcRunModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$RvcRunModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -15107,9 +15230,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$RvcRunModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$RvcRunModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -15368,9 +15494,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$RvcCleanModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$RvcCleanModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -15389,9 +15518,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$RvcCleanModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$RvcCleanModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -16083,9 +16215,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$DishwasherModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$DishwasherModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -16104,9 +16239,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DishwasherModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$DishwasherModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -17102,9 +17240,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$MicrowaveOvenModeClusterModeTagStruct");
                         return nullptr;
                     }
-                    jmethodID modeTagStructStructCtor_3 =
-                        env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-                    if (modeTagStructStructCtor_3 == nullptr)
+
+                    jmethodID modeTagStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                        "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                        &modeTagStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$MicrowaveOvenModeClusterModeTagStruct constructor");
                         return nullptr;
@@ -17124,9 +17265,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MicrowaveOvenModeClusterModeOptionStruct");
                     return nullptr;
                 }
-                jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(
-                    modeOptionStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-                if (modeOptionStructStructCtor_1 == nullptr)
+
+                jmethodID modeOptionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                                    &modeOptionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MicrowaveOvenModeClusterModeOptionStruct constructor");
                     return nullptr;
@@ -17638,9 +17782,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OperationalStateClusterOperationalStateStruct");
                     return nullptr;
                 }
-                jmethodID operationalStateStructStructCtor_1 =
-                    env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (operationalStateStructStructCtor_1 == nullptr)
+
+                jmethodID operationalStateStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                    &operationalStateStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$OperationalStateClusterOperationalStateStruct constructor");
                     return nullptr;
@@ -17717,9 +17864,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$OperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$OperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -17991,9 +18141,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$RvcOperationalStateClusterOperationalStateStruct");
                     return nullptr;
                 }
-                jmethodID operationalStateStructStructCtor_1 =
-                    env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (operationalStateStructStructCtor_1 == nullptr)
+
+                jmethodID operationalStateStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                    &operationalStateStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$RvcOperationalStateClusterOperationalStateStruct constructor");
                     return nullptr;
@@ -18070,9 +18223,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$RvcOperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$RvcOperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -18347,9 +18503,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$HepaFilterMonitoringClusterReplacementProductStruct");
                     return nullptr;
                 }
-                jmethodID replacementProductStructStructCtor_1 =
-                    env->GetMethodID(replacementProductStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (replacementProductStructStructCtor_1 == nullptr)
+
+                jmethodID replacementProductStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, replacementProductStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &replacementProductStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || replacementProductStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$HepaFilterMonitoringClusterReplacementProductStruct constructor");
                     return nullptr;
@@ -18627,9 +18786,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                  "Could not find class ChipStructs$ActivatedCarbonFilterMonitoringClusterReplacementProductStruct");
                     return nullptr;
                 }
-                jmethodID replacementProductStructStructCtor_1 =
-                    env->GetMethodID(replacementProductStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (replacementProductStructStructCtor_1 == nullptr)
+
+                jmethodID replacementProductStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, replacementProductStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &replacementProductStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || replacementProductStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl,
@@ -19588,11 +19750,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterMeasurementAccuracyRangeStruct");
                     return nullptr;
                 }
-                jmethodID measurementAccuracyRangeStructStructCtor_2 =
-                    env->GetMethodID(measurementAccuracyRangeStructStructClass_2, "<init>",
-                                     "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                                     "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (measurementAccuracyRangeStructStructCtor_2 == nullptr)
+
+                jmethodID measurementAccuracyRangeStructStructCtor_2;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, measurementAccuracyRangeStructStructClass_2, "<init>",
+                    "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
+                    "Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &measurementAccuracyRangeStructStructCtor_2);
+                if (err != CHIP_NO_ERROR || measurementAccuracyRangeStructStructCtor_2 == nullptr)
                 {
                     ChipLogError(
                         Zcl,
@@ -19616,10 +19781,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterMeasurementAccuracyStruct");
                 return nullptr;
             }
-            jmethodID measurementAccuracyStructStructCtor_0 =
-                env->GetMethodID(measurementAccuracyStructStructClass_0, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/ArrayList;)V");
-            if (measurementAccuracyStructStructCtor_0 == nullptr)
+
+            jmethodID measurementAccuracyStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, measurementAccuracyStructStructClass_0, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/ArrayList;)V",
+                &measurementAccuracyStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || measurementAccuracyStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipStructs$ElectricalEnergyMeasurementClusterMeasurementAccuracyStruct constructor");
@@ -19727,10 +19895,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -19838,10 +20009,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -19949,10 +20123,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -20060,10 +20237,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -20293,10 +20473,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlProgramStruct");
                     return nullptr;
                 }
-                jmethodID loadControlProgramStructStructCtor_1 =
-                    env->GetMethodID(loadControlProgramStructStructClass_1, "<init>",
-                                     "([BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                if (loadControlProgramStructStructCtor_1 == nullptr)
+
+                jmethodID loadControlProgramStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, loadControlProgramStructStructClass_1, "<init>",
+                    "([BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                    &loadControlProgramStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || loadControlProgramStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlProgramStruct constructor");
@@ -20592,10 +20775,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct");
                             return nullptr;
                         }
-                        jmethodID temperatureControlStructStructCtor_5 =
-                            env->GetMethodID(temperatureControlStructStructClass_5, "<init>",
-                                             "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                        if (temperatureControlStructStructCtor_5 == nullptr)
+
+                        jmethodID temperatureControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(
+                            env, temperatureControlStructStructClass_5, "<init>",
+                            "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                            &temperatureControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || temperatureControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -20641,9 +20827,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct");
                             return nullptr;
                         }
-                        jmethodID averageLoadControlStructStructCtor_5 =
-                            env->GetMethodID(averageLoadControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (averageLoadControlStructStructCtor_5 == nullptr)
+
+                        jmethodID averageLoadControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, averageLoadControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &averageLoadControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || averageLoadControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -20686,9 +20875,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                          "Could not find class ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct");
                             return nullptr;
                         }
-                        jmethodID dutyCycleControlStructStructCtor_5 =
-                            env->GetMethodID(dutyCycleControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (dutyCycleControlStructStructCtor_5 == nullptr)
+
+                        jmethodID dutyCycleControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, dutyCycleControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &dutyCycleControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || dutyCycleControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -20731,9 +20923,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct");
                             return nullptr;
                         }
-                        jmethodID powerSavingsControlStructStructCtor_5 =
-                            env->GetMethodID(powerSavingsControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (powerSavingsControlStructStructCtor_5 == nullptr)
+
+                        jmethodID powerSavingsControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, powerSavingsControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &powerSavingsControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || powerSavingsControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -20776,9 +20971,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct");
                             return nullptr;
                         }
-                        jmethodID heatingSourceControlStructStructCtor_5 =
-                            env->GetMethodID(heatingSourceControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (heatingSourceControlStructStructCtor_5 == nullptr)
+
+                        jmethodID heatingSourceControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, heatingSourceControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &heatingSourceControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || heatingSourceControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(Zcl,
                                          "Could not find ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct "
@@ -20804,11 +21002,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct");
                         return nullptr;
                     }
-                    jmethodID loadControlEventTransitionStructStructCtor_3 =
-                        env->GetMethodID(loadControlEventTransitionStructStructClass_3, "<init>",
-                                         "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/"
-                                         "util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                    if (loadControlEventTransitionStructStructCtor_3 == nullptr)
+
+                    jmethodID loadControlEventTransitionStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, loadControlEventTransitionStructStructClass_3, "<init>",
+                        "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/"
+                        "util/Optional;Ljava/util/Optional;)V",
+                        &loadControlEventTransitionStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || loadControlEventTransitionStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl,
                                      "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct "
@@ -20833,11 +21034,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct");
                     return nullptr;
                 }
-                jmethodID loadControlEventStructStructCtor_1 =
-                    env->GetMethodID(loadControlEventStructStructClass_1, "<init>",
-                                     "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/"
-                                     "Long;Ljava/util/ArrayList;)V");
-                if (loadControlEventStructStructCtor_1 == nullptr)
+
+                jmethodID loadControlEventStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, loadControlEventStructStructClass_1, "<init>",
+                    "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/Long;Ljava/util/"
+                    "ArrayList;)V",
+                    &loadControlEventStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || loadControlEventStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct constructor");
@@ -21118,10 +21322,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct");
                             return nullptr;
                         }
-                        jmethodID temperatureControlStructStructCtor_5 =
-                            env->GetMethodID(temperatureControlStructStructClass_5, "<init>",
-                                             "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                        if (temperatureControlStructStructCtor_5 == nullptr)
+
+                        jmethodID temperatureControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(
+                            env, temperatureControlStructStructClass_5, "<init>",
+                            "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                            &temperatureControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || temperatureControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -21167,9 +21374,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct");
                             return nullptr;
                         }
-                        jmethodID averageLoadControlStructStructCtor_5 =
-                            env->GetMethodID(averageLoadControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (averageLoadControlStructStructCtor_5 == nullptr)
+
+                        jmethodID averageLoadControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, averageLoadControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &averageLoadControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || averageLoadControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -21212,9 +21422,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                          "Could not find class ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct");
                             return nullptr;
                         }
-                        jmethodID dutyCycleControlStructStructCtor_5 =
-                            env->GetMethodID(dutyCycleControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (dutyCycleControlStructStructCtor_5 == nullptr)
+
+                        jmethodID dutyCycleControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, dutyCycleControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &dutyCycleControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || dutyCycleControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -21257,9 +21470,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct");
                             return nullptr;
                         }
-                        jmethodID powerSavingsControlStructStructCtor_5 =
-                            env->GetMethodID(powerSavingsControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (powerSavingsControlStructStructCtor_5 == nullptr)
+
+                        jmethodID powerSavingsControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, powerSavingsControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &powerSavingsControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || powerSavingsControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(
                                 Zcl,
@@ -21302,9 +21518,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct");
                             return nullptr;
                         }
-                        jmethodID heatingSourceControlStructStructCtor_5 =
-                            env->GetMethodID(heatingSourceControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                        if (heatingSourceControlStructStructCtor_5 == nullptr)
+
+                        jmethodID heatingSourceControlStructStructCtor_5;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, heatingSourceControlStructStructClass_5, "<init>",
+                                                                            "(Ljava/lang/Integer;)V",
+                                                                            &heatingSourceControlStructStructCtor_5);
+                        if (err != CHIP_NO_ERROR || heatingSourceControlStructStructCtor_5 == nullptr)
                         {
                             ChipLogError(Zcl,
                                          "Could not find ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct "
@@ -21330,11 +21549,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct");
                         return nullptr;
                     }
-                    jmethodID loadControlEventTransitionStructStructCtor_3 =
-                        env->GetMethodID(loadControlEventTransitionStructStructClass_3, "<init>",
-                                         "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/"
-                                         "util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                    if (loadControlEventTransitionStructStructCtor_3 == nullptr)
+
+                    jmethodID loadControlEventTransitionStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, loadControlEventTransitionStructStructClass_3, "<init>",
+                        "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/"
+                        "util/Optional;Ljava/util/Optional;)V",
+                        &loadControlEventTransitionStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || loadControlEventTransitionStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl,
                                      "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct "
@@ -21359,11 +21581,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct");
                     return nullptr;
                 }
-                jmethodID loadControlEventStructStructCtor_1 =
-                    env->GetMethodID(loadControlEventStructStructClass_1, "<init>",
-                                     "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/"
-                                     "Long;Ljava/util/ArrayList;)V");
-                if (loadControlEventStructStructCtor_1 == nullptr)
+
+                jmethodID loadControlEventStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, loadControlEventStructStructClass_1, "<init>",
+                    "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/Long;Ljava/util/"
+                    "ArrayList;)V",
+                    &loadControlEventStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || loadControlEventStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct constructor");
@@ -21724,10 +21949,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$DeviceEnergyManagementClusterPowerAdjustStruct");
                         return nullptr;
                     }
-                    jmethodID powerAdjustStructStructCtor_2 =
-                        env->GetMethodID(powerAdjustStructStructClass_2, "<init>",
-                                         "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-                    if (powerAdjustStructStructCtor_2 == nullptr)
+
+                    jmethodID powerAdjustStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, powerAdjustStructStructClass_2, "<init>",
+                        "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V", &powerAdjustStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || powerAdjustStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$DeviceEnergyManagementClusterPowerAdjustStruct constructor");
                         return nullptr;
@@ -22057,10 +22284,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                 ChipLogError(Zcl, "Could not find class ChipStructs$DeviceEnergyManagementClusterCostStruct");
                                 return nullptr;
                             }
-                            jmethodID costStructStructCtor_6 =
-                                env->GetMethodID(costStructStructClass_6, "<init>",
-                                                 "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/util/Optional;)V");
-                            if (costStructStructCtor_6 == nullptr)
+
+                            jmethodID costStructStructCtor_6;
+                            err = chip::JniReferences::GetInstance().FindMethod(
+                                env, costStructStructClass_6, "<init>",
+                                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                &costStructStructCtor_6);
+                            if (err != CHIP_NO_ERROR || costStructStructCtor_6 == nullptr)
                             {
                                 ChipLogError(Zcl, "Could not find ChipStructs$DeviceEnergyManagementClusterCostStruct constructor");
                                 return nullptr;
@@ -22157,13 +22387,16 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$DeviceEnergyManagementClusterSlotStruct");
                         return nullptr;
                     }
-                    jmethodID slotStructStructCtor_3 = env->GetMethodID(
-                        slotStructStructClass_3, "<init>",
+
+                    jmethodID slotStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, slotStructStructClass_3, "<init>",
                         "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/"
                         "lang/Long;Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
                         "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                        "Optional;Ljava/util/Optional;)V");
-                    if (slotStructStructCtor_3 == nullptr)
+                        "Optional;Ljava/util/Optional;)V",
+                        &slotStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || slotStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$DeviceEnergyManagementClusterSlotStruct constructor");
                         return nullptr;
@@ -22188,11 +22421,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DeviceEnergyManagementClusterForecastStruct");
                     return nullptr;
                 }
-                jmethodID forecastStructStructCtor_1 =
-                    env->GetMethodID(forecastStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/"
-                                     "Optional;Ljava/util/Optional;Ljava/lang/Boolean;Ljava/util/ArrayList;)V");
-                if (forecastStructStructCtor_1 == nullptr)
+
+                jmethodID forecastStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, forecastStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;Ljava/util/"
+                    "Optional;Ljava/lang/Boolean;Ljava/util/ArrayList;)V",
+                    &forecastStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || forecastStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$DeviceEnergyManagementClusterForecastStruct constructor");
                     return nullptr;
@@ -23033,9 +23269,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$EnergyPreferenceClusterBalanceStruct");
                     return nullptr;
                 }
-                jmethodID balanceStructStructCtor_1 =
-                    env->GetMethodID(balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (balanceStructStructCtor_1 == nullptr)
+
+                jmethodID balanceStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, balanceStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                    &balanceStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || balanceStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$EnergyPreferenceClusterBalanceStruct constructor");
                     return nullptr;
@@ -23132,9 +23371,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$EnergyPreferenceClusterBalanceStruct");
                     return nullptr;
                 }
-                jmethodID balanceStructStructCtor_1 =
-                    env->GetMethodID(balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-                if (balanceStructStructCtor_1 == nullptr)
+
+                jmethodID balanceStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, balanceStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                    &balanceStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || balanceStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$EnergyPreferenceClusterBalanceStruct constructor");
                     return nullptr;
@@ -33898,11 +34140,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfoStruct");
                     return nullptr;
                 }
-                jmethodID channelInfoStructStructCtor_1 =
-                    env->GetMethodID(channelInfoStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                                     "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (channelInfoStructStructCtor_1 == nullptr)
+
+                jmethodID channelInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, channelInfoStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
+                    "Optional;Ljava/util/Optional;)V",
+                    &channelInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || channelInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfoStruct constructor");
                     return nullptr;
@@ -33974,10 +34219,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterLineupInfoStruct");
                     return nullptr;
                 }
-                jmethodID lineupInfoStructStructCtor_1 =
-                    env->GetMethodID(lineupInfoStructStructClass_1, "<init>",
-                                     "(Ljava/lang/String;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V");
-                if (lineupInfoStructStructCtor_1 == nullptr)
+
+                jmethodID lineupInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, lineupInfoStructStructClass_1, "<init>",
+                    "(Ljava/lang/String;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V",
+                    &lineupInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || lineupInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterLineupInfoStruct constructor");
                     return nullptr;
@@ -34091,11 +34339,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfoStruct");
                     return nullptr;
                 }
-                jmethodID channelInfoStructStructCtor_1 =
-                    env->GetMethodID(channelInfoStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                                     "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (channelInfoStructStructCtor_1 == nullptr)
+
+                jmethodID channelInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, channelInfoStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
+                    "Optional;Ljava/util/Optional;)V",
+                    &channelInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || channelInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfoStruct constructor");
                     return nullptr;
@@ -34283,9 +34534,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TargetNavigatorClusterTargetInfoStruct");
                     return nullptr;
                 }
-                jmethodID targetInfoStructStructCtor_1 =
-                    env->GetMethodID(targetInfoStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (targetInfoStructStructCtor_1 == nullptr)
+
+                jmethodID targetInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, targetInfoStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &targetInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || targetInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$TargetNavigatorClusterTargetInfoStruct constructor");
                     return nullptr;
@@ -34561,9 +34815,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterPlaybackPositionStruct");
                     return nullptr;
                 }
-                jmethodID playbackPositionStructStructCtor_1 =
-                    env->GetMethodID(playbackPositionStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-                if (playbackPositionStructStructCtor_1 == nullptr)
+
+                jmethodID playbackPositionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, playbackPositionStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                    &playbackPositionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || playbackPositionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterPlaybackPositionStruct constructor");
                     return nullptr;
@@ -34694,9 +34951,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                         return nullptr;
                     }
-                    jmethodID trackAttributesStructStructCtor_3 =
-                        env->GetMethodID(trackAttributesStructStructClass_3, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                    if (trackAttributesStructStructCtor_3 == nullptr)
+
+                    jmethodID trackAttributesStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_3, "<init>",
+                                                                        "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                        &trackAttributesStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                         return nullptr;
@@ -34714,10 +34974,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                     return nullptr;
                 }
-                jmethodID trackStructStructCtor_1 = env->GetMethodID(
-                    trackStructStructClass_1, "<init>",
-                    "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-                if (trackStructStructCtor_1 == nullptr)
+
+                jmethodID trackStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, trackStructStructClass_1, "<init>",
+                    "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                    &trackStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || trackStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                     return nullptr;
@@ -34792,9 +35055,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                             return nullptr;
                         }
-                        jmethodID trackAttributesStructStructCtor_4 = env->GetMethodID(trackAttributesStructStructClass_4, "<init>",
-                                                                                       "(Ljava/lang/String;Ljava/util/Optional;)V");
-                        if (trackAttributesStructStructCtor_4 == nullptr)
+
+                        jmethodID trackAttributesStructStructCtor_4;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_4, "<init>",
+                                                                            "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                            &trackAttributesStructStructCtor_4);
+                        if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_4 == nullptr)
                         {
                             ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                             return nullptr;
@@ -34813,10 +35079,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                         return nullptr;
                     }
-                    jmethodID trackStructStructCtor_2 = env->GetMethodID(
-                        trackStructStructClass_2, "<init>",
-                        "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-                    if (trackStructStructCtor_2 == nullptr)
+
+                    jmethodID trackStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, trackStructStructClass_2, "<init>",
+                        "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                        &trackStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || trackStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                         return nullptr;
@@ -34887,9 +35156,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                         return nullptr;
                     }
-                    jmethodID trackAttributesStructStructCtor_3 =
-                        env->GetMethodID(trackAttributesStructStructClass_3, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                    if (trackAttributesStructStructCtor_3 == nullptr)
+
+                    jmethodID trackAttributesStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_3, "<init>",
+                                                                        "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                        &trackAttributesStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                         return nullptr;
@@ -34907,10 +35179,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                     return nullptr;
                 }
-                jmethodID trackStructStructCtor_1 = env->GetMethodID(
-                    trackStructStructClass_1, "<init>",
-                    "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-                if (trackStructStructCtor_1 == nullptr)
+
+                jmethodID trackStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, trackStructStructClass_1, "<init>",
+                    "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                    &trackStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || trackStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                     return nullptr;
@@ -34985,9 +35260,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                             return nullptr;
                         }
-                        jmethodID trackAttributesStructStructCtor_4 = env->GetMethodID(trackAttributesStructStructClass_4, "<init>",
-                                                                                       "(Ljava/lang/String;Ljava/util/Optional;)V");
-                        if (trackAttributesStructStructCtor_4 == nullptr)
+
+                        jmethodID trackAttributesStructStructCtor_4;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_4, "<init>",
+                                                                            "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                            &trackAttributesStructStructCtor_4);
+                        if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_4 == nullptr)
                         {
                             ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                             return nullptr;
@@ -35006,10 +35284,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                         return nullptr;
                     }
-                    jmethodID trackStructStructCtor_2 = env->GetMethodID(
-                        trackStructStructClass_2, "<init>",
-                        "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-                    if (trackStructStructCtor_2 == nullptr)
+
+                    jmethodID trackStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, trackStructStructClass_2, "<init>",
+                        "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                        &trackStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || trackStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                         return nullptr;
@@ -35208,10 +35489,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaInputClusterInputInfoStruct");
                     return nullptr;
                 }
-                jmethodID inputInfoStructStructCtor_1 =
-                    env->GetMethodID(inputInfoStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V");
-                if (inputInfoStructStructCtor_1 == nullptr)
+
+                jmethodID inputInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, inputInfoStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V", &inputInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || inputInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaInputClusterInputInfoStruct constructor");
                     return nullptr;
@@ -35885,9 +36168,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AudioOutputClusterOutputInfoStruct");
                     return nullptr;
                 }
-                jmethodID outputInfoStructStructCtor_1 = env->GetMethodID(
-                    outputInfoStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (outputInfoStructStructCtor_1 == nullptr)
+
+                jmethodID outputInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, outputInfoStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &outputInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || outputInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AudioOutputClusterOutputInfoStruct constructor");
                     return nullptr;
@@ -36118,9 +36404,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplicationStruct");
                     return nullptr;
                 }
-                jmethodID applicationStructStructCtor_2 =
-                    env->GetMethodID(applicationStructStructClass_2, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (applicationStructStructCtor_2 == nullptr)
+
+                jmethodID applicationStructStructCtor_2;
+                err = chip::JniReferences::GetInstance().FindMethod(env, applicationStructStructClass_2, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &applicationStructStructCtor_2);
+                if (err != CHIP_NO_ERROR || applicationStructStructCtor_2 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplicationStruct constructor");
                     return nullptr;
@@ -36154,10 +36443,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplicationEPStruct");
                     return nullptr;
                 }
-                jmethodID applicationEPStructStructCtor_1 = env->GetMethodID(
-                    applicationEPStructStructClass_1, "<init>",
-                    "(Lchip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationStruct;Ljava/util/Optional;)V");
-                if (applicationEPStructStructCtor_1 == nullptr)
+
+                jmethodID applicationEPStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, applicationEPStructStructClass_1, "<init>",
+                    "(Lchip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationStruct;Ljava/util/Optional;)V",
+                    &applicationEPStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || applicationEPStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplicationEPStruct constructor");
                     return nullptr;
@@ -36393,9 +36685,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationBasicClusterApplicationStruct");
                 return nullptr;
             }
-            jmethodID applicationStructStructCtor_0 =
-                env->GetMethodID(applicationStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-            if (applicationStructStructCtor_0 == nullptr)
+
+            jmethodID applicationStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, applicationStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                &applicationStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || applicationStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ApplicationBasicClusterApplicationStruct constructor");
                 return nullptr;
@@ -36798,9 +37093,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ContentControlClusterRatingNameStruct");
                     return nullptr;
                 }
-                jmethodID ratingNameStructStructCtor_1 =
-                    env->GetMethodID(ratingNameStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                if (ratingNameStructStructCtor_1 == nullptr)
+
+                jmethodID ratingNameStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, ratingNameStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                    &ratingNameStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || ratingNameStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ContentControlClusterRatingNameStruct constructor");
                     return nullptr;
@@ -36864,9 +37162,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ContentControlClusterRatingNameStruct");
                     return nullptr;
                 }
-                jmethodID ratingNameStructStructCtor_1 =
-                    env->GetMethodID(ratingNameStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                if (ratingNameStructStructCtor_1 == nullptr)
+
+                jmethodID ratingNameStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, ratingNameStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                    &ratingNameStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || ratingNameStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ContentControlClusterRatingNameStruct constructor");
                     return nullptr;
@@ -39914,9 +40215,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterTestListStructOctet");
                     return nullptr;
                 }
-                jmethodID testListStructOctetStructCtor_1 =
-                    env->GetMethodID(testListStructOctetStructClass_1, "<init>", "(Ljava/lang/Long;[B)V");
-                if (testListStructOctetStructCtor_1 == nullptr)
+
+                jmethodID testListStructOctetStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, testListStructOctetStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Long;[B)V", &testListStructOctetStructCtor_1);
+                if (err != CHIP_NO_ERROR || testListStructOctetStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterTestListStructOctet constructor");
                     return nullptr;
@@ -40200,11 +40503,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                         return nullptr;
                     }
-                    jmethodID simpleStructStructCtor_3 =
-                        env->GetMethodID(simpleStructStructClass_3, "<init>",
-                                         "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                         "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                    if (simpleStructStructCtor_3 == nullptr)
+
+                    jmethodID simpleStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, simpleStructStructClass_3, "<init>",
+                        "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/"
+                        "lang/Float;Ljava/lang/Double;)V",
+                        &simpleStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || simpleStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                         return nullptr;
@@ -40292,11 +40598,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                         return nullptr;
                     }
-                    jmethodID simpleStructStructCtor_3 =
-                        env->GetMethodID(simpleStructStructClass_3, "<init>",
-                                         "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                         "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                    if (simpleStructStructCtor_3 == nullptr)
+
+                    jmethodID simpleStructStructCtor_3;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, simpleStructStructClass_3, "<init>",
+                        "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/"
+                        "lang/Float;Ljava/lang/Double;)V",
+                        &simpleStructStructCtor_3);
+                    if (err != CHIP_NO_ERROR || simpleStructStructCtor_3 == nullptr)
                     {
                         ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                         return nullptr;
@@ -40406,11 +40715,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                             return nullptr;
                         }
-                        jmethodID simpleStructStructCtor_4 =
-                            env->GetMethodID(simpleStructStructClass_4, "<init>",
-                                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/"
-                                             "lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                        if (simpleStructStructCtor_4 == nullptr)
+
+                        jmethodID simpleStructStructCtor_4;
+                        err = chip::JniReferences::GetInstance().FindMethod(
+                            env, simpleStructStructClass_4, "<init>",
+                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
+                            "Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                            &simpleStructStructCtor_4);
+                        if (err != CHIP_NO_ERROR || simpleStructStructCtor_4 == nullptr)
                         {
                             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                             return nullptr;
@@ -40521,12 +40833,15 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterNullablesAndOptionalsStruct");
                     return nullptr;
                 }
-                jmethodID nullablesAndOptionalsStructStructCtor_1 = env->GetMethodID(
-                    nullablesAndOptionalsStructStructClass_1, "<init>",
+
+                jmethodID nullablesAndOptionalsStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, nullablesAndOptionalsStructStructClass_1, "<init>",
                     "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/Optional;Ljava/util/"
                     "Optional;Lchip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/Optional;Ljava/util/"
-                    "Optional;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (nullablesAndOptionalsStructStructCtor_1 == nullptr)
+                    "Optional;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &nullablesAndOptionalsStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || nullablesAndOptionalsStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterNullablesAndOptionalsStruct constructor");
                     return nullptr;
@@ -40619,11 +40934,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                 return nullptr;
             }
-            jmethodID simpleStructStructCtor_0 =
-                env->GetMethodID(simpleStructStructClass_0, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                 "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-            if (simpleStructStructCtor_0 == nullptr)
+
+            jmethodID simpleStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, simpleStructStructClass_0, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                "Float;Ljava/lang/Double;)V",
+                &simpleStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || simpleStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                 return nullptr;
@@ -40879,11 +41197,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                     return nullptr;
                 }
-                jmethodID simpleStructStructCtor_2 =
-                    env->GetMethodID(simpleStructStructClass_2, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                     "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                if (simpleStructStructCtor_2 == nullptr)
+
+                jmethodID simpleStructStructCtor_2;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, simpleStructStructClass_2, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                    "Float;Ljava/lang/Double;)V",
+                    &simpleStructStructCtor_2);
+                if (err != CHIP_NO_ERROR || simpleStructStructCtor_2 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                     return nullptr;
@@ -40926,11 +41247,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterTestFabricScoped");
                     return nullptr;
                 }
-                jmethodID testFabricScopedStructCtor_1 = env->GetMethodID(
-                    testFabricScopedStructClass_1, "<init>",
+
+                jmethodID testFabricScopedStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, testFabricScopedStructClass_1, "<init>",
                     "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/lang/Integer;Ljava/util/Optional;Ljava/lang/String;Lchip/"
-                    "devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-                if (testFabricScopedStructCtor_1 == nullptr)
+                    "devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/lang/Integer;)V",
+                    &testFabricScopedStructCtor_1);
+                if (err != CHIP_NO_ERROR || testFabricScopedStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterTestFabricScoped constructor");
                     return nullptr;
@@ -41715,11 +42039,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                     return nullptr;
                 }
-                jmethodID simpleStructStructCtor_1 =
-                    env->GetMethodID(simpleStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                     "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                if (simpleStructStructCtor_1 == nullptr)
+
+                jmethodID simpleStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, simpleStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                    "Float;Ljava/lang/Double;)V",
+                    &simpleStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                     return nullptr;

--- a/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
@@ -294,10 +294,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlTargetStruct");
                             return nullptr;
                         }
-                        jmethodID accessControlTargetStructStructCtor_4 =
-                            env->GetMethodID(accessControlTargetStructStructClass_4, "<init>",
-                                             "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
-                        if (accessControlTargetStructStructCtor_4 == nullptr)
+
+                        jmethodID accessControlTargetStructStructCtor_4;
+                        err = chip::JniReferences::GetInstance().FindMethod(
+                            env, accessControlTargetStructStructClass_4, "<init>",
+                            "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V", &accessControlTargetStructStructCtor_4);
+                        if (err != CHIP_NO_ERROR || accessControlTargetStructStructCtor_4 == nullptr)
                         {
                             ChipLogError(Zcl,
                                          "Could not find ChipStructs$AccessControlClusterAccessControlTargetStruct constructor");
@@ -326,10 +328,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlEntryStruct");
                     return nullptr;
                 }
-                jmethodID accessControlEntryStructStructCtor_1 = env->GetMethodID(
-                    accessControlEntryStructStructClass_1, "<init>",
-                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-                if (accessControlEntryStructStructCtor_1 == nullptr)
+
+                jmethodID accessControlEntryStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, accessControlEntryStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V",
+                    &accessControlEntryStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || accessControlEntryStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlEntryStruct constructor");
                     return nullptr;
@@ -358,11 +363,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$AccessControlClusterAccessControlEntryChangedEvent");
                 return nullptr;
             }
-            jmethodID accessControlEntryChangedStructCtor =
-                env->GetMethodID(accessControlEntryChangedStructClass, "<init>",
-                                 "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Lchip/devicecontroller/"
-                                 "ChipStructs$AccessControlClusterAccessControlEntryStruct;Ljava/lang/Integer;)V");
-            if (accessControlEntryChangedStructCtor == nullptr)
+
+            jmethodID accessControlEntryChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, accessControlEntryChangedStructClass, "<init>",
+                "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Lchip/devicecontroller/"
+                "ChipStructs$AccessControlClusterAccessControlEntryStruct;Ljava/lang/Integer;)V",
+                &accessControlEntryChangedStructCtor);
+            if (err != CHIP_NO_ERROR || accessControlEntryChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$AccessControlClusterAccessControlEntryChangedEvent constructor");
                 return nullptr;
@@ -449,9 +457,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlExtensionStruct");
                     return nullptr;
                 }
-                jmethodID accessControlExtensionStructStructCtor_1 =
-                    env->GetMethodID(accessControlExtensionStructStructClass_1, "<init>", "([BLjava/lang/Integer;)V");
-                if (accessControlExtensionStructStructCtor_1 == nullptr)
+
+                jmethodID accessControlExtensionStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, accessControlExtensionStructStructClass_1, "<init>",
+                                                                    "([BLjava/lang/Integer;)V",
+                                                                    &accessControlExtensionStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || accessControlExtensionStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlExtensionStruct constructor");
                     return nullptr;
@@ -479,11 +490,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$AccessControlClusterAccessControlExtensionChangedEvent");
                 return nullptr;
             }
-            jmethodID accessControlExtensionChangedStructCtor =
-                env->GetMethodID(accessControlExtensionChangedStructClass, "<init>",
-                                 "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Lchip/devicecontroller/"
-                                 "ChipStructs$AccessControlClusterAccessControlExtensionStruct;Ljava/lang/Integer;)V");
-            if (accessControlExtensionChangedStructCtor == nullptr)
+
+            jmethodID accessControlExtensionChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, accessControlExtensionChangedStructClass, "<init>",
+                "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Lchip/devicecontroller/"
+                "ChipStructs$AccessControlClusterAccessControlExtensionStruct;Ljava/lang/Integer;)V",
+                &accessControlExtensionChangedStructCtor);
+            if (err != CHIP_NO_ERROR || accessControlExtensionChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$AccessControlClusterAccessControlExtensionChangedEvent constructor");
@@ -542,9 +556,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ActionsClusterStateChangedEvent");
                 return nullptr;
             }
-            jmethodID stateChangedStructCtor =
-                env->GetMethodID(stateChangedStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V");
-            if (stateChangedStructCtor == nullptr)
+
+            jmethodID stateChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, stateChangedStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V",
+                                                                &stateChangedStructCtor);
+            if (err != CHIP_NO_ERROR || stateChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$ActionsClusterStateChangedEvent constructor");
                 return nullptr;
@@ -598,9 +615,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ActionsClusterActionFailedEvent");
                 return nullptr;
             }
-            jmethodID actionFailedStructCtor = env->GetMethodID(
-                actionFailedStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (actionFailedStructCtor == nullptr)
+
+            jmethodID actionFailedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, actionFailedStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V", &actionFailedStructCtor);
+            if (err != CHIP_NO_ERROR || actionFailedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$ActionsClusterActionFailedEvent constructor");
                 return nullptr;
@@ -644,8 +664,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BasicInformationClusterStartUpEvent");
                 return nullptr;
             }
-            jmethodID startUpStructCtor = env->GetMethodID(startUpStructClass, "<init>", "(Ljava/lang/Long;)V");
-            if (startUpStructCtor == nullptr)
+
+            jmethodID startUpStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, startUpStructClass, "<init>", "(Ljava/lang/Long;)V",
+                                                                &startUpStructCtor);
+            if (err != CHIP_NO_ERROR || startUpStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BasicInformationClusterStartUpEvent constructor");
                 return nullptr;
@@ -670,8 +693,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BasicInformationClusterShutDownEvent");
                 return nullptr;
             }
-            jmethodID shutDownStructCtor = env->GetMethodID(shutDownStructClass, "<init>", "()V");
-            if (shutDownStructCtor == nullptr)
+
+            jmethodID shutDownStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, shutDownStructClass, "<init>", "()V", &shutDownStructCtor);
+            if (err != CHIP_NO_ERROR || shutDownStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BasicInformationClusterShutDownEvent constructor");
                 return nullptr;
@@ -704,8 +729,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BasicInformationClusterLeaveEvent");
                 return nullptr;
             }
-            jmethodID leaveStructCtor = env->GetMethodID(leaveStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (leaveStructCtor == nullptr)
+
+            jmethodID leaveStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, leaveStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &leaveStructCtor);
+            if (err != CHIP_NO_ERROR || leaveStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BasicInformationClusterLeaveEvent constructor");
                 return nullptr;
@@ -739,9 +767,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BasicInformationClusterReachableChangedEvent");
                 return nullptr;
             }
-            jmethodID reachableChangedStructCtor =
-                env->GetMethodID(reachableChangedStructClass, "<init>", "(Ljava/lang/Boolean;)V");
-            if (reachableChangedStructCtor == nullptr)
+
+            jmethodID reachableChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, reachableChangedStructClass, "<init>",
+                                                                "(Ljava/lang/Boolean;)V", &reachableChangedStructCtor);
+            if (err != CHIP_NO_ERROR || reachableChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BasicInformationClusterReachableChangedEvent constructor");
                 return nullptr;
@@ -824,10 +854,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OtaSoftwareUpdateRequestorClusterStateTransitionEvent");
                 return nullptr;
             }
-            jmethodID stateTransitionStructCtor =
-                env->GetMethodID(stateTransitionStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)V");
-            if (stateTransitionStructCtor == nullptr)
+
+            jmethodID stateTransitionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, stateTransitionStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)V", &stateTransitionStructCtor);
+            if (err != CHIP_NO_ERROR || stateTransitionStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$OtaSoftwareUpdateRequestorClusterStateTransitionEvent constructor");
@@ -870,9 +902,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OtaSoftwareUpdateRequestorClusterVersionAppliedEvent");
                 return nullptr;
             }
-            jmethodID versionAppliedStructCtor =
-                env->GetMethodID(versionAppliedStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
-            if (versionAppliedStructCtor == nullptr)
+
+            jmethodID versionAppliedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, versionAppliedStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V", &versionAppliedStructCtor);
+            if (err != CHIP_NO_ERROR || versionAppliedStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$OtaSoftwareUpdateRequestorClusterVersionAppliedEvent constructor");
@@ -946,9 +980,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OtaSoftwareUpdateRequestorClusterDownloadErrorEvent");
                 return nullptr;
             }
-            jmethodID downloadErrorStructCtor = env->GetMethodID(
-                downloadErrorStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
-            if (downloadErrorStructCtor == nullptr)
+
+            jmethodID downloadErrorStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, downloadErrorStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V",
+                &downloadErrorStructCtor);
+            if (err != CHIP_NO_ERROR || downloadErrorStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$OtaSoftwareUpdateRequestorClusterDownloadErrorEvent constructor");
@@ -1057,9 +1094,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PowerSourceClusterWiredFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID wiredFaultChangeStructCtor =
-                env->GetMethodID(wiredFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (wiredFaultChangeStructCtor == nullptr)
+
+            jmethodID wiredFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, wiredFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &wiredFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || wiredFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PowerSourceClusterWiredFaultChangeEvent constructor");
                 return nullptr;
@@ -1116,9 +1156,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PowerSourceClusterBatFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID batFaultChangeStructCtor =
-                env->GetMethodID(batFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (batFaultChangeStructCtor == nullptr)
+
+            jmethodID batFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, batFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &batFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || batFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PowerSourceClusterBatFaultChangeEvent constructor");
                 return nullptr;
@@ -1176,9 +1219,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PowerSourceClusterBatChargeFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID batChargeFaultChangeStructCtor =
-                env->GetMethodID(batChargeFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (batChargeFaultChangeStructCtor == nullptr)
+
+            jmethodID batChargeFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, batChargeFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &batChargeFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || batChargeFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PowerSourceClusterBatChargeFaultChangeEvent constructor");
                 return nullptr;
@@ -1277,9 +1323,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$GeneralDiagnosticsClusterHardwareFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID hardwareFaultChangeStructCtor =
-                env->GetMethodID(hardwareFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (hardwareFaultChangeStructCtor == nullptr)
+
+            jmethodID hardwareFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, hardwareFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &hardwareFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || hardwareFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$GeneralDiagnosticsClusterHardwareFaultChangeEvent constructor");
                 return nullptr;
@@ -1338,9 +1387,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$GeneralDiagnosticsClusterRadioFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID radioFaultChangeStructCtor =
-                env->GetMethodID(radioFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (radioFaultChangeStructCtor == nullptr)
+
+            jmethodID radioFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, radioFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &radioFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || radioFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$GeneralDiagnosticsClusterRadioFaultChangeEvent constructor");
                 return nullptr;
@@ -1398,9 +1450,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$GeneralDiagnosticsClusterNetworkFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID networkFaultChangeStructCtor =
-                env->GetMethodID(networkFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (networkFaultChangeStructCtor == nullptr)
+
+            jmethodID networkFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, networkFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &networkFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || networkFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$GeneralDiagnosticsClusterNetworkFaultChangeEvent constructor");
                 return nullptr;
@@ -1433,8 +1488,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$GeneralDiagnosticsClusterBootReasonEvent");
                 return nullptr;
             }
-            jmethodID bootReasonStructCtor = env->GetMethodID(bootReasonStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (bootReasonStructCtor == nullptr)
+
+            jmethodID bootReasonStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, bootReasonStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &bootReasonStructCtor);
+            if (err != CHIP_NO_ERROR || bootReasonStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$GeneralDiagnosticsClusterBootReasonEvent constructor");
                 return nullptr;
@@ -1507,9 +1565,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SoftwareDiagnosticsClusterSoftwareFaultEvent");
                 return nullptr;
             }
-            jmethodID softwareFaultStructCtor =
-                env->GetMethodID(softwareFaultStructClass, "<init>", "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (softwareFaultStructCtor == nullptr)
+
+            jmethodID softwareFaultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, softwareFaultStructClass, "<init>",
+                                                                "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &softwareFaultStructCtor);
+            if (err != CHIP_NO_ERROR || softwareFaultStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SoftwareDiagnosticsClusterSoftwareFaultEvent constructor");
                 return nullptr;
@@ -1554,9 +1615,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ThreadNetworkDiagnosticsClusterConnectionStatusEvent");
                 return nullptr;
             }
-            jmethodID connectionStatusStructCtor =
-                env->GetMethodID(connectionStatusStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (connectionStatusStructCtor == nullptr)
+
+            jmethodID connectionStatusStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, connectionStatusStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;)V", &connectionStatusStructCtor);
+            if (err != CHIP_NO_ERROR || connectionStatusStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$ThreadNetworkDiagnosticsClusterConnectionStatusEvent constructor");
@@ -1615,9 +1678,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent");
                 return nullptr;
             }
-            jmethodID networkFaultChangeStructCtor =
-                env->GetMethodID(networkFaultChangeStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (networkFaultChangeStructCtor == nullptr)
+
+            jmethodID networkFaultChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, networkFaultChangeStructClass, "<init>",
+                                                                "(Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                                                                &networkFaultChangeStructCtor);
+            if (err != CHIP_NO_ERROR || networkFaultChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent constructor");
@@ -1662,8 +1728,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$WiFiNetworkDiagnosticsClusterDisconnectionEvent");
                 return nullptr;
             }
-            jmethodID disconnectionStructCtor = env->GetMethodID(disconnectionStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (disconnectionStructCtor == nullptr)
+
+            jmethodID disconnectionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, disconnectionStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &disconnectionStructCtor);
+            if (err != CHIP_NO_ERROR || disconnectionStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$WiFiNetworkDiagnosticsClusterDisconnectionEvent constructor");
                 return nullptr;
@@ -1704,9 +1773,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$WiFiNetworkDiagnosticsClusterAssociationFailureEvent");
                 return nullptr;
             }
-            jmethodID associationFailureStructCtor =
-                env->GetMethodID(associationFailureStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (associationFailureStructCtor == nullptr)
+
+            jmethodID associationFailureStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, associationFailureStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &associationFailureStructCtor);
+            if (err != CHIP_NO_ERROR || associationFailureStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$WiFiNetworkDiagnosticsClusterAssociationFailureEvent constructor");
@@ -1742,9 +1814,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$WiFiNetworkDiagnosticsClusterConnectionStatusEvent");
                 return nullptr;
             }
-            jmethodID connectionStatusStructCtor =
-                env->GetMethodID(connectionStatusStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (connectionStatusStructCtor == nullptr)
+
+            jmethodID connectionStatusStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, connectionStatusStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;)V", &connectionStatusStructCtor);
+            if (err != CHIP_NO_ERROR || connectionStatusStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$WiFiNetworkDiagnosticsClusterConnectionStatusEvent constructor");
                 return nullptr;
@@ -1790,8 +1864,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TimeSynchronizationClusterDSTTableEmptyEvent");
                 return nullptr;
             }
-            jmethodID DSTTableEmptyStructCtor = env->GetMethodID(DSTTableEmptyStructClass, "<init>", "()V");
-            if (DSTTableEmptyStructCtor == nullptr)
+
+            jmethodID DSTTableEmptyStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, DSTTableEmptyStructClass, "<init>", "()V",
+                                                                &DSTTableEmptyStructCtor);
+            if (err != CHIP_NO_ERROR || DSTTableEmptyStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$TimeSynchronizationClusterDSTTableEmptyEvent constructor");
                 return nullptr;
@@ -1824,8 +1901,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TimeSynchronizationClusterDSTStatusEvent");
                 return nullptr;
             }
-            jmethodID DSTStatusStructCtor = env->GetMethodID(DSTStatusStructClass, "<init>", "(Ljava/lang/Boolean;)V");
-            if (DSTStatusStructCtor == nullptr)
+
+            jmethodID DSTStatusStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, DSTStatusStructClass, "<init>", "(Ljava/lang/Boolean;)V",
+                                                                &DSTStatusStructCtor);
+            if (err != CHIP_NO_ERROR || DSTStatusStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$TimeSynchronizationClusterDSTStatusEvent constructor");
                 return nullptr;
@@ -1871,9 +1951,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TimeSynchronizationClusterTimeZoneStatusEvent");
                 return nullptr;
             }
-            jmethodID timeZoneStatusStructCtor =
-                env->GetMethodID(timeZoneStatusStructClass, "<init>", "(Ljava/lang/Long;Ljava/util/Optional;)V");
-            if (timeZoneStatusStructCtor == nullptr)
+
+            jmethodID timeZoneStatusStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, timeZoneStatusStructClass, "<init>", "(Ljava/lang/Long;Ljava/util/Optional;)V", &timeZoneStatusStructCtor);
+            if (err != CHIP_NO_ERROR || timeZoneStatusStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$TimeSynchronizationClusterTimeZoneStatusEvent constructor");
                 return nullptr;
@@ -1898,8 +1980,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TimeSynchronizationClusterTimeFailureEvent");
                 return nullptr;
             }
-            jmethodID timeFailureStructCtor = env->GetMethodID(timeFailureStructClass, "<init>", "()V");
-            if (timeFailureStructCtor == nullptr)
+
+            jmethodID timeFailureStructCtor;
+            err =
+                chip::JniReferences::GetInstance().FindMethod(env, timeFailureStructClass, "<init>", "()V", &timeFailureStructCtor);
+            if (err != CHIP_NO_ERROR || timeFailureStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$TimeSynchronizationClusterTimeFailureEvent constructor");
                 return nullptr;
@@ -1925,8 +2010,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TimeSynchronizationClusterMissingTrustedTimeSourceEvent");
                 return nullptr;
             }
-            jmethodID missingTrustedTimeSourceStructCtor = env->GetMethodID(missingTrustedTimeSourceStructClass, "<init>", "()V");
-            if (missingTrustedTimeSourceStructCtor == nullptr)
+
+            jmethodID missingTrustedTimeSourceStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, missingTrustedTimeSourceStructClass, "<init>", "()V",
+                                                                &missingTrustedTimeSourceStructCtor);
+            if (err != CHIP_NO_ERROR || missingTrustedTimeSourceStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$TimeSynchronizationClusterMissingTrustedTimeSourceEvent constructor");
@@ -1970,8 +2058,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BridgedDeviceBasicInformationClusterStartUpEvent");
                 return nullptr;
             }
-            jmethodID startUpStructCtor = env->GetMethodID(startUpStructClass, "<init>", "(Ljava/lang/Long;)V");
-            if (startUpStructCtor == nullptr)
+
+            jmethodID startUpStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, startUpStructClass, "<init>", "(Ljava/lang/Long;)V",
+                                                                &startUpStructCtor);
+            if (err != CHIP_NO_ERROR || startUpStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BridgedDeviceBasicInformationClusterStartUpEvent constructor");
                 return nullptr;
@@ -1997,8 +2088,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BridgedDeviceBasicInformationClusterShutDownEvent");
                 return nullptr;
             }
-            jmethodID shutDownStructCtor = env->GetMethodID(shutDownStructClass, "<init>", "()V");
-            if (shutDownStructCtor == nullptr)
+
+            jmethodID shutDownStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, shutDownStructClass, "<init>", "()V", &shutDownStructCtor);
+            if (err != CHIP_NO_ERROR || shutDownStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BridgedDeviceBasicInformationClusterShutDownEvent constructor");
                 return nullptr;
@@ -2023,8 +2116,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BridgedDeviceBasicInformationClusterLeaveEvent");
                 return nullptr;
             }
-            jmethodID leaveStructCtor = env->GetMethodID(leaveStructClass, "<init>", "()V");
-            if (leaveStructCtor == nullptr)
+
+            jmethodID leaveStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, leaveStructClass, "<init>", "()V", &leaveStructCtor);
+            if (err != CHIP_NO_ERROR || leaveStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BridgedDeviceBasicInformationClusterLeaveEvent constructor");
                 return nullptr;
@@ -2059,9 +2154,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$BridgedDeviceBasicInformationClusterReachableChangedEvent");
                 return nullptr;
             }
-            jmethodID reachableChangedStructCtor =
-                env->GetMethodID(reachableChangedStructClass, "<init>", "(Ljava/lang/Boolean;)V");
-            if (reachableChangedStructCtor == nullptr)
+
+            jmethodID reachableChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, reachableChangedStructClass, "<init>",
+                                                                "(Ljava/lang/Boolean;)V", &reachableChangedStructCtor);
+            if (err != CHIP_NO_ERROR || reachableChangedStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$BridgedDeviceBasicInformationClusterReachableChangedEvent constructor");
@@ -2105,8 +2202,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterSwitchLatchedEvent");
                 return nullptr;
             }
-            jmethodID switchLatchedStructCtor = env->GetMethodID(switchLatchedStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (switchLatchedStructCtor == nullptr)
+
+            jmethodID switchLatchedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, switchLatchedStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &switchLatchedStructCtor);
+            if (err != CHIP_NO_ERROR || switchLatchedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterSwitchLatchedEvent constructor");
                 return nullptr;
@@ -2139,8 +2239,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterInitialPressEvent");
                 return nullptr;
             }
-            jmethodID initialPressStructCtor = env->GetMethodID(initialPressStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (initialPressStructCtor == nullptr)
+
+            jmethodID initialPressStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, initialPressStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &initialPressStructCtor);
+            if (err != CHIP_NO_ERROR || initialPressStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterInitialPressEvent constructor");
                 return nullptr;
@@ -2173,8 +2276,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterLongPressEvent");
                 return nullptr;
             }
-            jmethodID longPressStructCtor = env->GetMethodID(longPressStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (longPressStructCtor == nullptr)
+
+            jmethodID longPressStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, longPressStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &longPressStructCtor);
+            if (err != CHIP_NO_ERROR || longPressStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterLongPressEvent constructor");
                 return nullptr;
@@ -2207,8 +2313,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterShortReleaseEvent");
                 return nullptr;
             }
-            jmethodID shortReleaseStructCtor = env->GetMethodID(shortReleaseStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (shortReleaseStructCtor == nullptr)
+
+            jmethodID shortReleaseStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, shortReleaseStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &shortReleaseStructCtor);
+            if (err != CHIP_NO_ERROR || shortReleaseStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterShortReleaseEvent constructor");
                 return nullptr;
@@ -2241,8 +2350,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterLongReleaseEvent");
                 return nullptr;
             }
-            jmethodID longReleaseStructCtor = env->GetMethodID(longReleaseStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (longReleaseStructCtor == nullptr)
+
+            jmethodID longReleaseStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, longReleaseStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &longReleaseStructCtor);
+            if (err != CHIP_NO_ERROR || longReleaseStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterLongReleaseEvent constructor");
                 return nullptr;
@@ -2283,9 +2395,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterMultiPressOngoingEvent");
                 return nullptr;
             }
-            jmethodID multiPressOngoingStructCtor =
-                env->GetMethodID(multiPressOngoingStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (multiPressOngoingStructCtor == nullptr)
+
+            jmethodID multiPressOngoingStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, multiPressOngoingStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &multiPressOngoingStructCtor);
+            if (err != CHIP_NO_ERROR || multiPressOngoingStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterMultiPressOngoingEvent constructor");
                 return nullptr;
@@ -2327,9 +2442,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SwitchClusterMultiPressCompleteEvent");
                 return nullptr;
             }
-            jmethodID multiPressCompleteStructCtor =
-                env->GetMethodID(multiPressCompleteStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (multiPressCompleteStructCtor == nullptr)
+
+            jmethodID multiPressCompleteStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, multiPressCompleteStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &multiPressCompleteStructCtor);
+            if (err != CHIP_NO_ERROR || multiPressCompleteStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SwitchClusterMultiPressCompleteEvent constructor");
                 return nullptr;
@@ -2452,8 +2570,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BooleanStateClusterStateChangeEvent");
                 return nullptr;
             }
-            jmethodID stateChangeStructCtor = env->GetMethodID(stateChangeStructClass, "<init>", "(Ljava/lang/Boolean;)V");
-            if (stateChangeStructCtor == nullptr)
+
+            jmethodID stateChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, stateChangeStructClass, "<init>", "(Ljava/lang/Boolean;)V",
+                                                                &stateChangeStructCtor);
+            if (err != CHIP_NO_ERROR || stateChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BooleanStateClusterStateChangeEvent constructor");
                 return nullptr;
@@ -2544,9 +2665,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -2565,10 +2689,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OvenCavityOperationalStateClusterOperationalErrorEvent");
                 return nullptr;
             }
-            jmethodID operationalErrorStructCtor =
-                env->GetMethodID(operationalErrorStructClass, "<init>",
-                                 "(Lchip/devicecontroller/ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct;)V");
-            if (operationalErrorStructCtor == nullptr)
+
+            jmethodID operationalErrorStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, operationalErrorStructClass, "<init>",
+                "(Lchip/devicecontroller/ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct;)V",
+                &operationalErrorStructCtor);
+            if (err != CHIP_NO_ERROR || operationalErrorStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$OvenCavityOperationalStateClusterOperationalErrorEvent constructor");
@@ -2655,9 +2782,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$OvenCavityOperationalStateClusterOperationCompletionEvent");
                 return nullptr;
             }
-            jmethodID operationCompletionStructCtor = env->GetMethodID(
-                operationCompletionStructClass, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (operationCompletionStructCtor == nullptr)
+
+            jmethodID operationCompletionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, operationCompletionStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &operationCompletionStructCtor);
+            if (err != CHIP_NO_ERROR || operationCompletionStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$OvenCavityOperationalStateClusterOperationCompletionEvent constructor");
@@ -2812,9 +2942,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$RefrigeratorAlarmClusterNotifyEvent");
                 return nullptr;
             }
-            jmethodID notifyStructCtor = env->GetMethodID(notifyStructClass, "<init>",
-                                                          "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-            if (notifyStructCtor == nullptr)
+
+            jmethodID notifyStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, notifyStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V",
+                &notifyStructCtor);
+            if (err != CHIP_NO_ERROR || notifyStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$RefrigeratorAlarmClusterNotifyEvent constructor");
                 return nullptr;
@@ -2878,8 +3011,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterSmokeAlarmEvent");
                 return nullptr;
             }
-            jmethodID smokeAlarmStructCtor = env->GetMethodID(smokeAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (smokeAlarmStructCtor == nullptr)
+
+            jmethodID smokeAlarmStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, smokeAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &smokeAlarmStructCtor);
+            if (err != CHIP_NO_ERROR || smokeAlarmStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterSmokeAlarmEvent constructor");
                 return nullptr;
@@ -2912,8 +3048,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterCOAlarmEvent");
                 return nullptr;
             }
-            jmethodID COAlarmStructCtor = env->GetMethodID(COAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (COAlarmStructCtor == nullptr)
+
+            jmethodID COAlarmStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, COAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &COAlarmStructCtor);
+            if (err != CHIP_NO_ERROR || COAlarmStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterCOAlarmEvent constructor");
                 return nullptr;
@@ -2946,8 +3085,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterLowBatteryEvent");
                 return nullptr;
             }
-            jmethodID lowBatteryStructCtor = env->GetMethodID(lowBatteryStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (lowBatteryStructCtor == nullptr)
+
+            jmethodID lowBatteryStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, lowBatteryStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &lowBatteryStructCtor);
+            if (err != CHIP_NO_ERROR || lowBatteryStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterLowBatteryEvent constructor");
                 return nullptr;
@@ -2972,8 +3114,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterHardwareFaultEvent");
                 return nullptr;
             }
-            jmethodID hardwareFaultStructCtor = env->GetMethodID(hardwareFaultStructClass, "<init>", "()V");
-            if (hardwareFaultStructCtor == nullptr)
+
+            jmethodID hardwareFaultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, hardwareFaultStructClass, "<init>", "()V",
+                                                                &hardwareFaultStructCtor);
+            if (err != CHIP_NO_ERROR || hardwareFaultStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterHardwareFaultEvent constructor");
                 return nullptr;
@@ -2998,8 +3143,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterEndOfServiceEvent");
                 return nullptr;
             }
-            jmethodID endOfServiceStructCtor = env->GetMethodID(endOfServiceStructClass, "<init>", "()V");
-            if (endOfServiceStructCtor == nullptr)
+
+            jmethodID endOfServiceStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, endOfServiceStructClass, "<init>", "()V",
+                                                                &endOfServiceStructCtor);
+            if (err != CHIP_NO_ERROR || endOfServiceStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterEndOfServiceEvent constructor");
                 return nullptr;
@@ -3025,8 +3173,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterSelfTestCompleteEvent");
                 return nullptr;
             }
-            jmethodID selfTestCompleteStructCtor = env->GetMethodID(selfTestCompleteStructClass, "<init>", "()V");
-            if (selfTestCompleteStructCtor == nullptr)
+
+            jmethodID selfTestCompleteStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, selfTestCompleteStructClass, "<init>", "()V",
+                                                                &selfTestCompleteStructCtor);
+            if (err != CHIP_NO_ERROR || selfTestCompleteStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterSelfTestCompleteEvent constructor");
                 return nullptr;
@@ -3051,8 +3202,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterAlarmMutedEvent");
                 return nullptr;
             }
-            jmethodID alarmMutedStructCtor = env->GetMethodID(alarmMutedStructClass, "<init>", "()V");
-            if (alarmMutedStructCtor == nullptr)
+
+            jmethodID alarmMutedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, alarmMutedStructClass, "<init>", "()V", &alarmMutedStructCtor);
+            if (err != CHIP_NO_ERROR || alarmMutedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterAlarmMutedEvent constructor");
                 return nullptr;
@@ -3077,8 +3230,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterMuteEndedEvent");
                 return nullptr;
             }
-            jmethodID muteEndedStructCtor = env->GetMethodID(muteEndedStructClass, "<init>", "()V");
-            if (muteEndedStructCtor == nullptr)
+
+            jmethodID muteEndedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, muteEndedStructClass, "<init>", "()V", &muteEndedStructCtor);
+            if (err != CHIP_NO_ERROR || muteEndedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterMuteEndedEvent constructor");
                 return nullptr;
@@ -3112,9 +3267,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterInterconnectSmokeAlarmEvent");
                 return nullptr;
             }
-            jmethodID interconnectSmokeAlarmStructCtor =
-                env->GetMethodID(interconnectSmokeAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (interconnectSmokeAlarmStructCtor == nullptr)
+
+            jmethodID interconnectSmokeAlarmStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, interconnectSmokeAlarmStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;)V", &interconnectSmokeAlarmStructCtor);
+            if (err != CHIP_NO_ERROR || interconnectSmokeAlarmStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterInterconnectSmokeAlarmEvent constructor");
                 return nullptr;
@@ -3149,9 +3306,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterInterconnectCOAlarmEvent");
                 return nullptr;
             }
-            jmethodID interconnectCOAlarmStructCtor =
-                env->GetMethodID(interconnectCOAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (interconnectCOAlarmStructCtor == nullptr)
+
+            jmethodID interconnectCOAlarmStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, interconnectCOAlarmStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;)V", &interconnectCOAlarmStructCtor);
+            if (err != CHIP_NO_ERROR || interconnectCOAlarmStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterInterconnectCOAlarmEvent constructor");
                 return nullptr;
@@ -3176,8 +3335,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SmokeCoAlarmClusterAllClearEvent");
                 return nullptr;
             }
-            jmethodID allClearStructCtor = env->GetMethodID(allClearStructClass, "<init>", "()V");
-            if (allClearStructCtor == nullptr)
+
+            jmethodID allClearStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, allClearStructClass, "<init>", "()V", &allClearStructCtor);
+            if (err != CHIP_NO_ERROR || allClearStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SmokeCoAlarmClusterAllClearEvent constructor");
                 return nullptr;
@@ -3240,9 +3401,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DishwasherAlarmClusterNotifyEvent");
                 return nullptr;
             }
-            jmethodID notifyStructCtor = env->GetMethodID(notifyStructClass, "<init>",
-                                                          "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-            if (notifyStructCtor == nullptr)
+
+            jmethodID notifyStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, notifyStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V",
+                &notifyStructCtor);
+            if (err != CHIP_NO_ERROR || notifyStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DishwasherAlarmClusterNotifyEvent constructor");
                 return nullptr;
@@ -3333,9 +3497,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipStructs$OperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$OperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -3354,10 +3521,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OperationalStateClusterOperationalErrorEvent");
                 return nullptr;
             }
-            jmethodID operationalErrorStructCtor =
-                env->GetMethodID(operationalErrorStructClass, "<init>",
-                                 "(Lchip/devicecontroller/ChipStructs$OperationalStateClusterErrorStateStruct;)V");
-            if (operationalErrorStructCtor == nullptr)
+
+            jmethodID operationalErrorStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, operationalErrorStructClass, "<init>",
+                "(Lchip/devicecontroller/ChipStructs$OperationalStateClusterErrorStateStruct;)V", &operationalErrorStructCtor);
+            if (err != CHIP_NO_ERROR || operationalErrorStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$OperationalStateClusterOperationalErrorEvent constructor");
                 return nullptr;
@@ -3442,9 +3611,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$OperationalStateClusterOperationCompletionEvent");
                 return nullptr;
             }
-            jmethodID operationCompletionStructCtor = env->GetMethodID(
-                operationCompletionStructClass, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (operationCompletionStructCtor == nullptr)
+
+            jmethodID operationCompletionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, operationCompletionStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &operationCompletionStructCtor);
+            if (err != CHIP_NO_ERROR || operationCompletionStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$OperationalStateClusterOperationCompletionEvent constructor");
                 return nullptr;
@@ -3515,9 +3687,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipStructs$RvcOperationalStateClusterErrorStateStruct");
                 return nullptr;
             }
-            jmethodID errorStateStructStructCtor_0 = env->GetMethodID(
-                errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (errorStateStructStructCtor_0 == nullptr)
+
+            jmethodID errorStateStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &errorStateStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$RvcOperationalStateClusterErrorStateStruct constructor");
                 return nullptr;
@@ -3536,10 +3711,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$RvcOperationalStateClusterOperationalErrorEvent");
                 return nullptr;
             }
-            jmethodID operationalErrorStructCtor =
-                env->GetMethodID(operationalErrorStructClass, "<init>",
-                                 "(Lchip/devicecontroller/ChipStructs$RvcOperationalStateClusterErrorStateStruct;)V");
-            if (operationalErrorStructCtor == nullptr)
+
+            jmethodID operationalErrorStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, operationalErrorStructClass, "<init>",
+                "(Lchip/devicecontroller/ChipStructs$RvcOperationalStateClusterErrorStateStruct;)V", &operationalErrorStructCtor);
+            if (err != CHIP_NO_ERROR || operationalErrorStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$RvcOperationalStateClusterOperationalErrorEvent constructor");
                 return nullptr;
@@ -3624,9 +3801,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$RvcOperationalStateClusterOperationCompletionEvent");
                 return nullptr;
             }
-            jmethodID operationCompletionStructCtor = env->GetMethodID(
-                operationCompletionStructClass, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (operationCompletionStructCtor == nullptr)
+
+            jmethodID operationCompletionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, operationCompletionStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &operationCompletionStructCtor);
+            if (err != CHIP_NO_ERROR || operationCompletionStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$RvcOperationalStateClusterOperationCompletionEvent constructor");
                 return nullptr;
@@ -3709,9 +3889,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BooleanStateConfigurationClusterAlarmsStateChangedEvent");
                 return nullptr;
             }
-            jmethodID alarmsStateChangedStructCtor =
-                env->GetMethodID(alarmsStateChangedStructClass, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-            if (alarmsStateChangedStructCtor == nullptr)
+
+            jmethodID alarmsStateChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, alarmsStateChangedStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                &alarmsStateChangedStructCtor);
+            if (err != CHIP_NO_ERROR || alarmsStateChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$BooleanStateConfigurationClusterAlarmsStateChangedEvent constructor");
@@ -3747,8 +3930,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$BooleanStateConfigurationClusterSensorFaultEvent");
                 return nullptr;
             }
-            jmethodID sensorFaultStructCtor = env->GetMethodID(sensorFaultStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (sensorFaultStructCtor == nullptr)
+
+            jmethodID sensorFaultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, sensorFaultStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &sensorFaultStructCtor);
+            if (err != CHIP_NO_ERROR || sensorFaultStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$BooleanStateConfigurationClusterSensorFaultEvent constructor");
                 return nullptr;
@@ -3809,9 +3995,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$ValveConfigurationAndControlClusterValveStateChangedEvent");
                 return nullptr;
             }
-            jmethodID valveStateChangedStructCtor =
-                env->GetMethodID(valveStateChangedStructClass, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-            if (valveStateChangedStructCtor == nullptr)
+
+            jmethodID valveStateChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, valveStateChangedStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                                &valveStateChangedStructCtor);
+            if (err != CHIP_NO_ERROR || valveStateChangedStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$ValveConfigurationAndControlClusterValveStateChangedEvent constructor");
@@ -3846,8 +4035,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ValveConfigurationAndControlClusterValveFaultEvent");
                 return nullptr;
             }
-            jmethodID valveFaultStructCtor = env->GetMethodID(valveFaultStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (valveFaultStructCtor == nullptr)
+
+            jmethodID valveFaultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, valveFaultStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &valveFaultStructCtor);
+            if (err != CHIP_NO_ERROR || valveFaultStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$ValveConfigurationAndControlClusterValveFaultEvent constructor");
                 return nullptr;
@@ -3981,10 +4173,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -4106,10 +4301,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -4134,9 +4332,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     Zcl, "Could not find class ChipEventStructs$ElectricalEnergyMeasurementClusterCumulativeEnergyMeasuredEvent");
                 return nullptr;
             }
-            jmethodID cumulativeEnergyMeasuredStructCtor =
-                env->GetMethodID(cumulativeEnergyMeasuredStructClass, "<init>", "(Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (cumulativeEnergyMeasuredStructCtor == nullptr)
+
+            jmethodID cumulativeEnergyMeasuredStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, cumulativeEnergyMeasuredStructClass, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &cumulativeEnergyMeasuredStructCtor);
+            if (err != CHIP_NO_ERROR || cumulativeEnergyMeasuredStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -4263,10 +4464,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -4388,10 +4592,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct");
                     return nullptr;
                 }
-                jmethodID energyMeasurementStructStructCtor_1 = env->GetMethodID(
-                    energyMeasurementStructStructClass_1, "<init>",
-                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (energyMeasurementStructStructCtor_1 == nullptr)
+
+                jmethodID energyMeasurementStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, energyMeasurementStructStructClass_1, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &energyMeasurementStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || energyMeasurementStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct constructor");
@@ -4416,9 +4623,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$ElectricalEnergyMeasurementClusterPeriodicEnergyMeasuredEvent");
                 return nullptr;
             }
-            jmethodID periodicEnergyMeasuredStructCtor =
-                env->GetMethodID(periodicEnergyMeasuredStructClass, "<init>", "(Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (periodicEnergyMeasuredStructCtor == nullptr)
+
+            jmethodID periodicEnergyMeasuredStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, periodicEnergyMeasuredStructClass, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &periodicEnergyMeasuredStructCtor);
+            if (err != CHIP_NO_ERROR || periodicEnergyMeasuredStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -4640,10 +4850,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                      "Could not find class ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct");
                         return nullptr;
                     }
-                    jmethodID temperatureControlStructStructCtor_2 =
-                        env->GetMethodID(temperatureControlStructStructClass_2, "<init>",
-                                         "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                    if (temperatureControlStructStructCtor_2 == nullptr)
+
+                    jmethodID temperatureControlStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(
+                        env, temperatureControlStructStructClass_2, "<init>",
+                        "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                        &temperatureControlStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || temperatureControlStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(
                             Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct constructor");
@@ -4695,9 +4908,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                      "Could not find class ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct");
                         return nullptr;
                     }
-                    jmethodID averageLoadControlStructStructCtor_2 =
-                        env->GetMethodID(averageLoadControlStructStructClass_2, "<init>", "(Ljava/lang/Integer;)V");
-                    if (averageLoadControlStructStructCtor_2 == nullptr)
+
+                    jmethodID averageLoadControlStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, averageLoadControlStructStructClass_2, "<init>",
+                                                                        "(Ljava/lang/Integer;)V",
+                                                                        &averageLoadControlStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || averageLoadControlStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(
                             Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct constructor");
@@ -4745,9 +4961,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                      "Could not find class ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct");
                         return nullptr;
                     }
-                    jmethodID dutyCycleControlStructStructCtor_2 =
-                        env->GetMethodID(dutyCycleControlStructStructClass_2, "<init>", "(Ljava/lang/Integer;)V");
-                    if (dutyCycleControlStructStructCtor_2 == nullptr)
+
+                    jmethodID dutyCycleControlStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, dutyCycleControlStructStructClass_2, "<init>",
+                                                                        "(Ljava/lang/Integer;)V",
+                                                                        &dutyCycleControlStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || dutyCycleControlStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(
                             Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct constructor");
@@ -4796,9 +5015,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                      "Could not find class ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct");
                         return nullptr;
                     }
-                    jmethodID powerSavingsControlStructStructCtor_2 =
-                        env->GetMethodID(powerSavingsControlStructStructClass_2, "<init>", "(Ljava/lang/Integer;)V");
-                    if (powerSavingsControlStructStructCtor_2 == nullptr)
+
+                    jmethodID powerSavingsControlStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, powerSavingsControlStructStructClass_2, "<init>",
+                                                                        "(Ljava/lang/Integer;)V",
+                                                                        &powerSavingsControlStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || powerSavingsControlStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(
                             Zcl,
@@ -4849,9 +5071,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                      "Could not find class ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct");
                         return nullptr;
                     }
-                    jmethodID heatingSourceControlStructStructCtor_2 =
-                        env->GetMethodID(heatingSourceControlStructStructClass_2, "<init>", "(Ljava/lang/Integer;)V");
-                    if (heatingSourceControlStructStructCtor_2 == nullptr)
+
+                    jmethodID heatingSourceControlStructStructCtor_2;
+                    err = chip::JniReferences::GetInstance().FindMethod(env, heatingSourceControlStructStructClass_2, "<init>",
+                                                                        "(Ljava/lang/Integer;)V",
+                                                                        &heatingSourceControlStructStructCtor_2);
+                    if (err != CHIP_NO_ERROR || heatingSourceControlStructStructCtor_2 == nullptr)
                     {
                         ChipLogError(
                             Zcl,
@@ -4877,11 +5102,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     Zcl, "Could not find class ChipEventStructs$DemandResponseLoadControlClusterLoadControlEventStatusChangeEvent");
                 return nullptr;
             }
-            jmethodID loadControlEventStatusChangeStructCtor =
-                env->GetMethodID(loadControlEventStatusChangeStructClass, "<init>",
-                                 "([BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/"
-                                 "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (loadControlEventStatusChangeStructCtor == nullptr)
+
+            jmethodID loadControlEventStatusChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, loadControlEventStatusChangeStructClass, "<init>",
+                "([BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/"
+                "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                &loadControlEventStatusChangeStructCtor);
+            if (err != CHIP_NO_ERROR || loadControlEventStatusChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$DemandResponseLoadControlClusterLoadControlEventStatusChangeEvent "
@@ -4922,8 +5150,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustStartEvent");
                 return nullptr;
             }
-            jmethodID powerAdjustStartStructCtor = env->GetMethodID(powerAdjustStartStructClass, "<init>", "()V");
-            if (powerAdjustStartStructCtor == nullptr)
+
+            jmethodID powerAdjustStartStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, powerAdjustStartStructClass, "<init>", "()V",
+                                                                &powerAdjustStartStructCtor);
+            if (err != CHIP_NO_ERROR || powerAdjustStartStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustStartEvent constructor");
                 return nullptr;
@@ -4970,9 +5201,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustEndEvent");
                 return nullptr;
             }
-            jmethodID powerAdjustEndStructCtor =
-                env->GetMethodID(powerAdjustEndStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;)V");
-            if (powerAdjustEndStructCtor == nullptr)
+
+            jmethodID powerAdjustEndStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, powerAdjustEndStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                &powerAdjustEndStructCtor);
+            if (err != CHIP_NO_ERROR || powerAdjustEndStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustEndEvent constructor");
                 return nullptr;
@@ -4998,8 +5232,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DeviceEnergyManagementClusterPausedEvent");
                 return nullptr;
             }
-            jmethodID pausedStructCtor = env->GetMethodID(pausedStructClass, "<init>", "()V");
-            if (pausedStructCtor == nullptr)
+
+            jmethodID pausedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, pausedStructClass, "<init>", "()V", &pausedStructCtor);
+            if (err != CHIP_NO_ERROR || pausedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DeviceEnergyManagementClusterPausedEvent constructor");
                 return nullptr;
@@ -5024,8 +5260,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DeviceEnergyManagementClusterResumedEvent");
                 return nullptr;
             }
-            jmethodID resumedStructCtor = env->GetMethodID(resumedStructClass, "<init>", "()V");
-            if (resumedStructCtor == nullptr)
+
+            jmethodID resumedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, resumedStructClass, "<init>", "()V", &resumedStructCtor);
+            if (err != CHIP_NO_ERROR || resumedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DeviceEnergyManagementClusterResumedEvent constructor");
                 return nullptr;
@@ -5067,8 +5305,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterEVConnectedEvent");
                 return nullptr;
             }
-            jmethodID EVConnectedStructCtor = env->GetMethodID(EVConnectedStructClass, "<init>", "(Ljava/lang/Long;)V");
-            if (EVConnectedStructCtor == nullptr)
+
+            jmethodID EVConnectedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, EVConnectedStructClass, "<init>", "(Ljava/lang/Long;)V",
+                                                                &EVConnectedStructCtor);
+            if (err != CHIP_NO_ERROR || EVConnectedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterEVConnectedEvent constructor");
                 return nullptr;
@@ -5142,10 +5383,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterEVNotDetectedEvent");
                 return nullptr;
             }
-            jmethodID EVNotDetectedStructCtor =
-                env->GetMethodID(EVNotDetectedStructClass, "<init>",
-                                 "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V");
-            if (EVNotDetectedStructCtor == nullptr)
+
+            jmethodID EVNotDetectedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, EVNotDetectedStructClass, "<init>",
+                "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V",
+                &EVNotDetectedStructCtor);
+            if (err != CHIP_NO_ERROR || EVNotDetectedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterEVNotDetectedEvent constructor");
                 return nullptr;
@@ -5194,9 +5438,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterEnergyTransferStartedEvent");
                 return nullptr;
             }
-            jmethodID energyTransferStartedStructCtor = env->GetMethodID(energyTransferStartedStructClass, "<init>",
-                                                                         "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
-            if (energyTransferStartedStructCtor == nullptr)
+
+            jmethodID energyTransferStartedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, energyTransferStartedStructClass, "<init>",
+                                                                "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V",
+                                                                &energyTransferStartedStructCtor);
+            if (err != CHIP_NO_ERROR || energyTransferStartedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterEnergyTransferStartedEvent constructor");
                 return nullptr;
@@ -5252,10 +5499,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterEnergyTransferStoppedEvent");
                 return nullptr;
             }
-            jmethodID energyTransferStoppedStructCtor =
-                env->GetMethodID(energyTransferStoppedStructClass, "<init>",
-                                 "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)V");
-            if (energyTransferStoppedStructCtor == nullptr)
+
+            jmethodID energyTransferStoppedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, energyTransferStoppedStructClass, "<init>",
+                "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)V", &energyTransferStoppedStructCtor);
+            if (err != CHIP_NO_ERROR || energyTransferStoppedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterEnergyTransferStoppedEvent constructor");
                 return nullptr;
@@ -5318,9 +5567,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterFaultEvent");
                 return nullptr;
             }
-            jmethodID faultStructCtor = env->GetMethodID(
-                faultStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (faultStructCtor == nullptr)
+
+            jmethodID faultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, faultStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                &faultStructCtor);
+            if (err != CHIP_NO_ERROR || faultStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterFaultEvent constructor");
                 return nullptr;
@@ -5352,8 +5604,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$EnergyEvseClusterRfidEvent");
                 return nullptr;
             }
-            jmethodID rfidStructCtor = env->GetMethodID(rfidStructClass, "<init>", "([B)V");
-            if (rfidStructCtor == nullptr)
+
+            jmethodID rfidStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, rfidStructClass, "<init>", "([B)V", &rfidStructCtor);
+            if (err != CHIP_NO_ERROR || rfidStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$EnergyEvseClusterRfidEvent constructor");
                 return nullptr;
@@ -5405,8 +5659,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DoorLockClusterDoorLockAlarmEvent");
                 return nullptr;
             }
-            jmethodID doorLockAlarmStructCtor = env->GetMethodID(doorLockAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (doorLockAlarmStructCtor == nullptr)
+
+            jmethodID doorLockAlarmStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, doorLockAlarmStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &doorLockAlarmStructCtor);
+            if (err != CHIP_NO_ERROR || doorLockAlarmStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DoorLockClusterDoorLockAlarmEvent constructor");
                 return nullptr;
@@ -5438,8 +5695,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DoorLockClusterDoorStateChangeEvent");
                 return nullptr;
             }
-            jmethodID doorStateChangeStructCtor = env->GetMethodID(doorStateChangeStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (doorStateChangeStructCtor == nullptr)
+
+            jmethodID doorStateChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, doorStateChangeStructClass, "<init>", "(Ljava/lang/Integer;)V",
+                                                                &doorStateChangeStructCtor);
+            if (err != CHIP_NO_ERROR || doorStateChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DoorLockClusterDoorStateChangeEvent constructor");
                 return nullptr;
@@ -5561,9 +5821,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                             ChipLogError(Zcl, "Could not find class ChipStructs$DoorLockClusterCredentialStruct");
                             return nullptr;
                         }
-                        jmethodID credentialStructStructCtor_3 =
-                            env->GetMethodID(credentialStructStructClass_3, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                        if (credentialStructStructCtor_3 == nullptr)
+
+                        jmethodID credentialStructStructCtor_3;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, credentialStructStructClass_3, "<init>",
+                                                                            "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                            &credentialStructStructCtor_3);
+                        if (err != CHIP_NO_ERROR || credentialStructStructCtor_3 == nullptr)
                         {
                             ChipLogError(Zcl, "Could not find ChipStructs$DoorLockClusterCredentialStruct constructor");
                             return nullptr;
@@ -5585,10 +5848,13 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DoorLockClusterLockOperationEvent");
                 return nullptr;
             }
-            jmethodID lockOperationStructCtor = env->GetMethodID(lockOperationStructClass, "<init>",
-                                                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
-                                                                 "lang/Integer;Ljava/lang/Long;Ljava/util/Optional;)V");
-            if (lockOperationStructCtor == nullptr)
+
+            jmethodID lockOperationStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, lockOperationStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
+                                                                "lang/Integer;Ljava/lang/Long;Ljava/util/Optional;)V",
+                                                                &lockOperationStructCtor);
+            if (err != CHIP_NO_ERROR || lockOperationStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DoorLockClusterLockOperationEvent constructor");
                 return nullptr;
@@ -5720,9 +5986,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                             ChipLogError(Zcl, "Could not find class ChipStructs$DoorLockClusterCredentialStruct");
                             return nullptr;
                         }
-                        jmethodID credentialStructStructCtor_3 =
-                            env->GetMethodID(credentialStructStructClass_3, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-                        if (credentialStructStructCtor_3 == nullptr)
+
+                        jmethodID credentialStructStructCtor_3;
+                        err = chip::JniReferences::GetInstance().FindMethod(env, credentialStructStructClass_3, "<init>",
+                                                                            "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                            &credentialStructStructCtor_3);
+                        if (err != CHIP_NO_ERROR || credentialStructStructCtor_3 == nullptr)
                         {
                             ChipLogError(Zcl, "Could not find ChipStructs$DoorLockClusterCredentialStruct constructor");
                             return nullptr;
@@ -5745,11 +6014,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DoorLockClusterLockOperationErrorEvent");
                 return nullptr;
             }
-            jmethodID lockOperationErrorStructCtor =
-                env->GetMethodID(lockOperationErrorStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                                 "Integer;Ljava/lang/Long;Ljava/util/Optional;)V");
-            if (lockOperationErrorStructCtor == nullptr)
+
+            jmethodID lockOperationErrorStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, lockOperationErrorStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
+                "Long;Ljava/util/Optional;)V",
+                &lockOperationErrorStructCtor);
+            if (err != CHIP_NO_ERROR || lockOperationErrorStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DoorLockClusterLockOperationErrorEvent constructor");
                 return nullptr;
@@ -5858,11 +6130,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$DoorLockClusterLockUserChangeEvent");
                 return nullptr;
             }
-            jmethodID lockUserChangeStructCtor =
-                env->GetMethodID(lockUserChangeStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                                 "Integer;Ljava/lang/Long;Ljava/lang/Integer;)V");
-            if (lockUserChangeStructCtor == nullptr)
+
+            jmethodID lockUserChangeStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, lockUserChangeStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
+                "Long;Ljava/lang/Integer;)V",
+                &lockUserChangeStructCtor);
+            if (err != CHIP_NO_ERROR || lockUserChangeStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$DoorLockClusterLockUserChangeEvent constructor");
                 return nullptr;
@@ -5920,8 +6195,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageLowEvent");
                 return nullptr;
             }
-            jmethodID supplyVoltageLowStructCtor = env->GetMethodID(supplyVoltageLowStructClass, "<init>", "()V");
-            if (supplyVoltageLowStructCtor == nullptr)
+
+            jmethodID supplyVoltageLowStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, supplyVoltageLowStructClass, "<init>", "()V",
+                                                                &supplyVoltageLowStructCtor);
+            if (err != CHIP_NO_ERROR || supplyVoltageLowStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageLowEvent constructor");
@@ -5948,8 +6226,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageHighEvent");
                 return nullptr;
             }
-            jmethodID supplyVoltageHighStructCtor = env->GetMethodID(supplyVoltageHighStructClass, "<init>", "()V");
-            if (supplyVoltageHighStructCtor == nullptr)
+
+            jmethodID supplyVoltageHighStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, supplyVoltageHighStructClass, "<init>", "()V",
+                                                                &supplyVoltageHighStructCtor);
+            if (err != CHIP_NO_ERROR || supplyVoltageHighStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageHighEvent constructor");
@@ -5976,8 +6257,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterPowerMissingPhaseEvent");
                 return nullptr;
             }
-            jmethodID powerMissingPhaseStructCtor = env->GetMethodID(powerMissingPhaseStructClass, "<init>", "()V");
-            if (powerMissingPhaseStructCtor == nullptr)
+
+            jmethodID powerMissingPhaseStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, powerMissingPhaseStructClass, "<init>", "()V",
+                                                                &powerMissingPhaseStructCtor);
+            if (err != CHIP_NO_ERROR || powerMissingPhaseStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterPowerMissingPhaseEvent constructor");
@@ -6004,8 +6288,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureLowEvent");
                 return nullptr;
             }
-            jmethodID systemPressureLowStructCtor = env->GetMethodID(systemPressureLowStructClass, "<init>", "()V");
-            if (systemPressureLowStructCtor == nullptr)
+
+            jmethodID systemPressureLowStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, systemPressureLowStructClass, "<init>", "()V",
+                                                                &systemPressureLowStructCtor);
+            if (err != CHIP_NO_ERROR || systemPressureLowStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureLowEvent constructor");
@@ -6033,8 +6320,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureHighEvent");
                 return nullptr;
             }
-            jmethodID systemPressureHighStructCtor = env->GetMethodID(systemPressureHighStructClass, "<init>", "()V");
-            if (systemPressureHighStructCtor == nullptr)
+
+            jmethodID systemPressureHighStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, systemPressureHighStructClass, "<init>", "()V",
+                                                                &systemPressureHighStructCtor);
+            if (err != CHIP_NO_ERROR || systemPressureHighStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureHighEvent constructor");
@@ -6061,8 +6351,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterDryRunningEvent");
                 return nullptr;
             }
-            jmethodID dryRunningStructCtor = env->GetMethodID(dryRunningStructClass, "<init>", "()V");
-            if (dryRunningStructCtor == nullptr)
+
+            jmethodID dryRunningStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, dryRunningStructClass, "<init>", "()V", &dryRunningStructCtor);
+            if (err != CHIP_NO_ERROR || dryRunningStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterDryRunningEvent constructor");
                 return nullptr;
@@ -6089,8 +6381,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterMotorTemperatureHighEvent");
                 return nullptr;
             }
-            jmethodID motorTemperatureHighStructCtor = env->GetMethodID(motorTemperatureHighStructClass, "<init>", "()V");
-            if (motorTemperatureHighStructCtor == nullptr)
+
+            jmethodID motorTemperatureHighStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, motorTemperatureHighStructClass, "<init>", "()V",
+                                                                &motorTemperatureHighStructCtor);
+            if (err != CHIP_NO_ERROR || motorTemperatureHighStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterMotorTemperatureHighEvent constructor");
@@ -6118,8 +6413,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterPumpMotorFatalFailureEvent");
                 return nullptr;
             }
-            jmethodID pumpMotorFatalFailureStructCtor = env->GetMethodID(pumpMotorFatalFailureStructClass, "<init>", "()V");
-            if (pumpMotorFatalFailureStructCtor == nullptr)
+
+            jmethodID pumpMotorFatalFailureStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, pumpMotorFatalFailureStructClass, "<init>", "()V",
+                                                                &pumpMotorFatalFailureStructCtor);
+            if (err != CHIP_NO_ERROR || pumpMotorFatalFailureStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -6148,8 +6446,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterElectronicTemperatureHighEvent");
                 return nullptr;
             }
-            jmethodID electronicTemperatureHighStructCtor = env->GetMethodID(electronicTemperatureHighStructClass, "<init>", "()V");
-            if (electronicTemperatureHighStructCtor == nullptr)
+
+            jmethodID electronicTemperatureHighStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, electronicTemperatureHighStructClass, "<init>", "()V",
+                                                                &electronicTemperatureHighStructCtor);
+            if (err != CHIP_NO_ERROR || electronicTemperatureHighStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -6177,8 +6478,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterPumpBlockedEvent");
                 return nullptr;
             }
-            jmethodID pumpBlockedStructCtor = env->GetMethodID(pumpBlockedStructClass, "<init>", "()V");
-            if (pumpBlockedStructCtor == nullptr)
+
+            jmethodID pumpBlockedStructCtor;
+            err =
+                chip::JniReferences::GetInstance().FindMethod(env, pumpBlockedStructClass, "<init>", "()V", &pumpBlockedStructCtor);
+            if (err != CHIP_NO_ERROR || pumpBlockedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterPumpBlockedEvent constructor");
                 return nullptr;
@@ -6204,8 +6508,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterSensorFailureEvent");
                 return nullptr;
             }
-            jmethodID sensorFailureStructCtor = env->GetMethodID(sensorFailureStructClass, "<init>", "()V");
-            if (sensorFailureStructCtor == nullptr)
+
+            jmethodID sensorFailureStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, sensorFailureStructClass, "<init>", "()V",
+                                                                &sensorFailureStructCtor);
+            if (err != CHIP_NO_ERROR || sensorFailureStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$PumpConfigurationAndControlClusterSensorFailureEvent constructor");
@@ -6233,8 +6540,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterElectronicNonFatalFailureEvent");
                 return nullptr;
             }
-            jmethodID electronicNonFatalFailureStructCtor = env->GetMethodID(electronicNonFatalFailureStructClass, "<init>", "()V");
-            if (electronicNonFatalFailureStructCtor == nullptr)
+
+            jmethodID electronicNonFatalFailureStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, electronicNonFatalFailureStructClass, "<init>", "()V",
+                                                                &electronicNonFatalFailureStructCtor);
+            if (err != CHIP_NO_ERROR || electronicNonFatalFailureStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -6263,8 +6573,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                              "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterElectronicFatalFailureEvent");
                 return nullptr;
             }
-            jmethodID electronicFatalFailureStructCtor = env->GetMethodID(electronicFatalFailureStructClass, "<init>", "()V");
-            if (electronicFatalFailureStructCtor == nullptr)
+
+            jmethodID electronicFatalFailureStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, electronicFatalFailureStructClass, "<init>", "()V",
+                                                                &electronicFatalFailureStructCtor);
+            if (err != CHIP_NO_ERROR || electronicFatalFailureStructCtor == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -6292,8 +6605,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterGeneralFaultEvent");
                 return nullptr;
             }
-            jmethodID generalFaultStructCtor = env->GetMethodID(generalFaultStructClass, "<init>", "()V");
-            if (generalFaultStructCtor == nullptr)
+
+            jmethodID generalFaultStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, generalFaultStructClass, "<init>", "()V",
+                                                                &generalFaultStructCtor);
+            if (err != CHIP_NO_ERROR || generalFaultStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$PumpConfigurationAndControlClusterGeneralFaultEvent constructor");
@@ -6319,8 +6635,10 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterLeakageEvent");
                 return nullptr;
             }
-            jmethodID leakageStructCtor = env->GetMethodID(leakageStructClass, "<init>", "()V");
-            if (leakageStructCtor == nullptr)
+
+            jmethodID leakageStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, leakageStructClass, "<init>", "()V", &leakageStructCtor);
+            if (err != CHIP_NO_ERROR || leakageStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$PumpConfigurationAndControlClusterLeakageEvent constructor");
                 return nullptr;
@@ -6346,8 +6664,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterAirDetectionEvent");
                 return nullptr;
             }
-            jmethodID airDetectionStructCtor = env->GetMethodID(airDetectionStructClass, "<init>", "()V");
-            if (airDetectionStructCtor == nullptr)
+
+            jmethodID airDetectionStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, airDetectionStructClass, "<init>", "()V",
+                                                                &airDetectionStructCtor);
+            if (err != CHIP_NO_ERROR || airDetectionStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$PumpConfigurationAndControlClusterAirDetectionEvent constructor");
@@ -6374,8 +6695,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$PumpConfigurationAndControlClusterTurbineOperationEvent");
                 return nullptr;
             }
-            jmethodID turbineOperationStructCtor = env->GetMethodID(turbineOperationStructClass, "<init>", "()V");
-            if (turbineOperationStructCtor == nullptr)
+
+            jmethodID turbineOperationStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, turbineOperationStructClass, "<init>", "()V",
+                                                                &turbineOperationStructCtor);
+            if (err != CHIP_NO_ERROR || turbineOperationStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$PumpConfigurationAndControlClusterTurbineOperationEvent constructor");
@@ -6659,9 +6983,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$TargetNavigatorClusterTargetInfoStruct");
                     return nullptr;
                 }
-                jmethodID targetInfoStructStructCtor_1 =
-                    env->GetMethodID(targetInfoStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-                if (targetInfoStructStructCtor_1 == nullptr)
+
+                jmethodID targetInfoStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(env, targetInfoStructStructClass_1, "<init>",
+                                                                    "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                                    &targetInfoStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || targetInfoStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$TargetNavigatorClusterTargetInfoStruct constructor");
                     return nullptr;
@@ -6694,9 +7021,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$TargetNavigatorClusterTargetUpdatedEvent");
                 return nullptr;
             }
-            jmethodID targetUpdatedStructCtor =
-                env->GetMethodID(targetUpdatedStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/lang/Integer;[B)V");
-            if (targetUpdatedStructCtor == nullptr)
+
+            jmethodID targetUpdatedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, targetUpdatedStructClass, "<init>", "(Ljava/util/ArrayList;Ljava/lang/Integer;[B)V", &targetUpdatedStructCtor);
+            if (err != CHIP_NO_ERROR || targetUpdatedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$TargetNavigatorClusterTargetUpdatedEvent constructor");
                 return nullptr;
@@ -6778,9 +7107,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterPlaybackPositionStruct");
                 return nullptr;
             }
-            jmethodID playbackPositionStructStructCtor_0 =
-                env->GetMethodID(playbackPositionStructStructClass_0, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-            if (playbackPositionStructStructCtor_0 == nullptr)
+
+            jmethodID playbackPositionStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(env, playbackPositionStructStructClass_0, "<init>",
+                                                                "(Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                &playbackPositionStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || playbackPositionStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterPlaybackPositionStruct constructor");
                 return nullptr;
@@ -6844,12 +7176,15 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$MediaPlaybackClusterStateChangedEvent");
                 return nullptr;
             }
-            jmethodID stateChangedStructCtor =
-                env->GetMethodID(stateChangedStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Lchip/devicecontroller/"
-                                 "ChipStructs$MediaPlaybackClusterPlaybackPositionStruct;Ljava/lang/Float;Ljava/lang/Long;Ljava/"
-                                 "lang/Long;Ljava/util/Optional;Ljava/lang/Boolean;)V");
-            if (stateChangedStructCtor == nullptr)
+
+            jmethodID stateChangedStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, stateChangedStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Lchip/devicecontroller/"
+                "ChipStructs$MediaPlaybackClusterPlaybackPositionStruct;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Ljava/"
+                "util/Optional;Ljava/lang/Boolean;)V",
+                &stateChangedStructCtor);
+            if (err != CHIP_NO_ERROR || stateChangedStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$MediaPlaybackClusterStateChangedEvent constructor");
                 return nullptr;
@@ -6973,8 +7308,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$AccountLoginClusterLoggedOutEvent");
                 return nullptr;
             }
-            jmethodID loggedOutStructCtor = env->GetMethodID(loggedOutStructClass, "<init>", "(Ljava/util/Optional;)V");
-            if (loggedOutStructCtor == nullptr)
+
+            jmethodID loggedOutStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, loggedOutStructClass, "<init>", "(Ljava/util/Optional;)V",
+                                                                &loggedOutStructCtor);
+            if (err != CHIP_NO_ERROR || loggedOutStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$AccountLoginClusterLoggedOutEvent constructor");
                 return nullptr;
@@ -7010,9 +7348,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$ContentControlClusterRemainingScreenTimeExpiredEvent");
                 return nullptr;
             }
-            jmethodID remainingScreenTimeExpiredStructCtor =
-                env->GetMethodID(remainingScreenTimeExpiredStructClass, "<init>", "()V");
-            if (remainingScreenTimeExpiredStructCtor == nullptr)
+
+            jmethodID remainingScreenTimeExpiredStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, remainingScreenTimeExpiredStructClass, "<init>", "()V",
+                                                                &remainingScreenTimeExpiredStructCtor);
+            if (err != CHIP_NO_ERROR || remainingScreenTimeExpiredStructCtor == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipEventStructs$ContentControlClusterRemainingScreenTimeExpiredEvent constructor");
@@ -7134,11 +7474,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                 return nullptr;
             }
-            jmethodID simpleStructStructCtor_0 =
-                env->GetMethodID(simpleStructStructClass_0, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                 "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-            if (simpleStructStructCtor_0 == nullptr)
+
+            jmethodID simpleStructStructCtor_0;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, simpleStructStructClass_0, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                "Float;Ljava/lang/Double;)V",
+                &simpleStructStructCtor_0);
+            if (err != CHIP_NO_ERROR || simpleStructStructCtor_0 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                 return nullptr;
@@ -7207,11 +7550,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                     return nullptr;
                 }
-                jmethodID simpleStructStructCtor_1 =
-                    env->GetMethodID(simpleStructStructClass_1, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                     "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                if (simpleStructStructCtor_1 == nullptr)
+
+                jmethodID simpleStructStructCtor_1;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, simpleStructStructClass_1, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                    "Float;Ljava/lang/Double;)V",
+                    &simpleStructStructCtor_1);
+                if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                     return nullptr;
@@ -7247,11 +7593,14 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$UnitTestingClusterTestEventEvent");
                 return nullptr;
             }
-            jmethodID testEventStructCtor =
-                env->GetMethodID(testEventStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lchip/devicecontroller/"
-                                 "ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-            if (testEventStructCtor == nullptr)
+
+            jmethodID testEventStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, testEventStructClass, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lchip/devicecontroller/"
+                "ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+                &testEventStructCtor);
+            if (err != CHIP_NO_ERROR || testEventStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$UnitTestingClusterTestEventEvent constructor");
                 return nullptr;
@@ -7286,9 +7635,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$UnitTestingClusterTestFabricScopedEventEvent");
                 return nullptr;
             }
-            jmethodID testFabricScopedEventStructCtor =
-                env->GetMethodID(testFabricScopedEventStructClass, "<init>", "(Ljava/lang/Integer;)V");
-            if (testFabricScopedEventStructCtor == nullptr)
+
+            jmethodID testFabricScopedEventStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(env, testFabricScopedEventStructClass, "<init>",
+                                                                "(Ljava/lang/Integer;)V", &testFabricScopedEventStructCtor);
+            if (err != CHIP_NO_ERROR || testFabricScopedEventStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$UnitTestingClusterTestFabricScopedEventEvent constructor");
                 return nullptr;
@@ -7348,9 +7699,11 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 ChipLogError(Zcl, "Could not find class ChipEventStructs$SampleMeiClusterPingCountEventEvent");
                 return nullptr;
             }
-            jmethodID pingCountEventStructCtor =
-                env->GetMethodID(pingCountEventStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
-            if (pingCountEventStructCtor == nullptr)
+
+            jmethodID pingCountEventStructCtor;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, pingCountEventStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V", &pingCountEventStructCtor);
+            if (err != CHIP_NO_ERROR || pingCountEventStructCtor == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipEventStructs$SampleMeiClusterPingCountEventEvent constructor");
                 return nullptr;

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -542,9 +542,12 @@ void CHIPScenesClusterViewSceneResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterAttributeValuePair");
                     return;
                 }
-                jmethodID attributeValuePairStructCtor_4 =
-                    env->GetMethodID(attributeValuePairStructClass_4, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-                if (attributeValuePairStructCtor_4 == nullptr)
+
+                jmethodID attributeValuePairStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, attributeValuePairStructClass_4, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                    &attributeValuePairStructCtor_4);
+                if (err != CHIP_NO_ERROR || attributeValuePairStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterAttributeValuePair constructor");
                     return;
@@ -563,9 +566,12 @@ void CHIPScenesClusterViewSceneResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterExtensionFieldSet");
                 return;
             }
-            jmethodID extensionFieldSetStructCtor_2 =
-                env->GetMethodID(extensionFieldSetStructClass_2, "<init>", "(Ljava/lang/Long;Ljava/util/ArrayList;)V");
-            if (extensionFieldSetStructCtor_2 == nullptr)
+
+            jmethodID extensionFieldSetStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(env, extensionFieldSetStructClass_2, "<init>",
+                                                                "(Ljava/lang/Long;Ljava/util/ArrayList;)V",
+                                                                &extensionFieldSetStructCtor_2);
+            if (err != CHIP_NO_ERROR || extensionFieldSetStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterExtensionFieldSet constructor");
                 return;
@@ -1127,9 +1133,12 @@ void CHIPScenesClusterEnhancedViewSceneResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterAttributeValuePair");
                     return;
                 }
-                jmethodID attributeValuePairStructCtor_4 =
-                    env->GetMethodID(attributeValuePairStructClass_4, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-                if (attributeValuePairStructCtor_4 == nullptr)
+
+                jmethodID attributeValuePairStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, attributeValuePairStructClass_4, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                                    &attributeValuePairStructCtor_4);
+                if (err != CHIP_NO_ERROR || attributeValuePairStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterAttributeValuePair constructor");
                     return;
@@ -1148,9 +1157,12 @@ void CHIPScenesClusterEnhancedViewSceneResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterExtensionFieldSet");
                 return;
             }
-            jmethodID extensionFieldSetStructCtor_2 =
-                env->GetMethodID(extensionFieldSetStructClass_2, "<init>", "(Ljava/lang/Long;Ljava/util/ArrayList;)V");
-            if (extensionFieldSetStructCtor_2 == nullptr)
+
+            jmethodID extensionFieldSetStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(env, extensionFieldSetStructClass_2, "<init>",
+                                                                "(Ljava/lang/Long;Ljava/util/ArrayList;)V",
+                                                                &extensionFieldSetStructCtor_2);
+            if (err != CHIP_NO_ERROR || extensionFieldSetStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterExtensionFieldSet constructor");
                 return;
@@ -1813,10 +1825,13 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResultStruct");
                 return;
             }
-            jmethodID wiFiInterfaceScanResultStructStructCtor_2 =
-                env->GetMethodID(wiFiInterfaceScanResultStructStructClass_2, "<init>",
-                                 "(Ljava/lang/Integer;[B[BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (wiFiInterfaceScanResultStructStructCtor_2 == nullptr)
+
+            jmethodID wiFiInterfaceScanResultStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, wiFiInterfaceScanResultStructStructClass_2, "<init>",
+                "(Ljava/lang/Integer;[B[BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                &wiFiInterfaceScanResultStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || wiFiInterfaceScanResultStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResultStruct constructor");
@@ -1904,11 +1919,14 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResultStruct");
                 return;
             }
-            jmethodID threadInterfaceScanResultStructStructCtor_2 =
-                env->GetMethodID(threadInterfaceScanResultStructStructClass_2, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/"
-                                 "Integer;[BLjava/lang/Integer;Ljava/lang/Integer;)V");
-            if (threadInterfaceScanResultStructStructCtor_2 == nullptr)
+
+            jmethodID threadInterfaceScanResultStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, threadInterfaceScanResultStructStructClass_2, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/"
+                "Integer;Ljava/lang/Integer;)V",
+                &threadInterfaceScanResultStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || threadInterfaceScanResultStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl,
                              "Could not find ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResultStruct constructor");
@@ -2893,10 +2911,13 @@ void CHIPGroupKeyManagementClusterKeySetReadResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeySetStruct");
         return;
     }
-    jmethodID groupKeySetStructStructCtor_0 =
-        env->GetMethodID(groupKeySetStructStructClass_0, "<init>",
-                         "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;[BLjava/lang/Long;[BLjava/lang/Long;)V");
-    if (groupKeySetStructStructCtor_0 == nullptr)
+
+    jmethodID groupKeySetStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(
+        env, groupKeySetStructStructClass_0, "<init>",
+        "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;[BLjava/lang/Long;[BLjava/lang/Long;)V",
+        &groupKeySetStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || groupKeySetStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupKeySetStruct constructor");
         return;
@@ -3205,9 +3226,12 @@ void CHIPOvenCavityOperationalStateClusterOperationalCommandResponseCallback::Ca
         ChipLogError(Zcl, "Could not find class ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct");
         return;
     }
-    jmethodID errorStateStructStructCtor_0 =
-        env->GetMethodID(errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-    if (errorStateStructStructCtor_0 == nullptr)
+
+    jmethodID errorStateStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                        "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                        &errorStateStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct constructor");
         return;
@@ -3764,9 +3788,12 @@ void CHIPOperationalStateClusterOperationalCommandResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$OperationalStateClusterErrorStateStruct");
         return;
     }
-    jmethodID errorStateStructStructCtor_0 =
-        env->GetMethodID(errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-    if (errorStateStructStructCtor_0 == nullptr)
+
+    jmethodID errorStateStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                        "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                        &errorStateStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$OperationalStateClusterErrorStateStruct constructor");
         return;
@@ -3878,9 +3905,12 @@ void CHIPRvcOperationalStateClusterOperationalCommandResponseCallback::CallbackF
         ChipLogError(Zcl, "Could not find class ChipStructs$RvcOperationalStateClusterErrorStateStruct");
         return;
     }
-    jmethodID errorStateStructStructCtor_0 =
-        env->GetMethodID(errorStateStructStructClass_0, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-    if (errorStateStructStructCtor_0 == nullptr)
+
+    jmethodID errorStateStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(env, errorStateStructStructClass_0, "<init>",
+                                                        "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                        &errorStateStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || errorStateStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$RvcOperationalStateClusterErrorStateStruct constructor");
         return;
@@ -4009,9 +4039,12 @@ void CHIPEnergyEvseClusterGetTargetsResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$EnergyEvseClusterChargingTargetStruct");
             return;
         }
-        jmethodID chargingTargetStructStructCtor_1 = env->GetMethodID(
-            chargingTargetStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (chargingTargetStructStructCtor_1 == nullptr)
+
+        jmethodID chargingTargetStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, chargingTargetStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                            &chargingTargetStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || chargingTargetStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$EnergyEvseClusterChargingTargetStruct constructor");
             return;
@@ -4565,9 +4598,12 @@ void CHIPDoorLockClusterGetUserResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$DoorLockClusterCredentialStruct");
                 return;
             }
-            jmethodID credentialStructStructCtor_2 =
-                env->GetMethodID(credentialStructStructClass_2, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (credentialStructStructCtor_2 == nullptr)
+
+            jmethodID credentialStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(env, credentialStructStructClass_2, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &credentialStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || credentialStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$DoorLockClusterCredentialStruct constructor");
                 return;
@@ -4957,9 +4993,12 @@ void CHIPThermostatClusterGetWeeklyScheduleResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThermostatClusterWeeklyScheduleTransitionStruct");
             return;
         }
-        jmethodID weeklyScheduleTransitionStructStructCtor_1 = env->GetMethodID(
-            weeklyScheduleTransitionStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (weeklyScheduleTransitionStructStructCtor_1 == nullptr)
+
+        jmethodID weeklyScheduleTransitionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, weeklyScheduleTransitionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                            &weeklyScheduleTransitionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || weeklyScheduleTransitionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ThermostatClusterWeeklyScheduleTransitionStruct constructor");
             return;
@@ -5170,9 +5209,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterPageTokenStruct");
                 return;
             }
-            jmethodID pageTokenStructStructCtor_3 = env->GetMethodID(
-                pageTokenStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (pageTokenStructStructCtor_3 == nullptr)
+
+            jmethodID pageTokenStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, pageTokenStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &pageTokenStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || pageTokenStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterPageTokenStruct constructor");
                 return;
@@ -5254,9 +5296,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterPageTokenStruct");
                 return;
             }
-            jmethodID pageTokenStructStructCtor_3 = env->GetMethodID(
-                pageTokenStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (pageTokenStructStructCtor_3 == nullptr)
+
+            jmethodID pageTokenStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, pageTokenStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                                &pageTokenStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || pageTokenStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterPageTokenStruct constructor");
                 return;
@@ -5277,9 +5322,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelPagingStruct");
         return;
     }
-    jmethodID channelPagingStructStructCtor_0 =
-        env->GetMethodID(channelPagingStructStructClass_0, "<init>", "(Ljava/util/Optional;Ljava/util/Optional;)V");
-    if (channelPagingStructStructCtor_0 == nullptr)
+
+    jmethodID channelPagingStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(env, channelPagingStructStructClass_0, "<init>",
+                                                        "(Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                        &channelPagingStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || channelPagingStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelPagingStruct constructor");
         return;
@@ -5389,11 +5437,14 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfoStruct");
             return;
         }
-        jmethodID channelInfoStructStructCtor_2 =
-            env->GetMethodID(channelInfoStructStructClass_2, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                             "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (channelInfoStructStructCtor_2 == nullptr)
+
+        jmethodID channelInfoStructStructCtor_2;
+        err =
+            chip::JniReferences::GetInstance().FindMethod(env, channelInfoStructStructClass_2, "<init>",
+                                                          "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/"
+                                                          "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                          &channelInfoStructStructCtor_2);
+        if (err != CHIP_NO_ERROR || channelInfoStructStructCtor_2 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfoStruct constructor");
             return;
@@ -5591,9 +5642,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterSeriesInfoStruct");
                     return;
                 }
-                jmethodID seriesInfoStructStructCtor_4 =
-                    env->GetMethodID(seriesInfoStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-                if (seriesInfoStructStructCtor_4 == nullptr)
+
+                jmethodID seriesInfoStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, seriesInfoStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                                                                    &seriesInfoStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || seriesInfoStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterSeriesInfoStruct constructor");
                     return;
@@ -5645,9 +5699,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterProgramCategoryStruct");
                     return;
                 }
-                jmethodID programCategoryStructStructCtor_4 =
-                    env->GetMethodID(programCategoryStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                if (programCategoryStructStructCtor_4 == nullptr)
+
+                jmethodID programCategoryStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, programCategoryStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                    &programCategoryStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || programCategoryStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterProgramCategoryStruct constructor");
                     return;
@@ -5687,9 +5744,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterProgramCastStruct");
                     return;
                 }
-                jmethodID programCastStructStructCtor_4 =
-                    env->GetMethodID(programCastStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-                if (programCastStructStructCtor_4 == nullptr)
+
+                jmethodID programCastStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, programCastStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                                                                    &programCastStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || programCastStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterProgramCastStruct constructor");
                     return;
@@ -5729,9 +5789,12 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterProgramCastStruct");
                     return;
                 }
-                jmethodID programCastStructStructCtor_4 =
-                    env->GetMethodID(programCastStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-                if (programCastStructStructCtor_4 == nullptr)
+
+                jmethodID programCastStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, programCastStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                                                                    &programCastStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || programCastStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterProgramCastStruct constructor");
                     return;
@@ -5753,13 +5816,16 @@ void CHIPChannelClusterProgramGuideResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterProgramStruct");
             return;
         }
-        jmethodID programStructStructCtor_1 = env->GetMethodID(
-            programStructStructClass_1, "<init>",
+
+        jmethodID programStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, programStructStructClass_1, "<init>",
             "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$ChannelClusterChannelInfoStruct;Ljava/lang/Long;Ljava/lang/"
             "Long;Ljava/lang/String;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
             "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/"
-            "util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (programStructStructCtor_1 == nullptr)
+            "util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+            &programStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || programStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterProgramStruct constructor");
             return;
@@ -6845,11 +6911,13 @@ void CHIPUnitTestingClusterTestStructArrayArgumentResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_2 =
-            env->GetMethodID(simpleStructStructClass_2, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_2 == nullptr)
+
+        jmethodID simpleStructStructCtor_2;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_2, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_2);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_2 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -6918,11 +6986,14 @@ void CHIPUnitTestingClusterTestStructArrayArgumentResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                 return;
             }
-            jmethodID simpleStructStructCtor_3 =
-                env->GetMethodID(simpleStructStructClass_3, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                 "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-            if (simpleStructStructCtor_3 == nullptr)
+
+            jmethodID simpleStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, simpleStructStructClass_3, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                "Float;Ljava/lang/Double;)V",
+                &simpleStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || simpleStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                 return;
@@ -6986,11 +7057,14 @@ void CHIPUnitTestingClusterTestStructArrayArgumentResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterNestedStructList");
             return;
         }
-        jmethodID nestedStructListStructCtor_1 = env->GetMethodID(
-            nestedStructListStructClass_1, "<init>",
+
+        jmethodID nestedStructListStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, nestedStructListStructClass_1, "<init>",
             "(Ljava/lang/Integer;Ljava/lang/Boolean;Lchip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/"
-            "ArrayList;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
-        if (nestedStructListStructCtor_1 == nullptr)
+            "ArrayList;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/util/ArrayList;)V",
+            &nestedStructListStructCtor_1);
+        if (err != CHIP_NO_ERROR || nestedStructListStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterNestedStructList constructor");
             return;
@@ -7060,11 +7134,13 @@ void CHIPUnitTestingClusterTestStructArrayArgumentResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_1 =
-            env->GetMethodID(simpleStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_1 == nullptr)
+
+        jmethodID simpleStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -7671,11 +7747,13 @@ void CHIPUnitTestingClusterTestComplexNullableOptionalResponseCallback::Callback
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_1 =
-            env->GetMethodID(simpleStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_1 == nullptr)
+
+        jmethodID simpleStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -7764,11 +7842,13 @@ void CHIPUnitTestingClusterTestComplexNullableOptionalResponseCallback::Callback
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_1 =
-            env->GetMethodID(simpleStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_1 == nullptr)
+
+        jmethodID simpleStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -7886,11 +7966,13 @@ void CHIPUnitTestingClusterTestComplexNullableOptionalResponseCallback::Callback
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_1 =
-            env->GetMethodID(simpleStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_1 == nullptr)
+
+        jmethodID simpleStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -8191,10 +8273,13 @@ void CHIPUnitTestingClusterSimpleStructResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
         return;
     }
-    jmethodID simpleStructStructCtor_0 = env->GetMethodID(simpleStructStructClass_0, "<init>",
-                                                          "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/"
-                                                          "String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-    if (simpleStructStructCtor_0 == nullptr)
+
+    jmethodID simpleStructStructCtor_0;
+    err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_0, "<init>",
+                                                        "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/"
+                                                        "String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                        &simpleStructStructCtor_0);
+    if (err != CHIP_NO_ERROR || simpleStructStructCtor_0 == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
         return;

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -767,10 +767,13 @@ void CHIPScenesFabricSceneInfoAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterSceneInfoStruct");
             return;
         }
-        jmethodID sceneInfoStructStructCtor_1 = env->GetMethodID(sceneInfoStructStructClass_1, "<init>",
-                                                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
-                                                                 "lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (sceneInfoStructStructCtor_1 == nullptr)
+
+        jmethodID sceneInfoStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, sceneInfoStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+            &sceneInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || sceneInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ScenesClusterSceneInfoStruct constructor");
             return;
@@ -3045,9 +3048,11 @@ void CHIPDescriptorDeviceTypeListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterDeviceTypeStruct");
             return;
         }
-        jmethodID deviceTypeStructStructCtor_1 =
-            env->GetMethodID(deviceTypeStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
-        if (deviceTypeStructStructCtor_1 == nullptr)
+
+        jmethodID deviceTypeStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, deviceTypeStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V", &deviceTypeStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || deviceTypeStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DescriptorClusterDeviceTypeStruct constructor");
             return;
@@ -3386,10 +3391,12 @@ void CHIPDescriptorTagListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterSemanticTagStruct");
             return;
         }
-        jmethodID semanticTagStructStructCtor_1 =
-            env->GetMethodID(semanticTagStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (semanticTagStructStructCtor_1 == nullptr)
+
+        jmethodID semanticTagStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, semanticTagStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;)V", &semanticTagStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || semanticTagStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DescriptorClusterSemanticTagStruct constructor");
             return;
@@ -3825,10 +3832,13 @@ void CHIPBindingBindingAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$BindingClusterTargetStruct");
             return;
         }
-        jmethodID targetStructStructCtor_1 = env->GetMethodID(
-            targetStructStructClass_1, "<init>",
-            "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V");
-        if (targetStructStructCtor_1 == nullptr)
+
+        jmethodID targetStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, targetStructStructClass_1, "<init>",
+            "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V",
+            &targetStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || targetStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$BindingClusterTargetStruct constructor");
             return;
@@ -4287,9 +4297,12 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlTargetStruct");
                     return;
                 }
-                jmethodID accessControlTargetStructStructCtor_4 = env->GetMethodID(
-                    accessControlTargetStructStructClass_4, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
-                if (accessControlTargetStructStructCtor_4 == nullptr)
+
+                jmethodID accessControlTargetStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, accessControlTargetStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V",
+                                                                    &accessControlTargetStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || accessControlTargetStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlTargetStruct constructor");
                     return;
@@ -4317,10 +4330,13 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlEntryStruct");
             return;
         }
-        jmethodID accessControlEntryStructStructCtor_1 = env->GetMethodID(
-            accessControlEntryStructStructClass_1, "<init>",
-            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-        if (accessControlEntryStructStructCtor_1 == nullptr)
+
+        jmethodID accessControlEntryStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, accessControlEntryStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V",
+            &accessControlEntryStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || accessControlEntryStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlEntryStruct constructor");
             return;
@@ -4418,9 +4434,11 @@ void CHIPAccessControlExtensionAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlExtensionStruct");
             return;
         }
-        jmethodID accessControlExtensionStructStructCtor_1 =
-            env->GetMethodID(accessControlExtensionStructStructClass_1, "<init>", "([BLjava/lang/Integer;)V");
-        if (accessControlExtensionStructStructCtor_1 == nullptr)
+
+        jmethodID accessControlExtensionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, accessControlExtensionStructStructClass_1, "<init>",
+                                                            "([BLjava/lang/Integer;)V", &accessControlExtensionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || accessControlExtensionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$AccessControlClusterAccessControlExtensionStruct constructor");
             return;
@@ -4824,10 +4842,13 @@ void CHIPActionsActionListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ActionsClusterActionStruct");
             return;
         }
-        jmethodID actionStructStructCtor_1 = env->GetMethodID(
-            actionStructStructClass_1, "<init>",
-            "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (actionStructStructCtor_1 == nullptr)
+
+        jmethodID actionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, actionStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+            &actionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || actionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ActionsClusterActionStruct constructor");
             return;
@@ -4941,10 +4962,12 @@ void CHIPActionsEndpointListsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ActionsClusterEndpointListStruct");
             return;
         }
-        jmethodID endpointListStructStructCtor_1 =
-            env->GetMethodID(endpointListStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (endpointListStructStructCtor_1 == nullptr)
+
+        jmethodID endpointListStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, endpointListStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V", &endpointListStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || endpointListStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ActionsClusterEndpointListStruct constructor");
             return;
@@ -5911,9 +5934,12 @@ void CHIPOtaSoftwareUpdateRequestorDefaultOTAProvidersAttributeCallback::Callbac
             ChipLogError(Zcl, "Could not find class ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation");
             return;
         }
-        jmethodID providerLocationStructCtor_1 =
-            env->GetMethodID(providerLocationStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (providerLocationStructCtor_1 == nullptr)
+
+        jmethodID providerLocationStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, providerLocationStructClass_1, "<init>",
+                                                            "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                            &providerLocationStructCtor_1);
+        if (err != CHIP_NO_ERROR || providerLocationStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation constructor");
             return;
@@ -9175,9 +9201,12 @@ void CHIPNetworkCommissioningNetworksAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterNetworkInfoStruct");
             return;
         }
-        jmethodID networkInfoStructStructCtor_1 = env->GetMethodID(
-            networkInfoStructStructClass_1, "<init>", "([BLjava/lang/Boolean;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (networkInfoStructStructCtor_1 == nullptr)
+
+        jmethodID networkInfoStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, networkInfoStructStructClass_1, "<init>",
+                                                            "([BLjava/lang/Boolean;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                            &networkInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || networkInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$NetworkCommissioningClusterNetworkInfoStruct constructor");
             return;
@@ -10191,11 +10220,14 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GeneralDiagnosticsClusterNetworkInterface");
             return;
         }
-        jmethodID networkInterfaceStructCtor_1 =
-            env->GetMethodID(networkInterfaceStructClass_1, "<init>",
-                             "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/"
-                             "ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-        if (networkInterfaceStructCtor_1 == nullptr)
+
+        jmethodID networkInterfaceStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, networkInterfaceStructClass_1, "<init>",
+            "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/ArrayList;Ljava/util/"
+            "ArrayList;Ljava/lang/Integer;)V",
+            &networkInterfaceStructCtor_1);
+        if (err != CHIP_NO_ERROR || networkInterfaceStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$GeneralDiagnosticsClusterNetworkInterface constructor");
             return;
@@ -10857,10 +10889,13 @@ void CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$SoftwareDiagnosticsClusterThreadMetricsStruct");
             return;
         }
-        jmethodID threadMetricsStructStructCtor_1 =
-            env->GetMethodID(threadMetricsStructStructClass_1, "<init>",
-                             "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (threadMetricsStructStructCtor_1 == nullptr)
+
+        jmethodID threadMetricsStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, threadMetricsStructStructClass_1, "<init>",
+            "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+            &threadMetricsStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || threadMetricsStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$SoftwareDiagnosticsClusterThreadMetricsStruct constructor");
             return;
@@ -11747,12 +11782,15 @@ void CHIPThreadNetworkDiagnosticsNeighborTableAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTableStruct");
             return;
         }
-        jmethodID neighborTableStructStructCtor_1 =
-            env->GetMethodID(neighborTableStructStructClass_1, "<init>",
-                             "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/"
-                             "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
-                             "Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
-        if (neighborTableStructStructCtor_1 == nullptr)
+
+        jmethodID neighborTableStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, neighborTableStructStructClass_1, "<init>",
+            "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/"
+            "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/"
+            "Boolean;Ljava/lang/Boolean;)V",
+            &neighborTableStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || neighborTableStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTableStruct constructor");
             return;
@@ -11911,11 +11949,14 @@ void CHIPThreadNetworkDiagnosticsRouteTableAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterRouteTableStruct");
             return;
         }
-        jmethodID routeTableStructStructCtor_1 =
-            env->GetMethodID(routeTableStructStructClass_1, "<init>",
-                             "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
-                             "lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
-        if (routeTableStructStructCtor_1 == nullptr)
+
+        jmethodID routeTableStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, routeTableStructStructClass_1, "<init>",
+            "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
+            "lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V",
+            &routeTableStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || routeTableStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ThreadNetworkDiagnosticsClusterRouteTableStruct constructor");
             return;
@@ -14797,9 +14838,12 @@ void CHIPTimeSynchronizationTimeZoneAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$TimeSynchronizationClusterTimeZoneStruct");
             return;
         }
-        jmethodID timeZoneStructStructCtor_1 =
-            env->GetMethodID(timeZoneStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V");
-        if (timeZoneStructStructCtor_1 == nullptr)
+
+        jmethodID timeZoneStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, timeZoneStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Optional;)V",
+                                                            &timeZoneStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || timeZoneStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$TimeSynchronizationClusterTimeZoneStruct constructor");
             return;
@@ -14912,9 +14956,12 @@ void CHIPTimeSynchronizationDSTOffsetAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$TimeSynchronizationClusterDSTOffsetStruct");
             return;
         }
-        jmethodID DSTOffsetStructStructCtor_1 =
-            env->GetMethodID(DSTOffsetStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-        if (DSTOffsetStructStructCtor_1 == nullptr)
+
+        jmethodID DSTOffsetStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, DSTOffsetStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V",
+                                                            &DSTOffsetStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || DSTOffsetStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$TimeSynchronizationClusterDSTOffsetStruct constructor");
             return;
@@ -16375,8 +16422,11 @@ void CHIPOperationalCredentialsNOCsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterNOCStruct");
             return;
         }
-        jmethodID NOCStructStructCtor_1 = env->GetMethodID(NOCStructStructClass_1, "<init>", "([B[BLjava/lang/Integer;)V");
-        if (NOCStructStructCtor_1 == nullptr)
+
+        jmethodID NOCStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, NOCStructStructClass_1, "<init>", "([B[BLjava/lang/Integer;)V",
+                                                            &NOCStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || NOCStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OperationalCredentialsClusterNOCStruct constructor");
             return;
@@ -16497,10 +16547,13 @@ void CHIPOperationalCredentialsFabricsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterFabricDescriptorStruct");
             return;
         }
-        jmethodID fabricDescriptorStructStructCtor_1 =
-            env->GetMethodID(fabricDescriptorStructStructClass_1, "<init>",
-                             "([BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;)V");
-        if (fabricDescriptorStructStructCtor_1 == nullptr)
+
+        jmethodID fabricDescriptorStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, fabricDescriptorStructStructClass_1, "<init>",
+            "([BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;)V",
+            &fabricDescriptorStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || fabricDescriptorStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OperationalCredentialsClusterFabricDescriptorStruct constructor");
             return;
@@ -16967,9 +17020,12 @@ void CHIPGroupKeyManagementGroupKeyMapAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct");
             return;
         }
-        jmethodID groupKeyMapStructStructCtor_1 = env->GetMethodID(groupKeyMapStructStructClass_1, "<init>",
-                                                                   "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (groupKeyMapStructStructCtor_1 == nullptr)
+
+        jmethodID groupKeyMapStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, groupKeyMapStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                            &groupKeyMapStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || groupKeyMapStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct constructor");
             return;
@@ -17095,10 +17151,12 @@ void CHIPGroupKeyManagementGroupTableAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct");
             return;
         }
-        jmethodID groupInfoMapStructStructCtor_1 =
-            env->GetMethodID(groupInfoMapStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/lang/Integer;)V");
-        if (groupInfoMapStructStructCtor_1 == nullptr)
+
+        jmethodID groupInfoMapStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, groupInfoMapStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/lang/Integer;)V", &groupInfoMapStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || groupInfoMapStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct constructor");
             return;
@@ -17472,9 +17530,11 @@ void CHIPFixedLabelLabelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$FixedLabelClusterLabelStruct");
             return;
         }
-        jmethodID labelStructStructCtor_1 =
-            env->GetMethodID(labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-        if (labelStructStructCtor_1 == nullptr)
+
+        jmethodID labelStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, labelStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/String;)V", &labelStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || labelStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$FixedLabelClusterLabelStruct constructor");
             return;
@@ -17842,9 +17902,11 @@ void CHIPUserLabelLabelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UserLabelClusterLabelStruct");
             return;
         }
-        jmethodID labelStructStructCtor_1 =
-            env->GetMethodID(labelStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
-        if (labelStructStructCtor_1 == nullptr)
+
+        jmethodID labelStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, labelStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/String;)V", &labelStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || labelStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UserLabelClusterLabelStruct constructor");
             return;
@@ -19371,9 +19433,12 @@ void CHIPIcdManagementRegisteredClientsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$IcdManagementClusterMonitoringRegistrationStruct");
             return;
         }
-        jmethodID monitoringRegistrationStructStructCtor_1 = env->GetMethodID(
-            monitoringRegistrationStructStructClass_1, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;)V");
-        if (monitoringRegistrationStructStructCtor_1 == nullptr)
+
+        jmethodID monitoringRegistrationStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, monitoringRegistrationStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;)V",
+                                                            &monitoringRegistrationStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || monitoringRegistrationStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$IcdManagementClusterMonitoringRegistrationStruct constructor");
             return;
@@ -20258,9 +20323,12 @@ void CHIPOvenCavityOperationalStateOperationalStateListAttributeCallback::Callba
             ChipLogError(Zcl, "Could not find class ChipStructs$OvenCavityOperationalStateClusterOperationalStateStruct");
             return;
         }
-        jmethodID operationalStateStructStructCtor_1 =
-            env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (operationalStateStructStructCtor_1 == nullptr)
+
+        jmethodID operationalStateStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                            &operationalStateStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OvenCavityOperationalStateClusterOperationalStateStruct constructor");
             return;
@@ -20672,9 +20740,12 @@ void CHIPOvenModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$OvenModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$OvenModeClusterModeTagStruct constructor");
                 return;
@@ -20693,9 +20764,12 @@ void CHIPOvenModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OvenModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OvenModeClusterModeOptionStruct constructor");
             return;
@@ -21714,9 +21788,12 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterSemanticTagStruct");
                 return;
             }
-            jmethodID semanticTagStructStructCtor_3 =
-                env->GetMethodID(semanticTagStructStructClass_3, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
-            if (semanticTagStructStructCtor_3 == nullptr)
+
+            jmethodID semanticTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, semanticTagStructStructClass_3, "<init>",
+                                                                "(Ljava/lang/Integer;Ljava/lang/Integer;)V",
+                                                                &semanticTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || semanticTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$ModeSelectClusterSemanticTagStruct constructor");
                 return;
@@ -21735,9 +21812,12 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ModeSelectClusterModeOptionStruct constructor");
             return;
@@ -22274,9 +22354,12 @@ void CHIPLaundryWasherModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$LaundryWasherModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$LaundryWasherModeClusterModeTagStruct constructor");
                 return;
@@ -22295,9 +22378,12 @@ void CHIPLaundryWasherModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$LaundryWasherModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$LaundryWasherModeClusterModeOptionStruct constructor");
             return;
@@ -22845,9 +22931,12 @@ void CHIPRefrigeratorAndTemperatureControlledCabinetModeSupportedModesAttributeC
                     Zcl, "Could not find class ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(
                     Zcl,
@@ -22870,9 +22959,12 @@ void CHIPRefrigeratorAndTemperatureControlledCabinetModeSupportedModesAttributeC
                          "Could not find class ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(
                 Zcl,
@@ -23938,9 +24030,12 @@ void CHIPRvcRunModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$RvcRunModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$RvcRunModeClusterModeTagStruct constructor");
                 return;
@@ -23959,9 +24054,12 @@ void CHIPRvcRunModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$RvcRunModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$RvcRunModeClusterModeOptionStruct constructor");
             return;
@@ -24431,9 +24529,12 @@ void CHIPRvcCleanModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$RvcCleanModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$RvcCleanModeClusterModeTagStruct constructor");
                 return;
@@ -24452,9 +24553,12 @@ void CHIPRvcCleanModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$RvcCleanModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$RvcCleanModeClusterModeOptionStruct constructor");
             return;
@@ -25569,9 +25673,12 @@ void CHIPDishwasherModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$DishwasherModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$DishwasherModeClusterModeTagStruct constructor");
                 return;
@@ -25590,9 +25697,12 @@ void CHIPDishwasherModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DishwasherModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DishwasherModeClusterModeOptionStruct constructor");
             return;
@@ -26986,9 +27096,12 @@ void CHIPMicrowaveOvenModeSupportedModesAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$MicrowaveOvenModeClusterModeTagStruct");
                 return;
             }
-            jmethodID modeTagStructStructCtor_3 =
-                env->GetMethodID(modeTagStructStructClass_3, "<init>", "(Ljava/util/Optional;Ljava/lang/Integer;)V");
-            if (modeTagStructStructCtor_3 == nullptr)
+
+            jmethodID modeTagStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(env, modeTagStructStructClass_3, "<init>",
+                                                                "(Ljava/util/Optional;Ljava/lang/Integer;)V",
+                                                                &modeTagStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || modeTagStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$MicrowaveOvenModeClusterModeTagStruct constructor");
                 return;
@@ -27007,9 +27120,12 @@ void CHIPMicrowaveOvenModeSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$MicrowaveOvenModeClusterModeOptionStruct");
             return;
         }
-        jmethodID modeOptionStructStructCtor_1 = env->GetMethodID(modeOptionStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
-        if (modeOptionStructStructCtor_1 == nullptr)
+
+        jmethodID modeOptionStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, modeOptionStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V",
+                                                            &modeOptionStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || modeOptionStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$MicrowaveOvenModeClusterModeOptionStruct constructor");
             return;
@@ -27897,9 +28013,12 @@ void CHIPOperationalStateOperationalStateListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OperationalStateClusterOperationalStateStruct");
             return;
         }
-        jmethodID operationalStateStructStructCtor_1 =
-            env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (operationalStateStructStructCtor_1 == nullptr)
+
+        jmethodID operationalStateStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                            &operationalStateStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$OperationalStateClusterOperationalStateStruct constructor");
             return;
@@ -28502,9 +28621,12 @@ void CHIPRvcOperationalStateOperationalStateListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$RvcOperationalStateClusterOperationalStateStruct");
             return;
         }
-        jmethodID operationalStateStructStructCtor_1 =
-            env->GetMethodID(operationalStateStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (operationalStateStructStructCtor_1 == nullptr)
+
+        jmethodID operationalStateStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, operationalStateStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/util/Optional;)V",
+                                                            &operationalStateStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || operationalStateStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$RvcOperationalStateClusterOperationalStateStruct constructor");
             return;
@@ -28956,9 +29078,12 @@ void CHIPHepaFilterMonitoringReplacementProductListAttributeCallback::CallbackFn
             ChipLogError(Zcl, "Could not find class ChipStructs$HepaFilterMonitoringClusterReplacementProductStruct");
             return;
         }
-        jmethodID replacementProductStructStructCtor_1 =
-            env->GetMethodID(replacementProductStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-        if (replacementProductStructStructCtor_1 == nullptr)
+
+        jmethodID replacementProductStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, replacementProductStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                            &replacementProductStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || replacementProductStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$HepaFilterMonitoringClusterReplacementProductStruct constructor");
             return;
@@ -29414,9 +29539,12 @@ void CHIPActivatedCarbonFilterMonitoringReplacementProductListAttributeCallback:
             ChipLogError(Zcl, "Could not find class ChipStructs$ActivatedCarbonFilterMonitoringClusterReplacementProductStruct");
             return;
         }
-        jmethodID replacementProductStructStructCtor_1 =
-            env->GetMethodID(replacementProductStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-        if (replacementProductStructStructCtor_1 == nullptr)
+
+        jmethodID replacementProductStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, replacementProductStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                            &replacementProductStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || replacementProductStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl,
                          "Could not find ChipStructs$ActivatedCarbonFilterMonitoringClusterReplacementProductStruct constructor");
@@ -31261,10 +31389,13 @@ void CHIPDemandResponseLoadControlLoadControlProgramsAttributeCallback::Callback
             ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlProgramStruct");
             return;
         }
-        jmethodID loadControlProgramStructStructCtor_1 =
-            env->GetMethodID(loadControlProgramStructStructClass_1, "<init>",
-                             "([BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
-        if (loadControlProgramStructStructCtor_1 == nullptr)
+
+        jmethodID loadControlProgramStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, loadControlProgramStructStructClass_1, "<init>",
+            "([BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V",
+            &loadControlProgramStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || loadControlProgramStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlProgramStruct constructor");
             return;
@@ -31576,10 +31707,13 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct");
                     return;
                 }
-                jmethodID temperatureControlStructStructCtor_5 =
-                    env->GetMethodID(temperatureControlStructStructClass_5, "<init>",
-                                     "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (temperatureControlStructStructCtor_5 == nullptr)
+
+                jmethodID temperatureControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, temperatureControlStructStructClass_5, "<init>",
+                    "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &temperatureControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || temperatureControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct constructor");
@@ -31623,9 +31757,12 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct");
                     return;
                 }
-                jmethodID averageLoadControlStructStructCtor_5 =
-                    env->GetMethodID(averageLoadControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (averageLoadControlStructStructCtor_5 == nullptr)
+
+                jmethodID averageLoadControlStructStructCtor_5;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, averageLoadControlStructStructClass_5, "<init>",
+                                                                  "(Ljava/lang/Integer;)V", &averageLoadControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || averageLoadControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct constructor");
@@ -31666,9 +31803,11 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct");
                     return;
                 }
-                jmethodID dutyCycleControlStructStructCtor_5 =
-                    env->GetMethodID(dutyCycleControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (dutyCycleControlStructStructCtor_5 == nullptr)
+
+                jmethodID dutyCycleControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(env, dutyCycleControlStructStructClass_5, "<init>",
+                                                                    "(Ljava/lang/Integer;)V", &dutyCycleControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || dutyCycleControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct constructor");
@@ -31709,9 +31848,12 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct");
                     return;
                 }
-                jmethodID powerSavingsControlStructStructCtor_5 =
-                    env->GetMethodID(powerSavingsControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (powerSavingsControlStructStructCtor_5 == nullptr)
+
+                jmethodID powerSavingsControlStructStructCtor_5;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, powerSavingsControlStructStructClass_5, "<init>",
+                                                                  "(Ljava/lang/Integer;)V", &powerSavingsControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || powerSavingsControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct constructor");
@@ -31753,9 +31895,12 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                                  "Could not find class ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct");
                     return;
                 }
-                jmethodID heatingSourceControlStructStructCtor_5 =
-                    env->GetMethodID(heatingSourceControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (heatingSourceControlStructStructCtor_5 == nullptr)
+
+                jmethodID heatingSourceControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(env, heatingSourceControlStructStructClass_5, "<init>",
+                                                                    "(Ljava/lang/Integer;)V",
+                                                                    &heatingSourceControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || heatingSourceControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct constructor");
@@ -31779,11 +31924,14 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
                              "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct");
                 return;
             }
-            jmethodID loadControlEventTransitionStructStructCtor_3 =
-                env->GetMethodID(loadControlEventTransitionStructStructClass_3, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                                 "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (loadControlEventTransitionStructStructCtor_3 == nullptr)
+
+            jmethodID loadControlEventTransitionStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, loadControlEventTransitionStructStructClass_3, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
+                "Optional;Ljava/util/Optional;)V",
+                &loadControlEventTransitionStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || loadControlEventTransitionStructStructCtor_3 == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct constructor");
@@ -31806,11 +31954,13 @@ void CHIPDemandResponseLoadControlEventsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct");
             return;
         }
-        jmethodID loadControlEventStructStructCtor_1 =
-            env->GetMethodID(loadControlEventStructStructClass_1, "<init>",
-                             "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/Long;Ljava/"
-                             "util/ArrayList;)V");
-        if (loadControlEventStructStructCtor_1 == nullptr)
+
+        jmethodID loadControlEventStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, loadControlEventStructStructClass_1, "<init>",
+                                                            "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/"
+                                                            "lang/Integer;Ljava/lang/Long;Ljava/util/ArrayList;)V",
+                                                            &loadControlEventStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || loadControlEventStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct constructor");
             return;
@@ -32123,10 +32273,13 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct");
                     return;
                 }
-                jmethodID temperatureControlStructStructCtor_5 =
-                    env->GetMethodID(temperatureControlStructStructClass_5, "<init>",
-                                     "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-                if (temperatureControlStructStructCtor_5 == nullptr)
+
+                jmethodID temperatureControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, temperatureControlStructStructClass_5, "<init>",
+                    "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                    &temperatureControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || temperatureControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct constructor");
@@ -32170,9 +32323,12 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct");
                     return;
                 }
-                jmethodID averageLoadControlStructStructCtor_5 =
-                    env->GetMethodID(averageLoadControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (averageLoadControlStructStructCtor_5 == nullptr)
+
+                jmethodID averageLoadControlStructStructCtor_5;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, averageLoadControlStructStructClass_5, "<init>",
+                                                                  "(Ljava/lang/Integer;)V", &averageLoadControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || averageLoadControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct constructor");
@@ -32213,9 +32369,11 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct");
                     return;
                 }
-                jmethodID dutyCycleControlStructStructCtor_5 =
-                    env->GetMethodID(dutyCycleControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (dutyCycleControlStructStructCtor_5 == nullptr)
+
+                jmethodID dutyCycleControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(env, dutyCycleControlStructStructClass_5, "<init>",
+                                                                    "(Ljava/lang/Integer;)V", &dutyCycleControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || dutyCycleControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(Zcl,
                                  "Could not find ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct constructor");
@@ -32256,9 +32414,12 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct");
                     return;
                 }
-                jmethodID powerSavingsControlStructStructCtor_5 =
-                    env->GetMethodID(powerSavingsControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (powerSavingsControlStructStructCtor_5 == nullptr)
+
+                jmethodID powerSavingsControlStructStructCtor_5;
+                err =
+                    chip::JniReferences::GetInstance().FindMethod(env, powerSavingsControlStructStructClass_5, "<init>",
+                                                                  "(Ljava/lang/Integer;)V", &powerSavingsControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || powerSavingsControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct constructor");
@@ -32300,9 +32461,12 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                                  "Could not find class ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct");
                     return;
                 }
-                jmethodID heatingSourceControlStructStructCtor_5 =
-                    env->GetMethodID(heatingSourceControlStructStructClass_5, "<init>", "(Ljava/lang/Integer;)V");
-                if (heatingSourceControlStructStructCtor_5 == nullptr)
+
+                jmethodID heatingSourceControlStructStructCtor_5;
+                err = chip::JniReferences::GetInstance().FindMethod(env, heatingSourceControlStructStructClass_5, "<init>",
+                                                                    "(Ljava/lang/Integer;)V",
+                                                                    &heatingSourceControlStructStructCtor_5);
+                if (err != CHIP_NO_ERROR || heatingSourceControlStructStructCtor_5 == nullptr)
                 {
                     ChipLogError(
                         Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct constructor");
@@ -32326,11 +32490,14 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
                              "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct");
                 return;
             }
-            jmethodID loadControlEventTransitionStructStructCtor_3 =
-                env->GetMethodID(loadControlEventTransitionStructStructClass_3, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                                 "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-            if (loadControlEventTransitionStructStructCtor_3 == nullptr)
+
+            jmethodID loadControlEventTransitionStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, loadControlEventTransitionStructStructClass_3, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
+                "Optional;Ljava/util/Optional;)V",
+                &loadControlEventTransitionStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || loadControlEventTransitionStructStructCtor_3 == nullptr)
             {
                 ChipLogError(
                     Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct constructor");
@@ -32353,11 +32520,13 @@ void CHIPDemandResponseLoadControlActiveEventsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct");
             return;
         }
-        jmethodID loadControlEventStructStructCtor_1 =
-            env->GetMethodID(loadControlEventStructStructClass_1, "<init>",
-                             "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/lang/Integer;Ljava/lang/Long;Ljava/"
-                             "util/ArrayList;)V");
-        if (loadControlEventStructStructCtor_1 == nullptr)
+
+        jmethodID loadControlEventStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, loadControlEventStructStructClass_1, "<init>",
+                                                            "([B[BLjava/lang/Integer;Ljava/lang/Long;Ljava/util/Optional;Ljava/"
+                                                            "lang/Integer;Ljava/lang/Long;Ljava/util/ArrayList;)V",
+                                                            &loadControlEventStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || loadControlEventStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct constructor");
             return;
@@ -32771,9 +32940,12 @@ void CHIPDeviceEnergyManagementPowerAdjustmentCapabilityAttributeCallback::Callb
                 ChipLogError(Zcl, "Could not find class ChipStructs$DeviceEnergyManagementClusterPowerAdjustStruct");
                 return;
             }
-            jmethodID powerAdjustStructStructCtor_2 = env->GetMethodID(
-                powerAdjustStructStructClass_2, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
-            if (powerAdjustStructStructCtor_2 == nullptr)
+
+            jmethodID powerAdjustStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, powerAdjustStructStructClass_2, "<init>",
+                "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V", &powerAdjustStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || powerAdjustStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$DeviceEnergyManagementClusterPowerAdjustStruct constructor");
                 return;
@@ -34446,9 +34618,11 @@ void CHIPEnergyPreferenceEnergyBalancesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$EnergyPreferenceClusterBalanceStruct");
             return;
         }
-        jmethodID balanceStructStructCtor_1 =
-            env->GetMethodID(balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (balanceStructStructCtor_1 == nullptr)
+
+        jmethodID balanceStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V", &balanceStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || balanceStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$EnergyPreferenceClusterBalanceStruct constructor");
             return;
@@ -34622,9 +34796,11 @@ void CHIPEnergyPreferenceLowPowerModeSensitivitiesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$EnergyPreferenceClusterBalanceStruct");
             return;
         }
-        jmethodID balanceStructStructCtor_1 =
-            env->GetMethodID(balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V");
-        if (balanceStructStructCtor_1 == nullptr)
+
+        jmethodID balanceStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, balanceStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/util/Optional;)V", &balanceStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || balanceStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$EnergyPreferenceClusterBalanceStruct constructor");
             return;
@@ -51253,11 +51429,14 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfoStruct");
             return;
         }
-        jmethodID channelInfoStructStructCtor_1 =
-            env->GetMethodID(channelInfoStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/"
-                             "Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (channelInfoStructStructCtor_1 == nullptr)
+
+        jmethodID channelInfoStructStructCtor_1;
+        err =
+            chip::JniReferences::GetInstance().FindMethod(env, channelInfoStructStructClass_1, "<init>",
+                                                          "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/"
+                                                          "Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V",
+                                                          &channelInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || channelInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfoStruct constructor");
             return;
@@ -51634,9 +51813,12 @@ void CHIPTargetNavigatorTargetListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$TargetNavigatorClusterTargetInfoStruct");
             return;
         }
-        jmethodID targetInfoStructStructCtor_1 =
-            env->GetMethodID(targetInfoStructStructClass_1, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-        if (targetInfoStructStructCtor_1 == nullptr)
+
+        jmethodID targetInfoStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, targetInfoStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                            &targetInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || targetInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$TargetNavigatorClusterTargetInfoStruct constructor");
             return;
@@ -52311,9 +52493,12 @@ void CHIPMediaPlaybackAvailableAudioTracksAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                     return;
                 }
-                jmethodID trackAttributesStructStructCtor_4 =
-                    env->GetMethodID(trackAttributesStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                if (trackAttributesStructStructCtor_4 == nullptr)
+
+                jmethodID trackAttributesStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                    &trackAttributesStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                     return;
@@ -52332,10 +52517,13 @@ void CHIPMediaPlaybackAvailableAudioTracksAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                 return;
             }
-            jmethodID trackStructStructCtor_2 = env->GetMethodID(
-                trackStructStructClass_2, "<init>",
-                "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-            if (trackStructStructCtor_2 == nullptr)
+
+            jmethodID trackStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, trackStructStructClass_2, "<init>",
+                "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                &trackStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || trackStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                 return;
@@ -52462,9 +52650,12 @@ void CHIPMediaPlaybackAvailableTextTracksAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackAttributesStruct");
                     return;
                 }
-                jmethodID trackAttributesStructStructCtor_4 =
-                    env->GetMethodID(trackAttributesStructStructClass_4, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-                if (trackAttributesStructStructCtor_4 == nullptr)
+
+                jmethodID trackAttributesStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(env, trackAttributesStructStructClass_4, "<init>",
+                                                                    "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                                    &trackAttributesStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || trackAttributesStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackAttributesStruct constructor");
                     return;
@@ -52483,10 +52674,13 @@ void CHIPMediaPlaybackAvailableTextTracksAttributeCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterTrackStruct");
                 return;
             }
-            jmethodID trackStructStructCtor_2 = env->GetMethodID(
-                trackStructStructClass_2, "<init>",
-                "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V");
-            if (trackStructStructCtor_2 == nullptr)
+
+            jmethodID trackStructStructCtor_2;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, trackStructStructClass_2, "<init>",
+                "(Ljava/lang/String;Lchip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct;)V",
+                &trackStructStructCtor_2);
+            if (err != CHIP_NO_ERROR || trackStructStructCtor_2 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterTrackStruct constructor");
                 return;
@@ -52873,10 +53067,12 @@ void CHIPMediaInputInputListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$MediaInputClusterInputInfoStruct");
             return;
         }
-        jmethodID inputInfoStructStructCtor_1 =
-            env->GetMethodID(inputInfoStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V");
-        if (inputInfoStructStructCtor_1 == nullptr)
+
+        jmethodID inputInfoStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, inputInfoStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V", &inputInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || inputInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$MediaInputClusterInputInfoStruct constructor");
             return;
@@ -54174,9 +54370,12 @@ void CHIPAudioOutputOutputListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AudioOutputClusterOutputInfoStruct");
             return;
         }
-        jmethodID outputInfoStructStructCtor_1 = env->GetMethodID(outputInfoStructStructClass_1, "<init>",
-                                                                  "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V");
-        if (outputInfoStructStructCtor_1 == nullptr)
+
+        jmethodID outputInfoStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, outputInfoStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V",
+                                                            &outputInfoStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || outputInfoStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$AudioOutputClusterOutputInfoStruct constructor");
             return;
@@ -55559,9 +55758,12 @@ void CHIPContentControlOnDemandRatingsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ContentControlClusterRatingNameStruct");
             return;
         }
-        jmethodID ratingNameStructStructCtor_1 =
-            env->GetMethodID(ratingNameStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-        if (ratingNameStructStructCtor_1 == nullptr)
+
+        jmethodID ratingNameStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, ratingNameStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                            &ratingNameStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || ratingNameStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ContentControlClusterRatingNameStruct constructor");
             return;
@@ -55661,9 +55863,12 @@ void CHIPContentControlScheduledContentRatingsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ContentControlClusterRatingNameStruct");
             return;
         }
-        jmethodID ratingNameStructStructCtor_1 =
-            env->GetMethodID(ratingNameStructStructClass_1, "<init>", "(Ljava/lang/String;Ljava/util/Optional;)V");
-        if (ratingNameStructStructCtor_1 == nullptr)
+
+        jmethodID ratingNameStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, ratingNameStructStructClass_1, "<init>",
+                                                            "(Ljava/lang/String;Ljava/util/Optional;)V",
+                                                            &ratingNameStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || ratingNameStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ContentControlClusterRatingNameStruct constructor");
             return;
@@ -56759,9 +56964,11 @@ void CHIPUnitTestingListStructOctetStringAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterTestListStructOctet");
             return;
         }
-        jmethodID testListStructOctetStructCtor_1 =
-            env->GetMethodID(testListStructOctetStructClass_1, "<init>", "(Ljava/lang/Long;[B)V");
-        if (testListStructOctetStructCtor_1 == nullptr)
+
+        jmethodID testListStructOctetStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(env, testListStructOctetStructClass_1, "<init>",
+                                                            "(Ljava/lang/Long;[B)V", &testListStructOctetStructCtor_1);
+        if (err != CHIP_NO_ERROR || testListStructOctetStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterTestListStructOctet constructor");
             return;
@@ -57006,11 +57213,14 @@ void CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                 return;
             }
-            jmethodID simpleStructStructCtor_3 =
-                env->GetMethodID(simpleStructStructClass_3, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                 "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-            if (simpleStructStructCtor_3 == nullptr)
+
+            jmethodID simpleStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, simpleStructStructClass_3, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                "Float;Ljava/lang/Double;)V",
+                &simpleStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || simpleStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                 return;
@@ -57096,11 +57306,14 @@ void CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                 return;
             }
-            jmethodID simpleStructStructCtor_3 =
-                env->GetMethodID(simpleStructStructClass_3, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                 "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-            if (simpleStructStructCtor_3 == nullptr)
+
+            jmethodID simpleStructStructCtor_3;
+            err = chip::JniReferences::GetInstance().FindMethod(
+                env, simpleStructStructClass_3, "<init>",
+                "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                "Float;Ljava/lang/Double;)V",
+                &simpleStructStructCtor_3);
+            if (err != CHIP_NO_ERROR || simpleStructStructCtor_3 == nullptr)
             {
                 ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                 return;
@@ -57202,11 +57415,14 @@ void CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                     ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
                     return;
                 }
-                jmethodID simpleStructStructCtor_4 =
-                    env->GetMethodID(simpleStructStructClass_4, "<init>",
-                                     "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                                     "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-                if (simpleStructStructCtor_4 == nullptr)
+
+                jmethodID simpleStructStructCtor_4;
+                err = chip::JniReferences::GetInstance().FindMethod(
+                    env, simpleStructStructClass_4, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                    "Float;Ljava/lang/Double;)V",
+                    &simpleStructStructCtor_4);
+                if (err != CHIP_NO_ERROR || simpleStructStructCtor_4 == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
                     return;
@@ -57310,12 +57526,15 @@ void CHIPUnitTestingListNullablesAndOptionalsStructAttributeCallback::CallbackFn
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterNullablesAndOptionalsStruct");
             return;
         }
-        jmethodID nullablesAndOptionalsStructStructCtor_1 =
-            env->GetMethodID(nullablesAndOptionalsStructStructClass_1, "<init>",
-                             "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/"
-                             "Optional;Ljava/util/Optional;Lchip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/"
-                             "util/Optional;Ljava/util/Optional;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/util/Optional;)V");
-        if (nullablesAndOptionalsStructStructCtor_1 == nullptr)
+
+        jmethodID nullablesAndOptionalsStructStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, nullablesAndOptionalsStructStructClass_1, "<init>",
+            "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/Optional;Ljava/util/"
+            "Optional;Lchip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/Optional;Ljava/util/"
+            "Optional;Ljava/util/ArrayList;Ljava/util/Optional;Ljava/util/Optional;)V",
+            &nullablesAndOptionalsStructStructCtor_1);
+        if (err != CHIP_NO_ERROR || nullablesAndOptionalsStructStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterNullablesAndOptionalsStruct constructor");
             return;
@@ -57597,11 +57816,13 @@ void CHIPUnitTestingListFabricScopedAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterSimpleStruct");
             return;
         }
-        jmethodID simpleStructStructCtor_2 =
-            env->GetMethodID(simpleStructStructClass_2, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
-                             "Integer;Ljava/lang/Float;Ljava/lang/Double;)V");
-        if (simpleStructStructCtor_2 == nullptr)
+
+        jmethodID simpleStructStructCtor_2;
+        err = chip::JniReferences::GetInstance().FindMethod(env, simpleStructStructClass_2, "<init>",
+                                                            "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/"
+                                                            "lang/String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V",
+                                                            &simpleStructStructCtor_2);
+        if (err != CHIP_NO_ERROR || simpleStructStructCtor_2 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterSimpleStruct constructor");
             return;
@@ -57643,11 +57864,14 @@ void CHIPUnitTestingListFabricScopedAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UnitTestingClusterTestFabricScoped");
             return;
         }
-        jmethodID testFabricScopedStructCtor_1 = env->GetMethodID(
-            testFabricScopedStructClass_1, "<init>",
+
+        jmethodID testFabricScopedStructCtor_1;
+        err = chip::JniReferences::GetInstance().FindMethod(
+            env, testFabricScopedStructClass_1, "<init>",
             "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/lang/Integer;Ljava/util/Optional;Ljava/lang/String;Lchip/"
-            "devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
-        if (testFabricScopedStructCtor_1 == nullptr)
+            "devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct;Ljava/util/ArrayList;Ljava/lang/Integer;)V",
+            &testFabricScopedStructCtor_1);
+        if (err != CHIP_NO_ERROR || testFabricScopedStructCtor_1 == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$UnitTestingClusterTestFabricScoped constructor");
             return;

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
+#include <string>
 
 namespace chip {
 
@@ -35,7 +36,7 @@ void JniReferences::SetJavaVm(JavaVM * jvm, const char * clsType)
     JNIEnv * env = GetEnvForCurrentThread();
     // Any chip.devicecontroller.* class will work here - just need something to call getClassLoader() on.
     jclass chipClass = env->FindClass(clsType);
-    VerifyOrReturn(chipClass != nullptr, ChipLogError(Support, "clsType can not found"));
+    VerifyOrReturn(chipClass != nullptr, ChipLogError(Support, "clsType can not be found"));
 
     jclass classClass              = env->FindClass("java/lang/Class");
     jclass classLoaderClass        = env->FindClass("java/lang/ClassLoader");
@@ -129,6 +130,19 @@ exit:
     return err;
 }
 
+static std::string StrReplaceAll(const std::string & source, const std::string & from, const std::string & to)
+{
+    std::string newString = source;
+    size_t pos            = 0;
+    while ((pos = newString.find(from, pos)) != std::string::npos)
+    {
+        newString.replace(pos, from.length(), to);
+        pos += to.length();
+    }
+
+    return newString;
+}
+
 CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
                                      jmethodID * methodId)
 {
@@ -146,23 +160,35 @@ CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * 
         return CHIP_NO_ERROR;
     }
 
-    // Try `j$` when enabling Java8.
-    std::string methodSignature_java8_str(methodSignature);
-    size_t pos = methodSignature_java8_str.find("java/util/Optional");
-    if (pos != std::string::npos)
-    {
-        // Replace all "java/util/Optional" with "j$/util/Optional".
-        while (pos != std::string::npos)
-        {
-            methodSignature_java8_str.replace(pos, strlen("java/util/Optional"), "j$/util/Optional");
-            pos = methodSignature_java8_str.find("java/util/Optional");
-        }
-        *methodId = env->GetMethodID(javaClass, methodName, methodSignature_java8_str.c_str());
-        env->ExceptionClear();
-    }
+    std::string method_signature = methodSignature;
+    method_signature             = StrReplaceAll(method_signature, "java/util/Optional", "j$/util/Optional");
+    *methodId                    = env->GetMethodID(javaClass, methodName, method_signature.data());
+    env->ExceptionClear();
 
     VerifyOrReturnError(*methodId != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
+    return CHIP_NO_ERROR;
+}
 
+CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jclass javaClass, const char * methodName, const char * methodSignature,
+                                     jmethodID * methodId)
+{
+    VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+    VerifyOrReturnError(javaClass != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+
+    *methodId = env->GetMethodID(javaClass, methodName, methodSignature);
+    env->ExceptionClear();
+
+    if (*methodId != nullptr)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    std::string method_signature = methodSignature;
+    method_signature             = StrReplaceAll(method_signature, "java/util/Optional", "j$/util/Optional");
+    *methodId                    = env->GetMethodID(javaClass, methodName, method_signature.data());
+    env->ExceptionClear();
+
+    VerifyOrReturnError(*methodId != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -82,6 +82,10 @@ public:
 
     CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
                           jmethodID * methodId);
+
+    CHIP_ERROR FindMethod(JNIEnv * env, jclass javaClass, const char * methodName, const char * methodSignature,
+                          jmethodID * methodId);
+
     void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);
 
     CHIP_ERROR N2J_ByteArray(JNIEnv * env, const uint8_t * inArray, jsize inArrayLen, jbyteArray & outArray);


### PR DESCRIPTION
This error was reported from our internal team, the root cause is the GetMethodID function is unable to find the constructor of the NetworkCommissioningClusterNetworkInfoStruct class.

The current codebase utilizes GetMethodID from JNIEnv, which inadvertently circumvents the corrections introduced in FindMethod tailored to handle Java 8 Optionals. This change is crucial to ensure the robustness and reliability of the code, especially in handling optional types in Java 8.


