### PR TITLE
[Silabs]Add a static assert to ensure there is no out of bound write

### DIFF
--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -143,7 +143,6 @@ private:
     static BLEManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
-
     enum class Flags : uint16_t
     {
         kAdvertisingEnabled     = 0x0001,
@@ -160,6 +159,10 @@ private:
         kMaxDeviceNameLength = 16,
         kUnusedIndex         = 0xFF,
     };
+
+    static constexpr uint8_t kFlagTlvSize       = 3; // 1 byte for length, 1b for type and 1b for the Flag value
+    static constexpr uint8_t kUUIDTlvSize       = 4; // 1 byte for length, 1b for type and 2b for the UUID value
+    static constexpr uint8_t kDeviceNameTlvSize = (2 + kMaxDeviceNameLength); // 1 byte for length, 1b for type and + device name
 
     struct CHIPoBLEConState
     {

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -444,8 +444,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     mDeviceNameLength = strlen(mDeviceName); // Device Name length + length field
     VerifyOrExit(mDeviceNameLength < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-    static_assert((2 + CHIP_ADV_SHORT_UUID_LEN + 2 + kMaxDeviceNameLength) <= MAX_RESPONSE_DATA_LEN,
-                  "Scan Response buffer is too small"); // UUID TLV(4) + Name TLV
+    static_assert((kUUIDTlvSize + kDeviceNameTlvSize) <= MAX_RESPONSE_DATA_LEN, "Scan Response buffer is too small");
 
     mDeviceIdInfoLength = sizeof(mDeviceIdInfo); // Servicedatalen + length+ UUID (Short)
     static_assert(sizeof(mDeviceIdInfo) + CHIP_ADV_SHORT_UUID_LEN + 1 <= UINT8_MAX, "Our length won't fit in a uint8_t");

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -444,6 +444,8 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     mDeviceNameLength = strlen(mDeviceName); // Device Name length + length field
     VerifyOrExit(mDeviceNameLength < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+    static_assert((2 + CHIP_ADV_SHORT_UUID_LEN + 2 + kMaxDeviceNameLength) <= MAX_RESPONSE_DATA_LEN,
+                  "Scan Response buffer is too small"); // UUID TLV(4) + Name TLV
 
     mDeviceIdInfoLength = sizeof(mDeviceIdInfo); // Servicedatalen + length+ UUID (Short)
     static_assert(sizeof(mDeviceIdInfo) + CHIP_ADV_SHORT_UUID_LEN + 1 <= UINT8_MAX, "Our length won't fit in a uint8_t");

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -563,6 +563,8 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     mDeviceNameLength = strlen(mDeviceName); // Device Name length + length field
     VerifyOrExit(mDeviceNameLength < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
+    static_assert((3 + (2 + CHIP_ADV_SHORT_UUID_LEN) + (2 + kMaxDeviceNameLength)) <= MAX_RESPONSE_DATA_LEN,
+                  "Scan Response buffer is too small"); // 1 byte TLV(3) + UUID TLV(4) + Name TLV
 
     mDeviceIdInfoLength = sizeof(mDeviceIdInfo); // Servicedatalen + length+ UUID (Short)
     static_assert(sizeof(mDeviceIdInfo) + CHIP_ADV_SHORT_UUID_LEN + 1 <= UINT8_MAX, "Our length won't fit in a uint8_t");

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -563,8 +563,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     mDeviceNameLength = strlen(mDeviceName); // Device Name length + length field
     VerifyOrExit(mDeviceNameLength < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-    static_assert((3 + (2 + CHIP_ADV_SHORT_UUID_LEN) + (2 + kMaxDeviceNameLength)) <= MAX_RESPONSE_DATA_LEN,
-                  "Scan Response buffer is too small"); // 1 byte TLV(3) + UUID TLV(4) + Name TLV
+    static_assert((kFlagTlvSize + kUUIDTlvSize + kDeviceNameTlvSize) <= MAX_RESPONSE_DATA_LEN, "Scan Response buffer is too small");
 
     mDeviceIdInfoLength = sizeof(mDeviceIdInfo); // Servicedatalen + length+ UUID (Short)
     static_assert(sizeof(mDeviceIdInfo) + CHIP_ADV_SHORT_UUID_LEN + 1 <= UINT8_MAX, "Our length won't fit in a uint8_t");


### PR DESCRIPTION
Ensure that a user increasing the `kMaxDeviceNameLength` constant will not unknowingly cause an out-of-bound write in the ble scan response buffer where the device name is added. 

