### PR TITLE
examples/iOS tv-casting-app: simplified discovery and connection APIs

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C0474062B3F7E5F0012AE95 /* MTREndpointFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C0474052B3F7E5F0012AE95 /* MTREndpointFilter.h */; };
+		3C04740C2B4604CF0012AE95 /* MTRCryptoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C04740B2B4604CF0012AE95 /* MTRCryptoUtils.h */; };
+		3C04740E2B4605B40012AE95 /* MTRCryptoUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C04740D2B4605B40012AE95 /* MTRCryptoUtils.mm */; };
+		3C2346212B362B4F00FA276E /* MTRCastingPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C2346202B362B4F00FA276E /* MTRCastingPlayer.h */; };
+		3C2346232B362B9500FA276E /* MTRCastingPlayerDiscovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C2346222B362B9500FA276E /* MTRCastingPlayerDiscovery.h */; };
+		3C2346252B362BBB00FA276E /* MTRCastingPlayerDiscovery.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C2346242B362BBB00FA276E /* MTRCastingPlayerDiscovery.mm */; };
+		3C2696FB2B4A5FC50026E771 /* MTREndpointFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2696FA2B4A5FC50026E771 /* MTREndpointFilter.m */; };
 		3C26AC8C2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C26AC8B2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp */; };
 		3C26AC902927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */; };
 		3C26AC9329282B8100BA6881 /* DeviceAttestationCredentialsHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C26AC9229282B8100BA6881 /* DeviceAttestationCredentialsHolder.m */; };
@@ -20,6 +27,8 @@
 		3C69204C2AA136BA00D0F613 /* MTRCommonCaseDeviceServerInitParamsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C69204B2AA136BA00D0F613 /* MTRCommonCaseDeviceServerInitParamsProvider.h */; };
 		3C81C74C28F7A777001CB9D1 /* ContentApp.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C74B28F7A777001CB9D1 /* ContentApp.mm */; };
 		3C81C75028F7A7D3001CB9D1 /* VideoPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C74F28F7A7D3001CB9D1 /* VideoPlayer.m */; };
