### PR TITLE
Fix JNI Typo for UnpairDeviceCallback.OnError

### DIFF
--- a/src/controller/java/AndroidCurrentFabricRemover.cpp
+++ b/src/controller/java/AndroidCurrentFabricRemover.cpp
@@ -38,7 +38,7 @@ AndroidCurrentFabricRemover::AndroidCurrentFabricRemover(DeviceController * cont
         env->ExceptionClear();
     }
 
-    mOnErrorMethod = env->GetMethodID(callbackClass, "onError", "(JI)V");
+    mOnErrorMethod = env->GetMethodID(callbackClass, "onError", "(IJ)V");
     if (mOnErrorMethod == nullptr)
     {
         ChipLogError(Controller, "Failed to access callback 'onError' method");


### PR DESCRIPTION
Fix JNI Typo for UnpairDeviceCallback.OnError with env->GetMethodID(callbackClass, "onError", "(IJ)V");
https://github.com/project-chip/connectedhomeip/issues/31273

