### PR TITLE
Introduce CommandSender::ExtendedCallback

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -66,7 +66,7 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse), mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
-    mPathSpecificErrorToOnResponseCallback = mpCallback->PathSpecificErrorGoesToOnResponseCallbacks();
+    mPathSpecificErrorToOnResponseCallback = mpCallback->ExtendedUsePathCallbacks();
 }
 
 CommandSender::~CommandSender()

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -397,9 +397,9 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         if (statusIB.IsSuccess() || usingExtendableCallbacks)
         {
             const ConcreteCommandPath concretePath = ConcreteCommandPath(endpointId, clusterId, commandId);
-            ResponseData responseData = { concretePath, statusIB };
-            responseData.data         = hasDataResponse ? &commandDataReader : nullptr;
-            responseData.commandRef   = commandRef;
+            ResponseData responseData              = { concretePath, statusIB };
+            responseData.data                      = hasDataResponse ? &commandDataReader : nullptr;
+            responseData.commandRef                = commandRef;
             OnResponseCallback(responseData);
         }
         else

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -66,6 +66,7 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse), mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
+    mPathSpecificErrorToOnResponseCallback = mpCallback->PathSpecificErrorGoesToOnResponseCallbacks();
 }
 
 CommandSender::~CommandSender()
@@ -384,7 +385,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
 
         if (mpCallback != nullptr)
         {
-            if (statusIB.IsSuccess())
+            if (statusIB.IsSuccess() || mPathSpecificErrorToOnResponseCallback)
             {
                 mpCallback->OnResponseWithAdditionalData(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
                                                          hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -66,7 +66,10 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse), mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
-    mPathSpecificErrorToOnResponseCallback = mpCallback->UsingExtendedPathCallbacks();
+    if (mpCallback != nullptr)
+    {
+        mUsingExtendedPathCallbacks = mpCallback->UsingExtendedPathCallbacks();
+    }
 }
 
 CommandSender::~CommandSender()
@@ -385,7 +388,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
 
         if (mpCallback != nullptr)
         {
-            if (statusIB.IsSuccess() || mPathSpecificErrorToOnResponseCallback)
+            if (statusIB.IsSuccess() || mUsingExtendedPathCallbacks)
             {
                 mpCallback->OnResponseWithAdditionalData(this, ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
                                                          hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -386,7 +386,9 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         }
         ReturnErrorOnFailure(err);
 
-        // TODO add comment here about why different path taken for mUsingExtendedCallbacks.
+        // When using ExtendedCallbacks, we are adhearing to a different API contract where path
+        // specific error are send to the OnResponse callback. For more information on the history
+        // of this issue please see https://github.com/project-chip/connectedhomeip/issues/30991
         if (statusIB.IsSuccess() || mUsingExtendedCallbacks)
         {
             OnResponseCallback(ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -66,7 +66,7 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse), mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
-    mPathSpecificErrorToOnResponseCallback = mpCallback->ExtendedUsePathCallbacks();
+    mPathSpecificErrorToOnResponseCallback = mpCallback->UsingExtendedPathCallbacks();
 }
 
 CommandSender::~CommandSender()

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -390,8 +390,8 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         }
         ReturnErrorOnFailure(err);
 
-        // When using ExtendedCallbacks, we are adhearing to a different API contract where path
-        // specific error are sent to the OnResponse callback. For more information on the history
+        // When using ExtendedCallbacks, we are adhering to a different API contract where path
+        // specific errors are sent to the OnResponse callback. For more information on the history
         // of this issue please see https://github.com/project-chip/connectedhomeip/issues/30991
         bool usingExtendedCallbacks = mpExtendedCallback != nullptr;
         if (statusIB.IsSuccess() || usingExtendedCallbacks)

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -68,10 +68,11 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     assertChipStackLockedByCurrentThread();
 }
 
-CommandSender::CommandSender(ExtendedCallback * apExtendedCallback, Messaging::ExchangeManager * apExchangeMgr, bool aIsTimedRequest,
-                             bool aSuppressResponse) :
+CommandSender::CommandSender(ExtendedCallback * apExtendedCallback, Messaging::ExchangeManager * apExchangeMgr,
+                             bool aIsTimedRequest, bool aSuppressResponse) :
     mExchangeCtx(*this),
-    mpExtendedCallback(apExtendedCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse), mTimedRequest(aIsTimedRequest)
+    mpExtendedCallback(apExtendedCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse),
+    mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
     mUsingExtendedCallbacks = true;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -397,9 +397,9 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         if (statusIB.IsSuccess() || usingExtendableCallbacks)
         {
             const ConcreteCommandPath concretePath = ConcreteCommandPath(endpointId, clusterId, commandId);
-            responseData.path = &concretePath;
-            responseData.statusIB = &statusIB;
-            responseData.data = hasDataResponse ? &commandDataReader : nullptr;
+            responseData.path                      = &concretePath;
+            responseData.statusIB                  = &statusIB;
+            responseData.data                      = hasDataResponse ? &commandDataReader : nullptr;
             OnResponseCallback(responseData);
         }
         else
@@ -433,7 +433,7 @@ CHIP_ERROR CommandSender::PrepareCommand(const CommandPathParams & aCommandPathP
     // We must not be in the middle of preparing a command, and must not have already sent InvokeRequestMessage.
     //
     bool usingExtendableCallbacks = mpExtendableCallback != nullptr;
-    bool canAddAnotherCommand   = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendableCallbacks);
+    bool canAddAnotherCommand     = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendableCallbacks);
     VerifyOrReturnError(mState == State::Idle || canAddAnotherCommand, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mFinishedCommandCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -68,10 +68,10 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
     assertChipStackLockedByCurrentThread();
 }
 