+		3C9437922B3B478E0096E5F4 /* MTRErrorUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C9437912B3B478E0096E5F4 /* MTRErrorUtils.h */; };
+		3C9437942B3B47A10096E5F4 /* MTRErrorUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C9437932B3B47A10096E5F4 /* MTRErrorUtils.mm */; };
 		3CCB87212869085400771BAD /* MatterTvCastingBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CCB87202869085400771BAD /* MatterTvCastingBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3CCB8737286A555500771BAD /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CCB8735286A555500771BAD /* libTvCastingCommon.a */; };
 		3CCB8738286A555500771BAD /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CCB8736286A555500771BAD /* libmbedtls.a */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -48,7 +57,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C0474052B3F7E5F0012AE95 /* MTREndpointFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTREndpointFilter.h; sourceTree = "<group>"; };
+		3C04740B2B4604CF0012AE95 /* MTRCryptoUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCryptoUtils.h; sourceTree = "<group>"; };
+		3C04740D2B4605B40012AE95 /* MTRCryptoUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCryptoUtils.mm; sourceTree = "<group>"; };
 		3C0D9CDF2920A30C00D3332B /* CommissionableDataProviderImpl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CommissionableDataProviderImpl.hpp; sourceTree = "<group>"; };
+		3C2346202B362B4F00FA276E /* MTRCastingPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCastingPlayer.h; sourceTree = "<group>"; };
+		3C2346222B362B9500FA276E /* MTRCastingPlayerDiscovery.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCastingPlayerDiscovery.h; sourceTree = "<group>"; };
+		3C2346242B362BBB00FA276E /* MTRCastingPlayerDiscovery.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCastingPlayerDiscovery.mm; sourceTree = "<group>"; };
+		3C2696FA2B4A5FC50026E771 /* MTREndpointFilter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTREndpointFilter.m; sourceTree = "<group>"; };
 		3C26AC8B2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DeviceAttestationCredentialsProviderImpl.hpp; sourceTree = "<group>"; };
 		3C26AC8F2927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DeviceAttestationCredentialsProviderImpl.mm; sourceTree = "<group>"; };
 		3C26AC91292700AD00BA6881 /* DeviceAttestationCredentialsHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeviceAttestationCredentialsHolder.h; sourceTree = "<group>"; };
@@ -69,6 +85,9 @@
 		3C81C74E28F7A7AE001CB9D1 /* ContentApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentApp.h; sourceTree = "<group>"; };
 		3C81C74F28F7A7D3001CB9D1 /* VideoPlayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VideoPlayer.m; sourceTree = "<group>"; };
 		3C81C75128F7A7DF001CB9D1 /* VideoPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoPlayer.h; sourceTree = "<group>"; };
+		3C9437882B364F5E0096E5F4 /* MTRCastingPlayer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCastingPlayer.mm; sourceTree = "<group>"; };
+		3C9437912B3B478E0096E5F4 /* MTRErrorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRErrorUtils.h; sourceTree = "<group>"; };
+		3C9437932B3B47A10096E5F4 /* MTRErrorUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRErrorUtils.mm; sourceTree = "<group>"; };
 		3CA1CA7728E243750023ED44 /* MediaPlaybackTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlaybackTypes.h; sourceTree = "<group>"; };
 		3CCB871D2869085400771BAD /* MatterTvCastingBridge.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MatterTvCastingBridge.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CCB87202869085400771BAD /* MatterTvCastingBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatterTvCastingBridge.h; sourceTree = "<group>"; };
@@ -112,6 +131,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C94378A2B3654720096E5F4 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		3C94378B2B36547A0096E5F4 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		3C94378C2B3654960096E5F4 /* Clusters */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Clusters;
+			sourceTree = "<group>";
+		};
 		3CCB87132869085400771BAD = {
 			isa = PBXGroup;
 			children = (
@@ -133,9 +173,18 @@
 		3CCB871F2869085400771BAD /* MatterTvCastingBridge */ = {
 			isa = PBXGroup;
 			children = (
+				3C94378A2B3654720096E5F4 /* Core */,
+				3C94378B2B36547A0096E5F4 /* Support */,
+				3C94378C2B3654960096E5F4 /* Clusters */,
 				3CCB87202869085400771BAD /* MatterTvCastingBridge.h */,
 				3CF71C092A992D0D003A5CE5 /* MTRCastingApp.h */,
 				3CF71C0B2A992D25003A5CE5 /* MTRCastingApp.mm */,
+				3C2346222B362B9500FA276E /* MTRCastingPlayerDiscovery.h */,
+				3C2346242B362BBB00FA276E /* MTRCastingPlayerDiscovery.mm */,
+				3C2346202B362B4F00FA276E /* MTRCastingPlayer.h */,
+				3C9437882B364F5E0096E5F4 /* MTRCastingPlayer.mm */,
+				3C0474052B3F7E5F0012AE95 /* MTREndpointFilter.h */,
+				3C2696FA2B4A5FC50026E771 /* MTREndpointFilter.m */,
 				3CF71C0D2A992DA2003A5CE5 /* MTRDataSource.h */,
 				3CF71C0F2A99312D003A5CE5 /* MTRCommissionableData.h */,
 				3CF71C112A993298003A5CE5 /* MTRCommissionableData.mm */,
@@ -148,6 +197,12 @@
 				3C6920452AA1093300D0F613 /* MTRDeviceAttestationCredentialsProvider.h */,
 				3C6920472AA1094000D0F613 /* MTRDeviceAttestationCredentialsProvider.mm */,
 				3C69204B2AA136BA00D0F613 /* MTRCommonCaseDeviceServerInitParamsProvider.h */,
+				3CF8532528E37ED800F07B9F /* MatterError.h */,
+				3CF8532628E37F1000F07B9F /* MatterError.mm */,
+				3C9437912B3B478E0096E5F4 /* MTRErrorUtils.h */,
+				3C9437932B3B47A10096E5F4 /* MTRErrorUtils.mm */,
+				3C04740B2B4604CF0012AE95 /* MTRCryptoUtils.h */,
+				3C04740D2B4605B40012AE95 /* MTRCryptoUtils.mm */,
 				3CCB873A286A593700771BAD /* CastingServerBridge.h */,
 				3CCB873D286A593700771BAD /* CastingServerBridge.mm */,
 				3C66FBFA2903279A00B63FE7 /* AppParameters.h */,
@@ -162,8 +217,6 @@
 				3C81C74B28F7A777001CB9D1 /* ContentApp.mm */,
 				3C81C75128F7A7DF001CB9D1 /* VideoPlayer.h */,
 				3C81C74F28F7A7D3001CB9D1 /* VideoPlayer.m */,
-				3CF8532528E37ED800F07B9F /* MatterError.h */,
-				3CF8532628E37F1000F07B9F /* MatterError.mm */,
 				3C4E53B428E5593700F293E8 /* ContentLauncherTypes.h */,
 				3C4E53B528E5595A00F293E8 /* ContentLauncherTypes.mm */,
 				3CA1CA7728E243750023ED44 /* MediaPlaybackTypes.h */,
@@ -191,6 +244,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C69204C2AA136BA00D0F613 /* MTRCommonCaseDeviceServerInitParamsProvider.h in Headers */,
+				3C2346212B362B4F00FA276E /* MTRCastingPlayer.h in Headers */,
+				3C2346232B362B9500FA276E /* MTRCastingPlayerDiscovery.h in Headers */,
 				3CD6D01A298CDA2100D7569A /* CommissionerDiscoveryDelegateImpl.h in Headers */,
 				3CF71C0E2A992DA2003A5CE5 /* MTRDataSource.h in Headers */,
 				3C26AC8C2926FE0C00BA6881 /* DeviceAttestationCredentialsProviderImpl.hpp in Headers */,
@@ -202,9 +257,12 @@
 				3CCB8740286A593700771BAD /* CastingServerBridge.h in Headers */,
 				3CE5ECCE2A673B30007CF331 /* CommissioningCallbackHandlers.h in Headers */,
 				3CCB8742286A593700771BAD /* ConversionUtils.hpp in Headers */,
+				3C9437922B3B478E0096E5F4 /* MTRErrorUtils.h in Headers */,
 				3CCB8741286A593700771BAD /* DiscoveredNodeData.h in Headers */,
+				3C0474062B3F7E5F0012AE95 /* MTREndpointFilter.h in Headers */,
 				3CCB87212869085400771BAD /* MatterTvCastingBridge.h in Headers */,
 				3C6920462AA1093300D0F613 /* MTRDeviceAttestationCredentialsProvider.h in Headers */,
+				3C04740C2B4604CF0012AE95 /* MTRCryptoUtils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -315,13 +373,17 @@
 				3CCB8744286A593700771BAD /* ConversionUtils.mm in Sources */,
 				3CF71C0C2A992D25003A5CE5 /* MTRCastingApp.mm in Sources */,
 				3C4E53B028E4F28100F293E8 /* MediaPlaybackTypes.mm in Sources */,
+				3C04740E2B4605B40012AE95 /* MTRCryptoUtils.mm in Sources */,
 				3CD73F1E2A9E83C1009D82D1 /* MTRCommissionableDataProvider.mm in Sources */,
 				3CD73F222A9EA078009D82D1 /* MTRDeviceAttestationCredentials.mm in Sources */,
+				3C2346252B362BBB00FA276E /* MTRCastingPlayerDiscovery.mm in Sources */,
 				3C66FBFC290327BB00B63FE7 /* AppParameters.mm in Sources */,
+				3C9437942B3B47A10096E5F4 /* MTRErrorUtils.mm in Sources */,
 				3CE868F42946D76200FCB92B /* CommissionableDataProviderImpl.mm in Sources */,
 				3C26AC9329282B8100BA6881 /* DeviceAttestationCredentialsHolder.m in Sources */,
 				3C26AC902927008900BA6881 /* DeviceAttestationCredentialsProviderImpl.mm in Sources */,
 				3CCB873F286A593700771BAD /* DiscoveredNodeData.mm in Sources */,
+				3C2696FB2B4A5FC50026E771 /* MTREndpointFilter.m in Sources */,
 				3C81C74C28F7A777001CB9D1 /* ContentApp.mm in Sources */,
 				3CF71C122A993298003A5CE5 /* MTRCommissionableData.mm in Sources */,
 				3C4AE650286A7D4D005B52A4 /* OnboardingPayload.m in Sources */,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingApp.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingApp.h
@@ -31,22 +31,41 @@
  */
 + (MTRCastingApp * _Nullable)getSharedInstance;
 
+- (dispatch_queue_t _Nullable)getWorkQueue;
+
+- (dispatch_queue_t _Nullable)getClientQueue;
+
 /**
- * @brief Initializes the MTRCastingApp with appParameters
+ * @brief Initializes the MTRCastingApp with an MTRDataSource
  *
  * @param dataSource provides all the parameters required to initialize the MTRCastingApp
  */
-- (MatterError * _Nonnull)initializeWithDataSource:(id<MTRDataSource> _Nonnull)dataSource;
+- (NSError * _Nullable)initializeWithDataSource:(id<MTRDataSource> _Nonnull)dataSource;
 
 /**
- * @brief Starts the Matter server that the MTRCastingApp runs on and registers all the necessary delegates
+ * @brief (async) Starts the Matter server that the MTRCastingApp runs on and registers all the necessary delegates
  */
-- (MatterError * _Nonnull)start;
+- (void)startWithCompletionBlock:(void (^_Nonnull __strong)(NSError * _Nullable __strong))completion;
 
 /**
- * @brief Stops the Matter server that the MTRCastingApp runs on
+ * @brief (async) Stops the Matter server that the MTRCastingApp runs on
  */
-- (MatterError * _Nonnull)stop;
+- (void)stopWithCompletionBlock:(void (^_Nonnull __strong)(NSError * _Nullable __strong))completion;
+
+/**
+ * @brief true, if MTRCastingApp is running. false otherwise
+ */
+- (bool)isRunning;
+
+/**
+ * @brief Tears down all active subscriptions.
+ */
+- (NSError * _Nullable)ShutdownAllSubscriptions;
+
+/**
+ * @brief Clears app cache that contains the information about CastingPlayers previously connected to
+ */
+- (NSError * _Nullable)ClearCache;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayer.h
@@ -1,0 +1,83 @@
+/**
+ *
+ *    Copyright (c) 2020-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTREndpointFilter.h"
+
+#import <Foundation/Foundation.h>
+
+#ifndef MTRCastingPlayer_h
+#define MTRCastingPlayer_h
+
+@class MTREndpoint;
+
+/**
+ * @brief MTRCastingPlayer represents a Matter commissioner that is able to play media to a physical
+ * output or to a display screen which is part of the device.
+ */
+@interface MTRCastingPlayer : NSObject
+
++ (NSInteger)kMinCommissioningWindowTimeoutSec;
+
+/**
+ * @brief (async) Verifies that a connection exists with this CastingPlayer, or triggers a new session request. If the
+ * CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk, this will execute the user
+ * directed commissioning process.
+ *
+ * @param completion - called back when the connection process completes. Parameter is nil if it completed successfully
+ * @param timeout -  time (in sec) to keep the commissioning window open, if commissioning is required.
+ * Needs to be >= CastingPlayer.kMinCommissioningWindowTimeoutSec.
+ * @param desiredEndpointFilter - Attributes (such as VendorId) describing an Endpoint that the client wants to interact
+ * with after commissioning. If this value is passed in, the VerifyOrEstablishConnection will force User Directed
+ * Commissioning, in case the desired Endpoint is not found in the on-device cached information about the CastingPlayer
+ * (if any)
+ */
+- (void)verifyOrEstablishConnectionWithCompletionBlock:(void (^_Nonnull)(NSError * _Nullable))completion timeout:(long long)timeout desiredEndpointFilter:(MTREndpointFilter * _Nullable)desiredEndpointFilter;
+
+/**
+ * @brief (async) Verifies that a connection exists with this CastingPlayer, or triggers a new session request. If the
+ * CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk, this will execute the user
+ * directed commissioning process.
+ *
+ * @param completion - called back when the connection process completes. Parameter is nil if it completed successfully
+ * @param desiredEndpointFilter - Attributes (such as VendorId) describing an Endpoint that the client wants to interact
+ * with after commissioning. If this value is passed in, the VerifyOrEstablishConnection will force User Directed
+ * Commissioning, in case the desired Endpoint is not found in the on-device cached information about the CastingPlayer
+ * (if any)
+ */
+- (void)verifyOrEstablishConnectionWithCompletionBlock:(void (^_Nonnull)(NSError * _Nullable))completion desiredEndpointFilter:(MTREndpointFilter * _Nullable)desiredEndpointFilter;
+
+/**
+ * @brief Sets the internal connection state of this CastingPlayer to "disconnected"
+ */
+- (void)disconnect;
+
+- (NSString * _Nonnull)identifier;
+- (NSString * _Nonnull)deviceName;
+- (uint16_t)vendorId;
+- (uint16_t)productId;
+- (uint32_t)deviceType;
+- (NSArray * _Nonnull)ipAddresses;
+
+// TODO
+// - (NSArray<MTREndpoint *> * _Nonnull)endpoints;
+
+- (nonnull instancetype)init UNAVAILABLE_ATTRIBUTE;
++ (nonnull instancetype)new UNAVAILABLE_ATTRIBUTE;
+
+@end
+
+#endif /* MTRCastingPlayer_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayer.mm
@@ -1,0 +1,169 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRCastingPlayer.h"
+
+#import "MTRCastingApp.h"
+#import "MTRErrorUtils.h"
+
+#import "core/CastingPlayer.h"
+
+#import <Foundation/Foundation.h>
+
+@interface MTRCastingPlayer ()
+
+@property (nonatomic, readwrite) matter::casting::memory::Strong<matter::casting::core::CastingPlayer> cppCastingPlayer;
+
+@end
+
+@implementation MTRCastingPlayer
+
+static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core::kCommissioningWindowTimeoutSec;
+
++ (NSInteger)kMinCommissioningWindowTimeoutSec
+{
+    return kMinCommissioningWindowTimeoutSec;
+}
+
+- (void)verifyOrEstablishConnectionWithCompletionBlock:(void (^_Nonnull)(NSError * _Nullable))completion desiredEndpointFilter:(MTREndpointFilter * _Nullable)desiredEndpointFilter
+{
+    [self verifyOrEstablishConnectionWithCompletionBlock:completion timeout:kMinCommissioningWindowTimeoutSec desiredEndpointFilter:desiredEndpointFilter];
+}
+
+- (void)verifyOrEstablishConnectionWithCompletionBlock:(void (^_Nonnull)(NSError * _Nullable))completion timeout:(long long)timeout desiredEndpointFilter:(MTREndpointFilter * _Nullable)desiredEndpointFilter
+{
+    ChipLogProgress(AppServer, "MTRCastingPlayer.verifyOrEstablishConnectionWithCompletionBlock called");
+    VerifyOrReturn([[MTRCastingApp getSharedInstance] isRunning], ChipLogError(AppServer, "MTRCastingApp NOT running"));
+
+    dispatch_queue_t workQueue = [[MTRCastingApp getSharedInstance] getWorkQueue];
+    dispatch_sync(workQueue, ^{
+        __block matter::casting::core::EndpointFilter cppDesiredEndpointFilter;
+        if (desiredEndpointFilter != nil) {
+            cppDesiredEndpointFilter.vendorId = desiredEndpointFilter.vendorId;
+            cppDesiredEndpointFilter.productId = desiredEndpointFilter.productId;
+        }
+
+        _cppCastingPlayer->VerifyOrEstablishConnection(
+            [completion](CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer) {
+                dispatch_queue_t clientQueue = [[MTRCastingApp getSharedInstance] getClientQueue];
+                dispatch_async(clientQueue, ^{
+                    completion(err == CHIP_NO_ERROR ? nil : [MTRErrorUtils NSErrorFromChipError:err]);
+                });
+            }, timeout, cppDesiredEndpointFilter);
+    });
+}
+
+- (void)disconnect
+{
+    ChipLogProgress(AppServer, "MTRCastingPlayer.disconnect called");
+    VerifyOrReturn([[MTRCastingApp getSharedInstance] isRunning], ChipLogError(AppServer, "MTRCastingApp NOT running"));
+
+    dispatch_queue_t workQueue = [[MTRCastingApp getSharedInstance] getWorkQueue];
+    dispatch_sync(workQueue, ^{
+        _cppCastingPlayer->Disconnect();
+    });
+}
+
+- (NSString * _Nonnull)description
+{
+    return [NSString stringWithFormat:@"%@ with Product ID: %d and Vendor ID: %d. Resolved IPAddr?: %@",
+                     self.deviceName, self.productId, self.vendorId, self.ipAddresses != nil && self.ipAddresses.count > 0 ? @"YES" : @"NO"];
+}
+
+- (instancetype _Nonnull)initWithCppCastingPlayer:(matter::casting::memory::Strong<matter::casting::core::CastingPlayer>)cppCastingPlayer
+{
+    if (self = [super init]) {
+        _cppCastingPlayer = cppCastingPlayer;
+    }
+    return self;
+}
+
+- (NSString * _Nonnull)identifier
+{
+    return [NSString stringWithCString:_cppCastingPlayer->GetId() encoding:NSUTF8StringEncoding];
+}
+
+- (NSString * _Nonnull)deviceName
+{
+    return [NSString stringWithCString:_cppCastingPlayer->GetDeviceName() encoding:NSUTF8StringEncoding];
+}
+
+- (uint16_t)productId
+{
+    return _cppCastingPlayer->GetProductId();
+}
+
+- (uint16_t)vendorId
+{
+    return _cppCastingPlayer->GetVendorId();
+}
+
+- (uint32_t)deviceType
+{
+    return _cppCastingPlayer->GetDeviceType();
+}
+
+- (NSArray * _Nonnull)ipAddresses
+{
+    NSMutableArray * ipAddresses = [NSMutableArray new];
+    for (size_t i = 0; i < _cppCastingPlayer->GetNumIPs(); i++) {
+        char addrCString[chip::Inet::IPAddress::kMaxStringLength];
+        _cppCastingPlayer->GetIPAddresses()[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+        ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
+    }
+    return ipAddresses;
+}
+
+// TODO convert to Obj-C endpoints and return
+/*- (NSArray<MTREndpoint *> * _Nonnull)endpoints
+{
+    return [NSMutableArray new];
+}*/
+
+- (BOOL)isEqualToMTRCastingPlayer:(MTRCastingPlayer * _Nullable)other
+{
+    return [self.identifier isEqualToString:other.identifier];
+}
+
+- (BOOL)isEqual:(id _Nullable)other
+{
+    if (other == nil) {
+        return NO;
+    }
+
+    if (self == other) {
+        return YES;
+    }
+
+    if (![other isKindOfClass:[MTRCastingPlayer class]]) {
+        return NO;
+    }
+
+    return [self isEqualToMTRCastingPlayer:(MTRCastingPlayer *) other];
+}
+
+- (NSUInteger)hash
+{
+    const NSUInteger prime = 31;
+    NSUInteger result = 1;
+
+    result = prime * result + [self.identifier hash];
+
+    return result;
+}
+
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayerDiscovery.h
@@ -1,0 +1,85 @@
+/**
+ *
+ *    Copyright (c) 2020-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRCastingPlayer.h"
+#import "MatterError.h"
+
+#ifndef MTRCastingPlayerDiscovery_h
+#define MTRCastingPlayerDiscovery_h
+
+/**
+ * MTRCastingPlayerDiscovery sends notification with ADD_CASTING_PLAYER_NOTIFICATION_NAME
+ * through the NSNotificationCenter if a new MTRCastingPlayer is added to the network
+ */
+extern NSString * _Nonnull const ADD_CASTING_PLAYER_NOTIFICATION_NAME;
+
+/**
+ * MTRCastingPlayerDiscovery sends notification with REMOVE_CASTING_PLAYER_NOTIFICATION_NAME
+ * through the NSNotificationCenter if a MTRCastingPlayer is removed from the network
+ */
+extern NSString * _Nonnull const REMOVE_CASTING_PLAYER_NOTIFICATION_NAME;
+
+/**
+ * MTRCastingPlayerDiscovery sends notification with UPDATE_CASTING_PLAYER_NOTIFICATION_NAME
+ * through the NSNotificationCenter if a previously added MTRCastingPlayer is updated
+ */
+extern NSString * _Nonnull const UPDATE_CASTING_PLAYER_NOTIFICATION_NAME;
+
+/**
+ * MTRCastingPlayerDiscovery sends ADD / REMOVE / UPDATE notifications through the
+ * NSNotificationCenter with userInfo set to an NSDictionary that has CASTING_PLAYER_KEY as the
+ * key to a MTRCastingPlayer object as value.
+ */
+extern NSString * _Nonnull const CASTING_PLAYER_KEY;
+
+/**
+ * @brief MTRCastingPlayerDiscovery is a singleton utility class for discovering MTRCastingPlayers.
+ */
+@interface MTRCastingPlayerDiscovery : NSObject
++ (MTRCastingPlayerDiscovery * _Nonnull)sharedInstance;
+
+- (nonnull instancetype)init UNAVAILABLE_ATTRIBUTE;
++ (nonnull instancetype)new UNAVAILABLE_ATTRIBUTE;
+
+@property (nonatomic, strong) NSArray<MTRCastingPlayer *> * _Nonnull castingPlayers;
+
+/**
+ * @brief Starts the discovery for MTRCastingPlayers
+ *
+ * @return Returns nil if discovery for CastingPlayers started successfully, NSError * describing the error otherwise.
+ */
+- (NSError * _Nullable)start;
+
+/**
+ * @brief Starts the discovery for MTRCastingPlayers
+ *
+ * @param filterBydeviceType if passed as a non-zero value, MTRCastingPlayerDiscovery will only discover
+ * MTRCastingPlayers whose deviceType matches filterBydeviceType
+ * @return Returns nil if discovery for MTRCastingPlayers started successfully, NSError * describing the error otherwise.
+ */
+- (NSError * _Nullable)start:(const uint32_t)filterBydeviceType;
+
+/**
+ * @brief Stop the discovery for MTRCastingPlayers
+ *
+ * @return Returns nil if discovery for MTRCastingPlayers stopped successfully, NSError * describing the error otherwise.
+ */
+- (NSError * _Nullable)stop;
+
+@end
+
+#endif /* MTRCastingPlayerDiscovery_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayerDiscovery.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCastingPlayerDiscovery.mm
@@ -1,0 +1,144 @@
+/**
+ *
+ *    Copyright (c) 2020-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRCastingPlayerDiscovery.h"
+
+#import "MTRCastingApp.h"
+
+#import "MTRCastingPlayer.mm"
+#import "MTRErrorUtils.h"
+
+#include "core/CastingPlayer.h"
+#include "core/CastingPlayerDiscovery.h"
+#include "core/Types.h"
+
+#include <platform/CHIPDeviceLayer.h>
+
+#import <Foundation/Foundation.h>
+
+using namespace matter::casting;
+
+/**
+ * @brief Singleton that reacts to CastingPlayer discovery results
+ */
+class MTRDiscoveryDelegateImpl : public matter::casting::core::DiscoveryDelegate {
+private:
+    MTRDiscoveryDelegateImpl() {};
+    static MTRDiscoveryDelegateImpl * _discoveryDelegateImpl;
+
+public:
+    static MTRDiscoveryDelegateImpl * GetInstance();
+    void HandleOnAdded(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> player) override;
+    void HandleOnUpdated(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> player) override;
+};
+
+@implementation MTRCastingPlayerDiscovery
+
+NSString * const ADD_CASTING_PLAYER_NOTIFICATION_NAME = @"didAddCastingPlayersNotification";
+NSString * const REMOVE_CASTING_PLAYER_NOTIFICATION_NAME = @"didRemoveCastingPlayersNotification";
+NSString * const UPDATE_CASTING_PLAYER_NOTIFICATION_NAME = @"didUpdateCastingPlayersNotification";
+NSString * const CASTING_PLAYER_KEY = @"castingPlayer";
+
+- init
+{
+    self = [super init];
+    if (self) {
+        dispatch_queue_t workQueue = [[MTRCastingApp getSharedInstance] getWorkQueue];
+        dispatch_sync(workQueue, ^{
+            core::CastingPlayerDiscovery::GetInstance()->SetDelegate(MTRDiscoveryDelegateImpl::GetInstance());
+        });
+    }
+    return self;
+}
+
++ (MTRCastingPlayerDiscovery *)sharedInstance
+{
+    static MTRCastingPlayerDiscovery * instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+- (NSError *)start
+{
+    return [self start:0]; // default to filterBydeviceType: 0
+}
+
+- (NSError *)start:(const uint32_t)filterBydeviceType
+{
+    ChipLogProgress(AppServer, "MTRCastingPlayerDiscovery.start called");
+    VerifyOrReturnValue([[MTRCastingApp getSharedInstance] isRunning], [MTRErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
+
+    dispatch_queue_t workQueue = [[MTRCastingApp getSharedInstance] getWorkQueue];
+    __block CHIP_ERROR err = CHIP_NO_ERROR;
+    dispatch_sync(workQueue, ^{
+        err = core::CastingPlayerDiscovery::GetInstance()->StartDiscovery(filterBydeviceType);
+    });
+
+    return [MTRErrorUtils NSErrorFromChipError:err];
+}
+
+- (NSError *)stop
+{
+    ChipLogProgress(AppServer, "MTRCastingPlayerDiscovery.stop called");
+    VerifyOrReturnValue([[MTRCastingApp getSharedInstance] isRunning], [MTRErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
+
+    dispatch_queue_t workQueue = [[MTRCastingApp getSharedInstance] getWorkQueue];
+    __block CHIP_ERROR err = CHIP_NO_ERROR;
+    dispatch_sync(workQueue, ^{
+        err = core::CastingPlayerDiscovery::GetInstance()->StopDiscovery();
+    });
+
+    return [MTRErrorUtils NSErrorFromChipError:err];
+}
+
+@end
+
+MTRDiscoveryDelegateImpl * MTRDiscoveryDelegateImpl::_discoveryDelegateImpl = nullptr;
+
+MTRDiscoveryDelegateImpl * MTRDiscoveryDelegateImpl::GetInstance()
+{
+    if (_discoveryDelegateImpl == nullptr) {
+        _discoveryDelegateImpl = new MTRDiscoveryDelegateImpl();
+    }
+    return _discoveryDelegateImpl;
+}
+
+void MTRDiscoveryDelegateImpl::HandleOnAdded(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> castingPlayer)
+{
+    ChipLogProgress(AppServer, "MTRDiscoveryDelegateImpl::HandleOnAdded called with CastingPlayer ID: %s", castingPlayer->GetId());
+    dispatch_queue_t clientQueue = [[MTRCastingApp getSharedInstance] getClientQueue];
+    VerifyOrReturn(clientQueue != nil, ChipLogError(AppServer, "MTRDiscoveryDelegateImpl::HandleOnAdded ClientQueue was nil"));
+    VerifyOrReturn(castingPlayer != nil, ChipLogError(AppServer, "MTRDiscoveryDelegateImpl::HandleOnAdded Cpp CastingPlayer was nil"));
+    dispatch_async(clientQueue, ^{
+        NSDictionary * dictionary = @ { CASTING_PLAYER_KEY : [[MTRCastingPlayer alloc] initWithCppCastingPlayer:castingPlayer] };
+        [[NSNotificationCenter defaultCenter] postNotificationName:ADD_CASTING_PLAYER_NOTIFICATION_NAME object:nil userInfo:dictionary];
+    });
+}
+
+void MTRDiscoveryDelegateImpl::HandleOnUpdated(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> castingPlayer)
+{
+    ChipLogProgress(AppServer, "MTRDiscoveryDelegateImpl::HandleOnUpdated called with CastingPlayer ID: %s", castingPlayer->GetId());
+    dispatch_queue_t clientQueue = [[MTRCastingApp getSharedInstance] getClientQueue];
+    VerifyOrReturn(clientQueue != nil);
+    dispatch_async(clientQueue, ^{
+        NSDictionary * dictionary = @ { CASTING_PLAYER_KEY : [[MTRCastingPlayer alloc] initWithCppCastingPlayer:castingPlayer] };
+        [[NSNotificationCenter defaultCenter] postNotificationName:UPDATE_CASTING_PLAYER_NOTIFICATION_NAME object:nil userInfo:dictionary];
+    });
+}

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCryptoUtils.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCryptoUtils.h
@@ -1,0 +1,47 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MatterError.h"
+
+#import <Foundation/Foundation.h>
+
+#ifndef MTRCryptoUtils_h
+#define MTRCryptoUtils_h
+
+@interface MTRCryptoUtils : NSObject
+
+/**
+ * @brief Convert an ASN.1 DER signature (per X9.62) as used by TLS libraries to SEC1 raw format
+ *
+ * Errors are:
+ *   - CHIP_ERROR_INVALID_ARGUMENT on any argument being invalid (e.g. nullptr), wrong sizes,
+ *     wrong or unsupported format,
+ *   - CHIP_ERROR_BUFFER_TOO_SMALL on running out of space at runtime.
+ *   - CHIP_ERROR_INTERNAL on any unexpected processing error.
+ *
+ * @param[in] feLengthBytes Field Element length in bytes (e.g. 32 for P256 curve)
+ * @param[in] asn1Signature ASN.1 DER signature input
+ * @param[out] outRawSignature Raw signature of <r,s> concatenated format output buffer. Size must be at
+ * least >= `2 * fe_length_bytes`. On success, the outRawSignature buffer will be re-assigned
+ * to have the correct size (2 * feLengthBytes).
+ * @return Returns an MatterError on error, MATTER_NO_ERROR otherwise
+ */
++ (MatterError * _Nonnull)ecdsaAsn1SignatureToRawWithFeLengthBytes:(NSUInteger)feLengthBytes asn1Signature:(CFDataRef _Nonnull)asn1Signature outRawSignature:(NSData * _Nonnull * _Nonnull)outRawSignature;
+
+@end
+
+#endif /* MTRCryptoUtils_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCryptoUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRCryptoUtils.mm
@@ -1,0 +1,55 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRCryptoUtils.h"
+#import "MTRErrorUtils.h"
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <Security/Security.h>
+
+@implementation MTRCryptoUtils
+
++ (MatterError *)ecdsaAsn1SignatureToRawWithFeLengthBytes:(NSUInteger)feLengthBytes asn1Signature:(CFDataRef)asn1Signature outRawSignature:(NSData **)outRawSignature
+{
+    // convert asn1Signature from CFDataRef to MutableByteSpan (asn1SignatureByteSpan)
+    uint8_t asn1SignatureBytes[256];
+    chip::MutableByteSpan asn1SignatureByteSpan = chip::MutableByteSpan(asn1SignatureBytes, sizeof(asn1SignatureBytes));
+    size_t signatureLen = CFDataGetLength(asn1Signature);
+    CFDataGetBytes(asn1Signature, CFRangeMake(0, signatureLen), asn1SignatureByteSpan.data());
+    asn1SignatureByteSpan.reduce_size(signatureLen);
+
+    // get a rawSignatureMutableByteSpan to pass to chip::Crypto::EcdsaAsn1SignatureToRaw
+    uint8_t * rawSignatureBytes = new uint8_t[(*outRawSignature).length];
+    chip::MutableByteSpan rawSignatureMutableByteSpan = chip::MutableByteSpan(rawSignatureBytes, (*outRawSignature).length);
+
+    // convert ASN.1 DER signature to SEC1 raw format
+    CHIP_ERROR err = chip::Crypto::EcdsaAsn1SignatureToRaw(feLengthBytes, chip::ByteSpan(asn1SignatureByteSpan.data(), asn1SignatureByteSpan.size()), rawSignatureMutableByteSpan);
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(AppServer, "chip::Crypto::EcdsaAsn1SignatureToRaw() failed");
+        return [MTRErrorUtils MatterErrorFromChipError:err];
+    }
+
+    // copy from rawSignatureMutableByteSpan into *outRawSignature
+    *outRawSignature = [NSData dataWithBytes:rawSignatureMutableByteSpan.data() length:rawSignatureMutableByteSpan.size()];
+    return MATTER_NO_ERROR;
+}
+
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRDataSource.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRDataSource.h
@@ -17,19 +17,42 @@
 
 #import "MTRCommissionableData.h"
 #import "MTRDeviceAttestationCredentials.h"
+#import "MatterError.h"
 
 #ifndef MTRDataSource_h
 #define MTRDataSource_h
 
 @protocol MTRDataSource <NSObject>
 
+/**
+ * @brief Queue used when calling the client code on completion blocks from any MatterTvCastingBridge API
+ */
 - (dispatch_queue_t _Nonnull)clientQueue;
 
+/**
+ * @brief Provide UniqueId used to generate the RotatingDeviceId advertised during commissioning by the MTRCastingApp
+ * Must be at least 16 bytes (i.e. ConfigurationManager::kMinRotatingDeviceIDUniqueIDLength)
+ */
 - (NSData * _Nonnull)castingAppDidReceiveRequestForRotatingDeviceIdUniqueId:(id _Nonnull)sender;
+
+/**
+ * @brief Provides MTRCommissionableData (such as setupPasscode, discriminator, etc) used to get the MTRCastingApp commissioned
+ */
 - (MTRCommissionableData * _Nonnull)castingAppDidReceiveRequestForCommissionableData:(id _Nonnull)sender;
+
+/**
+ * @brief Provides MTRDeviceAttestationCredentials of the MTRCastingApp used during commissioning
+ */
 - (MTRDeviceAttestationCredentials * _Nonnull)castingAppDidReceiveRequestForDeviceAttestationCredentials:(id _Nonnull)sender;
 
-- (NSData * _Nonnull)castingApp:(id _Nonnull)sender didReceiveRequestToSignCertificateRequest:(NSData * _Nonnull)csrData;
+/**
+ * @brief Request to signs a message using the device attestation private key
+ *
+ * @param csrData - The message to sign using the attestation private key.
+ * @param outRawSignature [in, out] - Buffer to receive the signature in raw <r,s> format.
+ * @returns MATTER_NO_ERROR on success. Otherwise, a MATTER_ERROR with a code corresponding to the underlying failure
+ */
+- (MatterError * _Nonnull)castingApp:(id _Nonnull)sender didReceiveRequestToSignCertificateRequest:(NSData * _Nonnull)csrData outRawSignature:(NSData * _Nonnull * _Nonnull)outRawSignature;
 
 @end
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTREndpointFilter.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTREndpointFilter.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2022 Project CHIP Authors
+ *    Copyright (c) 2020-2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,25 +15,19 @@
  *    limitations under the License.
  */
 
-import SwiftUI
+#import <Foundation/Foundation.h>
 
-struct ContentView: View {
-    var body: some View {
-        NavigationView {
-            if ProcessInfo.processInfo.environment["CHIP_CASTING_SIMPLIFIED"] == "1"
-            {
-                MTRDiscoveryExampleView()
-            }
-            else
-            {
-                StartFromCacheView()
-            }
-        }
-    }
-}
+#ifndef MTREndpointFilter_h
+#define MTREndpointFilter_h
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
-}
+/**
+ * @brief Describes a MTREndpoint that the client wants to connect to
+ */
+@interface MTREndpointFilter : NSObject
+// value of 0 means unspecified
+@property (nonatomic) uint16_t vendorId;
+@property (nonatomic) uint16_t productId;
+// std::vector<chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType> requiredDeviceTypes;
+
+@end
+#endif /* MTREndpointFilter_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTREndpointFilter.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTREndpointFilter.m
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2022 Project CHIP Authors
+ *    Copyright (c) 2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,25 +15,8 @@
  *    limitations under the License.
  */
 
-import SwiftUI
+#import "MTREndpointFilter.h"
 
-struct ContentView: View {
-    var body: some View {
-        NavigationView {
-            if ProcessInfo.processInfo.environment["CHIP_CASTING_SIMPLIFIED"] == "1"
-            {
-                MTRDiscoveryExampleView()
-            }
-            else
-            {
-                StartFromCacheView()
-            }
-        }
-    }
-}
+@implementation MTREndpointFilter
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
-}
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRErrorUtils.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRErrorUtils.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2022 Project CHIP Authors
+ *    Copyright (c) 2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,25 +15,25 @@
  *    limitations under the License.
  */
 
-import SwiftUI
+#import "MatterError.h"
+#include <lib/core/CHIPError.h>
 
-struct ContentView: View {
-    var body: some View {
-        NavigationView {
-            if ProcessInfo.processInfo.environment["CHIP_CASTING_SIMPLIFIED"] == "1"
-            {
-                MTRDiscoveryExampleView()
-            }
-            else
-            {
-                StartFromCacheView()
-            }
-        }
-    }
-}
+#import <Foundation/Foundation.h>
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
-}
+#ifndef MTRErrorUtils_h
+#define MTRErrorUtils_h
+
+/**
+ * @brief - Conversion utilities to/from CHIP_ERROR (C++) / MatterError (Objective C) / NSError
+ */
+@interface MTRErrorUtils : NSObject
+
++ (MatterError * _Nonnull)MatterErrorFromChipError:(CHIP_ERROR)chipError;
+
++ (NSError * _Nonnull)NSErrorFromChipError:(CHIP_ERROR)chipError;
+
++ (NSError * _Nonnull)NSErrorFromMatterError:(MatterError * _Nonnull)matterError;
+
+@end
+
+#endif /* MTRErrorUtils_h */

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRErrorUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MTRErrorUtils.mm
@@ -1,0 +1,41 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "MTRErrorUtils.h"
+
+#include <lib/core/CHIPError.h>
+
+@implementation MTRErrorUtils
+
++ (MatterError * _Nonnull)MatterErrorFromChipError:(CHIP_ERROR)chipError
+{
+    return [[MatterError alloc] initWithCode:chipError.AsInteger() message:[NSString stringWithUTF8String:chipError.AsString()]];
+}
+
++ (NSError * _Nonnull)NSErrorFromChipError:(CHIP_ERROR)chipError
+{
+    return chipError == CHIP_NO_ERROR ? nil : [NSError errorWithDomain:@"com.matter.casting" code:chipError.AsInteger() userInfo:@{ NSUnderlyingErrorKey : [NSString stringWithUTF8String:chipError.AsString()] }];
+}
+
++ (NSError * _Nonnull)NSErrorFromMatterError:(MatterError * _Nonnull)matterError
+{
+    return matterError == MATTER_NO_ERROR ? nil : [NSError errorWithDomain:@"com.matter.casting" code:matterError.code userInfo:@{ NSUnderlyingErrorKey : matterError.message }];
+}
+
+@end

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MatterTvCastingBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MatterTvCastingBridge.h
@@ -27,6 +27,10 @@ FOUNDATION_EXPORT const unsigned char MatterTvCastingBridgeVersionString[];
 
 // Add simplified casting API headers here
 #import "MTRCastingApp.h"
+#import "MTRCastingPlayer.h"
+#import "MTRCastingPlayerDiscovery.h"
 #import "MTRCommissionableData.h"
+#import "MTRCryptoUtils.h"
 #import "MTRDataSource.h"
 #import "MTRDeviceAttestationCredentials.h"
+#import "MTREndpointFilter.h"

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		3C81C75528F8C7B6001CB9D1 /* StartFromCacheViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C75428F8C7B6001CB9D1 /* StartFromCacheViewModel.swift */; };
 		3C81C75728F8E418001CB9D1 /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C75628F8E418001CB9D1 /* ConnectionView.swift */; };
 		3C81C75928F8E42D001CB9D1 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C81C75828F8E42D001CB9D1 /* ConnectionViewModel.swift */; };
+		3C94377D2B364D380096E5F4 /* MTRDiscoveryExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C94377C2B364D380096E5F4 /* MTRDiscoveryExampleViewModel.swift */; };
+		3C94377F2B364D510096E5F4 /* MTRConnectionExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C94377E2B364D510096E5F4 /* MTRConnectionExampleViewModel.swift */; };
+		3C94378E2B3B3CB00096E5F4 /* MTRDiscoveryExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C94378D2B3B3CB00096E5F4 /* MTRDiscoveryExampleView.swift */; };
+		3C9437902B3B3FF90096E5F4 /* MTRConnectionExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C94378F2B3B3FF90096E5F4 /* MTRConnectionExampleView.swift */; };
 		3CA1CA7A28E281080023ED44 /* ClusterSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7928E281080023ED44 /* ClusterSelectorView.swift */; };
 		3CA1CA7C28E282150023ED44 /* MediaPlaybackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7B28E282150023ED44 /* MediaPlaybackView.swift */; };
 		3CA1CA7E28E284950023ED44 /* MediaPlaybackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA1CA7D28E284950023ED44 /* MediaPlaybackViewModel.swift */; };
