### PR TITLE
[Silabs] Enabling Sleepy on 917 SoC device

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -300,7 +300,7 @@ extern "C" void vApplicationIdleHook(void)
     if (ConnectivityMgr().IsWiFiStationConnected())
     {
         // Let the M4 sleep once commissioning is done and device is in idle state
-        M4_sleep_wakeup();
+        sl_wfx_host_si91x_sleep_wakeup();
     }
 #endif
 }

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -259,7 +259,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ReturnErrorOnFailure(err);
 
     // OTA Requestor initialization will be triggered by the connectivity events
-    // PlatformMgr().AddEventHandler(ConnectivityEventCallback, reinterpret_cast<intptr_t>(nullptr));
+    PlatformMgr().AddEventHandler(ConnectivityEventCallback, reinterpret_cast<intptr_t>(nullptr));
 
     SILABS_LOG("Starting Platform Manager Event Loop");
     ReturnErrorOnFailure(PlatformMgr().StartEventLoopTask());

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -43,9 +43,6 @@
 
 #ifdef SIWX_917
 #include "wfx_rsi.h"
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-extern "C" void M4_sleep_wakeup(void);
-#endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
 #endif /* SIWX_917 */
 
 using namespace ::chip;

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -297,7 +297,8 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 extern "C" void vApplicationIdleHook(void)
 {
 #if SIWX_917 && CHIP_CONFIG_ENABLE_ICD_SERVER
-    if(ConnectivityMgr().IsWiFiStationConnected()) {
+    if (ConnectivityMgr().IsWiFiStationConnected())
+    {
         // Let the M4 sleep once commissioning is done and device is in idle state
         M4_sleep_wakeup();
     }

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -43,6 +43,9 @@
 
 #ifdef SIWX_917
 #include "wfx_rsi.h"
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+extern "C" void M4_sleep_wakeup(void);
+#endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
 #endif /* SIWX_917 */
 
 using namespace ::chip;
@@ -256,7 +259,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ReturnErrorOnFailure(err);
 
     // OTA Requestor initialization will be triggered by the connectivity events
-    PlatformMgr().AddEventHandler(ConnectivityEventCallback, reinterpret_cast<intptr_t>(nullptr));
+    // PlatformMgr().AddEventHandler(ConnectivityEventCallback, reinterpret_cast<intptr_t>(nullptr));
 
     SILABS_LOG("Starting Platform Manager Event Loop");
     ReturnErrorOnFailure(PlatformMgr().StartEventLoopTask());
@@ -296,5 +299,10 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 // ================================================================================
 extern "C" void vApplicationIdleHook(void)
 {
-    // FreeRTOS Idle callback
+#if SIWX_917 && CHIP_CONFIG_ENABLE_ICD_SERVER
+    if(ConnectivityMgr().IsWiFiStationConnected()) {
+        // Let the M4 sleep once commissioning is done and device is in idle state
+        M4_sleep_wakeup();
+    }
+#endif
 }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -238,7 +238,9 @@ void M4_sleep_wakeup()
             btn0_pressed = false;
             /* Configure RAM Usage and Retention Size */
             sl_si91x_m4_sleep_wakeup();
+#if SILABS_LOG_ENABLED
             silabsInitLog();
+#endif
         }
     }
 }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -42,9 +42,9 @@
 #include "ble_config.h"
 
 #if SL_ICD_ENABLED && SIWX_917
-#include "sl_si91x_m4_ps.h"
 #include "rsi_rom_power_save.h"
 #include "sl_si91x_button_pin_config.h"
+#include "sl_si91x_m4_ps.h"
 
 // TODO: should be removed once we are getting the press interrupt for button 0 with sleep
 #define BUTTON_PRESSED 1
@@ -219,24 +219,28 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
  * @return
  *        None
  *********************************************************************/