-CommandSender::CommandSender(ExtendedCallback * apExtendedCallback, Messaging::ExchangeManager * apExchangeMgr,
+CommandSender::CommandSender(ExtendableCallback * apExtendableCallback, Messaging::ExchangeManager * apExchangeMgr,
                              bool aIsTimedRequest, bool aSuppressResponse) :
     mExchangeCtx(*this),
-    mpExtendedCallback(apExtendedCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse),
+    mpExtendableCallback(apExtendableCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(aSuppressResponse),
     mTimedRequest(aIsTimedRequest)
 {
     assertChipStackLockedByCurrentThread();
@@ -89,7 +89,7 @@ CHIP_ERROR CommandSender::AllocateBuffer()
         // We are making sure that both callbacks are not set. This should never happen as the constructors
         // are strongly typed and only one should ever be set, but explicit check is here to ensure that is
         // always the case.
-        bool bothCallbacksAreSet = mpExtendedCallback != nullptr && mpCallback != nullptr;
+        bool bothCallbacksAreSet = mpExtendableCallback != nullptr && mpCallback != nullptr;
         VerifyOrDie(!bothCallbacksAreSet);
 
         mCommandMessageWriter.Reset();
@@ -334,7 +334,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         bool commandRefExpected = (mFinishedCommandCount > 1);
         bool hasDataResponse    = false;
         TLV::TLVReader commandDataReader;
-        AdditionalResponseData additionalResponseData;
+        ResponseData responseData;
 
         CommandStatusIB::Parser commandStatus;
         err = aInvokeResponse.GetStatus(&commandStatus);
@@ -349,7 +349,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             StatusIB::Parser status;
             commandStatus.GetErrorStatus(&status);
             ReturnErrorOnFailure(status.DecodeStatusIB(statusIB));
-            ReturnErrorOnFailure(GetRef(commandStatus, additionalResponseData.commandRef, commandRefExpected));
+            ReturnErrorOnFailure(GetRef(commandStatus, responseData.commandRef, commandRefExpected));
         }
         else if (CHIP_END_OF_TLV == err)
         {
@@ -361,7 +361,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             ReturnErrorOnFailure(commandPath.GetClusterId(&clusterId));
             ReturnErrorOnFailure(commandPath.GetCommandId(&commandId));
             commandData.GetFields(&commandDataReader);
-            ReturnErrorOnFailure(GetRef(commandData, additionalResponseData.commandRef, commandRefExpected));
+            ReturnErrorOnFailure(GetRef(commandData, responseData.commandRef, commandRefExpected));
             err             = CHIP_NO_ERROR;
             hasDataResponse = true;
         }
@@ -390,14 +390,17 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         }
         ReturnErrorOnFailure(err);
 
-        // When using ExtendedCallbacks, we are adhering to a different API contract where path
+        // When using ExtendableCallbacks, we are adhering to a different API contract where path
         // specific errors are sent to the OnResponse callback. For more information on the history
         // of this issue please see https://github.com/project-chip/connectedhomeip/issues/30991
-        bool usingExtendedCallbacks = mpExtendedCallback != nullptr;
-        if (statusIB.IsSuccess() || usingExtendedCallbacks)
+        bool usingExtendableCallbacks = mpExtendableCallback != nullptr;
+        if (statusIB.IsSuccess() || usingExtendableCallbacks)
         {
-            OnResponseCallback(ConcreteCommandPath(endpointId, clusterId, commandId), statusIB,
-                               hasDataResponse ? &commandDataReader : nullptr, additionalResponseData);
+            const ConcreteCommandPath concretePath = ConcreteCommandPath(endpointId, clusterId, commandId);
+            responseData.path = &concretePath;
+            responseData.statusIB = &statusIB;
+            responseData.data = hasDataResponse ? &commandDataReader : nullptr;
+            OnResponseCallback(responseData);
         }
         else
         {
@@ -429,8 +432,8 @@ CHIP_ERROR CommandSender::PrepareCommand(const CommandPathParams & aCommandPathP
     //
     // We must not be in the middle of preparing a command, and must not have already sent InvokeRequestMessage.
     //
-    bool usingExtendedCallbacks = mpExtendedCallback != nullptr;
-    bool canAddAnotherCommand   = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendedCallbacks);
+    bool usingExtendableCallbacks = mpExtendableCallback != nullptr;
+    bool canAddAnotherCommand   = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendableCallbacks);
     VerifyOrReturnError(mState == State::Idle || canAddAnotherCommand, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mFinishedCommandCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -430,7 +430,7 @@ CHIP_ERROR CommandSender::PrepareCommand(const CommandPathParams & aCommandPathP
     // We must not be in the middle of preparing a command, and must not have already sent InvokeRequestMessage.
     //
     bool usingExtendedCallbacks = mpExtendedCallback != nullptr;
-    bool canAddAnotherCommand = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendedCallbacks);
+    bool canAddAnotherCommand   = (mState == State::AddedCommand && mBatchCommandsEnabled && usingExtendedCallbacks);
     VerifyOrReturnError(mState == State::Idle || canAddAnotherCommand, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mFinishedCommandCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -552,7 +552,7 @@ private:
 
     Messaging::ExchangeHolder mExchangeCtx;
     Callback * mpCallback                      = nullptr;
-    ExtendableCallback * mpExtendableCallback      = nullptr;
+    ExtendableCallback * mpExtendableCallback  = nullptr;
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InvokeRequestMessage::Builder mInvokeRequestBuilder;
     // TODO Maybe we should change PacketBufferTLVWriter so we can finalize it

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -138,7 +138,7 @@ public:
     // to allow for future extendability.
     struct ErrorData
     {
-        /** 
+        /**
          * The following errors will be delivered through chipError
          *
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -146,7 +146,6 @@ public:
         CHIP_ERROR mChipError;
     };
 
-
     /**
      * @brief asdf
      *
@@ -193,9 +192,8 @@ public:
          * @param[in] aAdditionalResponseData
          *                            Additional response data that comes within the InvokeResponseMessage.
          */
-        virtual void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
-                                const StatusIB & aStatusIB, TLV::TLVReader * apData,
-                                const AdditionalResponseData & aAdditionalResponseData)
+        virtual void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatusIB,
+                                TLV::TLVReader * apData, const AdditionalResponseData & aAdditionalResponseData)
         {}
 
         /**
@@ -295,7 +293,9 @@ public:
     CommandSender(ExtendedCallback * apCallback, Messaging::ExchangeManager * apExchangeMgr, bool aIsTimedRequest = false,
                   bool aSuppressResponse = false);
     CommandSender(std::nullptr_t, Messaging::ExchangeManager * apExchangeMgr, bool aIsTimedRequest = false,
-                  bool aSuppressResponse = false) : CommandSender(static_cast<Callback *>(nullptr), apExchangeMgr, aIsTimedRequest, aSuppressResponse) {}
+                  bool aSuppressResponse = false) :
+        CommandSender(static_cast<Callback *>(nullptr), apExchangeMgr, aIsTimedRequest, aSuppressResponse)
+    {}
     ~CommandSender();
 
     /**
@@ -520,8 +520,7 @@ private:
 
     CHIP_ERROR SendCommandRequestInternal(const SessionHandle & session, Optional<System::Clock::Timeout> timeout);
 
-    void OnResponseCallback(const ConcreteCommandPath & aPath,
-                            const StatusIB & aStatusIB, TLV::TLVReader * apData,
+    void OnResponseCallback(const ConcreteCommandPath & aPath, const StatusIB & aStatusIB, TLV::TLVReader * apData,
                             const AdditionalResponseData & aAdditionalResponseData)
     {
         if (mUsingExtendedCallbacks)
@@ -544,7 +543,7 @@ private:
         {
             if (mpExtendedCallback)
             {
-                ErrorData errorData = {aError};
+                ErrorData errorData = { aError };
                 mpExtendedCallback->OnError(this, errorData);
             }
             return;

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -83,20 +83,17 @@ public:
         {}
 
         /**
-         * OnError will be called when an error occur *after* a successful call to SendCommandRequest(). The following
+         * OnError will be called when an error occurs *after* a successful call to SendCommandRequest(). The following
          * errors will be delivered through this call in the aError field:
          *
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
          * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
-         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
+         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific or path-specific
          *   status response from the server.  In that case,
          *   StatusIB::InitFromChipError can be used to extract the status.
-         * - CHIP_ERROR encapsulating a StatusIB: If we got a path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
-         *      - Note because CommandSender using `CommandSender::Callback` only support sending
-         *        single InvokeRequest, only one path specific error will ever be sent to OnError
-         *        callback
+         *      - Note CommandSender's using `CommandSender::Callback` only supports sending
+         *        single InvokeRequest. As a result, only one path-specific error is expected
+         *        to ever be sent to OnError callback.
          * - CHIP_ERROR*: All other cases.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
@@ -141,6 +138,16 @@ public:
     // to allow for future extendability.
     struct ErrorData
     {
+        /** 
+         * The following errors will be delivered through chipError
+         *
+         * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
+         * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
+         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
+         *   status response from the server.  In that case,
+         *   StatusIB::InitFromChipError can be used to extract the status.
+         * - CHIP_ERROR*: All other cases.
+         */
         CHIP_ERROR chipError;
     };
 
@@ -187,15 +194,7 @@ public:
         {}
 
         /**
-         * OnError will be called when an error occur *after* a successful call to SendCommandRequest(). The following
-         * errors will be delivered through this call in the aError field:
-         *
-         * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
-         * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
-         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
-         * - CHIP_ERROR*: All other cases.
+         * OnError will be called when an error occurs *after* a successful call to SendCommandRequest().
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy and free the object.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -59,10 +59,9 @@ public:
         virtual ~Callback() = default;
 
         /**
-         * OnResponse will be called when a successful response from server has been received and processed. Specifically:
+         * OnResponse will be called when a successful response from server has been received and processed.
+         * Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
-         *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
-         *      - Note this only happens if UsingExtendedPathCallbacks() returns true.
          *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
          *

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -70,15 +70,15 @@ public:
 
         /**
          * @brief Should CommandSender send path specific errors to OnResponse* callbacks.
-         * 
+         *
          * Any callbacks that override this method to return true must support capability of
          * handling multiple callbacks to OnResponse* callbacks even with non-successful StatusIB
          * values.
          *
          * Clients that want to support batch commands must override this method and return true.
-         * 
+         *
          * Callback SHALL always return a consistent value that does NOT change.
-         * 
+         *
          * @return true when callback's expect path specific error to come in OnResponse* callback
          * @return false when callback's expect path specific error to come in OnError callback
          */
@@ -163,7 +163,7 @@ public:
          *   StatusIB::InitFromChipError can be used to extract the status.
          *      - Note path specific error only come here happens if PathSpecificErrorGoesToOnResponseCallbacks()
          *        returns false.
-         *      - There isn't a guaranteeded way to differentiate between a non-path-specific error and a 
+         *      - There isn't a guaranteeded way to differentiate between a non-path-specific error and a
          *        path-specific error from the OnError callback.
          * - CHIP_ERROR*: All other cases.
          *

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -89,8 +89,8 @@ public:
         }
 
         /**
-         * OnResponseWithAdditionalData will be called for all path specific responses from the server has been received and processed.
-         * Specifically:
+         * OnResponseWithAdditionalData will be called for all path specific responses from the server has been received and
+         * processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
          *      - Note this only happens if PathSpecificErrorGoesToOnResponseCallbacks() returns true.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -132,11 +132,11 @@ public:
     struct ResponseData
     {
         // The command path field in invoke command response.
-        const ConcreteCommandPath * path;
+        const ConcreteCommandPath & path;
         // The status of the command. It can be any success status, including possibly a cluster-specific one.
         // If `data` is not null, statusIB will always be a generic SUCCESS status with no-cluster specific
         // information.
-        const StatusIB * statusIB;
+        const StatusIB & statusIB;
         // The command data, will be nullptr if the server returns a StatusIB.
         TLV::TLVReader * data;
         // Reference for the command. This should be associated with the reference value sent out in the initial
@@ -519,7 +519,7 @@ private:
         }
         else if (mpCallback)
         {
-            mpCallback->OnResponse(this, *aResponseData.path, *aResponseData.statusIB, aResponseData.data);
+            mpCallback->OnResponse(this, aResponseData.path, aResponseData.statusIB, aResponseData.data);
         }
     }
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -91,9 +91,9 @@ public:
          * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific or path-specific
          *   status response from the server.  In that case,
          *   StatusIB::InitFromChipError can be used to extract the status.
-         *      - Note CommandSender's using `CommandSender::Callback` only supports sending
-         *        single InvokeRequest. As a result, only one path-specific error is expected
-         *        to ever be sent to OnError callback.
+         *      - Note: a CommandSender using `CommandSender::Callback` only supports sending
+         *        a single InvokeRequest. As a result, only one path-specific error is expected
+         *        to ever be sent to the OnError callback.
          * - CHIP_ERROR*: All other cases.
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
@@ -105,7 +105,7 @@ public:
         virtual void OnError(const CommandSender * apCommandSender, CHIP_ERROR aError) {}
 
         /**
-         * OnDone will be called when CommandSender has finished all work and is safe to destroy and free the
+         * OnDone will be called when CommandSender has finished all work and it is safe to destroy and free the
          * allocated CommandSender object.
          *
          * This function will:
@@ -148,7 +148,7 @@ public:
          *   StatusIB::InitFromChipError can be used to extract the status.
          * - CHIP_ERROR*: All other cases.
          */
