### PR TITLE
Cleanup callbacks a bit: remove client-side attribute callbacks and some useless comments

### DIFF
--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -18,10 +18,7 @@
 
 {{#zcl_clusters}}
 
-/** @brief {{label}} Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAf{{asUpperCamelCase label}}ClusterInitCallback(chip::EndpointId endpoint);
@@ -36,42 +33,27 @@ void emberAf{{asUpperCamelCase label}}ClusterInitCallback(chip::EndpointId endpo
 // {{label}} Cluster
 //
 
-/** @brief {{label}} Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAf{{asUpperCamelCase label}}ClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief {{label}} Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void Matter{{asUpperCamelCase label}}ClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief {{label}} Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAf{{asUpperCamelCase label}}ClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief {{label}} Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void Matter{{asUpperCamelCase label}}ClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief {{label}} Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -79,32 +61,10 @@ void Matter{{asUpperCamelCase label}}ClusterServerAttributeChangedCallback(const
  */
 chip::Protocols::InteractionModel::Status Matter{{asUpperCamelCase label}}ClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief {{label}} Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status Matter{{asUpperCamelCase label}}ClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief {{label}} Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAf{{asUpperCamelCase label}}ClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief {{label}} Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAf{{asUpperCamelCase label}}ClusterClientTickCallback(chip::EndpointId endpoint);
 
 {{/zcl_clusters}}
 

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -33,906 +33,567 @@
 
 // Cluster Init Functions
 
-/** @brief Identify Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIdentifyClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Groups Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Scenes Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfScenesClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/Off Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/off Switch Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffSwitchConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Level Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLevelControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binary Input (Basic) Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBinaryInputBasicClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pulse Width Modulation Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPulseWidthModulationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Descriptor Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDescriptorClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binding Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBindingClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Access Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccessControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Actions Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActionsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Basic Information Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBasicInformationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Provider Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateProviderClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Requestor Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateRequestorClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Localization Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLocalizationConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Format Localization Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeFormatLocalizationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Localization Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitLocalizationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Commissioning Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralCommissioningClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Network Commissioning Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNetworkCommissioningClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Diagnostic Logs Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDiagnosticLogsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Diagnostics Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralDiagnosticsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Software Diagnostics Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSoftwareDiagnosticsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thread Network Diagnostics Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThreadNetworkDiagnosticsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief WiFi Network Diagnostics Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWiFiNetworkDiagnosticsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ethernet Network Diagnostics Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEthernetNetworkDiagnosticsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Synchronization Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeSynchronizationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Bridged Device Basic Information Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBridgedDeviceBasicInformationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Switch Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSwitchClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Administrator Commissioning Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAdministratorCommissioningClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational Credentials Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalCredentialsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Group Key Management Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupKeyManagementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fixed Label Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFixedLabelClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief User Label Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUserLabelClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Discovery Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyDiscoveryClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Valid Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyValidClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief ICD Management Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIcdManagementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Timer Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimerClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Cavity Operational State Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenCavityOperationalStateClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Dryer Controls Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryDryerControlsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Mode Select Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfModeSelectClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Controls Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherControlsClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Run Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcRunModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Clean Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcCleanModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator Alarm Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAlarmClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Air Quality Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAirQualityClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Smoke CO Alarm Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSmokeCoAlarmClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Alarm Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherAlarmClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Mode Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenModeClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational State Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Operational State Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcOperationalStateClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief HEPA Filter Monitoring Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfHepaFilterMonitoringClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActivatedCarbonFilterMonitoringClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Valve Configuration and Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfValveConfigurationAndControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Energy Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Demand Response Load Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDemandResponseLoadControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Device Energy Management Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDeviceEnergyManagementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy EVSE Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyEvseClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy Preference Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyPreferenceClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Door Lock Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDoorLockClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Window Covering Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWindowCoveringClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Barrier Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBarrierControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pump Configuration and Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPumpConfigurationAndControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fan Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFanControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat User Interface Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatUserInterfaceConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Color Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfColorControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ballast Configuration Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBallastConfigurationClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Illuminance Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIlluminanceMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pressure Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPressureMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Flow Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFlowMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Relative Humidity Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRelativeHumidityMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Occupancy Sensing Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOccupancySensingClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ozone Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOzoneConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM2.5 Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm25ConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFormaldehydeConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM1 Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm1ConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM10 Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm10ConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Radon Concentration Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRadonConcentrationMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Wake on LAN Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWakeOnLanClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Channel Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfChannelClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Target Navigator Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTargetNavigatorClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Playback Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaPlaybackClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Input Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaInputClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Low Power Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLowPowerClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Keypad Input Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfKeypadInputClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Launcher Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentLauncherClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Audio Output Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAudioOutputClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Launcher Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationLauncherClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Basic Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationBasicClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Account Login Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccountLoginClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Control Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentControlClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content App Observer Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentAppObserverClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Measurement Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalMeasurementClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Testing Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitTestingClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fault Injection Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFaultInjectionClusterInitCallback(chip::EndpointId endpoint);
 
-/** @brief Sample MEI Cluster Init
- *
- * Cluster Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSampleMeiClusterInitCallback(chip::EndpointId endpoint);
@@ -943,42 +604,27 @@ void emberAfSampleMeiClusterInitCallback(chip::EndpointId endpoint);
 // Identify Cluster
 //
 
-/** @brief Identify Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIdentifyClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Identify Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterIdentifyClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Identify Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Identify Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterIdentifyClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Identify Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -988,75 +634,36 @@ chip::Protocols::InteractionModel::Status
 MatterIdentifyClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Identify Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterIdentifyClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Identify Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfIdentifyClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Identify Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfIdentifyClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Groups Cluster
 //
 
-/** @brief Groups Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Groups Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterGroupsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Groups Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Groups Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterGroupsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Groups Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1066,75 +673,36 @@ chip::Protocols::InteractionModel::Status
 MatterGroupsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Groups Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterGroupsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Groups Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfGroupsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Groups Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfGroupsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Scenes Cluster
 //
 
-/** @brief Scenes Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfScenesClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Scenes Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterScenesClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Scenes Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Scenes Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterScenesClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Scenes Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1144,75 +712,36 @@ chip::Protocols::InteractionModel::Status
 MatterScenesClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Scenes Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterScenesClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Scenes Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfScenesClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Scenes Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfScenesClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // On/Off Cluster
 //
 
-/** @brief On/Off Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/Off Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOnOffClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief On/Off Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/Off Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOnOffClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief On/Off Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1222,75 +751,36 @@ chip::Protocols::InteractionModel::Status
 MatterOnOffClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief On/Off Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterOnOffClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief On/Off Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOnOffClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief On/Off Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOnOffClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // On/off Switch Configuration Cluster
 //
 
-/** @brief On/off Switch Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffSwitchConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/off Switch Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOnOffSwitchConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief On/off Switch Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOnOffSwitchConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief On/off Switch Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOnOffSwitchConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief On/off Switch Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1299,74 +789,36 @@ void MatterOnOffSwitchConfigurationClusterServerAttributeChangedCallback(const c
 chip::Protocols::InteractionModel::Status MatterOnOffSwitchConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief On/off Switch Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOnOffSwitchConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief On/off Switch Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOnOffSwitchConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief On/off Switch Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOnOffSwitchConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Level Control Cluster
 //
 
-/** @brief Level Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLevelControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Level Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLevelControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Level Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Level Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLevelControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Level Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1376,75 +828,36 @@ chip::Protocols::InteractionModel::Status
 MatterLevelControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Level Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterLevelControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Level Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLevelControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Level Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLevelControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Binary Input (Basic) Cluster
 //
 
-/** @brief Binary Input (Basic) Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBinaryInputBasicClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binary Input (Basic) Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBinaryInputBasicClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Binary Input (Basic) Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binary Input (Basic) Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBinaryInputBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Binary Input (Basic) Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1454,75 +867,36 @@ chip::Protocols::InteractionModel::Status
 MatterBinaryInputBasicClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Binary Input (Basic) Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterBinaryInputBasicClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Binary Input (Basic) Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBinaryInputBasicClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Binary Input (Basic) Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBinaryInputBasicClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Pulse Width Modulation Cluster
 //
 
-/** @brief Pulse Width Modulation Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPulseWidthModulationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pulse Width Modulation Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPulseWidthModulationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Pulse Width Modulation Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPulseWidthModulationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pulse Width Modulation Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPulseWidthModulationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Pulse Width Modulation Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1531,74 +905,36 @@ void MatterPulseWidthModulationClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterPulseWidthModulationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Pulse Width Modulation Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPulseWidthModulationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Pulse Width Modulation Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPulseWidthModulationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Pulse Width Modulation Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPulseWidthModulationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Descriptor Cluster
 //
 
-/** @brief Descriptor Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDescriptorClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Descriptor Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDescriptorClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Descriptor Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDescriptorClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Descriptor Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDescriptorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Descriptor Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1608,75 +944,36 @@ chip::Protocols::InteractionModel::Status
 MatterDescriptorClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Descriptor Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterDescriptorClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Descriptor Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDescriptorClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Descriptor Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDescriptorClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Binding Cluster
 //
 
-/** @brief Binding Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBindingClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binding Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBindingClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Binding Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBindingClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Binding Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBindingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Binding Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1686,75 +983,36 @@ chip::Protocols::InteractionModel::Status
 MatterBindingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Binding Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterBindingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Binding Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBindingClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Binding Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBindingClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Access Control Cluster
 //
 
-/** @brief Access Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccessControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Access Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterAccessControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Access Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccessControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Access Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterAccessControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Access Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1764,75 +1022,36 @@ chip::Protocols::InteractionModel::Status
 MatterAccessControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Access Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterAccessControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Access Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfAccessControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Access Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfAccessControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Actions Cluster
 //
 
-/** @brief Actions Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActionsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Actions Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterActionsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Actions Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActionsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Actions Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterActionsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Actions Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1842,75 +1061,36 @@ chip::Protocols::InteractionModel::Status
 MatterActionsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Actions Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterActionsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Actions Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfActionsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Actions Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfActionsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Basic Information Cluster
 //
 
-/** @brief Basic Information Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBasicInformationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Basic Information Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBasicInformationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Basic Information Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBasicInformationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Basic Information Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBasicInformationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Basic Information Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1920,75 +1100,36 @@ chip::Protocols::InteractionModel::Status
 MatterBasicInformationClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Basic Information Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterBasicInformationClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Basic Information Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBasicInformationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Basic Information Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBasicInformationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // OTA Software Update Provider Cluster
 //
 
-/** @brief OTA Software Update Provider Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateProviderClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Provider Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOtaSoftwareUpdateProviderClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Provider Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateProviderClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Provider Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOtaSoftwareUpdateProviderClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief OTA Software Update Provider Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -1997,74 +1138,36 @@ void MatterOtaSoftwareUpdateProviderClusterServerAttributeChangedCallback(const 
 chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateProviderClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief OTA Software Update Provider Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateProviderClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief OTA Software Update Provider Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOtaSoftwareUpdateProviderClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief OTA Software Update Provider Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOtaSoftwareUpdateProviderClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // OTA Software Update Requestor Cluster
 //
 
-/** @brief OTA Software Update Requestor Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateRequestorClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Requestor Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOtaSoftwareUpdateRequestorClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Requestor Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOtaSoftwareUpdateRequestorClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief OTA Software Update Requestor Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOtaSoftwareUpdateRequestorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief OTA Software Update Requestor Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2073,74 +1176,36 @@ void MatterOtaSoftwareUpdateRequestorClusterServerAttributeChangedCallback(const
 chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateRequestorClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief OTA Software Update Requestor Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateRequestorClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief OTA Software Update Requestor Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOtaSoftwareUpdateRequestorClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief OTA Software Update Requestor Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOtaSoftwareUpdateRequestorClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Localization Configuration Cluster
 //
 
-/** @brief Localization Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLocalizationConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Localization Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLocalizationConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Localization Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLocalizationConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Localization Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLocalizationConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Localization Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2149,74 +1214,36 @@ void MatterLocalizationConfigurationClusterServerAttributeChangedCallback(const 
 chip::Protocols::InteractionModel::Status MatterLocalizationConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Localization Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterLocalizationConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Localization Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLocalizationConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Localization Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLocalizationConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Time Format Localization Cluster
 //
 
-/** @brief Time Format Localization Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeFormatLocalizationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Format Localization Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTimeFormatLocalizationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Time Format Localization Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeFormatLocalizationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Format Localization Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTimeFormatLocalizationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Time Format Localization Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2225,74 +1252,36 @@ void MatterTimeFormatLocalizationClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterTimeFormatLocalizationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Time Format Localization Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterTimeFormatLocalizationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Time Format Localization Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTimeFormatLocalizationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Time Format Localization Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTimeFormatLocalizationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Unit Localization Cluster
 //
 
-/** @brief Unit Localization Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitLocalizationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Localization Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterUnitLocalizationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Localization Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitLocalizationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Localization Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterUnitLocalizationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Unit Localization Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2302,75 +1291,36 @@ chip::Protocols::InteractionModel::Status
 MatterUnitLocalizationClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Unit Localization Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterUnitLocalizationClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Unit Localization Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfUnitLocalizationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Unit Localization Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfUnitLocalizationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Power Source Configuration Cluster
 //
 
-/** @brief Power Source Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPowerSourceConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPowerSourceConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Power Source Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2379,74 +1329,36 @@ void MatterPowerSourceConfigurationClusterServerAttributeChangedCallback(const c
 chip::Protocols::InteractionModel::Status MatterPowerSourceConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Power Source Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPowerSourceConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Power Source Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPowerSourceConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Power Source Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPowerSourceConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Power Source Cluster
 //
 
-/** @brief Power Source Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPowerSourceClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPowerSourceClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Power Source Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPowerSourceClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Power Source Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2456,75 +1368,36 @@ chip::Protocols::InteractionModel::Status
 MatterPowerSourceClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Power Source Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterPowerSourceClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Power Source Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPowerSourceClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Power Source Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPowerSourceClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // General Commissioning Cluster
 //
 
-/** @brief General Commissioning Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Commissioning Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterGeneralCommissioningClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief General Commissioning Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Commissioning Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterGeneralCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief General Commissioning Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2533,74 +1406,36 @@ void MatterGeneralCommissioningClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterGeneralCommissioningClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief General Commissioning Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterGeneralCommissioningClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief General Commissioning Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfGeneralCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief General Commissioning Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfGeneralCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Network Commissioning Cluster
 //
 
-/** @brief Network Commissioning Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNetworkCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Network Commissioning Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterNetworkCommissioningClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Network Commissioning Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNetworkCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Network Commissioning Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterNetworkCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Network Commissioning Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2609,74 +1444,36 @@ void MatterNetworkCommissioningClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterNetworkCommissioningClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Network Commissioning Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterNetworkCommissioningClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Network Commissioning Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfNetworkCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Network Commissioning Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfNetworkCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Diagnostic Logs Cluster
 //
 
-/** @brief Diagnostic Logs Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDiagnosticLogsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Diagnostic Logs Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDiagnosticLogsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Diagnostic Logs Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDiagnosticLogsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Diagnostic Logs Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDiagnosticLogsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Diagnostic Logs Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2686,75 +1483,36 @@ chip::Protocols::InteractionModel::Status
 MatterDiagnosticLogsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Diagnostic Logs Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterDiagnosticLogsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Diagnostic Logs Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDiagnosticLogsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Diagnostic Logs Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDiagnosticLogsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // General Diagnostics Cluster
 //
 
-/** @brief General Diagnostics Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Diagnostics Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterGeneralDiagnosticsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief General Diagnostics Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGeneralDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief General Diagnostics Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterGeneralDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief General Diagnostics Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2763,74 +1521,36 @@ void MatterGeneralDiagnosticsClusterServerAttributeChangedCallback(const chip::a
 chip::Protocols::InteractionModel::Status MatterGeneralDiagnosticsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief General Diagnostics Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterGeneralDiagnosticsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief General Diagnostics Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfGeneralDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief General Diagnostics Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfGeneralDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Software Diagnostics Cluster
 //
 
-/** @brief Software Diagnostics Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSoftwareDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Software Diagnostics Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterSoftwareDiagnosticsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Software Diagnostics Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSoftwareDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Software Diagnostics Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterSoftwareDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Software Diagnostics Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2839,74 +1559,36 @@ void MatterSoftwareDiagnosticsClusterServerAttributeChangedCallback(const chip::
 chip::Protocols::InteractionModel::Status MatterSoftwareDiagnosticsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Software Diagnostics Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterSoftwareDiagnosticsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Software Diagnostics Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfSoftwareDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Software Diagnostics Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfSoftwareDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Thread Network Diagnostics Cluster
 //
 
-/** @brief Thread Network Diagnostics Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThreadNetworkDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thread Network Diagnostics Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterThreadNetworkDiagnosticsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Thread Network Diagnostics Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThreadNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thread Network Diagnostics Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterThreadNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Thread Network Diagnostics Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2915,74 +1597,36 @@ void MatterThreadNetworkDiagnosticsClusterServerAttributeChangedCallback(const c
 chip::Protocols::InteractionModel::Status MatterThreadNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Thread Network Diagnostics Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterThreadNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Thread Network Diagnostics Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfThreadNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Thread Network Diagnostics Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfThreadNetworkDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // WiFi Network Diagnostics Cluster
 //
 
-/** @brief WiFi Network Diagnostics Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWiFiNetworkDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief WiFi Network Diagnostics Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterWiFiNetworkDiagnosticsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief WiFi Network Diagnostics Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWiFiNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief WiFi Network Diagnostics Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterWiFiNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief WiFi Network Diagnostics Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -2991,74 +1635,36 @@ void MatterWiFiNetworkDiagnosticsClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterWiFiNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief WiFi Network Diagnostics Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterWiFiNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief WiFi Network Diagnostics Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief WiFi Network Diagnostics Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfWiFiNetworkDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Ethernet Network Diagnostics Cluster
 //
 
-/** @brief Ethernet Network Diagnostics Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEthernetNetworkDiagnosticsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ethernet Network Diagnostics Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterEthernetNetworkDiagnosticsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Ethernet Network Diagnostics Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEthernetNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ethernet Network Diagnostics Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterEthernetNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Ethernet Network Diagnostics Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3067,74 +1673,36 @@ void MatterEthernetNetworkDiagnosticsClusterServerAttributeChangedCallback(const
 chip::Protocols::InteractionModel::Status MatterEthernetNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Ethernet Network Diagnostics Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterEthernetNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Ethernet Network Diagnostics Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfEthernetNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Ethernet Network Diagnostics Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfEthernetNetworkDiagnosticsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Time Synchronization Cluster
 //
 
-/** @brief Time Synchronization Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeSynchronizationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Synchronization Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTimeSynchronizationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Time Synchronization Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimeSynchronizationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Time Synchronization Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTimeSynchronizationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Time Synchronization Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3143,75 +1711,37 @@ void MatterTimeSynchronizationClusterServerAttributeChangedCallback(const chip::
 chip::Protocols::InteractionModel::Status MatterTimeSynchronizationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Time Synchronization Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterTimeSynchronizationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Time Synchronization Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTimeSynchronizationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Time Synchronization Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTimeSynchronizationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Bridged Device Basic Information Cluster
 //
 
-/** @brief Bridged Device Basic Information Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBridgedDeviceBasicInformationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Bridged Device Basic Information Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBridgedDeviceBasicInformationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Bridged Device Basic Information Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBridgedDeviceBasicInformationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Bridged Device Basic Information Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBridgedDeviceBasicInformationClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Bridged Device Basic Information Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3220,74 +1750,36 @@ void MatterBridgedDeviceBasicInformationClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterBridgedDeviceBasicInformationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Bridged Device Basic Information Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterBridgedDeviceBasicInformationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Bridged Device Basic Information Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBridgedDeviceBasicInformationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Bridged Device Basic Information Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBridgedDeviceBasicInformationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Switch Cluster
 //
 
-/** @brief Switch Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSwitchClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Switch Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterSwitchClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Switch Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSwitchClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Switch Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterSwitchClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Switch Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3297,75 +1789,36 @@ chip::Protocols::InteractionModel::Status
 MatterSwitchClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Switch Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterSwitchClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Switch Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfSwitchClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Switch Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfSwitchClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Administrator Commissioning Cluster
 //
 
-/** @brief Administrator Commissioning Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAdministratorCommissioningClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Administrator Commissioning Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterAdministratorCommissioningClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Administrator Commissioning Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAdministratorCommissioningClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Administrator Commissioning Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterAdministratorCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Administrator Commissioning Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3374,74 +1827,36 @@ void MatterAdministratorCommissioningClusterServerAttributeChangedCallback(const
 chip::Protocols::InteractionModel::Status MatterAdministratorCommissioningClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Administrator Commissioning Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterAdministratorCommissioningClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Administrator Commissioning Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfAdministratorCommissioningClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Administrator Commissioning Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfAdministratorCommissioningClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Operational Credentials Cluster
 //
 
-/** @brief Operational Credentials Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalCredentialsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational Credentials Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOperationalCredentialsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Operational Credentials Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalCredentialsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational Credentials Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOperationalCredentialsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Operational Credentials Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3450,74 +1865,36 @@ void MatterOperationalCredentialsClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterOperationalCredentialsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Operational Credentials Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOperationalCredentialsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Operational Credentials Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOperationalCredentialsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Operational Credentials Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOperationalCredentialsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Group Key Management Cluster
 //
 
-/** @brief Group Key Management Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupKeyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Group Key Management Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterGroupKeyManagementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Group Key Management Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfGroupKeyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Group Key Management Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterGroupKeyManagementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Group Key Management Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3526,74 +1903,36 @@ void MatterGroupKeyManagementClusterServerAttributeChangedCallback(const chip::a
 chip::Protocols::InteractionModel::Status MatterGroupKeyManagementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Group Key Management Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterGroupKeyManagementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Group Key Management Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfGroupKeyManagementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Group Key Management Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfGroupKeyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Fixed Label Cluster
 //
 
-/** @brief Fixed Label Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFixedLabelClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fixed Label Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterFixedLabelClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Fixed Label Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFixedLabelClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fixed Label Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterFixedLabelClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Fixed Label Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3603,75 +1942,36 @@ chip::Protocols::InteractionModel::Status
 MatterFixedLabelClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Fixed Label Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterFixedLabelClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Fixed Label Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfFixedLabelClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Fixed Label Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfFixedLabelClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // User Label Cluster
 //
 
-/** @brief User Label Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUserLabelClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief User Label Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterUserLabelClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief User Label Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUserLabelClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief User Label Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterUserLabelClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief User Label Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3681,75 +1981,36 @@ chip::Protocols::InteractionModel::Status
 MatterUserLabelClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief User Label Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterUserLabelClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief User Label Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfUserLabelClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief User Label Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfUserLabelClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Proxy Configuration Cluster
 //
 
-/** @brief Proxy Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterProxyConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterProxyConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Proxy Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3758,74 +2019,36 @@ void MatterProxyConfigurationClusterServerAttributeChangedCallback(const chip::a
 chip::Protocols::InteractionModel::Status MatterProxyConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Proxy Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterProxyConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Proxy Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfProxyConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Proxy Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfProxyConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Proxy Discovery Cluster
 //
 
-/** @brief Proxy Discovery Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyDiscoveryClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Discovery Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterProxyDiscoveryClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Discovery Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyDiscoveryClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Discovery Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterProxyDiscoveryClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Proxy Discovery Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3835,75 +2058,36 @@ chip::Protocols::InteractionModel::Status
 MatterProxyDiscoveryClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Proxy Discovery Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterProxyDiscoveryClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Proxy Discovery Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfProxyDiscoveryClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Proxy Discovery Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfProxyDiscoveryClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Proxy Valid Cluster
 //
 
-/** @brief Proxy Valid Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyValidClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Valid Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterProxyValidClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Valid Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfProxyValidClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Proxy Valid Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterProxyValidClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Proxy Valid Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3913,75 +2097,36 @@ chip::Protocols::InteractionModel::Status
 MatterProxyValidClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Proxy Valid Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterProxyValidClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Proxy Valid Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfProxyValidClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Proxy Valid Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfProxyValidClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Boolean State Cluster
 //
 
-/** @brief Boolean State Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBooleanStateClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBooleanStateClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Boolean State Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -3991,75 +2136,36 @@ chip::Protocols::InteractionModel::Status
 MatterBooleanStateClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Boolean State Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterBooleanStateClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Boolean State Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBooleanStateClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Boolean State Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBooleanStateClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // ICD Management Cluster
 //
 
-/** @brief ICD Management Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIcdManagementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief ICD Management Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterIcdManagementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief ICD Management Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIcdManagementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief ICD Management Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterIcdManagementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief ICD Management Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4069,75 +2175,36 @@ chip::Protocols::InteractionModel::Status
 MatterIcdManagementClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief ICD Management Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterIcdManagementClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief ICD Management Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfIcdManagementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief ICD Management Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfIcdManagementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Timer Cluster
 //
 
-/** @brief Timer Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimerClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Timer Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTimerClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Timer Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTimerClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Timer Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTimerClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Timer Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4147,75 +2214,36 @@ chip::Protocols::InteractionModel::Status
 MatterTimerClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Timer Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterTimerClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Timer Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTimerClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Timer Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTimerClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Oven Cavity Operational State Cluster
 //
 
-/** @brief Oven Cavity Operational State Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenCavityOperationalStateClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Cavity Operational State Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOvenCavityOperationalStateClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Cavity Operational State Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenCavityOperationalStateClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Cavity Operational State Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOvenCavityOperationalStateClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Oven Cavity Operational State Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4224,74 +2252,36 @@ void MatterOvenCavityOperationalStateClusterServerAttributeChangedCallback(const
 chip::Protocols::InteractionModel::Status MatterOvenCavityOperationalStateClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Oven Cavity Operational State Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOvenCavityOperationalStateClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Oven Cavity Operational State Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOvenCavityOperationalStateClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Oven Cavity Operational State Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOvenCavityOperationalStateClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Oven Mode Cluster
 //
 
-/** @brief Oven Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOvenModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOvenModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Oven Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOvenModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Oven Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4301,75 +2291,36 @@ chip::Protocols::InteractionModel::Status
 MatterOvenModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Oven Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterOvenModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Oven Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOvenModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Oven Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOvenModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Laundry Dryer Controls Cluster
 //
 
-/** @brief Laundry Dryer Controls Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryDryerControlsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Dryer Controls Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLaundryDryerControlsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Dryer Controls Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryDryerControlsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Dryer Controls Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLaundryDryerControlsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Laundry Dryer Controls Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4378,74 +2329,36 @@ void MatterLaundryDryerControlsClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterLaundryDryerControlsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Laundry Dryer Controls Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterLaundryDryerControlsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Laundry Dryer Controls Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLaundryDryerControlsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Laundry Dryer Controls Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLaundryDryerControlsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Mode Select Cluster
 //
 
-/** @brief Mode Select Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfModeSelectClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Mode Select Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterModeSelectClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Mode Select Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfModeSelectClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Mode Select Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterModeSelectClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Mode Select Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4455,75 +2368,36 @@ chip::Protocols::InteractionModel::Status
 MatterModeSelectClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Mode Select Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterModeSelectClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Mode Select Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfModeSelectClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Mode Select Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfModeSelectClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Laundry Washer Mode Cluster
 //
 
-/** @brief Laundry Washer Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLaundryWasherModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLaundryWasherModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Laundry Washer Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4533,76 +2407,37 @@ chip::Protocols::InteractionModel::Status
 MatterLaundryWasherModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                 EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Laundry Washer Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterLaundryWasherModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Laundry Washer Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLaundryWasherModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Laundry Washer Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLaundryWasherModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Refrigerator And Temperature Controlled Cabinet Mode Cluster
 //
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRefrigeratorAndTemperatureControlledCabinetModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRefrigeratorAndTemperatureControlledCabinetModeClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4612,75 +2447,36 @@ chip::Protocols::InteractionModel::Status
 MatterRefrigeratorAndTemperatureControlledCabinetModeClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterRefrigeratorAndTemperatureControlledCabinetModeClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Refrigerator And Temperature Controlled Cabinet Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Laundry Washer Controls Cluster
 //
 
-/** @brief Laundry Washer Controls Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherControlsClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Controls Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLaundryWasherControlsClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Controls Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLaundryWasherControlsClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Laundry Washer Controls Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLaundryWasherControlsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Laundry Washer Controls Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4689,74 +2485,36 @@ void MatterLaundryWasherControlsClusterServerAttributeChangedCallback(const chip
 chip::Protocols::InteractionModel::Status MatterLaundryWasherControlsClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Laundry Washer Controls Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterLaundryWasherControlsClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Laundry Washer Controls Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLaundryWasherControlsClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Laundry Washer Controls Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLaundryWasherControlsClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // RVC Run Mode Cluster
 //
 
-/** @brief RVC Run Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcRunModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Run Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRvcRunModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Run Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcRunModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Run Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRvcRunModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief RVC Run Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4766,75 +2524,36 @@ chip::Protocols::InteractionModel::Status
 MatterRvcRunModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief RVC Run Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterRvcRunModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief RVC Run Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRvcRunModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief RVC Run Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRvcRunModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // RVC Clean Mode Cluster
 //
 
-/** @brief RVC Clean Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcCleanModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Clean Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRvcCleanModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Clean Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcCleanModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Clean Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRvcCleanModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief RVC Clean Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4844,75 +2563,36 @@ chip::Protocols::InteractionModel::Status
 MatterRvcCleanModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief RVC Clean Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterRvcCleanModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief RVC Clean Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRvcCleanModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief RVC Clean Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRvcCleanModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Temperature Control Cluster
 //
 
-/** @brief Temperature Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTemperatureControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTemperatureControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Temperature Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4921,74 +2601,36 @@ void MatterTemperatureControlClusterServerAttributeChangedCallback(const chip::a
 chip::Protocols::InteractionModel::Status MatterTemperatureControlClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Temperature Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterTemperatureControlClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Temperature Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTemperatureControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Temperature Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTemperatureControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Refrigerator Alarm Cluster
 //
 
-/** @brief Refrigerator Alarm Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator Alarm Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRefrigeratorAlarmClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator Alarm Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRefrigeratorAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Refrigerator Alarm Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRefrigeratorAlarmClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Refrigerator Alarm Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -4998,75 +2640,36 @@ chip::Protocols::InteractionModel::Status
 MatterRefrigeratorAlarmClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                 EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Refrigerator Alarm Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterRefrigeratorAlarmClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Refrigerator Alarm Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRefrigeratorAlarmClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Refrigerator Alarm Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRefrigeratorAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Dishwasher Mode Cluster
 //
 
-/** @brief Dishwasher Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDishwasherModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDishwasherModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Dishwasher Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5076,75 +2679,36 @@ chip::Protocols::InteractionModel::Status
 MatterDishwasherModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Dishwasher Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterDishwasherModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Dishwasher Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDishwasherModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Dishwasher Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDishwasherModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Air Quality Cluster
 //
 
-/** @brief Air Quality Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAirQualityClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Air Quality Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterAirQualityClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Air Quality Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAirQualityClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Air Quality Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterAirQualityClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Air Quality Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5154,75 +2718,36 @@ chip::Protocols::InteractionModel::Status
 MatterAirQualityClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Air Quality Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterAirQualityClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Air Quality Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfAirQualityClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Air Quality Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfAirQualityClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Smoke CO Alarm Cluster
 //
 
-/** @brief Smoke CO Alarm Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSmokeCoAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Smoke CO Alarm Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterSmokeCoAlarmClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Smoke CO Alarm Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSmokeCoAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Smoke CO Alarm Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterSmokeCoAlarmClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Smoke CO Alarm Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5232,75 +2757,36 @@ chip::Protocols::InteractionModel::Status
 MatterSmokeCoAlarmClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Smoke CO Alarm Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterSmokeCoAlarmClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Smoke CO Alarm Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfSmokeCoAlarmClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Smoke CO Alarm Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfSmokeCoAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Dishwasher Alarm Cluster
 //
 
-/** @brief Dishwasher Alarm Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherAlarmClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Alarm Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDishwasherAlarmClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Alarm Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDishwasherAlarmClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Dishwasher Alarm Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDishwasherAlarmClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Dishwasher Alarm Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5310,75 +2796,36 @@ chip::Protocols::InteractionModel::Status
 MatterDishwasherAlarmClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Dishwasher Alarm Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterDishwasherAlarmClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Dishwasher Alarm Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDishwasherAlarmClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Dishwasher Alarm Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDishwasherAlarmClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Microwave Oven Mode Cluster
 //
 
-/** @brief Microwave Oven Mode Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenModeClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Mode Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterMicrowaveOvenModeClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Mode Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenModeClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Mode Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterMicrowaveOvenModeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Microwave Oven Mode Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5388,75 +2835,36 @@ chip::Protocols::InteractionModel::Status
 MatterMicrowaveOvenModeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                 EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Microwave Oven Mode Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterMicrowaveOvenModeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Microwave Oven Mode Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfMicrowaveOvenModeClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Microwave Oven Mode Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfMicrowaveOvenModeClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Microwave Oven Control Cluster
 //
 
-/** @brief Microwave Oven Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterMicrowaveOvenControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMicrowaveOvenControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Microwave Oven Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterMicrowaveOvenControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Microwave Oven Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5465,74 +2873,36 @@ void MatterMicrowaveOvenControlClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterMicrowaveOvenControlClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Microwave Oven Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterMicrowaveOvenControlClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Microwave Oven Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfMicrowaveOvenControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Microwave Oven Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfMicrowaveOvenControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Operational State Cluster
 //
 
-/** @brief Operational State Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalStateClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational State Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOperationalStateClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Operational State Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOperationalStateClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Operational State Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOperationalStateClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Operational State Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5542,75 +2912,36 @@ chip::Protocols::InteractionModel::Status
 MatterOperationalStateClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Operational State Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterOperationalStateClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Operational State Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOperationalStateClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Operational State Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOperationalStateClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // RVC Operational State Cluster
 //
 
-/** @brief RVC Operational State Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcOperationalStateClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Operational State Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRvcOperationalStateClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Operational State Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRvcOperationalStateClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief RVC Operational State Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRvcOperationalStateClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief RVC Operational State Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5619,74 +2950,36 @@ void MatterRvcOperationalStateClusterServerAttributeChangedCallback(const chip::
 chip::Protocols::InteractionModel::Status MatterRvcOperationalStateClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief RVC Operational State Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterRvcOperationalStateClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief RVC Operational State Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRvcOperationalStateClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief RVC Operational State Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRvcOperationalStateClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // HEPA Filter Monitoring Cluster
 //
 
-/** @brief HEPA Filter Monitoring Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfHepaFilterMonitoringClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief HEPA Filter Monitoring Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterHepaFilterMonitoringClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief HEPA Filter Monitoring Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfHepaFilterMonitoringClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief HEPA Filter Monitoring Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterHepaFilterMonitoringClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief HEPA Filter Monitoring Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5695,75 +2988,37 @@ void MatterHepaFilterMonitoringClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterHepaFilterMonitoringClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief HEPA Filter Monitoring Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterHepaFilterMonitoringClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief HEPA Filter Monitoring Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfHepaFilterMonitoringClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief HEPA Filter Monitoring Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfHepaFilterMonitoringClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Activated Carbon Filter Monitoring Cluster
 //
 
-/** @brief Activated Carbon Filter Monitoring Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActivatedCarbonFilterMonitoringClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterActivatedCarbonFilterMonitoringClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfActivatedCarbonFilterMonitoringClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterActivatedCarbonFilterMonitoringClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5772,74 +3027,36 @@ void MatterActivatedCarbonFilterMonitoringClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterActivatedCarbonFilterMonitoringClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Activated Carbon Filter Monitoring Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterActivatedCarbonFilterMonitoringClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Activated Carbon Filter Monitoring Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfActivatedCarbonFilterMonitoringClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Activated Carbon Filter Monitoring Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfActivatedCarbonFilterMonitoringClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Boolean State Configuration Cluster
 //
 
-/** @brief Boolean State Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBooleanStateConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBooleanStateConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Boolean State Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBooleanStateConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Boolean State Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5848,75 +3065,37 @@ void MatterBooleanStateConfigurationClusterServerAttributeChangedCallback(const 
 chip::Protocols::InteractionModel::Status MatterBooleanStateConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Boolean State Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterBooleanStateConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Boolean State Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBooleanStateConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Boolean State Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBooleanStateConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Valve Configuration and Control Cluster
 //
 
-/** @brief Valve Configuration and Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfValveConfigurationAndControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Valve Configuration and Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterValveConfigurationAndControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Valve Configuration and Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfValveConfigurationAndControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Valve Configuration and Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterValveConfigurationAndControlClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Valve Configuration and Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -5925,74 +3104,36 @@ void MatterValveConfigurationAndControlClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterValveConfigurationAndControlClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Valve Configuration and Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterValveConfigurationAndControlClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Valve Configuration and Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfValveConfigurationAndControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Valve Configuration and Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfValveConfigurationAndControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Electrical Energy Measurement Cluster
 //
 
-/** @brief Electrical Energy Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalEnergyMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Energy Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterElectricalEnergyMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Energy Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalEnergyMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Energy Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterElectricalEnergyMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Electrical Energy Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6001,74 +3142,36 @@ void MatterElectricalEnergyMeasurementClusterServerAttributeChangedCallback(cons
 chip::Protocols::InteractionModel::Status MatterElectricalEnergyMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Electrical Energy Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterElectricalEnergyMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Electrical Energy Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfElectricalEnergyMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Electrical Energy Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfElectricalEnergyMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Demand Response Load Control Cluster
 //
 
-/** @brief Demand Response Load Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDemandResponseLoadControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Demand Response Load Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDemandResponseLoadControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Demand Response Load Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDemandResponseLoadControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Demand Response Load Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDemandResponseLoadControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Demand Response Load Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6077,74 +3180,36 @@ void MatterDemandResponseLoadControlClusterServerAttributeChangedCallback(const 
 chip::Protocols::InteractionModel::Status MatterDemandResponseLoadControlClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Demand Response Load Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterDemandResponseLoadControlClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Demand Response Load Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDemandResponseLoadControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Demand Response Load Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDemandResponseLoadControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Device Energy Management Cluster
 //
 
-/** @brief Device Energy Management Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDeviceEnergyManagementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Device Energy Management Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDeviceEnergyManagementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Device Energy Management Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDeviceEnergyManagementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Device Energy Management Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDeviceEnergyManagementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Device Energy Management Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6153,74 +3218,36 @@ void MatterDeviceEnergyManagementClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterDeviceEnergyManagementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Device Energy Management Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterDeviceEnergyManagementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Device Energy Management Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDeviceEnergyManagementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Device Energy Management Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDeviceEnergyManagementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Energy EVSE Cluster
 //
 
-/** @brief Energy EVSE Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyEvseClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy EVSE Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterEnergyEvseClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Energy EVSE Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyEvseClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy EVSE Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterEnergyEvseClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Energy EVSE Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6230,75 +3257,36 @@ chip::Protocols::InteractionModel::Status
 MatterEnergyEvseClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Energy EVSE Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterEnergyEvseClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Energy EVSE Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfEnergyEvseClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Energy EVSE Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfEnergyEvseClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Energy Preference Cluster
 //
 
-/** @brief Energy Preference Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyPreferenceClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy Preference Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterEnergyPreferenceClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Energy Preference Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfEnergyPreferenceClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Energy Preference Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterEnergyPreferenceClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Energy Preference Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6308,75 +3296,36 @@ chip::Protocols::InteractionModel::Status
 MatterEnergyPreferenceClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Energy Preference Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterEnergyPreferenceClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Energy Preference Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfEnergyPreferenceClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Energy Preference Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfEnergyPreferenceClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Door Lock Cluster
 //
 
-/** @brief Door Lock Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDoorLockClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Door Lock Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterDoorLockClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Door Lock Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Door Lock Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterDoorLockClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Door Lock Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6386,75 +3335,36 @@ chip::Protocols::InteractionModel::Status
 MatterDoorLockClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Door Lock Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterDoorLockClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Door Lock Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfDoorLockClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Door Lock Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfDoorLockClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Window Covering Cluster
 //
 
-/** @brief Window Covering Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWindowCoveringClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Window Covering Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterWindowCoveringClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Window Covering Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Window Covering Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterWindowCoveringClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Window Covering Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6464,75 +3374,36 @@ chip::Protocols::InteractionModel::Status
 MatterWindowCoveringClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Window Covering Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterWindowCoveringClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Window Covering Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Window Covering Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Barrier Control Cluster
 //
 
-/** @brief Barrier Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBarrierControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Barrier Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBarrierControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Barrier Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Barrier Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBarrierControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Barrier Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6542,75 +3413,36 @@ chip::Protocols::InteractionModel::Status
 MatterBarrierControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Barrier Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterBarrierControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Barrier Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBarrierControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Barrier Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBarrierControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Pump Configuration and Control Cluster
 //
 
-/** @brief Pump Configuration and Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPumpConfigurationAndControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pump Configuration and Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPumpConfigurationAndControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Pump Configuration and Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPumpConfigurationAndControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pump Configuration and Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Pump Configuration and Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6619,74 +3451,36 @@ void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(cons
 chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Pump Configuration and Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Pump Configuration and Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPumpConfigurationAndControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Pump Configuration and Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPumpConfigurationAndControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Thermostat Cluster
 //
 
-/** @brief Thermostat Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterThermostatClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterThermostatClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Thermostat Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6696,75 +3490,36 @@ chip::Protocols::InteractionModel::Status
 MatterThermostatClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Thermostat Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterThermostatClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Thermostat Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfThermostatClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Thermostat Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfThermostatClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Fan Control Cluster
 //
 
-/** @brief Fan Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFanControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fan Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterFanControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Fan Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fan Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterFanControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Fan Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6774,76 +3529,37 @@ chip::Protocols::InteractionModel::Status
 MatterFanControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Fan Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterFanControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Fan Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfFanControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Fan Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfFanControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Thermostat User Interface Configuration Cluster
 //
 
-/** @brief Thermostat User Interface Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatUserInterfaceConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat User Interface Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterThermostatUserInterfaceConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat User Interface Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfThermostatUserInterfaceConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Thermostat User Interface Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterThermostatUserInterfaceConfigurationClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Thermostat User Interface Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6852,74 +3568,36 @@ void MatterThermostatUserInterfaceConfigurationClusterServerAttributeChangedCall
 chip::Protocols::InteractionModel::Status MatterThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Thermostat User Interface Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterThermostatUserInterfaceConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Thermostat User Interface Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfThermostatUserInterfaceConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Thermostat User Interface Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfThermostatUserInterfaceConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Color Control Cluster
 //
 
-/** @brief Color Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfColorControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Color Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterColorControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Color Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Color Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterColorControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Color Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -6929,75 +3607,36 @@ chip::Protocols::InteractionModel::Status
 MatterColorControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Color Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterColorControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Color Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfColorControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Color Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfColorControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Ballast Configuration Cluster
 //
 
-/** @brief Ballast Configuration Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBallastConfigurationClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ballast Configuration Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterBallastConfigurationClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Ballast Configuration Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ballast Configuration Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterBallastConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Ballast Configuration Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7006,74 +3645,36 @@ void MatterBallastConfigurationClusterServerAttributeChangedCallback(const chip:
 chip::Protocols::InteractionModel::Status MatterBallastConfigurationClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Ballast Configuration Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterBallastConfigurationClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Ballast Configuration Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfBallastConfigurationClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Ballast Configuration Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfBallastConfigurationClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Illuminance Measurement Cluster
 //
 
-/** @brief Illuminance Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIlluminanceMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Illuminance Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterIlluminanceMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Illuminance Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfIlluminanceMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Illuminance Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterIlluminanceMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Illuminance Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7082,74 +3683,36 @@ void MatterIlluminanceMeasurementClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterIlluminanceMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Illuminance Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterIlluminanceMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Illuminance Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfIlluminanceMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Illuminance Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfIlluminanceMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Temperature Measurement Cluster
 //
 
-/** @brief Temperature Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTemperatureMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTemperatureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Temperature Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTemperatureMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Temperature Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7158,74 +3721,36 @@ void MatterTemperatureMeasurementClusterServerAttributeChangedCallback(const chi
 chip::Protocols::InteractionModel::Status MatterTemperatureMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Temperature Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterTemperatureMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Temperature Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTemperatureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Temperature Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTemperatureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Pressure Measurement Cluster
 //
 
-/** @brief Pressure Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPressureMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pressure Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPressureMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Pressure Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Pressure Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPressureMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Pressure Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7234,74 +3759,36 @@ void MatterPressureMeasurementClusterServerAttributeChangedCallback(const chip::
 chip::Protocols::InteractionModel::Status MatterPressureMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Pressure Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPressureMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Pressure Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPressureMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Pressure Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPressureMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Flow Measurement Cluster
 //
 
-/** @brief Flow Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFlowMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Flow Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterFlowMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Flow Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Flow Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterFlowMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Flow Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7311,75 +3798,36 @@ chip::Protocols::InteractionModel::Status
 MatterFlowMeasurementClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Flow Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterFlowMeasurementClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Flow Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfFlowMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Flow Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfFlowMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Relative Humidity Measurement Cluster
 //
 
-/** @brief Relative Humidity Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRelativeHumidityMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Relative Humidity Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRelativeHumidityMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Relative Humidity Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Relative Humidity Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRelativeHumidityMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Relative Humidity Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7388,74 +3836,36 @@ void MatterRelativeHumidityMeasurementClusterServerAttributeChangedCallback(cons
 chip::Protocols::InteractionModel::Status MatterRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Relative Humidity Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Relative Humidity Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRelativeHumidityMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Relative Humidity Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRelativeHumidityMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Occupancy Sensing Cluster
 //
 
-/** @brief Occupancy Sensing Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Occupancy Sensing Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOccupancySensingClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Occupancy Sensing Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Occupancy Sensing Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOccupancySensingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Occupancy Sensing Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7465,76 +3875,37 @@ chip::Protocols::InteractionModel::Status
 MatterOccupancySensingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Occupancy Sensing Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterOccupancySensingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Occupancy Sensing Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOccupancySensingClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Occupancy Sensing Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOccupancySensingClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Carbon Monoxide Concentration Measurement Cluster
 //
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterCarbonMonoxideConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7543,75 +3914,37 @@ void MatterCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCa
 chip::Protocols::InteractionModel::Status MatterCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Carbon Monoxide Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfCarbonMonoxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Carbon Monoxide Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Carbon Dioxide Concentration Measurement Cluster
 //
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterCarbonDioxideConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7620,75 +3953,37 @@ void MatterCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCal
 chip::Protocols::InteractionModel::Status MatterCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Carbon Dioxide Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfCarbonDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Carbon Dioxide Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Nitrogen Dioxide Concentration Measurement Cluster
 //
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterNitrogenDioxideConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7697,75 +3992,37 @@ void MatterNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedC
 chip::Protocols::InteractionModel::Status MatterNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfNitrogenDioxideConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Ozone Concentration Measurement Cluster
 //
 
-/** @brief Ozone Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOzoneConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ozone Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterOzoneConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Ozone Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Ozone Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Ozone Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7774,75 +4031,37 @@ void MatterOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Ozone Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Ozone Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfOzoneConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Ozone Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfOzoneConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // PM2.5 Concentration Measurement Cluster
 //
 
-/** @brief PM2.5 Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm25ConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM2.5 Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPm25ConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief PM2.5 Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm25ConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM2.5 Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPm25ConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief PM2.5 Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7851,75 +4070,37 @@ void MatterPm25ConcentrationMeasurementClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterPm25ConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief PM2.5 Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPm25ConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief PM2.5 Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPm25ConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief PM2.5 Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPm25ConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Formaldehyde Concentration Measurement Cluster
 //
 
-/** @brief Formaldehyde Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFormaldehydeConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterFormaldehydeConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFormaldehydeConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterFormaldehydeConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -7928,74 +4109,36 @@ void MatterFormaldehydeConcentrationMeasurementClusterServerAttributeChangedCall
 chip::Protocols::InteractionModel::Status MatterFormaldehydeConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Formaldehyde Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterFormaldehydeConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Formaldehyde Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfFormaldehydeConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Formaldehyde Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfFormaldehydeConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // PM1 Concentration Measurement Cluster
 //
 
-/** @brief PM1 Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm1ConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM1 Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPm1ConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief PM1 Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm1ConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM1 Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPm1ConcentrationMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief PM1 Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8004,75 +4147,37 @@ void MatterPm1ConcentrationMeasurementClusterServerAttributeChangedCallback(cons
 chip::Protocols::InteractionModel::Status MatterPm1ConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief PM1 Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPm1ConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief PM1 Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPm1ConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief PM1 Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPm1ConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // PM10 Concentration Measurement Cluster
 //
 
-/** @brief PM10 Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm10ConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM10 Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterPm10ConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief PM10 Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfPm10ConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief PM10 Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterPm10ConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief PM10 Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8081,75 +4186,37 @@ void MatterPm10ConcentrationMeasurementClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterPm10ConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief PM10 Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterPm10ConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief PM10 Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfPm10ConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief PM10 Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfPm10ConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Total Volatile Organic Compounds Concentration Measurement Cluster
 //
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTotalVolatileOrganicCompoundsConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTotalVolatileOrganicCompoundsConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8159,76 +4226,37 @@ chip::Protocols::InteractionModel::Status
 MatterTotalVolatileOrganicCompoundsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterTotalVolatileOrganicCompoundsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Total Volatile Organic Compounds Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Radon Concentration Measurement Cluster
 //
 
-/** @brief Radon Concentration Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRadonConcentrationMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Radon Concentration Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterRadonConcentrationMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Radon Concentration Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfRadonConcentrationMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Radon Concentration Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterRadonConcentrationMeasurementClusterServerAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Radon Concentration Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8237,74 +4265,36 @@ void MatterRadonConcentrationMeasurementClusterServerAttributeChangedCallback(
 chip::Protocols::InteractionModel::Status MatterRadonConcentrationMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Radon Concentration Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterRadonConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Radon Concentration Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfRadonConcentrationMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Radon Concentration Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfRadonConcentrationMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Wake on LAN Cluster
 //
 
-/** @brief Wake on LAN Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWakeOnLanClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Wake on LAN Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterWakeOnLanClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Wake on LAN Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfWakeOnLanClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Wake on LAN Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterWakeOnLanClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Wake on LAN Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8314,75 +4304,36 @@ chip::Protocols::InteractionModel::Status
 MatterWakeOnLanClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Wake on LAN Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterWakeOnLanClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Wake on LAN Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfWakeOnLanClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Wake on LAN Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfWakeOnLanClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Channel Cluster
 //
 
-/** @brief Channel Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfChannelClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Channel Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterChannelClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Channel Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfChannelClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Channel Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterChannelClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Channel Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8392,75 +4343,36 @@ chip::Protocols::InteractionModel::Status
 MatterChannelClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Channel Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterChannelClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Channel Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfChannelClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Channel Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfChannelClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Target Navigator Cluster
 //
 
-/** @brief Target Navigator Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTargetNavigatorClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Target Navigator Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterTargetNavigatorClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Target Navigator Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfTargetNavigatorClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Target Navigator Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterTargetNavigatorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Target Navigator Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8470,75 +4382,36 @@ chip::Protocols::InteractionModel::Status
 MatterTargetNavigatorClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Target Navigator Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterTargetNavigatorClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Target Navigator Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfTargetNavigatorClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Target Navigator Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfTargetNavigatorClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Media Playback Cluster
 //
 
-/** @brief Media Playback Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaPlaybackClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Playback Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterMediaPlaybackClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Media Playback Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaPlaybackClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Playback Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterMediaPlaybackClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Media Playback Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8548,75 +4421,36 @@ chip::Protocols::InteractionModel::Status
 MatterMediaPlaybackClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Media Playback Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterMediaPlaybackClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Media Playback Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfMediaPlaybackClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Media Playback Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfMediaPlaybackClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Media Input Cluster
 //
 
-/** @brief Media Input Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaInputClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Input Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterMediaInputClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Media Input Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfMediaInputClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Media Input Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterMediaInputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Media Input Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8626,75 +4460,36 @@ chip::Protocols::InteractionModel::Status
 MatterMediaInputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Media Input Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterMediaInputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Media Input Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfMediaInputClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Media Input Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfMediaInputClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Low Power Cluster
 //
 
-/** @brief Low Power Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLowPowerClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Low Power Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterLowPowerClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Low Power Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfLowPowerClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Low Power Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterLowPowerClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Low Power Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8704,75 +4499,36 @@ chip::Protocols::InteractionModel::Status
 MatterLowPowerClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Low Power Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterLowPowerClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Low Power Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfLowPowerClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Low Power Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfLowPowerClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Keypad Input Cluster
 //
 
-/** @brief Keypad Input Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfKeypadInputClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Keypad Input Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterKeypadInputClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Keypad Input Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfKeypadInputClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Keypad Input Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterKeypadInputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Keypad Input Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8782,75 +4538,36 @@ chip::Protocols::InteractionModel::Status
 MatterKeypadInputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Keypad Input Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterKeypadInputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Keypad Input Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfKeypadInputClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Keypad Input Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfKeypadInputClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Content Launcher Cluster
 //
 
-/** @brief Content Launcher Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentLauncherClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Launcher Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterContentLauncherClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Content Launcher Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentLauncherClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Launcher Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterContentLauncherClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Content Launcher Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8860,75 +4577,36 @@ chip::Protocols::InteractionModel::Status
 MatterContentLauncherClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Content Launcher Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterContentLauncherClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Content Launcher Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfContentLauncherClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Content Launcher Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfContentLauncherClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Audio Output Cluster
 //
 
-/** @brief Audio Output Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAudioOutputClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Audio Output Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterAudioOutputClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Audio Output Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAudioOutputClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Audio Output Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterAudioOutputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Audio Output Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -8938,75 +4616,36 @@ chip::Protocols::InteractionModel::Status
 MatterAudioOutputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Audio Output Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterAudioOutputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Audio Output Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfAudioOutputClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Audio Output Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfAudioOutputClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Application Launcher Cluster
 //
 
-/** @brief Application Launcher Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationLauncherClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Launcher Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterApplicationLauncherClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Application Launcher Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationLauncherClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Launcher Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterApplicationLauncherClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Application Launcher Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9015,74 +4654,36 @@ void MatterApplicationLauncherClusterServerAttributeChangedCallback(const chip::
 chip::Protocols::InteractionModel::Status MatterApplicationLauncherClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Application Launcher Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterApplicationLauncherClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Application Launcher Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfApplicationLauncherClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Application Launcher Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfApplicationLauncherClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Application Basic Cluster
 //
 
-/** @brief Application Basic Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationBasicClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Basic Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterApplicationBasicClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Application Basic Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfApplicationBasicClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Application Basic Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterApplicationBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Application Basic Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9092,75 +4693,36 @@ chip::Protocols::InteractionModel::Status
 MatterApplicationBasicClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Application Basic Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterApplicationBasicClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Application Basic Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfApplicationBasicClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Application Basic Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfApplicationBasicClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Account Login Cluster
 //
 
-/** @brief Account Login Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccountLoginClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Account Login Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterAccountLoginClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Account Login Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfAccountLoginClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Account Login Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterAccountLoginClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Account Login Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9170,75 +4732,36 @@ chip::Protocols::InteractionModel::Status
 MatterAccountLoginClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Account Login Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterAccountLoginClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Account Login Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfAccountLoginClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Account Login Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfAccountLoginClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Content Control Cluster
 //
 
-/** @brief Content Control Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentControlClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Control Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterContentControlClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Content Control Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentControlClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content Control Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterContentControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Content Control Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9248,75 +4771,36 @@ chip::Protocols::InteractionModel::Status
 MatterContentControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Content Control Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterContentControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Content Control Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfContentControlClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Content Control Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfContentControlClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Content App Observer Cluster
 //
 
-/** @brief Content App Observer Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentAppObserverClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content App Observer Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterContentAppObserverClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Content App Observer Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfContentAppObserverClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Content App Observer Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterContentAppObserverClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Content App Observer Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9325,74 +4809,36 @@ void MatterContentAppObserverClusterServerAttributeChangedCallback(const chip::a
 chip::Protocols::InteractionModel::Status MatterContentAppObserverClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Content App Observer Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterContentAppObserverClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Content App Observer Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfContentAppObserverClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Content App Observer Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfContentAppObserverClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Electrical Measurement Cluster
 //
 
-/** @brief Electrical Measurement Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalMeasurementClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Measurement Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterElectricalMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Measurement Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Electrical Measurement Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterElectricalMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Electrical Measurement Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9401,74 +4847,36 @@ void MatterElectricalMeasurementClusterServerAttributeChangedCallback(const chip
 chip::Protocols::InteractionModel::Status MatterElectricalMeasurementClusterServerPreAttributeChangedCallback(
     const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Electrical Measurement Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status MatterElectricalMeasurementClusterClientPreAttributeChangedCallback(
-    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Electrical Measurement Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfElectricalMeasurementClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Electrical Measurement Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfElectricalMeasurementClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Unit Testing Cluster
 //
 
-/** @brief Unit Testing Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitTestingClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Testing Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterUnitTestingClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Testing Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfUnitTestingClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Unit Testing Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterUnitTestingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Unit Testing Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9478,75 +4886,36 @@ chip::Protocols::InteractionModel::Status
 MatterUnitTestingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Unit Testing Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterUnitTestingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Unit Testing Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfUnitTestingClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Unit Testing Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfUnitTestingClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Fault Injection Cluster
 //
 
-/** @brief Fault Injection Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFaultInjectionClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fault Injection Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterFaultInjectionClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Fault Injection Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfFaultInjectionClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Fault Injection Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterFaultInjectionClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Fault Injection Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9556,75 +4925,36 @@ chip::Protocols::InteractionModel::Status
 MatterFaultInjectionClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Fault Injection Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterFaultInjectionClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Fault Injection Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfFaultInjectionClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Fault Injection Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfFaultInjectionClusterClientTickCallback(chip::EndpointId endpoint);
 
 //
 // Sample MEI Cluster
 //
 
-/** @brief Sample MEI Cluster Server Init
- *
- * Server Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSampleMeiClusterServerInitCallback(chip::EndpointId endpoint);
 
-/** @brief Sample MEI Cluster Server Shutdown
- *
- * Server Shutdown
- *
+/**
  * @param endpoint    Endpoint that is being shutdown
  */
 void MatterSampleMeiClusterServerShutdownCallback(chip::EndpointId endpoint);
 
-/** @brief Sample MEI Cluster Client Init
- *
- * Client Init
- *
+/**
  * @param endpoint    Endpoint that is being initialized
  */
 void emberAfSampleMeiClusterClientInitCallback(chip::EndpointId endpoint);
 
-/** @brief Sample MEI Cluster Server Attribute Changed
- *
- * Server Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path that changed
  */
 void MatterSampleMeiClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
-/** @brief Sample MEI Cluster Server Pre Attribute Changed
- *
- * Server Pre Attribute Changed
- *
+/**
  * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
@@ -9634,34 +4964,10 @@ chip::Protocols::InteractionModel::Status
 MatterSampleMeiClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-/** @brief Sample MEI Cluster Client Pre Attribute Changed
- *
- * Client Pre Attribute Changed
- *
- * @param attributePath Concrete attribute path to be changed
- * @param attributeType Attribute type
- * @param size          Attribute size
- * @param value         Attribute value
- */
-chip::Protocols::InteractionModel::Status
-MatterSampleMeiClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
-                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
-
-/** @brief Sample MEI Cluster Server Tick
- *
- * Server Tick
- *
+/**
  * @param endpoint  Endpoint that is being served
  */
 void emberAfSampleMeiClusterServerTickCallback(chip::EndpointId endpoint);
-
-/** @brief Sample MEI Cluster Client Tick
- *
- * Client Tick
- *
- * @param endpoint  Endpoint that is being served
- */
-void emberAfSampleMeiClusterClientTickCallback(chip::EndpointId endpoint);
 
 // Cluster Commands Callback
 


### PR DESCRIPTION
Generally this makes the code shorter, especially since we check in generated code.