-void M4_sleep_wakeup() {
-  if (wfx_rsi.dev_state & WFX_RSI_ST_SLEEP_READY) {
-    // TODO: should be removed once we are getting the press interrupt for button 0 with sleep
-    if (!RSI_NPSSGPIO_GetPin(SL_BUTTON_BTN0_PIN) && !btn0_pressed) {
-      sl_button_on_change(SL_BUTTON_BTN0_NUMBER, BUTTON_PRESSED);
-      btn0_pressed = true;
-    }
-    if (RSI_NPSSGPIO_GetPin(SL_BUTTON_BTN0_PIN)) {
+void M4_sleep_wakeup()
+{
+    if (wfx_rsi.dev_state & WFX_RSI_ST_SLEEP_READY)
+    {
+        // TODO: should be removed once we are getting the press interrupt for button 0 with sleep
+        if (!RSI_NPSSGPIO_GetPin(SL_BUTTON_BTN0_PIN) && !btn0_pressed)
+        {
+            sl_button_on_change(SL_BUTTON_BTN0_NUMBER, BUTTON_PRESSED);
+            btn0_pressed = true;
+        }
+        if (RSI_NPSSGPIO_GetPin(SL_BUTTON_BTN0_PIN))
+        {
 #ifdef DISPLAY_ENABLED
-      // if LCD is enabled, power down the lcd before setting the M4 to sleep
-      sl_si91x_hardware_setup();
+            // if LCD is enabled, power down the lcd before setting the M4 to sleep
+            sl_si91x_hardware_setup();
 #endif
-      btn0_pressed = false;
-      /* Configure RAM Usage and Retention Size */
-      sl_si91x_m4_sleep_wakeup();
-      silabsInitLog();
+            btn0_pressed = false;
+            /* Configure RAM Usage and Retention Size */
+            sl_si91x_m4_sleep_wakeup();
+            silabsInitLog();
+        }
     }
-  }
 }
 #endif /* SIWX_917 */
 
@@ -329,7 +333,8 @@ static sl_status_t wfx_rsi_init(void)
 #if SL_ICD_ENABLED
     uint8_t xtal_enable = 1;
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
-    if (status != SL_STATUS_OK) {
+    if (status != SL_STATUS_OK)
+    {
         SILABS_LOG("Failed to bring m4_ta_secure_handshake: 0x%lx\r\n", status);
         return status;
     }
@@ -552,8 +557,8 @@ static sl_status_t wfx_rsi_do_join(void)
         sl_wifi_set_join_callback(join_callback_handler, NULL);
 
         // Setting the listen interval to 0 which will set it to DTIM interval
-        sl_wifi_listen_interval_t sleep_interval = { .listen_interval = 0};
-        status = sl_wifi_set_listen_interval(SL_WIFI_CLIENT_INTERFACE, sleep_interval);
+        sl_wifi_listen_interval_t sleep_interval = { .listen_interval = 0 };
+        status                                   = sl_wifi_set_listen_interval(SL_WIFI_CLIENT_INTERFACE, sleep_interval);
 
         /* Try to connect Wifi with given Credentials
          * untill there is a success or maximum number of tries allowed

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -223,16 +223,14 @@ void M4_sleep_wakeup() {
       btn0_pressed = true;
     }
     if (RSI_NPSSGPIO_GetPin(SL_BUTTON_BTN0_PIN)) {
-#ifdef CONFIG_ENABLE_UART
+#ifdef DISPLAY_ENABLED
       // if LCD is enabled, power down the lcd before setting the M4 to sleep
       sl_si91x_hardware_setup();
 #endif
-      SILABS_LOG("M4 sleep successful");
       btn0_pressed = false;
       /* Configure RAM Usage and Retention Size */
       sl_si91x_m4_sleep_wakeup();
       silabsInitLog();
-      SILABS_LOG("M4 wakeup successful");
     }
   }
 }
@@ -328,9 +326,8 @@ static sl_status_t wfx_rsi_init(void)
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
     if (status != SL_STATUS_OK) {
         SILABS_LOG("Failed to bring m4_ta_secure_handshake: 0x%lx\r\n", status);
-    return;
+        return status;
     }
-    SILABS_LOG("m4_ta_secure_handshake Success\r\n");
 #endif /* SL_ICD_ENABLED */
 #endif /* SLI_SI91X_MCU_INTERFACE */
 

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -326,7 +326,7 @@ static sl_status_t wfx_rsi_init(void)
         return status;
     }
 #else // For SoC