@@ -57,6 +61,10 @@
 		3C81C75428F8C7B6001CB9D1 /* StartFromCacheViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartFromCacheViewModel.swift; sourceTree = "<group>"; };
 		3C81C75628F8E418001CB9D1 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
 		3C81C75828F8E42D001CB9D1 /* ConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionViewModel.swift; sourceTree = "<group>"; };
+		3C94377C2B364D380096E5F4 /* MTRDiscoveryExampleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTRDiscoveryExampleViewModel.swift; sourceTree = "<group>"; };
+		3C94377E2B364D510096E5F4 /* MTRConnectionExampleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTRConnectionExampleViewModel.swift; sourceTree = "<group>"; };
+		3C94378D2B3B3CB00096E5F4 /* MTRDiscoveryExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTRDiscoveryExampleView.swift; sourceTree = "<group>"; };
+		3C94378F2B3B3FF90096E5F4 /* MTRConnectionExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTRConnectionExampleView.swift; sourceTree = "<group>"; };
 		3CA19434285BA780004768D5 /* ContentLauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherView.swift; sourceTree = "<group>"; };
 		3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherViewModel.swift; sourceTree = "<group>"; };
 		3CA1CA7928E281080023ED44 /* ClusterSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterSelectorView.swift; sourceTree = "<group>"; };
@@ -119,6 +127,10 @@
 				3C75075E284C1DF800D7DB3A /* TvCasting.entitlements */,
 				3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */,
 				3C6920492AA1368F00D0F613 /* MTRInitializationExample.swift */,
