### PR TITLE
Follow-up PR: update RefreshLiveness naming

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -617,7 +617,7 @@ exit:
             // a subscription and have a valid value for mMaxInterval which the function
             // relies on.
             //
-            mpCallback.RefreshLiveness(*this);
+            mpCallback.NotifySubscriptionStillActive(*this);
             err = RefreshLivenessCheckTimer();
         }
     }

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -90,7 +90,7 @@ public:
          * receives an OnDone call to destroy the object.
          *
          */
-        virtual void RefreshLiveness(const ReadClient & apReadClient) {}
+        virtual void NotifySubscriptionStillActive(const ReadClient & apReadClient) {}
 
         /**
          * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.


### PR DESCRIPTION
Rename "RefreshLiveness" to "NotifySubscriptionStillActive" in readClient.

fixes: https://github.com/project-chip/connectedhomeip/pull/31319/files#r1448102716
