### PR TITLE
Allow reserving space for MoreChunkedMessages in InvokeResponseMessage

### DIFF
--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -111,9 +111,9 @@ public:
     InvokeResponseMessage::Builder & MoreChunkedMessages(const bool aMoreChunkedMessages);
 
     /**
-     *  @brief Set True if the set of InvokeResponseIB have to be sent across multiple packets in a single transaction
-     *  @param [in] aMoreChunkedMessages  true if more chunked messages are needed
-     *  @return A reference to *this
+     *  @brief Reserved space in TLVWriter for MoreChunkedMessages
+     *  @return CHIP_NO_ERROR upon successfully reserving space for MoreChunkedMessages
+     *  @return other CHIP error see TLVWriter::ReserveBuffer for more details.
      */
     CHIP_ERROR ReserveSpaceForMoreChunkedMessages();
 

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -140,7 +140,7 @@ public:
 
 private:
     InvokeResponseIBs::Builder mInvokeResponses;
-    bool mIsEndBufferReserved = false;
+    bool mIsEndBufferReserved              = false;
     bool mIsMoreChunkMessageBufferReserved = false;
 };
 } // namespace InvokeResponseMessage

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -111,11 +111,25 @@ public:
     InvokeResponseMessage::Builder & MoreChunkedMessages(const bool aMoreChunkedMessages);
 
     /**
+     *  @brief Set True if the set of InvokeResponseIB have to be sent across multiple packets in a single transaction
+     *  @param [in] aMoreChunkedMessages  true if more chunked messages are needed
+     *  @return A reference to *this
+     */
+    CHIP_ERROR ReserveSpaceForMoreChunkedMessages();
+
+    /**
      *  @brief Mark the end of this InvokeResponseMessage
      *
      *  @return The builder's final status.
      */
     CHIP_ERROR EndOfInvokeResponseMessage();
+
+    /**
+     *  @brief Get number of bytes required in the buffer by MoreChunkedMessages
+     *
+     *  @return Expected number of bytes required in the buffer by MoreChunkedMessages()
+     */
+    uint32_t GetSizeForMoreChunkResponses();
 
     /**
      *  @brief Get number of bytes required in the buffer by EndOfInvokeResponseMessage()
@@ -127,6 +141,7 @@ public:
 private:
     InvokeResponseIBs::Builder mInvokeResponses;
     bool mIsEndBufferReserved = false;
+    bool mIsMoreChunkMessageBufferReserved = false;
 };
 } // namespace InvokeResponseMessage
 } // namespace app

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -2136,6 +2136,29 @@ void InvokeResponseMessageEndOfMessageReservationTest(nlTestSuite * apSuite, voi
     NL_TEST_ASSERT(apSuite, remainingLengthAfterInitWithReservation == remainingLengthAfterEndingInvokeResponseMessage);
 }
 
+void InvokeResponseMessageReservationForEndandMoreChunkTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    InvokeResponseMessage::Builder invokeResponseMessageBuilder;
+    const uint32_t kSmallBufferSize = 100;
+    writer.Init(chip::System::PacketBufferHandle::New(kSmallBufferSize, /* aReservedSize = */ 0), /* useChainedBuffers = */ false);
+    err = invokeResponseMessageBuilder.InitWithEndBufferReserved(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeResponseMessageBuilder.ReserveSpaceForMoreChunkedMessages();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remainingLengthAllReservations = writer.GetRemainingFreeLength();
+
+    invokeResponseMessageBuilder.MoreChunkedMessages(/* aMoreChunkedMessages = */ true);
+    NL_TEST_ASSERT(apSuite, invokeResponseMessageBuilder.GetError() == CHIP_NO_ERROR);
+    err = invokeResponseMessageBuilder.EndOfInvokeResponseMessage();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    uint32_t remainingLengthAfterEndingInvokeResponseMessage = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(apSuite, remainingLengthAllReservations == remainingLengthAfterEndingInvokeResponseMessage);
+}
+
 void InvokeResponsesEndOfResponseReservationTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2373,6 +2396,7 @@ const nlTest sTests[] =
                 NL_TEST_DEF("InvokeRequestsEndOfRequestReservationTest", InvokeRequestsEndOfRequestReservationTest),
                 NL_TEST_DEF("InvokeInvokeResponseMessageTest", InvokeInvokeResponseMessageTest),
                 NL_TEST_DEF("InvokeResponseMessageEndOfMessageReservationTest", InvokeResponseMessageEndOfMessageReservationTest),
+                NL_TEST_DEF("InvokeResponseMessageReservationForEndandMoreChunkTest", InvokeResponseMessageReservationForEndandMoreChunkTest),
                 NL_TEST_DEF("InvokeResponsesEndOfResponseReservationTest", InvokeResponsesEndOfResponseReservationTest),
                 NL_TEST_DEF("ReportDataMessageTest", ReportDataMessageTest),
                 NL_TEST_DEF("ReadRequestMessageTest", ReadRequestMessageTest),


### PR DESCRIPTION
This will make sure we have enough space at the end of a message to put `MoreChunkedMessages`. This will be used by `CommandHandler` when we know we have outstanding commands that are being processed.