### PR TITLE
[Silabs] Adding the spi_multiplex.h for only NCP not SOC devices

### DIFF
--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -25,7 +25,7 @@
 #include "glib.h"
 #include "lcd.h"
 
-#if SL_WIFI &&  !defined(SIWX_917)
+#if SL_WIFI && !defined(SIWX_917)
 // Only needed for wifi NCP devices
 #include "spi_multiplex.h"
 #endif // SL_WIFI

--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -25,7 +25,8 @@
 #include "glib.h"
 #include "lcd.h"
 
-#if SL_WIFI
+#if SL_WIFI &&  !defined(SIWX_917)
+// Only needed for wifi NCP devices
 #include "spi_multiplex.h"
 #endif // SL_WIFI
 


### PR DESCRIPTION
spi_multiplex.h was added by default for Wifi due to which SoC was failing.

Adding a condition so this header file is not included for the SoC devices