### PR TITLE
Follow-up Persistent Subscription tests

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -357,6 +357,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_linux_lock_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
 
+    # Build the Linux LIT ICD example.
+    enable_linux_lit_icd_app_build =
+        enable_default_builds && (host_os == "linux" || host_os == "mac")
+
     # Build the cc13x2x7_26x2x7 lock app example.
     enable_cc13x2x7_26x2x7_lock_app_build = enable_ti_simplelink_builds
 
@@ -608,6 +612,16 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
 
     extra_build_deps += [ ":linux_lock_app" ]
+  }
+
+  if (enable_linux_lit_icd_app_build) {
+    group("linux_lit_icd_app") {
+      deps = [
+        "${chip_root}/examples/lit-icd-app/linux(${standalone_toolchain})",
+      ]
+    }
+
+    extra_build_deps += [ ":linux_lit_icd_app" ]
   }
 
   if (enable_efr32_lock_app_build) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -616,9 +616,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   if (enable_linux_lit_icd_app_build) {
     group("linux_lit_icd_app") {
-      deps = [
-        "${chip_root}/examples/lit-icd-app/linux(${standalone_toolchain})",
-      ]
+      deps =
+          [ "${chip_root}/examples/lit-icd-app/linux(${standalone_toolchain})" ]
     }
 
     extra_build_deps += [ ":linux_lit_icd_app" ]

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
@@ -1670,6 +1670,7 @@ endpoint 0 {
     ram      attribute clusterRevision default = 1;
 
     handle command OpenCommissioningWindow;
+    handle command OpenBasicCommissioningWindow;
     handle command RevokeCommissioning;
   }
 

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
@@ -2550,6 +2550,14 @@
               "isEnabled": 1
             },
             {
+              "name": "OpenBasicCommissioningWindow",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
               "name": "RevokeCommissioning",
               "code": 2,
               "mfgCode": null,

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -568,6 +568,12 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);
 
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    // Set ReadHandler Capacity for Subscriptions
+    chip::app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(LinuxDeviceOptions::GetInstance().subscriptionCapacity);
+    chip::app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
+#endif
+
     // Now that the server has started and we are done with our startup logging,
     // log our discovery/onboarding information again so it's not lost in the
     // noise.

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -570,7 +570,8 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     // Set ReadHandler Capacity for Subscriptions
-    chip::app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(LinuxDeviceOptions::GetInstance().subscriptionCapacity);
+    chip::app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(
+        LinuxDeviceOptions::GetInstance().subscriptionCapacity);
     chip::app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
 #endif
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -534,7 +534,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 #endif
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     case kDeviceOption_SubscriptionCapacity:
-        LinuxDeviceOptions::GetInstance().subscriptionCapacity = static_cast<size_t>(atoi(aValue));
+        LinuxDeviceOptions::GetInstance().subscriptionCapacity = static_cast<int32_t>(atoi(aValue));
         break;
 #endif
     default:

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -272,7 +272,7 @@ const char * sDeviceOptionHelp =
 #endif
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     "  --subscription-capacity\n"
-    "       Max subscriptions number for the device to manage\n"
+    "       Max number of subscriptions the device will allow\n"
 #endif
     "\n";
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -148,7 +148,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "rpc-server-port", kArgumentRequired, kOptionRpcServerPort },
 #endif
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    { "subscription-capacity", kArgumentRequired, kDeviceOption_SubscriptionCapacity},
+    { "subscription-capacity", kArgumentRequired, kDeviceOption_SubscriptionCapacity },
 #endif
     {}
 };

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -87,6 +87,9 @@ enum
 #if defined(PW_RPC_ENABLED)
     kOptionRpcServerPort = 0x1023,
 #endif
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    kDeviceOption_SubscriptionCapacity = 0x1024,
+#endif
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -143,6 +146,9 @@ OptionDef sDeviceOptionDefs[] = {
     { "simulate-no-internal-time", kNoArgument, kOptionSimulateNoInternalTime },
 #if defined(PW_RPC_ENABLED)
     { "rpc-server-port", kArgumentRequired, kOptionRpcServerPort },
+#endif
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    { "subscription-capacity", kArgumentRequired, kDeviceOption_SubscriptionCapacity},
 #endif
     {}
 };
@@ -263,6 +269,10 @@ const char * sDeviceOptionHelp =
 #if defined(PW_RPC_ENABLED)
     "  --rpc-server-port\n"
     "       Start RPC server on specified port\n"
+#endif
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    "  --subscription-capacity\n"
+    "       Max subscriptions number for the device to manage\n"
 #endif
     "\n";
 
@@ -520,6 +530,11 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 #if defined(PW_RPC_ENABLED)
     case kOptionRpcServerPort:
         LinuxDeviceOptions::GetInstance().rpcServerPort = static_cast<uint16_t>(atoi(aValue));
+        break;
+#endif
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    case kDeviceOption_SubscriptionCapacity:
+        LinuxDeviceOptions::GetInstance().subscriptionCapacity = static_cast<size_t>(atoi(aValue));
         break;
 #endif
     default:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -72,7 +72,7 @@ struct LinuxDeviceOptions
     uint16_t rpcServerPort = 33000;
 #endif
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    size_t subscriptionCapacity = CHIP_IM_MAX_NUM_SUBSCRIPTIONS;
+    int32_t subscriptionCapacity = CHIP_IM_MAX_NUM_SUBSCRIPTIONS;
 #endif
     static LinuxDeviceOptions & GetInstance();
 };

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -71,6 +71,9 @@ struct LinuxDeviceOptions
 #if defined(PW_RPC_ENABLED)
     uint16_t rpcServerPort = 33000;
 #endif
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    size_t subscriptionCapacity = CHIP_IM_MAX_NUM_SUBSCRIPTIONS;
+#endif
     static LinuxDeviceOptions & GetInstance();
 };
 

--- a/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
   libgirepository1.0-dev \
   libglib2.0-dev \
   libjpeg-dev \
+  openssh-server \
   psmisc \
   python3-dev \
   python3-pip \
@@ -55,7 +56,12 @@ RUN apt-get update \
   && echo "ctrl_interface=/run/wpa_supplicant" >> /etc/wpa_supplicant/wpa_supplicant.conf \
   && echo "update_config=1" >> /etc/wpa_supplicant/wpa_supplicant.conf \
   && rm -rf /var/lib/apt/lists/* \
-  && pip3 install --no-cache-dir click==8.0.3
+  && pip3 install --no-cache-dir click==8.0.3 paramiko \
+  && mkdir /var/run/sshd \
+  && echo 'root:admin' | chpasswd \
+  && sed -i 's/#Port 22/Port 2222/' /etc/ssh/sshd_config \
+  && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+  && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 COPY CHIPCirqueDaemon.py /bin/CHIPCirqueDaemon.py
 COPY entrypoint.sh /opt/entrypoint.sh
@@ -65,3 +71,4 @@ WORKDIR /
 ENTRYPOINT ["/opt/entrypoint.sh"]
 
 EXPOSE 80
+EXPOSE 2222

--- a/scripts/build/gn_gen_cirque.sh
+++ b/scripts/build/gn_gen_cirque.sh
@@ -36,7 +36,7 @@ echo "Setup build environment"
 source "./scripts/activate.sh"
 
 echo "Build: GN configure"
-gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args out/debug --args='target_os="all"'"chip_build_tests=false chip_enable_wifi=false chip_im_force_fabric_quota_check=true enable_default_builds=false enable_host_gcc_build=true enable_standalone_chip_tool_build=true enable_linux_all_clusters_app_build=true enable_linux_lighting_app_build=true"
+gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args out/debug --args='target_os="all"'"chip_build_tests=false chip_enable_wifi=false chip_im_force_fabric_quota_check=true enable_default_builds=false enable_host_gcc_build=true enable_standalone_chip_tool_build=true enable_linux_all_clusters_app_build=true enable_linux_lighting_app_build=true enable_linux_lit_icd_app_build=true"
 
 echo "Build: Ninja build"
 time ninja -C out/debug all check

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -49,6 +49,8 @@ CIRQUE_TESTS=(
     "CommissioningFailureOnReportTest"
     "PythonCommissioningTest"
     "CommissioningWindowTest"
+    "SubscriptionResumptionTest"
+    "SubscriptionResumptionCapacityTest"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1417,7 +1417,8 @@ class ChipDeviceControllerBase():
 
         return asyncio.run(self.WriteAttribute(nodeid, [(endpoint, req, dataVersion)]))
 
-    def ZCLSubscribeAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, blocking=True):
+    def ZCLSubscribeAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, blocking=True,
+            keepSubscriptions=False, autoResubscribe=True):
         ''' Wrapper over ReadAttribute for a single attribute
             Returns a SubscriptionTransaction. See ReadAttribute for more information.
         '''
@@ -1428,7 +1429,8 @@ class ChipDeviceControllerBase():
             req = eval(f"GeneratedObjects.{cluster}.Attributes.{attribute}")
         except BaseException:
             raise UnknownAttribute(cluster, attribute)
-        return asyncio.run(self.ReadAttribute(nodeid, [(endpoint, req)], None, False, reportInterval=(minInterval, maxInterval)))
+        return asyncio.run(self.ReadAttribute(nodeid, [(endpoint, req)], None, False, reportInterval=(minInterval, maxInterval),
+            keepSubscriptions=keepSubscriptions, autoResubscribe=autoResubscribe))
 
     def ZCLCommandList(self):
         self.CheckIsActive()

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1418,7 +1418,7 @@ class ChipDeviceControllerBase():
         return asyncio.run(self.WriteAttribute(nodeid, [(endpoint, req, dataVersion)]))
 
     def ZCLSubscribeAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, blocking=True,
-            keepSubscriptions=False, autoResubscribe=True):
+                              keepSubscriptions=False, autoResubscribe=True):
         ''' Wrapper over ReadAttribute for a single attribute
             Returns a SubscriptionTransaction. See ReadAttribute for more information.
         '''
@@ -1430,7 +1430,7 @@ class ChipDeviceControllerBase():
         except BaseException:
             raise UnknownAttribute(cluster, attribute)
         return asyncio.run(self.ReadAttribute(nodeid, [(endpoint, req)], None, False, reportInterval=(minInterval, maxInterval),
-            keepSubscriptions=keepSubscriptions, autoResubscribe=autoResubscribe))
+                                              keepSubscriptions=keepSubscriptions, autoResubscribe=autoResubscribe))
 
     def ZCLCommandList(self):
         self.CheckIsActive()

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -22,6 +22,7 @@ import faulthandler
 import inspect
 import logging
 import os
+import paramiko
 import secrets
 import sys
 import threading
@@ -40,6 +41,9 @@ from chip import ChipDeviceCtrl
 from chip.ChipStack import ChipStack
 from chip.crypto import p256keypair
 from chip.utils import CommissioningBuildingBlocks
+
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..", "..", "..")
 
 logger = logging.getLogger('PythonMatterControllerTEST')
 logger.setLevel(logging.INFO)
@@ -1316,3 +1320,271 @@ class BaseTestHelper:
             status = ex.status
 
         return status == IM.Status.UnsupportedAccess
+
+    def TestSubscriptionResumption(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int, remote_server_app: str):
+        desiredPath = None
+        receivedUpdate = False
+        updateLock = threading.Lock()
+        updateCv = threading.Condition(updateLock)
+
+        def OnValueReport(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
+            nonlocal desiredPath, updateCv, updateLock, receivedUpdate
+            if path.Path != desiredPath:
+                return
+
+            data = transaction.GetAttribute(path)
+            logger.info(
+                f"Received report from server: path: {path.Path}, value: {data}")
+            with updateLock:
+                receivedUpdate = True
+                updateCv.notify_all()
+
+        class _restartRemoteDevice(threading.Thread):
+            def __init__(self, remote_ip: str, ssh_port: int, remote_server_app: str):
+                super(_restartRemoteDevice, self).__init__()
+                self.remote_ip = remote_ip
+                self.ssh_port = ssh_port
+                self.remote_server_app = remote_server_app
+
+            def run(self):
+                client = paramiko.SSHClient()
+                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                try:
+                    client.connect(self.remote_ip, self.ssh_port, "root", "admin")
+                    client.exec_command(
+                        ("kill \"$(ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                         "awk \'{{print $2}}\')\"").format(self.remote_server_app))
+                    time.sleep(1)
+                    stdin, stdout, stderr = client.exec_command(
+                            ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                             "awk \'{{print $2}}\'").format(self.remote_server_app))
+                    if not stdout.read().decode().strip():
+                        logger.info(f"Succeed to kill remote process {self.remote_server_app}")
+                    else:
+                        logger.error(f"Failed to kill remote process {self.remote_server_app}")
+
+                    client.exec_command(
+                        ("CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+                         "-ex run -ex \"thread apply all bt\" --args {} --thread --discriminator 3840").format(
+                             os.path.join(CHIP_REPO, "out/debug/standalone", self.remote_server_app)))
+
+                finally:
+                    client.close()
+
+        try:
+            desiredPath = Clusters.Attribute.AttributePath(
+                EndpointId=1, ClusterId=6, AttributeId=0)
+            # OnOff Cluster, OnOff Attribute
+            subscription = self.devCtrl.ZCLSubscribeAttribute(
+                "OnOff", "OnOff", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+            subscription.SetAttributeUpdateCallback(OnValueReport)
+
+            self.logger.info("Restart remote deivce")
+            restartRemoteThread = _restartRemoteDevice(remote_ip, ssh_port, remote_server_app)
+            restartRemoteThread.start()
+            # After device restarts, the attribute will be set dirty so the subscription can receive
+            # the update
+            with updateCv:
+                while receivedUpdate is False:
+                    if not updateCv.wait(30.0):
+                        self.logger.error(
+                            "Failed to receive subscription resumption report")
+                        break
+
+            restartRemoteThread.join(30.0)
+
+            #
+            # Clean-up by shutting down the sub. Otherwise, we're going to get callbacks through
+            # OnValueChange on what will soon become an invalid execution context above.
+            #
+            subscription.Shutdown()
+
+            if restartRemoteThread.is_alive():
+                # Thread join timed out
+                self.logger.error("Failed to join change thread")
+                return False
+
+            return receivedUpdate
+
+        except Exception as ex:
+            self.logger.exception(f"Failed to finish API test: {ex}")
+            return False
+
+        return True
+
+    def TestSubscriptionResumptionCapacity(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
+            remote_server_app: str, subscription_capacity: int):
+
+        class _restartRemoteDevice(threading.Thread):
+            def __init__(self, remote_ip: str, ssh_port: int, remote_server_app: str, subscription_capacity: int):
+                super(_restartRemoteDevice, self).__init__()
+                self.remote_ip = remote_ip
+                self.ssh_port = ssh_port
+                self.remote_server_app = remote_server_app
+                self.subscription_capacity = subscription_capacity
+
+            def run(self):
+                client = paramiko.SSHClient()
+                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                try:
+                    client.connect(self.remote_ip, self.ssh_port, "root", "admin")
+                    client.exec_command(
+                        ("kill \"$(ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                         "awk \'{{print $2}}\')\"").format(self.remote_server_app))
+                    time.sleep(1)
+                    stdin, stdout, stderr = client.exec_command(
+                            ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                             "awk \'{{print $2}}\'").format(self.remote_server_app))
+                    if not stdout.read().decode().strip():
+                        logger.info(f"Succeed to kill remote process {self.remote_server_app}")
+                    else:
+                        logger.error(f"Failed to kill remote process {self.remote_server_app}")
+
+                    client.exec_command("systemctl restart avahi-deamon.service")
+                    client.exec_command(
+                        ("CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+                         "-ex run -ex \"thread apply all bt\" --args {} --thread --discriminator 3840 "
+                         "--subscription-capacity {}").format(
+                             os.path.join(CHIP_REPO, "out/debug/standalone", self.remote_server_app),
+                             self.subscription_capacity))
+
+                finally:
+                    client.close()
+
+        try:
+            desiredPath = Clusters.Attribute.AttributePath(
+                EndpointId=1, ClusterId=6, AttributeId=0)
+            # OnOff Cluster, OnOff Attribute
+            for i in range(subscription_capacity):
+                self.devCtrl.ZCLSubscribeAttribute(
+                    "OnOff", "OnOff", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+
+            self.logger.info("Shutdown Controller 1")
+            self.devCtrl.Shutdown()
+
+            self.logger.info("Restart remote deivce")
+            restartRemoteThread = _restartRemoteDevice(remote_ip, ssh_port, remote_server_app, subscription_capacity)
+            restartRemoteThread.start()
+            time.sleep(6)
+
+            self.logger.info("Send a new subscription request from the second controller")
+            # Close previous session so that the controller 2 will res-establish the session to the remote device
+            self.devCtrl2.CloseSession(nodeid)
+            self.devCtrl2.ZCLSubscribeAttribute(
+                "OnOff", "OnOff", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+            restartRemoteThread.join(10.0)
+
+            if restartRemoteThread.is_alive():
+                # Thread join timed out
+                self.logger.error("Failed to join change thread")
+                return False
+
+            return True
+
+        except Exception as ex:
+            self.logger.exception(f"Failed to finish API test: {ex}")
+            return False
+
+        return True
+
+    def TestSubscriptionResumptionCapacityStep1(self, nodeid: int, endpoint: int, subscription_capacity: int):
+
+        try:
+            # OnOff Cluster, OnOff Attribute
+            for i in range(subscription_capacity):
+                self.devCtrl.ZCLSubscribeAttribute(
+                    "OnOff", "OnOff", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+
+            logger.info("Send OpenBasicCommissioningWindow command on fist controller")
+            asyncio.run(
+                self.devCtrl.SendCommand(
+                    nodeid,
+                    0,
+                    Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(180),
+                    timedRequestTimeoutMs=10000
+                ))
+            return True
+
+        except Exception as ex:
+            self.logger.exception(f"Failed to finish API test: {ex}")
+            return False
+
+        return True
+
+    def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
+            remote_server_app: str, subscription_capacity: int):
+        remoteDeviceRestarted = False
+        updateLock = threading.Lock()
+        updateCv = threading.Condition(updateLock)
+
+        class _restartRemoteDevice(threading.Thread):
+            def __init__(self, remote_ip: str, ssh_port: int, remote_server_app: str, subscription_capacity: int):
+                super(_restartRemoteDevice, self).__init__()
+                self.remote_ip = remote_ip
+                self.ssh_port = ssh_port
+                self.remote_server_app = remote_server_app
+                self.subscription_capacity = subscription_capacity
+
+            def run(self):
+                client = paramiko.SSHClient()
+                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                try:
+                    client.connect(self.remote_ip, self.ssh_port, "root", "admin")
+                    client.exec_command(
+                        ("kill \"$(ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                         "awk \'{{print $2}}\')\"").format(self.remote_server_app))
+                    time.sleep(1)
+                    stdin, stdout, stderr = client.exec_command(
+                            ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                             "awk \'{{print $2}}\'").format(self.remote_server_app))
+                    if not stdout.read().decode().strip():
+                        logger.info(f"Succeed to kill remote process {self.remote_server_app}")
+                    else:
+                        logger.error(f"Failed to kill remote process {self.remote_server_app}")
+
+                    client.exec_command("systemctl restart avahi-deamon.service")
+                    client.exec_command(
+                        ("CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+                         "-ex run -ex \"thread apply all bt\" --args {} --thread --discriminator 3840 "
+                         "--subscription-capacity {}").format(
+                             os.path.join(CHIP_REPO, "out/debug/standalone", self.remote_server_app),
+                             self.subscription_capacity))
+                    with updateLock:
+                        remoteDeviceRestarted = True
+                        updateCv.notifyAll()
+
+                finally:
+                    client.close()
+
+        try:
+            self.logger.info("Restart remote deivce")
+            restartRemoteThread = _restartRemoteDevice(remote_ip, ssh_port, remote_server_app, subscription_capacity)
+            restartRemoteThread.start()
+            with updateCv:
+                while remoteDeviceRestarted is False:
+                    if not updateCv.wait(8.0):
+                        self.logger.error(
+                            "Failed to restart the remote device")
+                        break
+            # Wait for some time so that the device will be resolving the address of the first controller
+            time.sleep(3)
+
+            self.logger.info("Send a new subscription request from the second controller")
+            # Close previous session so that the second controller will res-establish the session with the remote device
+            self.devCtrl.CloseSession(nodeid)
+            self.devCtrl.ZCLSubscribeAttribute(
+                "OnOff", "OnOff", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+            restartRemoteThread.join(10.0)
+
+            if restartRemoteThread.is_alive():
+                # Thread join timed out
+                self.logger.error("Failed to join change thread")
+                return False
+
+            return True
+
+        except Exception as ex:
+            self.logger.exception(f"Failed to finish API test: {ex}")
+            return False
+
+        return True

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1437,7 +1437,6 @@ class BaseTestHelper:
 
     def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
                                                 remote_server_app: str, subscription_capacity: int):
-        remoteDeviceRestarted = False
         updateLock = threading.Lock()
         updateCv = threading.Condition(updateLock)
 
@@ -1474,7 +1473,6 @@ class BaseTestHelper:
                              os.path.join(CHIP_REPO, "out/debug/standalone", self.remote_server_app),
                              self.subscription_capacity))
                     with updateLock:
-                        remoteDeviceRestarted = True
                         updateCv.notifyAll()
 
                 finally:
@@ -1485,11 +1483,10 @@ class BaseTestHelper:
             restartRemoteThread = _restartRemoteDevice(remote_ip, ssh_port, remote_server_app, subscription_capacity)
             restartRemoteThread.start()
             with updateCv:
-                while remoteDeviceRestarted is False:
-                    if not updateCv.wait(8.0):
-                        self.logger.error(
-                            "Failed to restart the remote device")
-                        break
+                if not updateCv.wait(8.0):
+                    self.logger.error(
+                        "Failed to restart the remote device")
+
             # Wait for some time so that the device will be resolving the address of the first controller
             time.sleep(3)
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1405,7 +1405,7 @@ class BaseTestHelper:
     requests when resuming the maximum subscriptions. The steps for this test are:
     1. Commission the server app to the first fabric and send maximum subscription requests from the controller in
     the first fabric to establish maximum subscriptions.
-    2. Open the commissioning window to make the server app can be commissioned to the second fabric
+    2. Open the commissioning window to make the server app can be commissioned to the second fabric.
     3. Shutdown the controller in the first fabric to extend the time of resuming subscriptions. The server app will
     keep resolving the address of the first controller for a while after rebooting.
     4. Commission the server app to the second fabric.
@@ -1417,7 +1417,7 @@ class BaseTestHelper:
 
     BaseTestHelper provides two controllers. However, if using the two controller (devCtrl and devCtrl2) in one
     MobileDevice to execute this Cirque test, the CHIPEndDevice can still resolve the address for first controller
-    even if the first controller is shutdown by 'self.devCtrl.Shutdown()'. And the server will fail to estalish the
+    even if the first controller is shutdown by 'self.devCtrl.Shutdown()'. And the server will fail to establish the
     subscriptions immediately, which makes it hard to send the new subscription request from the second controller
     at the time of server app resuming maximum subscriptions.
     So we will use two controller containers for this test and divide the test to two steps. The Step1 is executed in

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1368,7 +1368,7 @@ class BaseTestHelper:
 
             self.logger.info("Restart remote deivce")
             restartRemoteThread = restartRemoteDevice(
-                    remote_ip, ssh_port, "root", "admin", remote_server_app, "--thread --discriminator 3840")
+                remote_ip, ssh_port, "root", "admin", remote_server_app, "--thread --discriminator 3840")
             restartRemoteThread.start()
             # After device restarts, the attribute will be set dirty so the subscription can receive
             # the update
@@ -1423,6 +1423,7 @@ class BaseTestHelper:
     So we will use two controller containers for this test and divide the test to two steps. The Step1 is executed in
     controller 1 in container 1 while the Step2 is executed in controller 2 in container 2
     '''
+
     def TestSubscriptionResumptionCapacityStep1(self, nodeid: int, endpoint: int, subscription_capacity: int):
         try:
             # BasicInformation Cluster, NodeLabel Attribute
@@ -1447,7 +1448,7 @@ class BaseTestHelper:
         return True
 
     def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
-            remote_server_app: str, subscription_capacity: int):
+                                                remote_server_app: str, subscription_capacity: int):
         try:
             self.logger.info("Restart remote deivce")
             extra_agrs = f"--thread --discriminator 3840 --subscription-capacity {subscription_capacity}"

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -22,7 +22,6 @@ import faulthandler
 import inspect
 import logging
 import os
-import paramiko
 import secrets
 import sys
 import threading
@@ -37,6 +36,7 @@ import chip.discovery
 import chip.FabricAdmin
 import chip.interaction_model as IM
 import chip.native
+import paramiko
 from chip import ChipDeviceCtrl
 from chip.ChipStack import ChipStack
 from chip.crypto import p256keypair

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1356,8 +1356,8 @@ class BaseTestHelper:
                          "awk \'{{print $2}}\')\"").format(self.remote_server_app))
                     time.sleep(1)
                     stdin, stdout, stderr = client.exec_command(
-                            ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
-                             "awk \'{{print $2}}\'").format(self.remote_server_app))
+                        ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                         "awk \'{{print $2}}\'").format(self.remote_server_app))
                     if not stdout.read().decode().strip():
                         logger.info(f"Succeed to kill remote process {self.remote_server_app}")
                     else:
@@ -1436,7 +1436,7 @@ class BaseTestHelper:
         return True
 
     def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
-            remote_server_app: str, subscription_capacity: int):
+                                                remote_server_app: str, subscription_capacity: int):
         remoteDeviceRestarted = False
         updateLock = threading.Lock()
         updateCv = threading.Condition(updateLock)
@@ -1459,8 +1459,8 @@ class BaseTestHelper:
                          "awk \'{{print $2}}\')\"").format(self.remote_server_app))
                     time.sleep(1)
                     stdin, stdout, stderr = client.exec_command(
-                            ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
-                             "awk \'{{print $2}}\'").format(self.remote_server_app))
+                        ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                         "awk \'{{print $2}}\'").format(self.remote_server_app))
                     if not stdout.read().decode().strip():
                         logger.info(f"Succeed to kill remote process {self.remote_server_app}")
                     else:

--- a/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
@@ -42,7 +42,7 @@ logger.addHandler(sh)
 
 class restartRemoteDevice(threading.Thread):
     def __init__(self, remote_ip: str, ssh_port: int, user: str, password: str, remote_server_app: str,
-            extra_args: str):
+                 extra_args: str):
         super(restartRemoteDevice, self).__init__()
         self.remote_ip = remote_ip
         self.ssh_port = ssh_port

--- a/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This is used to restart the remote device in cirque test
+
+import logging
+import os
+import paramiko
+import sys
+import threading
+import time
+
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..", "..", "..")
+
+logger = logging.getLogger("CirqueRestartRemoteDevice")
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+sh.setStream(sys.stdout)
+logger.addHandler(sh)
+
+
+class restartRemoteDevice(threading.Thread):
+    def __init__(self, remote_ip: str, ssh_port: int, user: str, password: str, remote_server_app: str,
+            extra_args: str):
+        super(restartRemoteDevice, self).__init__()
+        self.remote_ip = remote_ip
+        self.ssh_port = ssh_port
+        self.user = user
+        self.password = password
+        self.remote_server_app = remote_server_app
+        self.extra_args = extra_args
+
+    def run(self):
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            client.connect(self.remote_ip, self.ssh_port, self.user, self.password)
+            client.exec_command(
+                ("kill \"$(ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                 "awk \'{{print $2}}\')\"").format(self.remote_server_app))
+            time.sleep(1)
+            stdin, stdout, stderr = client.exec_command(
+                ("ps aux | grep -E \'out/debug/standalone/{}\' | grep -v grep | grep -v gdb | "
+                 "awk \'{{print $2}}\'").format(self.remote_server_app))
+            if not stdout.read().decode().strip():
+                logger.info(f"Succeed to kill remote process {self.remote_server_app}")
+            else:
+                logger.error(f"Failed to kill remote process {self.remote_server_app}")
+
+            restart_remote_device_command = (
+                "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+                "-ex run -ex \"thread apply all bt\" --args {} {}").format(
+                    os.path.join(CHIP_REPO, "out/debug/standalone", self.remote_server_app), self.extra_args)
+            client.exec_command(restart_remote_device_command)
+
+        finally:
+            client.close()

--- a/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
@@ -25,7 +25,10 @@ import sys
 import threading
 import time
 
-import paramiko
+try:
+    import paramiko
+except ImportError:
+    pass
 
 CHIP_REPO = os.path.join(os.path.abspath(
     os.path.dirname(__file__)), "..", "..", "..", "..", "..")

--- a/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
+++ b/src/controller/python/test/test_scripts/cirque_restart_remote_device.py
@@ -21,10 +21,11 @@
 
 import logging
 import os
-import paramiko
 import sys
 import threading
 import time
+
+import paramiko
 
 CHIP_REPO = os.path.join(os.path.abspath(
     os.path.dirname(__file__)), "..", "..", "..", "..", "..")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -21,7 +21,6 @@
 
 import os
 import sys
-import time
 from optparse import OptionParser
 
 from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -31,6 +31,7 @@ TEST_SETUPPIN = 20202021
 
 TEST_ENDPOINT_ID = 0
 
+
 def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
     logger.info("Testing discovery")
     device = test.TestDiscovery(discriminator=discriminator)

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -29,7 +29,7 @@ from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
 TEST_DISCRIMINATOR = 3840
 TEST_SETUPPIN = 20202021
 
-TEST_ENDPOINT_ID = 1
+TEST_ENDPOINT_ID = 0
 
 def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
     logger.info("Testing discovery")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -31,23 +31,6 @@ TEST_SETUPPIN = 20202021
 TEST_ENDPOINT_ID = 0
 
 
-def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
-    logger.info("Testing discovery")
-    device = test.TestDiscovery(discriminator=discriminator)
-    FailIfNot(device, "Failed to discover any devices.")
-
-    address = device.addresses[0]
-
-    if address_override:
-        address = address_override
-
-    logger.info("Testing commissioning")
-    FailIfNot(test.TestCommissioning(ip=address,
-                                     setuppin=setup_pin,
-                                     nodeid=device_nodeid),
-              "Failed to finish key exchange")
-
-
 def main():
     optParser = OptionParser()
     optParser.add_option(
@@ -125,7 +108,9 @@ def main():
     test = BaseTestHelper(
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
-    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+    FailIfNot(
+        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioing")
 
     FailIfNot(
         test.TestSubscriptionResumptionCapacityStep1(options.nodeid, TEST_ENDPOINT_ID, options.subscriptionCapacity),

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Commissioning test.
+
+import os
+import sys
+import time
+from optparse import OptionParser
+
+from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
+
+TEST_DISCRIMINATOR = 3840
+TEST_SETUPPIN = 20202021
+
+TEST_ENDPOINT_ID = 1
+
+def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
+    logger.info("Testing discovery")
+    device = test.TestDiscovery(discriminator=discriminator)
+    FailIfNot(device, "Failed to discover any devices.")
+
+    address = device.addresses[0]
+
+    if address_override:
+        address = address_override
+
+    logger.info("Testing commissioning")
+    FailIfNot(test.TestCommissioning(ip=address,
+                                     setuppin=setup_pin,
+                                     nodeid=device_nodeid),
+              "Failed to finish key exchange")
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=90,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+        metavar="<device-addr>",
+    )
+    optParser.add_option(
+        "--nodeid",
+        action="store",
+        dest="nodeid",
+        default=1,
+        type=int,
+        help="The Node ID issued to the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--discriminator",
+        action="store",
+        dest="discriminator",
+        default=TEST_DISCRIMINATOR,
+        type=int,
+        help="Discriminator of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--setuppin",
+        action="store",
+        dest="setuppin",
+        default=TEST_SETUPPIN,
+        type=int,
+        help="Setup PIN of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "-p",
+        "--paa-trust-store-path",
+        action="store",
+        dest="paaTrustStorePath",
+        default='',
+        type='str',
+        help="Path that contains valid and trusted PAA Root Certificates.",
+        metavar="<paa-trust-store-path>"
+    )
+    optParser.add_option(
+        "--subscription-capacity",
+        action="store",
+        dest="subscriptionCapacity",
+        default=3,
+        type=int,
+        help="Subscription resumption capacity",
+        metavar="<subscription-capacity>"
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = BaseTestHelper(
+        nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
+
+    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+
+    FailIfNot(
+        test.TestSubscriptionResumptionCapacityStep1(options.nodeid, TEST_ENDPOINT_ID, options.subscriptionCapacity),
+        "Failed on step 1 of testing subscription resumption capacity")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as ex:
+        logger.exception(ex)
+        TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -33,23 +33,6 @@ TEST_ENDPOINT_ID = 0
 TEST_SSH_PORT = 2222
 
 
-def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
-    logger.info("Testing discovery")
-    device = test.TestDiscovery(discriminator=discriminator)
-    FailIfNot(device, "Failed to discover any devices.")
-
-    address = device.addresses[0]
-
-    if address_override:
-        address = address_override
-
-    logger.info("Testing commissioning")
-    FailIfNot(test.TestCommissioning(ip=address,
-                                     setuppin=setup_pin,
-                                     nodeid=device_nodeid),
-              "Failed to finish key exchange")
-
-
 def main():
     optParser = OptionParser()
     optParser.add_option(
@@ -137,7 +120,9 @@ def main():
     test = BaseTestHelper(
         nodeid=112244, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
-    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+    FailIfNot(
+        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioing")
 
     FailIfNot(
         test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Commissioning test.
+
+import os
+import sys
+import time
+from optparse import OptionParser
+
+from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
+
+TEST_DISCRIMINATOR = 3840
+TEST_SETUPPIN = 20202021
+
+TEST_ENDPOINT_ID = 1
+
+TEST_SSH_PORT=2222
+
+
+def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
+    logger.info("Testing discovery")
+    device = test.TestDiscovery(discriminator=discriminator)
+    FailIfNot(device, "Failed to discover any devices.")
+
+    address = device.addresses[0]
+
+    if address_override:
+        address = address_override
+
+    logger.info("Testing commissioning")
+    FailIfNot(test.TestCommissioning(ip=address,
+                                     setuppin=setup_pin,
+                                     nodeid=device_nodeid),
+              "Failed to finish key exchange")
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=90,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+        metavar="<device-addr>",
+    )
+    optParser.add_option(
+        "--nodeid",
+        action="store",
+        dest="nodeid",
+        default=1,
+        type=int,
+        help="The Node ID issued to the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--discriminator",
+        action="store",
+        dest="discriminator",
+        default=TEST_DISCRIMINATOR,
+        type=int,
+        help="Discriminator of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--setuppin",
+        action="store",
+        dest="setuppin",
+        default=TEST_SETUPPIN,
+        type=int,
+        help="Setup PIN of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "-p",
+        "--paa-trust-store-path",
+        action="store",
+        dest="paaTrustStorePath",
+        default='',
+        type='str',
+        help="Path that contains valid and trusted PAA Root Certificates.",
+        metavar="<paa-trust-store-path>"
+    )
+    optParser.add_option(
+        "--remote-server-app",
+        action="store",
+        dest="remoteServerApp",
+        default='',
+        type='str',
+        help="Remote Server App",
+        metavar="<remote-server-app>"
+    )
+    optParser.add_option(
+        "--subscription-capacity",
+        action="store",
+        dest="subscriptionCapacity",
+        default=3,
+        type=int,
+        help="Subscription resumption capacity",
+        metavar="<subscription-capacity>"
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    # Use a different node ID for the second controller
+    test = BaseTestHelper(
+        nodeid=112244, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
+
+    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+
+    FailIfNot(
+        test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+            TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity),
+        "Failed on testing subscription resumption capacity")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as ex:
+        logger.exception(ex)
+        TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -29,7 +29,7 @@ from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
 TEST_DISCRIMINATOR = 3840
 TEST_SETUPPIN = 20202021
 
-TEST_ENDPOINT_ID = 1
+TEST_ENDPOINT_ID = 0
 
 TEST_SSH_PORT=2222
 

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -21,7 +21,6 @@
 
 import os
 import sys
-import time
 from optparse import OptionParser
 
 from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -31,7 +31,7 @@ TEST_SETUPPIN = 20202021
 
 TEST_ENDPOINT_ID = 0
 
-TEST_SSH_PORT=2222
+TEST_SSH_PORT = 2222
 
 
 def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
@@ -142,7 +142,7 @@ def main():
 
     FailIfNot(
         test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-            TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity),
+                                                     TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity),
         "Failed on testing subscription resumption capacity")
 
     timeoutTicker.stop()

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -33,23 +33,6 @@ TEST_ENDPOINT_ID = 0
 TEST_SSH_PORT = 2222
 
 
-def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
-    logger.info("Testing discovery")
-    device = test.TestDiscovery(discriminator=discriminator)
-    FailIfNot(device, "Failed to discover any devices.")
-
-    address = device.addresses[0]
-
-    if address_override:
-        address = address_override
-
-    logger.info("Testing commissioning")
-    FailIfNot(test.TestCommissioning(ip=address,
-                                     setuppin=setup_pin,
-                                     nodeid=device_nodeid),
-              "Failed to finish key exchange")
-
-
 def main():
     optParser = OptionParser()
     optParser.add_option(
@@ -127,7 +110,9 @@ def main():
     test = BaseTestHelper(
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
-    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+    FailIfNot(
+        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioing")
 
     FailIfNot(
         test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Commissioning test.
+
+import os
+import sys
+import time
+from optparse import OptionParser
+
+from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
+
+TEST_DISCRIMINATOR = 3840
+TEST_SETUPPIN = 20202021
+
+TEST_ENDPOINT_ID = 1
+
+TEST_SSH_PORT=2222
+
+
+def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
+    logger.info("Testing discovery")
+    device = test.TestDiscovery(discriminator=discriminator)
+    FailIfNot(device, "Failed to discover any devices.")
+
+    address = device.addresses[0]
+
+    if address_override:
+        address = address_override
+
+    logger.info("Testing commissioning")
+    FailIfNot(test.TestCommissioning(ip=address,
+                                     setuppin=setup_pin,
+                                     nodeid=device_nodeid),
+              "Failed to finish key exchange")
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=90,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+        metavar="<device-addr>",
+    )
+    optParser.add_option(
+        "--nodeid",
+        action="store",
+        dest="nodeid",
+        default=1,
+        type=int,
+        help="The Node ID issued to the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--discriminator",
+        action="store",
+        dest="discriminator",
+        default=TEST_DISCRIMINATOR,
+        type=int,
+        help="Discriminator of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "--setuppin",
+        action="store",
+        dest="setuppin",
+        default=TEST_SETUPPIN,
+        type=int,
+        help="Setup PIN of the device",
+        metavar="<nodeid>"
+    )
+    optParser.add_option(
+        "-p",
+        "--paa-trust-store-path",
+        action="store",
+        dest="paaTrustStorePath",
+        default='',
+        type='str',
+        help="Path that contains valid and trusted PAA Root Certificates.",
+        metavar="<paa-trust-store-path>"
+    )
+    optParser.add_option(
+        "--remote-server-app",
+        action="store",
+        dest="remoteServerApp",
+        default='',
+        type='str',
+        help="Remote Server App",
+        metavar="<remote-server-app>"
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = BaseTestHelper(
+        nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
+
+    ethernet_commissioning(test, options.discriminator, options.setuppin, options.deviceAddress, options.nodeid)
+
+    FailIfNot(
+        test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+            TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as ex:
+        logger.exception(ex)
+        TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -29,7 +29,7 @@ from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
 TEST_DISCRIMINATOR = 3840
 TEST_SETUPPIN = 20202021
 
-TEST_ENDPOINT_ID = 1
+TEST_ENDPOINT_ID = 0
 
 TEST_SSH_PORT=2222
 

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -21,7 +21,6 @@
 
 import os
 import sys
-import time
 from optparse import OptionParser
 
 from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -31,7 +31,7 @@ TEST_SETUPPIN = 20202021
 
 TEST_ENDPOINT_ID = 0
 
-TEST_SSH_PORT=2222
+TEST_SSH_PORT = 2222
 
 
 def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
@@ -132,7 +132,7 @@ def main():
 
     FailIfNot(
         test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-            TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
+                                        TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
 
     timeoutTicker.stop()
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -38,8 +38,8 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
-TEST_END_DEVICE_APP="lit-icd-app"
-TEST_SUBSCRIPTION_CAPACITY=3
+TEST_END_DEVICE_APP = "lit-icd-app"
+TEST_SUBSCRIPTION_CAPACITY = 3
 
 
 # TODO: If using one Mobile Device, the CHIPEndDevice can still resolve the address for first controller
@@ -119,7 +119,7 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
         command1 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
                     "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --subscription-capacity {}").format(
                         os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
-                            "subscription_resumption_capacity_test_ctrl1.py"),
+                                     "subscription_resumption_capacity_test_ctrl1.py"),
                         ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
                         TEST_SUBSCRIPTION_CAPACITY)
         ret1 = self.execute_device_cmd(req_ids[0], command1)
@@ -131,7 +131,7 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
                     "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {} "
                     "--subscription-capacity {}").format(
                         os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
-                            "subscription_resumption_capacity_test_ctrl2.py"),
+                                     "subscription_resumption_capacity_test_ctrl2.py"),
                         ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
                         TEST_END_DEVICE_APP, TEST_SUBSCRIPTION_CAPACITY)
         ret2 = self.execute_device_cmd(req_ids[1], command2)

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2024 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('SubscriptionResumptionTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+CHIP_PORT = 5540
+
+CIRQUE_URL = "http://localhost:5000"
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..")
+TEST_EXTPANID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
+TEST_END_DEVICE_APP="chip-lighting-app"
+TEST_SUBSCRIPTION_CAPACITY=3
+
+
+# TODO: If using one Mobile Device, the CHIPEndDevice can still resolve the address for first controller
+# even if it was shutdown.
+# Use two containers for two controller in two different fabrics.
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'MobileDevice',
+        'base_image': '@default',
+        'capability': ['TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 25},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device1': {
+        'type': 'MobileDevice',
+        'base_image': '@default',
+        'capability': ['TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 25},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device2': {
+        'type': 'CHIPEndDevice',
+        'base_image': '@default',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 25},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    }
+}
+
+
+class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+
+    def test_routine(self):
+        self.run_subscription_resumption_capacity_test()
+
+    def run_subscription_resumption_capacity_test(self):
+        ethernet_ip = [device['description']['ipv6_addr'] for device in self.non_ap_devices
+                       if device['type'] == 'CHIPEndDevice'][0]
+        server_ids = [device['id'] for device in self.non_ap_devices
+                      if device['type'] == 'CHIPEndDevice']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'MobileDevice']
+
+        server_device_id = server_ids[0]
+        # Start SSH server
+        self.execute_device_cmd(server_device_id, "service ssh start")
+        self.execute_device_cmd(
+            server_device_id,
+            ("CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+             "-ex run -ex \"thread apply all bt\" --args {} --thread --discriminator {} "
+             "--subscription-capacity {}").format(
+                 os.path.join(CHIP_REPO, "out/debug/standalone", TEST_END_DEVICE_APP), TEST_DISCRIMINATOR,
+                 TEST_SUBSCRIPTION_CAPACITY))
+
+        self.reset_thread_devices(server_ids)
+
+        for req_device_id in req_ids:
+            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
+            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+
+        command1 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
+                    "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --subscription-capacity {}").format(
+                        os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
+                            "subscription_resumption_capacity_test_ctrl1.py"),
+                        ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+                        TEST_SUBSCRIPTION_CAPACITY)
+        ret1 = self.execute_device_cmd(req_ids[0], command1)
+
+        self.assertEqual(ret1['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+        command2 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
+                    "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {} "
+                    "--subscription-capacity {}").format(
+                        os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
+                            "subscription_resumption_capacity_test_ctrl2.py"),
+                        ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+                        TEST_END_DEVICE_APP, TEST_SUBSCRIPTION_CAPACITY)
+        ret2 = self.execute_device_cmd(req_ids[1], command2)
+
+        self.assertEqual(ret2['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+        # Check the device can evit existing subscriptions
+        self.logger.info("checking device log for {}".format(
+            self.get_device_pretty_id(server_device_id)))
+        self.assertFalse(self.sequenceMatch(self.get_device_log(server_device_id).decode('utf-8'), [
+            "Failed to get required resources by evicting existing subscriptions"]),
+            "SubscriptionResumptionCapacity test failed: find abort log from device {}".format(server_device_id))
+
+
+if __name__ == "__main__":
+    sys.exit(TestSubscriptionResumptionCapacity(DEVICE_CONFIG).run_test())

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -29,12 +29,11 @@ Steps for this test:
     7. Verify that the device can still handle this subscription request.
 '''
 
+
 import logging
 import os
 import sys
-
 from helper.CHIPTestBase import CHIPVirtualHome
-
 logger = logging.getLogger('SubscriptionResumptionCapacityTest')
 logger.setLevel(logging.INFO)
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -15,6 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+'''
+Test to verify that the device can still handle new subscription requests when resuming the maximum subscriptions.
+Steps for this test:
+    1. Commission the server app to the first fabric and send maximum subscription requests from the controller in
+    the first fabric to establish maximum subscriptions.
+    2. Open the commissioning window to make the server app can be commissioned to the second fabric.
+    3. Shutdown the controller in the first fabric to extend the time of resuming subscriptions. The server app will
+    keep resolving the address of the first controller for a while after rebooting.
+    4. Commission the server app to the second fabric.
+    5. Restart the server app and the server app will start resuming subscriptions.
+    6. When the server app is resuming subscriptions, send a new subscription request from the second controller.
+    7. Verify that the device can still handle this subscription request.
+'''
+
 import logging
 import os
 import sys
@@ -43,7 +57,9 @@ TEST_SUBSCRIPTION_CAPACITY = 3
 
 
 # TODO: If using one Mobile Device, the CHIPEndDevice can still resolve the address for first controller
-# even if it was shutdown.
+# even if it is shutdown by 'devCtrl.Shutdown()'. And the server will fail to estalish the subscriptions
+# immediately, which makes it hard to send the new subscription request from the second controller.
+
 # Use two containers for two controller in two different fabrics.
 DEVICE_CONFIG = {
     'device0': {

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -15,7 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-'''
+import logging
+import os
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+"""
 Test to verify that the device can still handle new subscription requests when resuming the maximum subscriptions.
 Steps for this test:
     1. Commission the server app to the first fabric and send maximum subscription requests from the controller in
@@ -27,14 +33,7 @@ Steps for this test:
     5. Restart the server app and the server app will start resuming subscriptions.
     6. When the server app is resuming subscriptions, send a new subscription request from the second controller.
     7. Verify that the device can still handle this subscription request.
-'''
-
-
-import logging
-import os
-import sys
-
-from helper.CHIPTestBase import CHIPVirtualHome
+"""
 
 logger = logging.getLogger('SubscriptionResumptionCapacityTest')
 logger.setLevel(logging.INFO)

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -33,7 +33,9 @@ Steps for this test:
 import logging
 import os
 import sys
+
 from helper.CHIPTestBase import CHIPVirtualHome
+
 logger = logging.getLogger('SubscriptionResumptionCapacityTest')
 logger.setLevel(logging.INFO)
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -21,7 +21,7 @@ import sys
 
 from helper.CHIPTestBase import CHIPVirtualHome
 
-logger = logging.getLogger('SubscriptionResumptionTest')
+logger = logging.getLogger('SubscriptionResumptionCapacityTest')
 logger.setLevel(logging.INFO)
 
 sh = logging.StreamHandler()
@@ -38,7 +38,7 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
-TEST_END_DEVICE_APP="chip-lighting-app"
+TEST_END_DEVICE_APP="lit-icd-app"
 TEST_SUBSCRIPTION_CAPACITY=3
 
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -23,12 +23,11 @@ Steps for this test:
     3. Verify that the server app with resume the subscription and send a report to the controller
 '''
 
+
 import logging
 import os
 import sys
-
 from helper.CHIPTestBase import CHIPVirtualHome
-
 logger = logging.getLogger('SubscriptionResumptionTest')
 logger.setLevel(logging.INFO)
 
@@ -68,6 +67,7 @@ DEVICE_CONFIG = {
         "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
     }
 }
+
 
 class TestSubscriptionResumption(CHIPVirtualHome):
     def __init__(self, device_config):

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -15,20 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-'''
-Basic Subscription Resumption Test to validate that the device can resume subscriptions after restarting.
-Steps for this test:
-    1. Subcription an attribute on the controller
-    2. Restart the server app
-    3. Verify that the server app with resume the subscription and send a report to the controller
-'''
-
-
 import logging
 import os
 import sys
 
 from helper.CHIPTestBase import CHIPVirtualHome
+
+"""
+Basic Subscription Resumption Test to validate that the device can resume subscriptions after restarting.
+Steps for this test:
+    1. Subcription an attribute on the controller
+    2. Restart the server app
+    3. Verify that the server app with resume the subscription and send a report to the controller
+"""
 
 logger = logging.getLogger('SubscriptionResumptionTest')
 logger.setLevel(logging.INFO)

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2024 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('SubscriptionResumptionTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+CHIP_PORT = 5540
+
+CIRQUE_URL = "http://localhost:5000"
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..")
+TEST_EXTPANID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
+TEST_END_DEVICE_APP="chip-lighting-app"
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'MobileDevice',
+        'base_image': '@default',
+        'capability': ['TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 25},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device1': {
+        'type': 'CHIPEndDevice',
+        'base_image': '@default',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 25},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    }
+}
+
+
+class TestSubscriptionResumption(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+
+    def test_routine(self):
+        self.run_subscription_resumption_test()
+
+    def run_subscription_resumption_test(self):
+        ethernet_ip = [device['description']['ipv6_addr'] for device in self.non_ap_devices
+                       if device['type'] == 'CHIPEndDevice'][0]
+        server_ids = [device['id'] for device in self.non_ap_devices
+                      if device['type'] == 'CHIPEndDevice']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'MobileDevice']
+
+        server_device_id = server_ids[0]
+        # Start SSH server
+        self.execute_device_cmd(server_device_id, "service ssh start")
+        self.execute_device_cmd(
+            server_device_id,
+            ("CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" "
+             "-ex run -ex \"thread apply all bt\" --args {} --thread --discriminator {}").format(
+                os.path.join(CHIP_REPO, "out/debug/standalone", TEST_END_DEVICE_APP), TEST_DISCRIMINATOR))
+
+        self.reset_thread_devices(server_ids)
+
+        req_device_id = req_ids[0]
+
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+
+        command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
+                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {}").format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/subscription_resumption_test.py"), ethernet_ip,
+            os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS), TEST_END_DEVICE_APP)
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+        # Check the device can resume subscriptions
+        self.logger.info("checking device log for {}".format(
+            self.get_device_pretty_id(server_device_id)))
+        self.assertTrue(self.sequenceMatch(self.get_device_log(server_device_id).decode('utf-8'), [
+            "Resuming 1 subscriptions in 1 seconds",
+            "Registered a ReadHandler that will schedule a report"]),
+            "SubscriptionResumption test failed: cannot find matching string from device {}".format(server_device_id))
+
+
+if __name__ == "__main__":
+    sys.exit(TestSubscriptionResumption(DEVICE_CONFIG).run_test())

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -38,7 +38,7 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
-TEST_END_DEVICE_APP="lit-icd-app"
+TEST_END_DEVICE_APP = "lit-icd-app"
 
 DEVICE_CONFIG = {
     'device0': {

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -27,7 +27,9 @@ Steps for this test:
 import logging
 import os
 import sys
+
 from helper.CHIPTestBase import CHIPVirtualHome
+
 logger = logging.getLogger('SubscriptionResumptionTest')
 logger.setLevel(logging.INFO)
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -38,7 +38,7 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
-TEST_END_DEVICE_APP="chip-lighting-app"
+TEST_END_DEVICE_APP="lit-icd-app"
 
 DEVICE_CONFIG = {
     'device0': {

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -15,6 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+'''
+Basic Subscription Resumption Test to validate that the device can resume subscriptions after restarting.
+Steps for this test:
+    1. Subcription an attribute on the controller
+    2. Restart the server app
+    3. Verify that the server app with resume the subscription and send a report to the controller
+'''
+
 import logging
 import os
 import sys
@@ -60,7 +68,6 @@ DEVICE_CONFIG = {
         "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
     }
 }
-
 
 class TestSubscriptionResumption(CHIPVirtualHome):
     def __init__(self, device_config):


### PR DESCRIPTION
Fixes #30971

In this PR:

- Add an option to set subscription capacity for linux examples
- Add a basic subscription resumption cirque test. The steps for this test are: 
    1. Subscribe a attribute on the controller
    2. restart the server app
    3. Check whether the controller receive the attribute report after the server app restarts
- Add a subscription resumption capacity test. The steps for this test are in #30971