### PR TITLE
fix a crash error in tv-app

### DIFF
--- a/examples/tv-app/android/App/build.gradle
+++ b/examples/tv-app/android/App/build.gradle
@@ -1,12 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.kotlin_version = '1.9.20'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/examples/tv-app/android/App/platform-app/build.gradle
+++ b/examples/tv-app/android/App/platform-app/build.gradle
@@ -68,4 +68,5 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'com.google.zxing:core:3.3.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }


### PR DESCRIPTION
a small PR to fix crash error
`java.lang.NoClassDefFoundError: Failed resolution of: Lkotlin/enums/EnumEntriesKt...`
Because the tv-app project import onboardPayload.jar which compiled by Kotlin, we must to import kotlin runtime package 
