### PR TITLE
[Silabs][Hotfix]Remove spi_multiplex include for 917 soc

### DIFF
--- a/examples/thermostat/silabs/src/ThermostatUI.cpp
+++ b/examples/thermostat/silabs/src/ThermostatUI.cpp
@@ -25,9 +25,9 @@
 #include "glib.h"
 #include "lcd.h"
 
-#if SL_WIFI
+#if SL_WIFI && !SIWX_917
 #include "spi_multiplex.h"
-#endif // SL_WIFI
+#endif // SL_WIFI && !SIWX_917
 
 // LCD line define
 constexpr uint8_t kTempLcdInitialX = 30;


### PR DESCRIPTION
the spi_mutiplex.h include doesn't exist for the 917 wifi soc platform. It is only used for ef32 + wifi ncp combos.

Fix the #idef condition