### PR TITLE
Test_TC_DGWIFI_2_1 WiFiVersion enum8 maxValue should be 6

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DGWIFI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGWIFI_2_1.yaml
@@ -56,7 +56,7 @@ tests:
           constraints:
               type: enum8
               minValue: 0
-              maxValue: 5
+              maxValue: 6
 
     - label: "Step 5: Reads ChannelNumber attribute constraints"
       PICS: DGWIFI.S.A0003


### PR DESCRIPTION
Test DG-WiFi-2.1 fails step 4 because the maxValue for WiFiVersion is incorrect.

The Matter Spec 1.2, Section 11.14.5.2. WiFiVersionEnum Type has a range from 0 (802.11a) to 6 (802.11ah) which is not accounted for in the test.

Updated the maxValue in the test to accommodate the correct number of elements in the type.

Tested with the updated YAML on "TH Fall2023, Sha: 3f84bff5" and step 4 now passes.