-#if SL_ICD_ENABLED 
+#if SL_ICD_ENABLED
     uint8_t xtal_enable = 1;
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
     if (status != SL_STATUS_OK) {

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.c
@@ -211,7 +211,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
 
 #if SIWX_917
 /******************************************************************
- * @fn   M4_sleep_wakeup()
+ * @fn   sl_wfx_host_si91x_sleep_wakeup()
  * @brief
  *       M4 going to sleep
  *
@@ -219,7 +219,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
  * @return
  *        None
  *********************************************************************/
-void M4_sleep_wakeup()
+void sl_wfx_host_si91x_sleep_wakeup()
 {
     if (wfx_rsi.dev_state & WFX_RSI_ST_SLEEP_READY)
     {

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
@@ -28,16 +28,16 @@
 //! Disable feature
 #define RSI_DISABLE 0
 
-#define IVT_OFFSET_ADDR 0x8202000  /*<!Application IVT location VTOR offset>        */
+#define IVT_OFFSET_ADDR 0x8202000         /*<!Application IVT location VTOR offset>        */
 #define WKP_RAM_USAGE_LOCATION 0x24061EFC /*<!Bootloader RAM usage location upon wake up  */
 
 #define WIRELESS_WAKEUP_IRQHandler NPSS_TO_MCU_WIRELESS_INTR_IRQn
 #define WIRELESS_WAKEUP_IRQHandler_Priority 17
 
 /* Constants required to manipulate the NVIC. */
-#define portNVIC_SHPR3_REG (*((volatile uint32_t *)0xe000ed20))
-#define portNVIC_PENDSV_PRI  (((uint32_t)(0x3f << 4)) << 16UL)
-#define portNVIC_SYSTICK_PRI (((uint32_t)(0x3f << 4)) << 24UL)
+#define portNVIC_SHPR3_REG (*((volatile uint32_t *) 0xe000ed20))
+#define portNVIC_PENDSV_PRI (((uint32_t) (0x3f << 4)) << 16UL)
+#define portNVIC_SYSTICK_PRI (((uint32_t) (0x3f << 4)) << 24UL)
 
 static const sl_wifi_device_configuration_t config = {
     .boot_option = LOAD_NWP_FW,

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
@@ -28,17 +28,6 @@
 //! Disable feature
 #define RSI_DISABLE 0
 
-#define IVT_OFFSET_ADDR 0x8202000         /*<!Application IVT location VTOR offset>        */
-#define WKP_RAM_USAGE_LOCATION 0x24061EFC /*<!Bootloader RAM usage location upon wake up  */
-
-#define WIRELESS_WAKEUP_IRQHandler NPSS_TO_MCU_WIRELESS_INTR_IRQn
-#define WIRELESS_WAKEUP_IRQHandler_Priority 17
-
-/* Constants required to manipulate the NVIC. */
-#define portNVIC_SHPR3_REG (*((volatile uint32_t *) 0xe000ed20))
-#define portNVIC_PENDSV_PRI (((uint32_t) (0x3f << 4)) << 16UL)
-#define portNVIC_SYSTICK_PRI (((uint32_t) (0x3f << 4)) << 24UL)
-
 static const sl_wifi_device_configuration_t config = {
     .boot_option = LOAD_NWP_FW,
     .mac_address = NULL,

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
@@ -28,7 +28,16 @@
 //! Disable feature
 #define RSI_DISABLE 0
 
-#define SI91X_LISTEN_INTERVAL 0
+#define IVT_OFFSET_ADDR 0x8202000  /*<!Application IVT location VTOR offset>        */
+#define WKP_RAM_USAGE_LOCATION 0x24061EFC /*<!Bootloader RAM usage location upon wake up  */
+
+#define WIRELESS_WAKEUP_IRQHandler NPSS_TO_MCU_WIRELESS_INTR_IRQn
+#define WIRELESS_WAKEUP_IRQHandler_Priority 17
+
+/* Constants required to manipulate the NVIC. */
+#define portNVIC_SHPR3_REG (*((volatile uint32_t *)0xe000ed20))
+#define portNVIC_PENDSV_PRI  (((uint32_t)(0x3f << 4)) << 16UL)
+#define portNVIC_SYSTICK_PRI (((uint32_t)(0x3f << 4)) << 24UL)
 
 static const sl_wifi_device_configuration_t config = {
     .boot_option = LOAD_NWP_FW,

--- a/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
@@ -94,7 +94,7 @@ int32_t wfx_rsi_reset_count();
 int32_t wfx_rsi_disconnect();
 int32_t wfx_wifi_rsi_init(void);
 #if SL_ICD_ENABLED
-void M4_sleep_wakeup();
+void sl_wfx_host_si91x_sleep_wakeup();
 int32_t wfx_rsi_power_save();
 #endif /* SL_ICD_ENABLED */
 

--- a/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
@@ -53,6 +53,7 @@
 #define WFX_RSI_ST_STA_READY (WFX_RSI_ST_STA_CONNECTED | WFX_RSI_ST_STA_DHCP_DONE)
 #define WFX_RSI_ST_STARTED (0x200)     /* RSI task started			*/
 #define WFX_RSI_ST_SCANSTARTED (0x400) /* Scan Started				*/
+#define WFX_RSI_ST_SLEEP_READY (0x800) /* Notify the M4 to go to sleep*/
 
 struct wfx_rsi
 {
@@ -92,6 +93,9 @@ int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_rsi_reset_count();
 int32_t wfx_rsi_disconnect();
 int32_t wfx_wifi_rsi_init(void);
+#if SL_ICD_ENABLED
+int32_t wfx_rsi_power_save();
+#endif /* SL_ICD_ENABLED */
 
 #ifdef __cplusplus
 }

--- a/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/wfx_rsi.h
@@ -94,6 +94,7 @@ int32_t wfx_rsi_reset_count();
 int32_t wfx_rsi_disconnect();
 int32_t wfx_wifi_rsi_init(void);
 #if SL_ICD_ENABLED
+void M4_sleep_wakeup();
 int32_t wfx_rsi_power_save();
 #endif /* SL_ICD_ENABLED */
 

--- a/examples/platform/silabs/display/demo-ui.c
+++ b/examples/platform/silabs/display/demo-ui.c
@@ -23,6 +23,7 @@
 #include "dmd/dmd.h"
 #include "em_types.h"
 #include "glib.h"
+#include "sl_memlcd.h"
 #if SL_WIFI && !SIWX_917
 #include "spi_multiplex.h"
 #endif // SL_WIFI && !SIWX_917
@@ -102,6 +103,9 @@ void demoUIInit(GLIB_Context_t * context)
 
 sl_status_t updateDisplay(void)
 {
+#if SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
+    sl_memlcd_post_wakeup_init();
+#endif // SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
 #if SL_LCDCTRL_MUX
     sl_wfx_host_pre_lcd_spi_transfer();
 #endif // SL_LCDCTRL_MUX

--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -27,7 +27,6 @@
 
 #if (SIWX_917)
 #include "rsi_chip.h"
-#include "sl_memlcd.h"
 #endif
 
 #ifdef QR_CODE_ENABLED
@@ -135,9 +134,6 @@ int SilabsLCD::Update(void)
 
 void SilabsLCD::WriteDemoUI(bool state)
 {
-#if SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
-    sl_memlcd_post_wakeup_init();
-#endif // SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
     if (mCurrentScreen != DemoScreen)
     {
         mCurrentScreen = DemoScreen;
@@ -237,9 +233,6 @@ void SilabsLCD::SetScreen(Screen_e screen)
 
 void SilabsLCD::CycleScreens(void)
 {
-#if SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
-    sl_memlcd_post_wakeup_init();
-#endif // SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
 #ifdef QR_CODE_ENABLED
     if (mCurrentScreen < QRCodeScreen)
 #else

--- a/examples/platform/silabs/display/lcd.cpp
+++ b/examples/platform/silabs/display/lcd.cpp
@@ -27,6 +27,7 @@
 
 #if (SIWX_917)
 #include "rsi_chip.h"
+#include "sl_memlcd.h"
 #endif
 
 #ifdef QR_CODE_ENABLED
@@ -134,6 +135,9 @@ int SilabsLCD::Update(void)
 
 void SilabsLCD::WriteDemoUI(bool state)
 {
+#if SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
+    sl_memlcd_post_wakeup_init();
+#endif // SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
     if (mCurrentScreen != DemoScreen)
     {
         mCurrentScreen = DemoScreen;
@@ -233,6 +237,9 @@ void SilabsLCD::SetScreen(Screen_e screen)
 
 void SilabsLCD::CycleScreens(void)
 {
+#if SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
+    sl_memlcd_post_wakeup_init();
+#endif // SIWX_917 && SL_ICD_ENABLED && DISPLAY_ENABLED
 #ifdef QR_CODE_ENABLED
     if (mCurrentScreen < QRCodeScreen)
 #else

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -114,9 +114,9 @@ if [ "$#" == "0" ]; then
         siwx917_commissionable_data
             Build with the commissionable data given in DeviceConfig.h (only for SiWx917)
         alarm_based_wakeup
-            Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled (default false)
+            Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled (Default false)
         alarm_periodic_time
-            Periodic time at which the DUT should wakeup (Default: 30sec) 
+            Periodic time at which the 917 SoC should wakeup (Default: 30sec) 
         Presets
         --icd
             enable ICD features, set thread mtd

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -113,6 +113,10 @@ if [ "$#" == "0" ]; then
             Use provided hardware version at build time
         siwx917_commissionable_data
             Build with the commissionable data given in DeviceConfig.h (only for SiWx917)
+        alarm_based_wakeup
+            Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled (default false)
+        alarm_periodic_time
+            Periodic time at which the DUT should wakeup (Default: 30sec) 
         Presets
         --icd
             enable ICD features, set thread mtd

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -113,9 +113,9 @@ if [ "$#" == "0" ]; then
             Use provided hardware version at build time
         siwx917_commissionable_data
             Build with the commissionable data given in DeviceConfig.h (only for SiWx917)
-        alarm_based_wakeup
+        si91x_alarm_based_wakeup
             Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled (Default false)
-        alarm_periodic_time
+        si91x_alarm_periodic_time
             Periodic time at which the 917 SoC should wakeup (Default: 30sec)
         Presets
         --icd

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -116,7 +116,7 @@ if [ "$#" == "0" ]; then
         alarm_based_wakeup
             Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled (Default false)
         alarm_periodic_time
-            Periodic time at which the 917 SoC should wakeup (Default: 30sec) 
+            Periodic time at which the 917 SoC should wakeup (Default: 30sec)
         Presets
         --icd
             enable ICD features, set thread mtd

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -164,9 +164,15 @@ void KeyValueStoreManagerImpl::ScheduleKeyMapSave(void)
         During commissioning, the key map will be modified multiples times subsequently.
         Commit the key map in nvm once it as stabilized.
     */
+#if SIWX_917 && CHIP_CONFIG_ENABLE_ICD_SERVER
+    // TODO: Remove this when RTC timer is added MATTER-2705
+    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap, reinterpret_cast<const uint8_t *>(mKvsKeyMap),
+                                      sizeof(mKvsKeyMap));
+#else
     SystemLayer().StartTimer(
         std::chrono::duration_cast<System::Clock::Timeout>(System::Clock::Seconds32(SILABS_KVS_SAVE_DELAY_SECONDS)),
         KeyValueStoreManagerImpl::OnScheduledKeyMapSave, NULL);
+#endif // defined(SIWX_917) && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -162,6 +162,12 @@ void sl_ble_event_handling_task(void)
         default:
             break;
         }
+
+        if (chip::DeviceLayer::ConnectivityMgr().IsWiFiStationConnected()) {
+            // Once DUT is connected adding a 500ms delay
+            // TODO: Fix this with a better event handling
+            vTaskDelay(pdMS_TO_TICKS(500));
+        }
     }
 }
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -163,7 +163,8 @@ void sl_ble_event_handling_task(void)
             break;
         }
 
-        if (chip::DeviceLayer::ConnectivityMgr().IsWiFiStationConnected()) {
+        if (chip::DeviceLayer::ConnectivityMgr().IsWiFiStationConnected())
+        {
             // Once DUT is connected adding a 500ms delay
             // TODO: Fix this with a better event handling
             vTaskDelay(pdMS_TO_TICKS(500));

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -24,6 +24,13 @@ import("silabs_board.gni")
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/SiWx917"
 
+declare_args() {
+  # Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled
+  alarm_based_wakeup = false
+
+  # Periodic time at which the DUT should wakeup
+  alarm_periodic_time = 30
+}
 # Defines an siwx917 SDK build target.
 #
 # Parameters:
@@ -260,11 +267,14 @@ template("siwx917_sdk") {
         "SL_ICD_SUPPORTED_CLIENTS_PER_FABRIC=${sl_icd_supported_clients_per_fabric}",
         "SL_SI91X_MCU_WIRELESS_BASED_WAKEUP=1",
         "SL_SI91X_MCU_BUTTON_BASED_WAKEUP=1",
-        "SL_SI91X_MCU_ALARM_BASED_WAKEUP=1",
-        "ALARM_PERIODIC_TIME=5",
       ]
 
-
+      if (alarm_based_wakeup) {
+        defines += [
+          "SL_SI91X_MCU_ALARM_BASED_WAKEUP=1",
+          "ALARM_PERIODIC_TIME=${alarm_periodic_time}",
+        ]
+      }
     }
 
     if (chip_build_libshell) {  # matter shell

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -247,7 +247,6 @@ template("siwx917_sdk") {
     }
     if (!disable_lcd) {
       defines += [
-        "DISPLAY_ENABLED",
         "CONFIG_ENABLE_UART",
         "SI91X_SYSRTC_COUNT=1",
         "SYSCALLS_WRITE",
@@ -528,6 +527,7 @@ template("siwx917_sdk") {
       ]
     }
 
-    public_configs = [ ":${sdk_target_name}_config" ]
+    public_configs = [ ":${sdk_target_name}_config",
+          "${examples_plat_dir}:siwx917-common-config", ]
   }
 }

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -247,6 +247,7 @@ template("siwx917_sdk") {
     }
     if (!disable_lcd) {
       defines += [
+        "DISPLAY_ENABLED",
         "CONFIG_ENABLE_UART",
         "SI91X_SYSRTC_COUNT=1",
         "SYSCALLS_WRITE",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -182,7 +182,6 @@ template("siwx917_sdk") {
       "SL_BOARD_REV=\"A00\"",
       "SPI_MULTI_SLAVE=1",
       "SYSCALLS_WRITE=1",
-      "SSI_ULP_MASTER=1",
       "__STATIC_INLINE=static inline",
       "SL_SI91X_SI917_RAM_MEM_CONFIG=2",
       "SL_SI91x_DUAL_INTERRUPTS_ERRATA=1",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -31,6 +31,7 @@ declare_args() {
   # Periodic time at which the DUT should wakeup
   alarm_periodic_time = 30
 }
+
 # Defines an siwx917 SDK build target.
 #
 # Parameters:
@@ -255,7 +256,7 @@ template("siwx917_sdk") {
 
     # Enabling led interface
     if (use_wstk_leds) {
-    defines += [ "ENABLE_WSTK_LEDS" ]
+      defines += [ "ENABLE_WSTK_LEDS" ]
     }
 
     if (chip_enable_icd_server) {
@@ -490,7 +491,7 @@ template("siwx917_sdk") {
       ]
     }
 
-    if(chip_enable_icd_server) {
+    if (chip_enable_icd_server) {
       sources += [
         "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_rtc.c",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -26,10 +26,10 @@ examples_plat_dir = "${chip_root}/examples/platform/silabs/SiWx917"
 
 declare_args() {
   # Enable the Alarm Based Wakeup for 917 SoC when sleep is enabled
-  alarm_based_wakeup = false
+  si91x_alarm_based_wakeup = false
 
-  # Periodic time at which the DUT should wakeup
-  alarm_periodic_time = 30
+  # Periodic time at which the 917 SoC should wakeup
+  si91x_alarm_periodic_time = 30
 }
 
 # Defines an siwx917 SDK build target.
@@ -270,10 +270,10 @@ template("siwx917_sdk") {
         "SL_SI91X_MCU_BUTTON_BASED_WAKEUP=1",
       ]
 
-      if (alarm_based_wakeup) {
+      if (si91x_alarm_based_wakeup) {
         defines += [
           "SL_SI91X_MCU_ALARM_BASED_WAKEUP=1",
-          "ALARM_PERIODIC_TIME=${alarm_periodic_time}",
+          "ALARM_PERIODIC_TIME=${si91x_alarm_periodic_time}",
         ]
       }
     }

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -143,12 +143,12 @@ template("siwx917_sdk") {
       "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "SL_HEAP_SIZE=32768",
       "SL_WIFI=1",
-      "CCP_SI917_BRINGUP",
+      "CCP_SI917_BRINGUP=1",
       "SL_COMPONENT_CATALOG_PRESENT",
-      "RS911X_WIFI",
+      "RS911X_WIFI=1",
       "RSI_WLAN_ENABLE",
-      "SLI_SI91X_ENABLE_OS",
-      "SLI_SI91X_MCU_INTERFACE",  #Enable CCP bus Interface
+      "SLI_SI91X_ENABLE_OS=1",
+      "SLI_SI91X_MCU_INTERFACE=1",  #Enable CCP bus Interface
       "RSI_WLAN_API_ENABLE",
       "NVM3_DEFAULT_NVM_SIZE=40960",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=4092",
@@ -159,43 +159,47 @@ template("siwx917_sdk") {
       "__HEAP_SIZE=0",
       "PLATFORM_HEADER=\"platform-header.h\"",
       "USE_NVM3=1",
-      "RSI_ARM_CM4F",
-      "SIWX_917",
-      "CHIP_9117",
+      "SIWX_917=1",
+      "CHIP_9117=1",
       "SLI_SI91X_ENABLE_BLE=1",
       "SL_SI91X_ENABLE_LITTLE_ENDIAN=1",
       "TINYCRYPT_PRIMITIVES",
       "OPTIMIZE_TINYCRYPT_ASM",
       "__error_t_defined",
       "RSI_SAMPLE_HAL",
-      "ENABLE_IPMU_APIS",
-      "SLI_SI91X_MCU_MOV_ROM_API_TO_FLASH",
-      "DEBUG_UART",
-      "SLI_SI91X_MCU_ENABLE_FLASH_BASED_EXECUTION",
-      "SL_WIFI_COMPONENT_INCLUDED",
+      "DEBUG_UART=1",
+      "SLI_SI91X_MCU_ENABLE_FLASH_BASED_EXECUTION=1",
+      "SL_WIFI_COMPONENT_INCLUDED=1",
       "SLI_SI917=1",
+      "SI917=1",
       "ROMDRIVER_PRESENT=1",
       "SL_CATALOG_FREERTOS_KERNEL_PRESENT=1",
-      "SL_PLATFORM_EXAMPLES_ENABLE",
       "SLI_SI91X_MCU_CONFIG_RADIO_BOARD_BASE_VER=1",
-      "FLASH_PAGE_SIZE",
-      "SL_NVM3_PRESENT",
-      "ROM_WIRELESS",
       "BRD4325A",  #TODO: should be removed after SoC macro clean-up
-      "CONNECTIVITY_PLATFORM",
-      "SLI_SI917B0 = 1",
+      "SLI_SI917B0=1",
       "SLI_SI91X_MCU_COMMON_FLASH_MODE=1",
-      "EXECUTION_FROM_RAM",
       "SLI_SI91X_MCU_CONFIG_RADIO_BOARD_VER2=1",
       "SL_BOARD_REV=\"A00\"",
       "SPI_MULTI_SLAVE=1",
       "SYSCALLS_WRITE=1",
-      "SI91X_SYSRTC_COUNT=1",
       "SSI_ULP_MASTER=1",
-      "SL_MEMLCD_EXTCOMIN_PORT=0",
       "__STATIC_INLINE=static inline",
-      "SL_SI91X_SI917_RAM_MEM_CONFIG=3",
+      "SL_SI91X_SI917_RAM_MEM_CONFIG=2",
       "SL_SI91x_DUAL_INTERRUPTS_ERRATA=1",
+      "EXT_IRQ_COUNT=75",
+      "FLASH_PAGE_SIZE=1",
+      "DEBUG_ENABLE=1",
+      "ENABLE_DEBUG_MODULE=1",
+      "SI91X_SYSRTC_PRESENT=1",
+      "TA_DEEP_SLEEP_COMMON_FLASH=1",
+      "SI917_SOC=1",
+      "SI91X_PLATFORM=1",
+      "SL_NET_COMPONENT_INCLUDED=1",
+      "SRAM_BASE=0x0cUL",
+      "SRAM_SIZE=0x4fc00UL",
+      "SLI_SI91X_MCU_ENABLE_IPMU_APIS=1",
+      "RADIO_CONFIG_DMP_SUPPORT=1",
+      "configUSE_POSIX_ERRNO=1",
     ]
 
     if (chip_build_libshell) {
@@ -245,18 +249,23 @@ template("siwx917_sdk") {
 
     # Enabling led interface
     if (use_wstk_leds) {
-      defines += [ "ENABLE_WSTK_LEDS" ]
+    defines += [ "ENABLE_WSTK_LEDS" ]
     }
 
     if (chip_enable_icd_server) {
       defines += [
-        "WIFI_DEBUG_ENABLED=1",
         "SL_ICD_ENABLED=1",
         "SL_ACTIVE_MODE_THRESHOLD=${sl_active_mode_threshold_ms}",
         "SL_ACTIVE_MODE_INTERVAL=${sl_active_mode_interval_ms}",
         "SL_IDLE_MODE_INTERVAL=${sl_idle_mode_interval_s}",
         "SL_ICD_SUPPORTED_CLIENTS_PER_FABRIC=${sl_icd_supported_clients_per_fabric}",
+        "SL_SI91X_MCU_WIRELESS_BASED_WAKEUP=1",
+        "SL_SI91X_MCU_BUTTON_BASED_WAKEUP=1",
+        "SL_SI91X_MCU_ALARM_BASED_WAKEUP=1",
+        "ALARM_PERIODIC_TIME=5",
       ]
+
+
     }
 
     if (chip_build_libshell) {  # matter shell
@@ -472,6 +481,13 @@ template("siwx917_sdk") {
       ]
     }
 
+    if(chip_enable_icd_server) {
+      sources += [
+        "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/support/src/sl_si91x_m4_ps.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_rtc.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_time_period.c",
+      ]
+    }
     public_deps = [
       ":siwx917_mbedtls_config",
       "${segger_rtt_root}:segger_rtt",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -527,7 +527,9 @@ template("siwx917_sdk") {
       ]
     }
 
-    public_configs = [ ":${sdk_target_name}_config",
-          "${examples_plat_dir}:siwx917-common-config", ]
+    public_configs = [
+      ":${sdk_target_name}_config",
+      "${examples_plat_dir}:siwx917-common-config",
+    ]
   }
 }

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -108,8 +108,8 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
-  disable_lcd = false
-  show_qr_code = true
+  disable_lcd = true
+  show_qr_code = false
   wifi_soc = true
 } else if (silabs_board == "BRD4180A") {
   assert(

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -108,8 +108,6 @@ if (silabs_board == "BRD4304A") {
 } else if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
-  disable_lcd = true
-  show_qr_code = false
   wifi_soc = true
 } else if (silabs_board == "BRD4180A") {
   assert(


### PR DESCRIPTION
M4 sleep was not enabled on the 917 SoC

1. Enabling the 917 SoC sleep whenever the device go to the idle task.
2. Reinit silabs logs and lcd after every wakeup on the MCU
3. Adding Alarm based periodic wakeup as an extra argument which can be enabled/disabled from the user.
4. Update matter_support