### PR TITLE
Corrects the constraint of FanMode to exclude deprecated values

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_FAN_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FAN_2_1.yaml
@@ -38,8 +38,7 @@ tests:
       response:
           constraints:
               type: enum8
-              minValue: 0
-              maxValue: 6
+              anyOf: [0, 1, 2, 3, 5]
 
     - label: "Step 3: TH reads from the DUT the the FanModeSequence attribute"
       PICS: FAN.S.A0001


### PR DESCRIPTION
Corrects the constraint of FanMode to exclude deprecated values.

Fixes #31230
