### PR TITLE
[ICD] Add event generation to the ICDM cluster

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -301,8 +301,10 @@ template("chip_data_model") {
         deps += [
           "${chip_root}/src/app/icd:configuration-data",
           "${chip_root}/src/app/icd:icd_config",
+          "${chip_root}/src/app/icd:manager",
           "${chip_root}/src/app/icd:monitoring-table",
           "${chip_root}/src/app/icd:notifier",
+          "${chip_root}/src/app/icd:observer",
         ]
       } else if (cluster == "resource-monitoring-server") {
         sources += [


### PR DESCRIPTION
#### Description
Adds the OnTransitionToActiveMode event to the ICDM cluster server.

- PR converts ICDM server class to a singleton for it to be able to register with the ICDM Manager for events

#### Tests
Manual tests to validate the cluster generates the event
