### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-31 : [silabs] Update gsdk and wifi-sdk
+32 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=e0800ce0375563dfeea8ffc32ebc78d5aaf4f091
+ARG ZEPHYR_REVISION=d074f4f945919a37214a5f8ee608f4107c108c20
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- soc: riscv: riscv-privelege: telink_b9x: Enable wfi emulation for B91 SoC.
- soc: riscv: riscv-privilege: telink: Add Telink b92 soc PMP support.
- west.yml: Create module for using OpenThread Telink precompiled libraries.
- samples: net: openthread: cli: Update configuration.
- drivers: flash: Move data buffer out of retention memory. Add driver multi initialization.

**Testing**
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully