### PR TITLE
[icd] create callback to indicate an alive subscription

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -617,6 +617,7 @@ exit:
             // a subscription and have a valid value for mMaxInterval which the function
             // relies on.
             //
+            mpCallback.RefreshLiveness(*this);
             err = RefreshLivenessCheckTimer();
         }
     }

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -84,6 +84,15 @@ public:
         virtual ~Callback() = default;
 
         /**
+         * Used to notify a (maybe empty) report data is received from peer and the subscription and the peer is alive.
+         *
+         * This object MUST continue to exist after this call is completed. The application shall wait until it
+         * receives an OnDone call to destroy the object.
+         *
+         */
+        virtual void RefreshLiveness(const ReadClient& apReadClient) {}
+
+        /**
          * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.
          *
          * This object MUST continue to exist after this call is completed. The application shall wait until it

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -90,7 +90,7 @@ public:
          * receives an OnDone call to destroy the object.
          *
          */
-        virtual void RefreshLiveness(const ReadClient& apReadClient) {}
+        virtual void RefreshLiveness(const ReadClient & apReadClient) {}
 
         /**
          * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.


### PR DESCRIPTION
Issue: #17256 

For a LIT ICD, when some (not all) of subscription are no longer active the controller won't receive a check-in message.

Also, the controller don't know the subscription is alive if the peer only generates empty reports.

This PR adds a `RefreshLiveness` callback, which can be used to kick the API added in #30812 to resolve the above issues.