-        CHIP_ERROR chipError;
+        CHIP_ERROR error;
     };
 
     /**
@@ -161,15 +161,15 @@ public:
      *    as functionality expands, a parameter whose type is defined in this header is used
      *    as the argument to the callbacks
      *
-     * To support batch commands client needs to be using ExtendedCallback
+     * To support batch commands client must use ExtendedCallback.
      */
-    class ExtendedCallback
+    class ExtendableCallback
     {
     public:
         virtual ~ExtendedCallback() = default;
 
         /**
-         * OnResponse will be called for all path specific responses from the server that has been received
+         * OnResponse will be called for all path specific responses from the server that have been received
          * and processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
@@ -194,12 +194,12 @@ public:
         {}
 
         /**
-         * OnError will be called when an error occurs *after* a successful call to SendCommandRequest().
+         * OnError will be called when a non-path-specific error occurs *after* a successful call to SendCommandRequest().
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy and free the object.
          *
-         * NOTE: Path specific error do NOT come to OnError, but instead go to OnResponse.
+         * NOTE: Path specific errors do NOT come to OnError, but instead go to OnResponse.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aErrorData      A error data regarding error that occurred.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -507,12 +507,12 @@ private:
     void OnResponseCallback(const ConcreteCommandPath & aPath, const StatusIB & aStatusIB, TLV::TLVReader * apData,
                             const AdditionalResponseData & aAdditionalResponseData)
     {
+        // mpExtendedCallback and mpCallback are mutually exclusive.
         if (mpExtendedCallback)
         {
             mpExtendedCallback->OnResponse(this, aPath, aStatusIB, apData, aAdditionalResponseData);
         }
-        // mpCallback is a legacy path that is omitted if using extended callbacks
-        if (mpCallback)
+        else if (mpCallback)
         {
             mpCallback->OnResponse(this, aPath, aStatusIB, apData);
         }
@@ -520,13 +520,13 @@ private:
 
     void OnErrorCallback(CHIP_ERROR aError)
     {
+        // mpExtendedCallback and mpCallback are mutually exclusive.
         if (mpExtendedCallback)
         {
             ErrorData errorData = { aError };
             mpExtendedCallback->OnError(this, errorData);
         }
-        // mpCallback is a legacy path that is omitted if using extended callbacks
-        if (mpCallback)
+        else if (mpCallback)
         {
             mpCallback->OnError(this, aError);
         }
@@ -534,12 +534,12 @@ private:
 
     void OnDoneCallback()
     {
+        // mpExtendedCallback and mpCallback are mutually exclusive.
         if (mpExtendedCallback)
         {
             mpExtendedCallback->OnDone(this);
         }
-        // mpCallback is a legacy path that is omitted if using extended callbacks
-        if (mpCallback)
+        else if (mpCallback)
         {
             mpCallback->OnDone(this);
         }

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -199,7 +199,7 @@ public:
          *
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy and free the object.
-         * 
+         *
          * NOTE: Path specific error do NOT come to OnError, but instead go to OnResponse.
          *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -53,6 +53,9 @@ namespace app {
 class CommandSender final : public Messaging::ExchangeDelegate
 {
 public:
+    // TODO(#30453) Reorder CommandSender::Callback and CommandSender::ExtendableCallback. To keep follow up
+    // review simple, this was not done initially, and is expected to be completed within day of PR
+    // introducing CommandSender::ExtendableCallback getting merged.
     /**
      * @brief Legacy callbacks for CommandSender
      */

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -489,7 +489,7 @@ private:
     bool mTimedRequest                          = false;
     bool mBufferAllocated                       = false;
     bool mBatchCommandsEnabled                  = false;
-    bool mPathSpecificErrorToOnResponseCallback = false;
+    bool mUsingExtendedPathCallbacks = false;
 };
 
 } // namespace app

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -68,9 +68,6 @@ public:
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * It is advised that subclasses should only override this or `OnResponseWithAdditionalData`. But, it shouldn't actually
-         * matter if both are overridden, just that `OnResponse` will never be called by CommandSender directly.
-         *
          * @param[in] apCommandSender The command sender object that initiated the command transaction.
          * @param[in] aPath           The command path field in invoke command response.
          * @param[in] aStatusIB       It will always have a success status. If apData is null, it can be any success status,

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -149,7 +149,7 @@ public:
 
     /**
      * @brief asdf
-     * 
+     *
      * The two major differences between ExtendedCallback and Callback are:
      * 1. Path-specific errors go to OnResponse instead of OnError
      *       - Note: Non-path-specific errors still go to OnError.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -82,7 +82,7 @@ public:
          * @return true when callback's expect path specific error to come in OnResponse* callback
          * @return false when callback's expect path specific error to come in OnError callback
          */
