### PR TITLE
Fix typo in washer-controls-cluster.xml

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2950,7 +2950,7 @@ cluster RefrigeratorAndTemperatureControlledCabinetMode = 82 {
   command ChangeToMode(ChangeToModeRequest): ChangeToModeResponse = 0;
 }
 
-/** This cluster supports remotely monitoring and controling the different typs of functionality available to a washing device, such as a washing machine. */
+/** This cluster supports remotely monitoring and controlling the different types of functionality available to a washing device, such as a washing machine. */
 cluster LaundryWasherControls = 83 {
   revision 1;
 

--- a/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
@@ -38,7 +38,7 @@ limitations under the License.
     <define>LAUNDRY_WASHER_CONTROLS_CLUSTER</define>
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
-    <description>This cluster supports remotely monitoring and controling the different typs of functionality available to a washing device, such as a washing machine.</description>
+    <description>This cluster supports remotely monitoring and controlling the different types of functionality available to a washing device, such as a washing machine.</description>
 
     <globalAttribute side="either" code="0xFFFD" value="1" />
 

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3257,7 +3257,7 @@ cluster RefrigeratorAndTemperatureControlledCabinetMode = 82 {
   command ChangeToMode(ChangeToModeRequest): ChangeToModeResponse = 0;
 }
 
-/** This cluster supports remotely monitoring and controling the different typs of functionality available to a washing device, such as a washing machine. */
+/** This cluster supports remotely monitoring and controlling the different types of functionality available to a washing device, such as a washing machine. */
 cluster LaundryWasherControls = 83 {
   revision 1;
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -5474,7 +5474,7 @@ MTR_PROVISIONALLY_AVAILABLE
 /**
  * Cluster Laundry Washer Controls
  *
- * This cluster supports remotely monitoring and controling the different typs of functionality available to a washing device, such as a washing machine.
+ * This cluster supports remotely monitoring and controlling the different types of functionality available to a washing device, such as a washing machine.
  */
 MTR_PROVISIONALLY_AVAILABLE
 @interface MTRBaseClusterLaundryWasherControls : MTRGenericBaseCluster

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -2560,7 +2560,7 @@ MTR_PROVISIONALLY_AVAILABLE
 
 /**
  * Cluster Laundry Washer Controls
- *    This cluster supports remotely monitoring and controling the different typs of functionality available to a washing device, such as a washing machine.
+ *    This cluster supports remotely monitoring and controlling the different types of functionality available to a washing device, such as a washing machine.
  */
 MTR_PROVISIONALLY_AVAILABLE
 @interface MTRClusterLaundryWasherControls : MTRGenericCluster


### PR DESCRIPTION
Fixing a typo in comment inside the washer-controls-cluster.xml. 