+				3C94378D2B3B3CB00096E5F4 /* MTRDiscoveryExampleView.swift */,
+				3C94377C2B364D380096E5F4 /* MTRDiscoveryExampleViewModel.swift */,
+				3C94378F2B3B3FF90096E5F4 /* MTRConnectionExampleView.swift */,
+				3C94377E2B364D510096E5F4 /* MTRConnectionExampleViewModel.swift */,
 				EAF14298296D561900E17793 /* CertTestView.swift */,
 				EAF1429A296D57DF00E17793 /* CertTestViewModel.swift */,
 				3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */,
@@ -177,6 +189,8 @@
 			dependencies = (
 			);
 			name = TvCasting;
+			packageProductDependencies = (
+			);
 			productName = TvCasting;
 			productReference = 3CC0E8F62841DD3400EC6A18 /* TvCasting.app */;
 			productType = "com.apple.product-type.application";
@@ -233,13 +247,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C81C75328F8C79E001CB9D1 /* StartFromCacheView.swift in Sources */,
+				3C94377F2B364D510096E5F4 /* MTRConnectionExampleViewModel.swift in Sources */,
 				3C81C75528F8C7B6001CB9D1 /* StartFromCacheViewModel.swift in Sources */,
 				3CCB8745286A5D0F00771BAD /* CommissionerDiscoveryView.swift in Sources */,
 				3CCB8746286A5D0F00771BAD /* CommissionerDiscoveryViewModel.swift in Sources */,
 				3C81C75928F8E42D001CB9D1 /* ConnectionViewModel.swift in Sources */,
 				3CA1CA7A28E281080023ED44 /* ClusterSelectorView.swift in Sources */,