-        bool PathSpecificErrorGoesToOnResponseCallbacks()
+        virtual bool ExtendedUsePathCallbacks()
         {
             // Legacy code had path specific errors go to OnError which is why this is set to false.
             return false;
@@ -93,7 +93,7 @@ public:
          * processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
-         *      - Note this only happens if PathSpecificErrorGoesToOnResponseCallbacks() returns true.
+         *      - Note this only happens if ExtendedUsePathCallbacks() returns true.
          *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
          *
@@ -128,7 +128,7 @@ public:
          * OnResponse will be called when a successful response from server has been received and processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
-         *      - Note this only happens if PathSpecificErrorGoesToOnResponseCallbacks() returns true.
+         *      - Note this only happens if ExtendedUsePathCallbacks() returns true.
          *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
          *
@@ -161,7 +161,7 @@ public:
          * - CHIP_ERROR encapsulating a StatusIB: If we got a path-specific
          *   status response from the server.  In that case,
          *   StatusIB::InitFromChipError can be used to extract the status.
-         *      - Note path specific error only come here happens if PathSpecificErrorGoesToOnResponseCallbacks()
+         *      - Note path specific error only come here happens if ExtendedUsePathCallbacks()
          *        returns false.
          *      - There isn't a guaranteeded way to differentiate between a non-path-specific error and a
          *        path-specific error from the OnError callback.

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -82,7 +82,7 @@ public:
          * @return true when callback's expect path specific error to come in OnResponse* callback
          * @return false when callback's expect path specific error to come in OnError callback
          */
-        virtual bool ExtendedUsePathCallbacks()
+        virtual bool UsingExtendedPathCallbacks()
         {
             // Legacy code had path specific errors go to OnError which is why this is set to false.
             return false;
@@ -93,7 +93,7 @@ public:
          * processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
-         *      - Note this only happens if ExtendedUsePathCallbacks() returns true.
+         *      - Note this only happens if UsingExtendedPathCallbacks() returns true.
          *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
          *
@@ -128,7 +128,7 @@ public:
          * OnResponse will be called when a successful response from server has been received and processed. Specifically:
          *  - When a status code is received and it is IM::Success, aData will be nullptr.
          *  - When a status code is received and it is IM and/or cluster error, aData will be nullptr.
-         *      - Note this only happens if ExtendedUsePathCallbacks() returns true.
+         *      - Note this only happens if UsingExtendedPathCallbacks() returns true.
          *  - When a data response is received, aData will point to a valid TLVReader initialized to point at the struct container
          *    that contains the data payload (callee will still need to open and process the container).
          *
@@ -161,7 +161,7 @@ public:
          * - CHIP_ERROR encapsulating a StatusIB: If we got a path-specific
          *   status response from the server.  In that case,
          *   StatusIB::InitFromChipError can be used to extract the status.
-         *      - Note path specific error only come here happens if ExtendedUsePathCallbacks()
+         *      - Note path specific error only come here happens if UsingExtendedPathCallbacks()
          *        returns false.
          *      - There isn't a guaranteeded way to differentiate between a non-path-specific error and a
          *        path-specific error from the OnError callback.

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -220,8 +220,8 @@ public:
     {
         IgnoreUnusedVariable(apCommandSender);
         IgnoreUnusedVariable(aData);
-        ChipLogDetail(Controller, "Received response for command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x", aPath.mClusterId,
-                      aPath.mCommandId, aPath.mEndpointId);
+        ChipLogDetail(Controller, "Received response for command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x",
+                      aPath.mClusterId, aPath.mCommandId, aPath.mEndpointId);
         onResponseCalledTimes++;
     }
     void OnError(const CommandSender * apCommandSender, const CommandSender::ErrorData & aErrorData) override

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -220,7 +220,7 @@ public:
     {
         IgnoreUnusedVariable(apCommandSender);
         IgnoreUnusedVariable(aData);
-        ChipLogDetail(Controller, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x", aPath.mClusterId,
+        ChipLogDetail(Controller, "Received response for command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x", aPath.mClusterId,
                       aPath.mCommandId, aPath.mEndpointId);
         onResponseCalledTimes++;
     }

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -212,22 +212,21 @@ public:
     CHIP_ERROR mError         = CHIP_NO_ERROR;
 } mockCommandSenderDelegate;
 
-class MockCommandSenderExtendedCallback : public CommandSender::ExtendedCallback
+class MockCommandSenderExtendableCallback : public CommandSender::ExtendableCallback
 {
 public:
-    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatus,
-                    TLV::TLVReader * aData, const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
+    void OnResponse(CommandSender * apCommandSender, const CommandSender::ResponseData & aResponseData) override
     {
         IgnoreUnusedVariable(apCommandSender);
-        IgnoreUnusedVariable(aData);
+        const ConcreteCommandPath & path = *aResponseData.path;
         ChipLogDetail(Controller, "Received response for command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x",
-                      aPath.mClusterId, aPath.mCommandId, aPath.mEndpointId);
+                      path.mClusterId, path.mCommandId, path.mEndpointId);
         onResponseCalledTimes++;
     }
     void OnError(const CommandSender * apCommandSender, const CommandSender::ErrorData & aErrorData) override
     {
-        ChipLogError(Controller, "OnError happens with %" CHIP_ERROR_FORMAT, aErrorData.chipError.Format());
-        mError = aErrorData.chipError;
+        ChipLogError(Controller, "OnError happens with %" CHIP_ERROR_FORMAT, aErrorData.error.Format());
+        mError = aErrorData.error;
         onErrorCalledTimes++;
     }
     void OnDone(CommandSender * apCommandSender) override { onFinalCalledTimes++; }
@@ -295,9 +294,9 @@ public:
 #endif
 
     static void TestCommandSenderLegacyCallbackUnsupportedCommand(nlTestSuite * apSuite, void * apContext);
-    static void TestCommandSenderExtendedCallbackUnsupportedCommand(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandSenderExtendableCallbackUnsupportedCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderLegacyCallbackBuildingBatchCommandFails(nlTestSuite * apSuite, void * apContext);
-    static void TestCommandSenderExtendedCallbackBuildingBatchCommandFails(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandSenderExtendableCallbackBuildingBatchCommandFails(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandSuccessResponseFlow(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandAsyncSuccessResponseFlow(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandFailureResponseFlow(nlTestSuite * apSuite, void * apContext);
@@ -1256,7 +1255,7 @@ void TestCommandInteraction::TestCommandSenderLegacyCallbackUnsupportedCommand(n
 }
 
 // Because UnsupportedCommand is a path specific error we will expect it to come via on response when using Extended Path.
-void TestCommandInteraction::TestCommandSenderExtendedCallbackUnsupportedCommand(nlTestSuite * apSuite, void * apContext)
+void TestCommandInteraction::TestCommandSenderExtendableCallbackUnsupportedCommand(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
     CHIP_ERROR err    = CHIP_NO_ERROR;
@@ -1310,7 +1309,7 @@ void TestCommandInteraction::TestCommandSenderLegacyCallbackBuildingBatchCommand
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
-void TestCommandInteraction::TestCommandSenderExtendedCallbackBuildingBatchCommandFails(nlTestSuite * apSuite, void * apContext)
+void TestCommandInteraction::TestCommandSenderExtendableCallbackBuildingBatchCommandFails(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
     CHIP_ERROR err    = CHIP_NO_ERROR;
@@ -1834,9 +1833,9 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestCommandHandlerReleaseWithExchangeClosed", chip::app::TestCommandInteraction::TestCommandHandlerReleaseWithExchangeClosed),
 #endif
     NL_TEST_DEF("TestCommandSenderLegacyCallbackUnsupportedCommand", chip::app::TestCommandInteraction::TestCommandSenderLegacyCallbackUnsupportedCommand),
-    NL_TEST_DEF("TestCommandSenderExtendedCallbackUnsupportedCommand", chip::app::TestCommandInteraction::TestCommandSenderExtendedCallbackUnsupportedCommand),
+    NL_TEST_DEF("TestCommandSenderExtendableCallbackUnsupportedCommand", chip::app::TestCommandInteraction::TestCommandSenderExtendableCallbackUnsupportedCommand),
     NL_TEST_DEF("TestCommandSenderLegacyCallbackBuildingBatchCommandFails", chip::app::TestCommandInteraction::TestCommandSenderLegacyCallbackBuildingBatchCommandFails),
-    NL_TEST_DEF("TestCommandSenderExtendedCallbackBuildingBatchCommandFails", chip::app::TestCommandInteraction::TestCommandSenderExtendedCallbackBuildingBatchCommandFails),
+    NL_TEST_DEF("TestCommandSenderExtendableCallbackBuildingBatchCommandFails", chip::app::TestCommandInteraction::TestCommandSenderExtendableCallbackBuildingBatchCommandFails),
     NL_TEST_DEF("TestCommandSenderCommandSuccessResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandSuccessResponseFlow),
     NL_TEST_DEF("TestCommandSenderCommandAsyncSuccessResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandAsyncSuccessResponseFlow),
     NL_TEST_DEF("TestCommandSenderCommandSpecificResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandSpecificResponseFlow),

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -218,9 +218,8 @@ public:
     void OnResponse(CommandSender * apCommandSender, const CommandSender::ResponseData & aResponseData) override
     {
         IgnoreUnusedVariable(apCommandSender);
-        const ConcreteCommandPath & path = *aResponseData.path;
         ChipLogDetail(Controller, "Received response for command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%x",
-                      path.mClusterId, path.mCommandId, path.mEndpointId);
+                      aResponseData.path.mClusterId, aResponseData.path.mCommandId, aResponseData.path.mEndpointId);
         onResponseCalledTimes++;
     }
     void OnError(const CommandSender * apCommandSender, const CommandSender::ErrorData & aErrorData) override

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -212,11 +212,6 @@ public:
     CHIP_ERROR mError         = CHIP_NO_ERROR;
 } mockCommandSenderDelegate;
 
-class MockCommandSenderUsingExtendedPathCallbacks : public MockCommandSenderCallback
-{
-    bool UsingExtendedPathCallbacks() override { return true; }
-} mockCommandSenderExtendedPathDelegate;
-
 class MockCommandHandlerCallback : public CommandHandler::Callback
 {
 public:
@@ -266,8 +261,6 @@ public:
     static void TestCommandHandlerReleaseWithExchangeClosed(nlTestSuite * apSuite, void * apContext);
 #endif
 
-    static void TestCommandSenderLegacyUnsupportedCommand(nlTestSuite * apSuite, void * apContext);
-    static void TestCommandSenderExtendedPathUnsupportedCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandSuccessResponseFlow(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandAsyncSuccessResponseFlow(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderCommandFailureResponseFlow(nlTestSuite * apSuite, void * apContext);
@@ -1203,52 +1196,6 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
     }
 }
 
-void TestCommandInteraction::TestCommandSenderLegacyUnsupportedCommand(nlTestSuite * apSuite, void * apContext)
-{
-    TestContext & ctx = *static_cast<TestContext *>(apContext);
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-
-    mockCommandSenderDelegate.ResetCounter();
-    app::CommandSender commandSender(&mockCommandSenderDelegate, &ctx.GetExchangeManager());
-
-    AddInvokeRequestData(apSuite, apContext, &commandSender, kTestNonExistCommandId);
-    err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    ctx.DrainAndServiceIO();
-
-    NL_TEST_ASSERT(apSuite,
-                   mockCommandSenderDelegate.onResponseCalledTimes == 0 && mockCommandSenderDelegate.onFinalCalledTimes == 1 &&
-                       mockCommandSenderDelegate.onErrorCalledTimes == 1);
-
-    NL_TEST_ASSERT(apSuite, GetNumActiveHandlerObjects() == 0);
-    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
-}
-
-// Because UnsupportedCommand is a path specific error we will expect it to come via on response when using Extended Path.
-void TestCommandInteraction::TestCommandSenderExtendedPathUnsupportedCommand(nlTestSuite * apSuite, void * apContext)
-{
-    TestContext & ctx = *static_cast<TestContext *>(apContext);
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-
-    mockCommandSenderExtendedPathDelegate.ResetCounter();
-    app::CommandSender commandSender(&mockCommandSenderExtendedPathDelegate, &ctx.GetExchangeManager());
-
-    AddInvokeRequestData(apSuite, apContext, &commandSender, kTestNonExistCommandId);
-    err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    ctx.DrainAndServiceIO();
-
-    NL_TEST_ASSERT(apSuite,
-                   mockCommandSenderExtendedPathDelegate.onResponseCalledTimes == 1 &&
-                       mockCommandSenderExtendedPathDelegate.onFinalCalledTimes == 1 &&
-                       mockCommandSenderExtendedPathDelegate.onErrorCalledTimes == 0);
-
-    NL_TEST_ASSERT(apSuite, GetNumActiveHandlerObjects() == 0);
-    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
-}
-
 void TestCommandInteraction::TestCommandSenderCommandSuccessResponseFlow(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
@@ -1736,8 +1683,7 @@ const nlTest sTests[] =
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     NL_TEST_DEF("TestCommandHandlerReleaseWithExchangeClosed", chip::app::TestCommandInteraction::TestCommandHandlerReleaseWithExchangeClosed),
 #endif
-    NL_TEST_DEF("TestCommandSenderLegacyUnsupportedCommand", chip::app::TestCommandInteraction::TestCommandSenderLegacyUnsupportedCommand),
-    NL_TEST_DEF("TestCommandSenderExtendedPathUnsupportedCommand", chip::app::TestCommandInteraction::TestCommandSenderExtendedPathUnsupportedCommand),
+
     NL_TEST_DEF("TestCommandSenderCommandSuccessResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandSuccessResponseFlow),
     NL_TEST_DEF("TestCommandSenderCommandAsyncSuccessResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandAsyncSuccessResponseFlow),
     NL_TEST_DEF("TestCommandSenderCommandSpecificResponseFlow", chip::app::TestCommandInteraction::TestCommandSenderCommandSpecificResponseFlow),

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -215,9 +215,8 @@ public:
 class MockCommandSenderExtendedCallback : public CommandSender::ExtendedCallback
 {
 public:
-    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
-                    const StatusIB & aStatus, TLV::TLVReader * aData,
-                    const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
+    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const StatusIB & aStatus,
+                    TLV::TLVReader * aData, const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
     {
         IgnoreUnusedVariable(apCommandSender);
         IgnoreUnusedVariable(aData);
@@ -1291,14 +1290,14 @@ void TestCommandInteraction::TestCommandSenderLegacyCallbackBuildingBatchCommand
 
     // TODO(#30453): Once CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED is removed we will need
     // to call SetCommandSenderConfig with remoteMaxPathsPerInvoke set to 2.
-    commandSender.mBatchCommandsEnabled = true;
+    commandSender.mBatchCommandsEnabled    = true;
     commandSender.mRemoteMaxPathsPerInvoke = 2;
 
     auto commandPathParams = MakeTestCommandPath();
-    err = commandSender.PrepareCommand(commandPathParams, commandParameters);
+    err                    = commandSender.PrepareCommand(commandPathParams, commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     chip::TLV::TLVWriter * writer = commandSender.GetCommandDataIBTLVWriter();
-    err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
+    err                           = writer->PutBoolean(chip::TLV::ContextTag(1), true);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = commandSender.FinishCommand(commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1322,14 +1321,14 @@ void TestCommandInteraction::TestCommandSenderExtendedCallbackBuildingBatchComma
 
     // TODO(#30453): Once CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED is removed we will need
     // to call SetCommandSenderConfig with remoteMaxPathsPerInvoke set to 2.
-    commandSender.mBatchCommandsEnabled = true;
+    commandSender.mBatchCommandsEnabled    = true;
     commandSender.mRemoteMaxPathsPerInvoke = 2;
 
     auto commandPathParams = MakeTestCommandPath();
-    err = commandSender.PrepareCommand(commandPathParams, commandParameters);
+    err                    = commandSender.PrepareCommand(commandPathParams, commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     chip::TLV::TLVWriter * writer = commandSender.GetCommandDataIBTLVWriter();
-    err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
+    err                           = writer->PutBoolean(chip::TLV::ContextTag(1), true);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = commandSender.FinishCommand(commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1338,7 +1337,7 @@ void TestCommandInteraction::TestCommandSenderExtendedCallbackBuildingBatchComma
     err = commandSender.PrepareCommand(commandPathParams, commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     writer = commandSender.GetCommandDataIBTLVWriter();
-    err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
+    err    = writer->PutBoolean(chip::TLV::ContextTag(1), true);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = commandSender.FinishCommand(commandParameters);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -214,10 +214,7 @@ public:
 
 class MockCommandSenderUsingExtendedPathCallbacks : public MockCommandSenderCallback
 {
-    bool UsingExtendedPathCallbacks() override
-    {
-        return true;
-    }
+    bool UsingExtendedPathCallbacks() override { return true; }
 } mockCommandSenderExtendedPathDelegate;
 
 class MockCommandHandlerCallback : public CommandHandler::Callback
@@ -1244,7 +1241,8 @@ void TestCommandInteraction::TestCommandSenderExtendedPathUnsupportedCommand(nlT
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(apSuite,
-                   mockCommandSenderExtendedPathDelegate.onResponseCalledTimes == 1 && mockCommandSenderExtendedPathDelegate.onFinalCalledTimes == 1 &&
+                   mockCommandSenderExtendedPathDelegate.onResponseCalledTimes == 1 &&
+                       mockCommandSenderExtendedPathDelegate.onFinalCalledTimes == 1 &&
                        mockCommandSenderExtendedPathDelegate.onErrorCalledTimes == 0);
 
     NL_TEST_ASSERT(apSuite, GetNumActiveHandlerObjects() == 0);

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -149,7 +149,13 @@ class AsyncBatchCommandsTransaction:
             self._handleError(status, 0, IndexError(f"CommandSenderCallback has given us an unexpected index value {index}"))
             return
 
-        if (len(response) == 0):
+        if status.IMStatus != chip.interaction_model.Status.Success:
+            try:
+                self._responses[index] = chip.interaction_model.InteractionModelError(
+                    chip.interaction_model.Status(status.IMStatus), status.ClusterStatus)
+            except AttributeError as ex:
+                self._handleError(status, 0, ex)
+        elif (len(response) == 0):
             self._responses[index] = None
         else:
             # If a type hasn't been assigned, let's auto-deduce it.
@@ -173,9 +179,7 @@ class AsyncBatchCommandsTransaction:
 
     def _handleError(self, imError: Status, chipError: PyChipError, exception: Exception):
         if self._future.done():
-            # TODO Right now this even callback happens if there was a real IM Status error on one command.
-            # We need to update OnError to allow providing a CommandRef that we can try associating with it.
-            logger.exception(f"Recieved another error, but we have sent error. imError:{imError}, chipError {chipError}")
+            logger.exception(f"Recieved another error. Only expecting one error. imError:{imError}, chipError {chipError}")
             return
         if exception:
             self._future.set_exception(exception)

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -104,7 +104,7 @@ public:
             size = writer.GetLengthWritten();
         }
 
-        const app::StatusIB & statusIB = *aResponseData.statusIB;
+        const app::StatusIB & statusIB = aResponseData.statusIB;
 
         // For legacy specific reasons when we are not processing a batch command we simply forward this to the OnError callback
         // for more information on why see https://github.com/project-chip/connectedhomeip/issues/30991.
@@ -132,7 +132,7 @@ public:
             return;
         }
 
-        const ConcreteCommandPath & path = *aResponseData.path;
+        const ConcreteCommandPath & path = aResponseData.path;
 
         gOnCommandSenderResponseCallback(
             mAppContext, path.mEndpointId, path.mClusterId, path.mCommandId, index, to_underlying(statusIB.mStatus),

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -121,9 +121,9 @@ public:
             return;
         }
 
-        chip::CommandRef commandRef = aAdditionalResponseData.mCommandRef.ValueOr(0);
+        chip::CommandRef commandRef = aAdditionalResponseData.commandRef.ValueOr(0);
         size_t index                = 0;
-        err                         = GetIndexFromCommandRef(commandRef, index);
+        err                         = GetIndexFrocommandRef(commandRef, index);
         if (err != CHIP_NO_ERROR && mIsBatchedCommands)
         {
             CommandSender::ErrorData errorData = { err };
@@ -137,9 +137,9 @@ public:
             size);
     }
 
-    void OnError(const CommandSender * apCommandSender, CommandSender::ErrorData aErrorData) override
+    void OnError(const CommandSender * apCommandSender, const CommandSender::ErrorData & aErrorData) override
     {
-        CHIP_ERROR protocolError = aErrorData.mChipError;
+        CHIP_ERROR protocolError = aErrorData.chipError;
         StatusIB status(protocolError);
         gOnCommandSenderErrorCallback(mAppContext, to_underlying(status.mStatus),
                                       status.mClusterStatus.ValueOr(chip::python::kUndefinedClusterStatus),
@@ -157,31 +157,31 @@ public:
         delete this;
     };
 
-    CHIP_ERROR GetIndexFromCommandRef(uint16_t aCommandRef, size_t & aIndex)
+    CHIP_ERROR GetIndexFrocommandRef(uint16_t aCommandRef, size_t & aIndex)
     {
-        auto search = mCommandRefToIndex.find(aCommandRef);
-        if (search == mCommandRefToIndex.end())
+        auto search = commandRefToIndex.find(aCommandRef);
+        if (search == commandRefToIndex.end())
         {
             return CHIP_ERROR_KEY_NOT_FOUND;
         }
-        aIndex = mCommandRefToIndex[aCommandRef];
+        aIndex = commandRefToIndex[aCommandRef];
         return CHIP_NO_ERROR;
     }
 
     CHIP_ERROR AddCommandRefToIndexLookup(uint16_t aCommandRef, size_t aIndex)
     {
-        auto search = mCommandRefToIndex.find(aCommandRef);
-        if (search != mCommandRefToIndex.end())
+        auto search = commandRefToIndex.find(aCommandRef);
+        if (search != commandRefToIndex.end())
         {
             return CHIP_ERROR_DUPLICATE_KEY_ID;
         }
-        mCommandRefToIndex[aCommandRef] = aIndex;
+        commandRefToIndex[aCommandRef] = aIndex;
         return CHIP_NO_ERROR;
     }
 
 private:
     PyObject mAppContext = nullptr;
-    std::unordered_map<uint16_t, size_t> mCommandRefToIndex;
+    std::unordered_map<uint16_t, size_t> commandRefToIndex;
     bool mIsBatchedCommands;
 };
 
@@ -306,8 +306,8 @@ PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProx
 
             // CommandSender provides us with the CommandReference for this associated command. In order to match responses
             // we have to add CommandRef to index lookup.
-            VerifyOrExit(additionalParams.mCommandRef.HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
-            SuccessOrExit(err = callback->AddCommandRefToIndexLookup(additionalParams.mCommandRef.Value(), i));
+            VerifyOrExit(additionalParams.commandRef.HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
+            SuccessOrExit(err = callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i));
         }
     }
 

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -82,9 +82,8 @@ public:
         mAppContext(appContext), mIsBatchedCommands(isBatchedCommands)
     {}
 
-    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath,
-                    const app::StatusIB & aStatus, TLV::TLVReader * aData,
-                    const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
+    void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, const app::StatusIB & aStatus,
+                    TLV::TLVReader * aData, const CommandSender::AdditionalResponseData & aAdditionalResponseData) override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
         uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];
@@ -99,7 +98,7 @@ public:
             err = writer.CopyContainer(TLV::AnonymousTag(), *aData);
             if (err != CHIP_NO_ERROR)
             {
-                CommandSender::ErrorData errorData = {err};
+                CommandSender::ErrorData errorData = { err };
                 this->OnError(apCommandSender, errorData);
                 return;
             }
@@ -110,14 +109,14 @@ public:
         // for more information on why see https://github.com/project-chip/connectedhomeip/issues/30991.
         if (!mIsBatchedCommands && !aStatus.IsSuccess())
         {
-            CommandSender::ErrorData errorData = {aStatus.ToChipError()};
+            CommandSender::ErrorData errorData = { aStatus.ToChipError() };
             this->OnError(apCommandSender, errorData);
             return;
         }
 
         if (err != CHIP_NO_ERROR)
         {
-            CommandSender::ErrorData errorData = {err};
+            CommandSender::ErrorData errorData = { err };
             this->OnError(apCommandSender, errorData);
             return;
         }
@@ -127,7 +126,7 @@ public:
         err                         = GetIndexFromCommandRef(commandRef, index);
         if (err != CHIP_NO_ERROR && mIsBatchedCommands)
         {
-            CommandSender::ErrorData errorData = {err};
+            CommandSender::ErrorData errorData = { err };
             this->OnError(apCommandSender, errorData);
             return;
         }


### PR DESCRIPTION
Fixes: #30991

The two major differences between  `CommandSender::ExtendedCallback` and `CommandSender::Callback` are:
1. Path-specific errors go to OnResponse instead of OnError (Note: Non-path-specific errors still go to OnError)
2. Instead of having new parameters at the end of the function arguments list that contains defaults, the additional data is captured in a single struct defined in `CommandSender` so as functionality expands and more data needs to pass into the callback they are added to the struct instead of function argument list.

Alternatives considered:
* Earlier iteration of this PR where we had `Callback::PathSpecificErrorGoesToOnResponseCallbacks`, where we would call OnResponse* callback with path specific errors.
* #31017
* #30998

Test:
* CI Passes
  * New test cases is `src/app/tests/TestCommandInteraction.cpp` pass
* With local PR that makes changes to `chip-repl`, verified able to receive two path specific errors.

