### PR TITLE
Fix Chef RVC compilation failure

### DIFF
--- a/examples/chef/common/chef-rvc-operational-state-delegate.cpp
+++ b/examples/chef/common/chef-rvc-operational-state-delegate.cpp
@@ -128,7 +128,7 @@ void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
     gOperationalStateDelegate           = new OperationalStateDelegate;
     EndpointId operationalStateEndpoint = 0x01;
-    gOperationalStateInstance = new OperationalState::Instance(gOperationalStateDelegate, operationalStateEndpoint);
+    gOperationalStateInstance           = new OperationalState::Instance(gOperationalStateDelegate, operationalStateEndpoint);
 
     gOperationalStateInstance->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped));
 
@@ -137,8 +137,8 @@ void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
 // Init RVC Operational State cluster
 
-static RvcOperationalState::Instance * gRvcOperationalStateInstance  = nullptr;
-static RvcOperationalStateDelegate * gRvcOperationalStateDelegate = nullptr;
+static RvcOperationalState::Instance * gRvcOperationalStateInstance = nullptr;
+static RvcOperationalStateDelegate * gRvcOperationalStateDelegate   = nullptr;
 
 void RvcOperationalState::Shutdown()
 {
@@ -161,8 +161,7 @@ void emberAfRvcOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
     gRvcOperationalStateDelegate        = new RvcOperationalStateDelegate;
     EndpointId operationalStateEndpoint = 0x01;
-    gRvcOperationalStateInstance =
-        new RvcOperationalState::Instance(gRvcOperationalStateDelegate, operationalStateEndpoint);
+    gRvcOperationalStateInstance        = new RvcOperationalState::Instance(gRvcOperationalStateDelegate, operationalStateEndpoint);
 
     gRvcOperationalStateInstance->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped));
 

--- a/examples/chef/common/chef-rvc-operational-state-delegate.cpp
+++ b/examples/chef/common/chef-rvc-operational-state-delegate.cpp
@@ -128,7 +128,7 @@ void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
     gOperationalStateDelegate           = new OperationalStateDelegate;
     EndpointId operationalStateEndpoint = 0x01;
-    gOperationalStateInstance = new Instance(gOperationalStateDelegate, operationalStateEndpoint, Clusters::OperationalState::Id);
+    gOperationalStateInstance = new OperationalState::Instance(gOperationalStateDelegate, operationalStateEndpoint);
 
     gOperationalStateInstance->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped));
 
@@ -137,7 +137,7 @@ void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
 // Init RVC Operational State cluster
 
-static OperationalState::Instance * gRvcOperationalStateInstance  = nullptr;
+static RvcOperationalState::Instance * gRvcOperationalStateInstance  = nullptr;
 static RvcOperationalStateDelegate * gRvcOperationalStateDelegate = nullptr;
 
 void RvcOperationalState::Shutdown()
@@ -162,7 +162,7 @@ void emberAfRvcOperationalStateClusterInitCallback(chip::EndpointId endpointId)
     gRvcOperationalStateDelegate        = new RvcOperationalStateDelegate;
     EndpointId operationalStateEndpoint = 0x01;
     gRvcOperationalStateInstance =
-        new Instance(gRvcOperationalStateDelegate, operationalStateEndpoint, Clusters::RvcOperationalState::Id);
+        new RvcOperationalState::Instance(gRvcOperationalStateDelegate, operationalStateEndpoint);
 
     gRvcOperationalStateInstance->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped));
 

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -1451,6 +1451,8 @@ endpoint 1 {
     ram      attribute clusterRevision default = 1;
 
     handle command Pause;
+    handle command Stop;
+    handle command Start;
     handle command Resume;
     handle command OperationalCommandResponse;
   }

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.zap
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.zap
@@ -2838,6 +2838,22 @@
               "isEnabled": 1
             },
             {
+              "name": "Stop",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "Start",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
               "name": "Resume",
               "code": 3,
               "mfgCode": null,


### PR DESCRIPTION
Fix Chef RVC example compilation failure caused by #30795
Add `Start()` & `Stop()` commands removed by #29509 