+				3C94378E2B3B3CB00096E5F4 /* MTRDiscoveryExampleView.swift in Sources */,
 				EAF14299296D561900E17793 /* CertTestView.swift in Sources */,
 				3C69204A2AA1368F00D0F613 /* MTRInitializationExample.swift in Sources */,
+				3C94377D2B364D380096E5F4 /* MTRDiscoveryExampleViewModel.swift in Sources */,
 				3CCB8747286A5D0F00771BAD /* CommissioningView.swift in Sources */,
 				3CCB8748286A5D0F00771BAD /* CommissioningViewModel.swift in Sources */,
 				3CAC955B29BA948700BEA5C3 /* ExampleDAC.swift in Sources */,
@@ -251,6 +268,7 @@
 				3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */,
 				3CA1CA7C28E282150023ED44 /* MediaPlaybackView.swift in Sources */,
 				3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */,
+				3C9437902B3B3FF90096E5F4 /* MTRConnectionExampleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRConnectionExampleView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRConnectionExampleView.swift
@@ -1,0 +1,69 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import SwiftUI
+
+struct MTRConnectionExampleView: View {
+    var selectedCastingPlayer: MTRCastingPlayer?
+    
+    @StateObject var viewModel = MTRConnectionExampleViewModel();
+    
+    init(_selectedCastingPlayer: MTRCastingPlayer?) {
+        self.selectedCastingPlayer = _selectedCastingPlayer
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Verifying or Establishing Connection to Casting Player: \(self.selectedCastingPlayer!.deviceName())").padding()
+            if let connectionSuccess = viewModel.connectionSuccess
+            {
+                if let connectionStatus = viewModel.connectionStatus
+                {
+                    Text(connectionStatus).padding()
+                }
+                
+                if(connectionSuccess)
+                {
+                    /* TODO add this back in
+                     NavigationLink(
+                        destination: ClusterSelectorView(),
+                        label: {
+                            Text("Next")
+                                .frame(width: 100, height: 30, alignment: .center)
+                                .border(Color.black, width: 1)
+                        }
+                    ).background(Color.blue)
+                        .foregroundColor(Color.white)
+                        .frame(maxHeight: .infinity, alignment: .bottom)
+                        .padding()*/
+                }
+            }
+        }
+        .navigationTitle("Connecting...")
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+        .onAppear(perform: {
+            viewModel.connect(selectedCastingPlayer: self.selectedCastingPlayer)
+        })
+    }
+}
+
+struct MTRConnectionExampleView_Previews: PreviewProvider {
+    static var previews: some View {
+        MTRConnectionExampleView(_selectedCastingPlayer: nil)
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRConnectionExampleViewModel.swift
@@ -1,0 +1,50 @@
+/**
+ *
+ *    Copyright (c) 2020-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import Foundation
+import os.log
+
+class MTRConnectionExampleViewModel: ObservableObject {
+    let Log = Logger(subsystem: "com.matter.casting",
+                     category: "MTRConnectionExampleViewModel")
+    
+    // VendorId of the MTREndpoint on the MTRCastingPlayer that the MTRCastingApp desires to interact with after connection
+    let kDesiredEndpointVendorId: UInt16 = 65521;
+    
+    @Published var connectionSuccess: Bool?;
+
+    @Published var connectionStatus: String?;
+
+    func connect(selectedCastingPlayer: MTRCastingPlayer?) {
+        let desiredEndpointFilter: MTREndpointFilter = MTREndpointFilter()
+        desiredEndpointFilter.vendorId = kDesiredEndpointVendorId
+        selectedCastingPlayer?.verifyOrEstablishConnection(completionBlock: { err in
+            self.Log.error("MTRConnectionExampleViewModel connect() completed with \(err)")
+            if(err == nil)
+            {
+                self.connectionSuccess = true
+                self.connectionStatus = "Connected!"
+            }
+            else
+            {
+                self.connectionSuccess = false
+                self.connectionStatus = "Connection failed with \(String(describing: err))"
+            }
+        }, desiredEndpointFilter: desiredEndpointFilter)
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRDiscoveryExampleView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRDiscoveryExampleView.swift
@@ -1,0 +1,85 @@
+/**
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import SwiftUI
+
+extension MTRCastingPlayer : Identifiable {
+    public var id: String {
+        identifier()
+    }
+}
+
+struct MTRDiscoveryExampleView: View {
+    @StateObject var viewModel = MTRDiscoveryExampleViewModel()
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Button("Start Discovery", action: viewModel.startDiscovery)
+                .frame(width: 350, height: 30, alignment: .center)
+                .border(Color.black, width: 1)
+                .background(Color.blue)
+                .foregroundColor(Color.white)
+                .padding(1)
+
+            Button("Stop Discovery", action: viewModel.stopDiscovery)
+                .frame(width: 350, height: 30, alignment: .center)
+                .border(Color.black, width: 1)
+                .background(Color.blue)
+                .foregroundColor(Color.white)
+                .padding(1)
+
+            Button("Clear Results", action: viewModel.clearResults)
+                .frame(width: 350, height: 30, alignment: .center)
+                .border(Color.black, width: 1)
+                .background(Color.blue)
+                .foregroundColor(Color.white)
+                .padding(1)
+
+            if(viewModel.discoveryHasError)
+            {
+                Text("Discovery request failed. Check logs for details")
+            }
+            else if(!viewModel.displayedCastingPlayers.isEmpty)
+            {
+                Text("Select a Casting player...")
+                ForEach(viewModel.displayedCastingPlayers) { castingPlayer in
+                    NavigationLink(
+                        destination: {
+                            MTRConnectionExampleView(_selectedCastingPlayer: castingPlayer)
+                        },
+                        label: {
+                            Text(castingPlayer.description)
+                        }
+                    )
+                    .frame(width: 350, height: 50, alignment: .center)
+                    .border(Color.black, width: 1)
+                    .background(Color.blue)
+                    .foregroundColor(Color.white)
+                    .padding(1)
+                }
+            }
+        }
+        .navigationTitle("Casting Player Discovery")
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+    }        
+}
+
+struct MTRDiscoveryExampleView_Previews: PreviewProvider {
+    static var previews: some View {
+        MTRDiscoveryExampleView()
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRDiscoveryExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MTRDiscoveryExampleViewModel.swift
@@ -1,0 +1,126 @@
+/**
+ *
+ *    Copyright (c) 2020-2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Foundation
+import os.log
+
+class MTRDiscoveryExampleViewModel: ObservableObject {
+    let Log = Logger(subsystem: "com.matter.casting",
+                     category: "MTRDiscoveryExampleViewModel")
+    let kTargetPlayerDeviceType: UInt64 = 35
+    
+    @Published var displayedCastingPlayers: [MTRCastingPlayer] = []
+    
+    @Published var discoveryHasError: Bool = false;
+    
+    func startDiscovery() {
+        Log.info("startDiscovery() called")
+        clearResults()
+        
+        // add observers
+        NotificationCenter.default.addObserver(self, selector: #selector(self.didAddDiscoveredCastingPlayers), name: NSNotification.Name(ADD_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.didRemoveDiscoveredCastingPlayers), name: NSNotification.Name(REMOVE_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.didUpdateDiscoveredCastingPlayers), name: NSNotification.Name(UPDATE_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+
+        if let err:Error = MTRCastingPlayerDiscovery.sharedInstance().start(UInt32(kTargetPlayerDeviceType))
+        {
+            Log.error("MTRCastingPlayerDiscovery.start failed with \(err)")
+            self.discoveryHasError = true
+        }
+        self.discoveryHasError = false
+    }
+    
+    func stopDiscovery() {
+        Log.info("stopDiscovery() called")
+        if let err:Error = MTRCastingPlayerDiscovery.sharedInstance().stop()
+        {
+            Log.error("MTRCastingPlayerDiscovery.stop failed with \(err)")
+            self.discoveryHasError = true
+        }
+        else
+        {
+            // remove observers
+            NotificationCenter.default.removeObserver(self, name: NSNotification.Name(ADD_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSNotification.Name(REMOVE_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSNotification.Name(UPDATE_CASTING_PLAYER_NOTIFICATION_NAME), object: nil)
+        }
+        self.discoveryHasError = false
+    }
+    
+    func clearResults() {
+        Log.info("clearResults() called")
+        DispatchQueue.main.async
+        {
+            self.displayedCastingPlayers.removeAll()
+        }
+    }
+    
+    @objc
+    func didAddDiscoveredCastingPlayers(notification: Notification)
+    {
+        Log.info("didAddDiscoveredCastingPlayers() called")
+        guard let userInfo = notification.userInfo,
+            let castingPlayer     = userInfo["castingPlayer"] as? MTRCastingPlayer else {
+            self.Log.error("didAddDiscoveredCastingPlayers called with no MTRCastingPlayer")
+            return
+        }
+        
+        self.Log.info("didAddDiscoveredCastingPlayers notified of a MTRCastingPlayer with ID: \(castingPlayer.identifier())")
+
+        DispatchQueue.main.async
+        {
+            self.displayedCastingPlayers.append(castingPlayer)
+        }
+    }
+    
+    @objc
+    func didRemoveDiscoveredCastingPlayers(notification: Notification)
+    {
+        Log.info("didRemoveDiscoveredCastingPlayers() called")
+        guard let userInfo = notification.userInfo,
+            let castingPlayer     = userInfo["castingPlayer"] as? MTRCastingPlayer else {
+            self.Log.error("didRemoveDiscoveredCastingPlayers called with no MTRCastingPlayer")
+            return
+        }
+        
+        self.Log.info("didRemoveDiscoveredCastingPlayers notified of a MTRCastingPlayer with ID: \(castingPlayer.identifier())")
+        DispatchQueue.main.async
+        {
+            self.displayedCastingPlayers.removeAll(where: {$0 == castingPlayer})
+        }
+    }
+    
+    @objc
+    func didUpdateDiscoveredCastingPlayers(notification: Notification)
+    {
+        Log.info("didUpdateDiscoveredCastingPlayers() called")
+        guard let userInfo = notification.userInfo,
+            let castingPlayer     = userInfo["castingPlayer"] as? MTRCastingPlayer else {
+            self.Log.error("didUpdateDiscoveredCastingPlayers called with no MTRCastingPlayer")
+            return
+        }
+        
+        self.Log.info("didUpdateDiscoveredCastingPlayers notified of a MTRCastingPlayer with ID: \(castingPlayer.identifier())")
+        if let index = displayedCastingPlayers.firstIndex(where: { castingPlayer.identifier() == $0.identifier() })
+        {
+            DispatchQueue.main.async
+            {
+                self.displayedCastingPlayers[index] = castingPlayer
+            }
+        }
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCastingApp.swift
@@ -33,10 +33,11 @@ struct TvCastingApp: App {
                     {
                         self.Log.info("CHIP_CASTING_SIMPLIFIED = 1")
                         
-                        let err: MatterError = MTRInitializationExample().initialize()
-                        if !MATTER_NO_ERROR.isEqual(err)
+                        let err: Error? = MTRInitializationExample().initialize()
+                        if err != nil
                         {
-                            self.Log.error("CastingApp initialization failed \(err)")
+                            self.Log.error("MTRCastingApp initialization failed \(err)")
+                            return
                         }
                     }
                     else
@@ -73,11 +74,12 @@ struct TvCastingApp: App {
                     {
                         if let castingApp = MTRCastingApp.getSharedInstance()
                         {
-                            let err: MatterError = castingApp.stop()
-                            if !MATTER_NO_ERROR.isEqual(err)
-                            {
-                                self.Log.error("CastingApp stop failed \(err)")
-                            }
+                            castingApp.stop(completionBlock: { (err : Error?) -> () in
+                                if err != nil
+                                {
+                                    self.Log.error("MTRCastingApp stop failed \(err)")
+                                }
+                            })
                         }
                     }
                     else if let castingServerBridge = CastingServerBridge.getSharedInstance()
@@ -91,11 +93,12 @@ struct TvCastingApp: App {
                     {
                         if let castingApp = MTRCastingApp.getSharedInstance()
                         {
-                            let err: MatterError = castingApp.start()
-                            if !MATTER_NO_ERROR.isEqual(err)
-                            {
-                                self.Log.error("CastingApp start failed \(err)")
-                            }
+                            castingApp.start(completionBlock: { (err : Error?) -> () in
+                                if err != nil
+                                {
+                                    self.Log.error("MTRCastingApp start failed \(err)")
+                                }
+                            })
                         }
                     }
                     else

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -165,12 +165,10 @@ int main(int argc, char * argv[])
 #endif
 
     CastingPlayerDiscovery::GetInstance()->SetDelegate(DiscoveryDelegateImpl::GetInstance());
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, 0,
-                        ChipLogError(AppServer, "CastingPlayerDiscovery::SetDelegate failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     // Discover CastingPlayers
     err = CastingPlayerDiscovery::GetInstance()->StartDiscovery(kTargetPlayerDeviceType);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, 0,
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, -1,
                         ChipLogError(AppServer, "CastingPlayerDiscovery::StartDiscovery failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -103,6 +103,7 @@ chip_data_model("tv-casting-common") {
     "core/CastingPlayerDiscovery.cpp",
     "core/CastingPlayerDiscovery.h",
     "core/Command.h",
+    "core/Endpoint.cpp",
     "core/Endpoint.h",
     "core/Types.h",
     "support/AppParameters.h",

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
@@ -55,13 +55,15 @@ public:
     /**
      * @brief Starts the Matter server that the CastingApp runs on and registers all the necessary delegates
      * CastingApp.
+     * If the CastingApp was previously connected to a CastingPlayer and then Stopped by calling the Stop()
+     * API, it will re-connect to the CastingPlayer.
      *
      * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server started successfully, specific error code otherwise.
      */
     CHIP_ERROR Start();
 
     /**
-     * @brief Stops the Matter server that the CastingApp runs on
+     * @brief Stops the Matter server that the CastingApp runs on.
      *
      * @return CHIP_ERROR - CHIP_NO_ERROR if Matter server stopped successfully, specific error code otherwise.
      */
@@ -76,6 +78,11 @@ public:
      * @brief Tears down all active subscriptions.
      */
     CHIP_ERROR ShutdownAllSubscriptions();
+
+    /**
+     * @brief Clears app cache that contains the information about CastingPlayers previously connected to
+     */
+    CHIP_ERROR ClearCache();
 
 private:
     CastingApp();

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -121,7 +121,7 @@ public:
      * @param onCompleted for success - called back with CHIP_NO_ERROR and CastingPlayer *.
      * For failure - called back with an error and nullptr.
      * @param commissioningWindowTimeoutSec (Optional) time (in sec) to keep the commissioning window open, if commissioning is
-     * required. Defaults to kCommissioningWindowTimeoutSec.
+     * required. Needs to be >= kCommissioningWindowTimeoutSec.
      * @param desiredEndpointFilter (Optional) Attributes (such as VendorId) describing an Endpoint that the client wants to
      * interact with after commissioning. If this value is passed in, the VerifyOrEstablishConnection will force User Directed
      * Commissioning, in case the desired Endpoint is not found in the on device CastingStore.
@@ -129,6 +129,11 @@ public:
     void VerifyOrEstablishConnection(ConnectCallback onCompleted,
                                      unsigned long long int commissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec,
                                      EndpointFilter desiredEndpointFilter                 = EndpointFilter());
+
+    /**
+     * @brief Sets the internal connection state of this CastingPlayer to "disconnected"
+     */
+    void Disconnect();
 
     /**
      * @brief Find an existing session for this CastingPlayer, or trigger a new session

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -77,7 +77,7 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
 {
     ChipLogProgress(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice() called");
     VerifyOrReturn(mClientDelegate != nullptr,
-                   ChipLogError(NotSpecified, "CastingPlayerDeviceDiscoveryDelegate, mClientDelegate is a nullptr"));
+                   ChipLogError(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice mClientDelegate is a nullptr"));
 
     // convert nodeData to CastingPlayer
     CastingPlayerAttributes attributes;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -72,8 +72,7 @@ public:
 };
 
 /**
- * @brief CastingPlayerDiscovery represents the discovery of Casting Players.
- * This class is a singleton.
+ * @brief CastingPlayerDiscovery is a singleton utility class for discovering CastingPlayers.
  */
 class CastingPlayerDiscovery
 {

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Endpoint.h"
+
+#include "clusters/Clusters.h"
+
+namespace matter {
+namespace casting {
+namespace core {
+
+void Endpoint::RegisterClusters(std::vector<chip::ClusterId> clusters)
+{
+    for (chip::ClusterId clusterId : clusters)
+    {
+        switch (clusterId)
+        {
+        case chip::app::Clusters::ApplicationBasic::Id:
+            RegisterCluster<clusters::application_basic::ApplicationBasicCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::ApplicationLauncher::Id:
+            RegisterCluster<clusters::application_launcher::ApplicationLauncherCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::ContentLauncher::Id:
+            RegisterCluster<clusters::content_launcher::ContentLauncherCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::KeypadInput::Id:
+            RegisterCluster<clusters::keypad_input::KeypadInputCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::LevelControl::Id:
+            RegisterCluster<clusters::level_control::LevelControlCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::OnOff::Id:
+            RegisterCluster<clusters::on_off::OnOffCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::MediaPlayback::Id:
+            RegisterCluster<clusters::media_playback::MediaPlaybackCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::TargetNavigator::Id:
+            RegisterCluster<clusters::target_navigator::TargetNavigatorCluster>(clusterId);
+            break;
+
+        case chip::app::Clusters::WakeOnLan::Id:
+            RegisterCluster<clusters::wake_on_lan::WakeOnLanCluster>(clusterId);
+            break;
+
+        default:
+            ChipLogProgress(AppServer, "Skipping registration of clusterId %d for endpointId %d", clusterId, GetId());
+            break;
+        }
+    }
+}
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -112,6 +112,8 @@ public:
         return serverList;
     }
 
+    void RegisterClusters(std::vector<chip::ClusterId> clusters);
+
     /**
      * @brief Registers a cluster of type T against the passed in clusterId
      * for this Endpoint

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -74,24 +74,23 @@ private:
         kCastingStoreDataVersionTag = 1,
 
         kCastingPlayersContainerTag,
-        kCastingPlayerContainerTag,
         kCastingPlayerIdTag,
         kCastingPlayerNodeIdTag,
         kCastingPlayerFabricIndexTag,
         kCastingPlayerVendorIdTag,
         kCastingPlayerProductIdTag,
         kCastingPlayerDeviceTypeIdTag,
+        kCastingPlayerPortTag,
+        kCastingPlayerInstanceNameTag,
         kCastingPlayerDeviceNameTag,
         kCastingPlayerHostNameTag,
 
         kCastingPlayerEndpointsContainerTag,
-        kCastingPlayerEndpointContainerTag,
         kCastingPlayerEndpointIdTag,
         kCastingPlayerEndpointVendorIdTag,
         kCastingPlayerEndpointProductIdTag,
 
         kCastingPlayerEndpointDeviceTypeListContainerTag,
-        kCastingPlayerEndpointDeviceTypeStructContainerTag,
         kCastingPlayerEndpointDeviceTypeTag,
         kCastingPlayerEndpointDeviceTypeRevisionTag,
 

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -76,7 +76,12 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
             [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                 ChipLogError(AppServer, "ChipDeviceEventHandler::Handle: Connection to CastingPlayer failed");
                 CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-                support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
+                CHIP_ERROR err = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(AppServer, "CastingStore::Delete() failed. Err: %" CHIP_ERROR_FORMAT, err.Format());
+                }
+
                 VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
                 CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
                 CastingPlayer::mTargetCastingPlayer = nullptr;
@@ -185,6 +190,17 @@ void ChipDeviceEventHandler::HandleCommissioningComplete(const chip::DeviceLayer
     targetNodeId         = event->CommissioningComplete.nodeId;
     targetFabricIndex    = event->CommissioningComplete.fabricIndex;
     runPostCommissioning = true;
+}
+
+CHIP_ERROR ChipDeviceEventHandler::SetUdcStatus(bool udcInProgress)
+{
+    if (sUdcInProgress == udcInProgress)
+    {
+        ChipLogError(AppServer, "UDC in progress state is already %d", sUdcInProgress);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    sUdcInProgress = udcInProgress;
+    return CHIP_NO_ERROR;
 }
 
 }; // namespace support

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.h
@@ -43,16 +43,7 @@ public:
      * If UDC was already in progress when this method was called, it will return a CHIP_ERROR_INCORRECT_STATE without changing the
      * internal state.
      */
-    static CHIP_ERROR SetUdcStatus(bool udcInProgress)
-    {
-        if (sUdcInProgress == udcInProgress)
-        {
-            ChipLogError(AppServer, "UDC in progress state is already %d", sUdcInProgress);
-            return CHIP_ERROR_INCORRECT_STATE;
-        }
-        sUdcInProgress = udcInProgress;
-        return CHIP_NO_ERROR;
-    }
+    static CHIP_ERROR SetUdcStatus(bool udcInProgress);
 
 private:
     /**


### PR DESCRIPTION
This change simplifies and decouples the implementation of the discovery and connection APIs for the iOS tv-casting-app from the old CastingServerBridge.h/mm.

Change summary

*   MTRCastingPlayerDiscovery exposes discovery related APIs and leverages the NSNotificationCenter for discovery notifications.
*   MTRCastingPlayer represents the discovered CastingPlayers and exposes the verifyOrEstablishConnection APIs that allow the client to connect to the CastingPlayer.
*   APIs.md contains updated documentation for the newly exposed discovery and connection APIs for iOS.

Testing

Verified and tested locally with Linux TV app