### PR TITLE
Handle energy type naming in data model xml handlers

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
@@ -104,8 +104,8 @@ _REF_NAME_MAPPING = {
 
 # Handle odd casing and naming
 _CASE_RENAMES_MAPPING = {
-  "power_mW": "power_mw",
-  "energy_mWh": "energy_mwh"
+    "power_mW": "power_mw",
+    "energy_mWh": "energy_mwh"
 }
 
 

--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/parsing.py
@@ -102,6 +102,13 @@ _REF_NAME_MAPPING = {
 }
 
 
+# Handle odd casing and naming
+_CASE_RENAMES_MAPPING = {
+  "power_mW": "power_mw",
+  "energy_mWh": "energy_mwh"
+}
+
+
 def ParseType(t: str) -> ParsedType:
     """Parse a data type entry.
 
@@ -122,6 +129,9 @@ def ParseType(t: str) -> ParsedType:
 
     if t in _REF_NAME_MAPPING:
         t = _REF_NAME_MAPPING[t]
+
+    if t in _CASE_RENAMES_MAPPING:
+        t = _CASE_RENAMES_MAPPING[t]
 
     return ParsedType(name=NormalizeDataType(t), is_list=is_list)
 

--- a/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
+++ b/scripts/py_matter_idl/matter_idl/test_data_model_xml.py
@@ -415,6 +415,19 @@ class TestXmlParser(unittest.TestCase):
                     <access read="true" write="true"/>
                     <mandatoryConform/>
                   </field>
+                  <field id="3" name="NominalPower" type="power-mW">
+                    <access read="true" write="true"/>
+                    <mandatoryConform>
+                      <feature name="PFR"/>
+                    </mandatoryConform>
+                    <constraint type="desc"/>
+                  </field>
+                  <field id="4" name="MaximumEnergy" type="energy-mWh">
+                    <access read="true" write="true"/>
+                    <mandatoryConform>
+                      <feature name="PFR"/>
+                    </mandatoryConform>
+                  </field>
                 </struct>
               </dataTypes>
               <attributes>
@@ -443,10 +456,13 @@ class TestXmlParser(unittest.TestCase):
                   char_string id = 0;
                   int8u items[] = 1;
                   endpoint_no endpoints[] = 2;
+                  optional power_mw nominalPower = 3;
+                  optional energy_mwh maximumEnergy = 4;
                }
 
                readonly attribute OutputInfoStruct outputList[] = 0;
                readonly attribute optional enum8 testConform = 1;
+
 
                readonly attribute attrib_id attributeList[] = 65531;
                readonly attribute event_id eventList[] = 65530;


### PR DESCRIPTION
The types in xml contain uppercase W, handle a re-mapping into types that our idl uses.

specifically we do `power_mw` instead of `power_mW` and similar for energy.