### PR TITLE
Remove CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -434,7 +434,7 @@ CHIP_ERROR CommandSender::PrepareCommand(const CommandPathParams & aCommandPathP
     //
     // We must not be in the middle of preparing a command, and must not have already sent InvokeRequestMessage.
     //
-    bool canAddAnotherCommand     = (mState == State::AddedCommand && mBatchCommandsEnabled);
+    bool canAddAnotherCommand = (mState == State::AddedCommand && mBatchCommandsEnabled);
     VerifyOrReturnError(mState == State::Idle || canAddAnotherCommand, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mFinishedCommandCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -304,7 +304,7 @@ public:
      * @return CHIP_ERROR_INVALID_ARGUMENT
      *                      Invalid argument value.
      * @return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
-     *                      CommandSender has not been provided callbacks expected for supporting batck commands.
+     *                      CommandSender has not been provided callbacks expected for supporting batch commands.
      */
     CHIP_ERROR SetCommandSenderConfig(ConfigParameters & aConfigParams);
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -304,7 +304,7 @@ public:
      * @return CHIP_ERROR_INVALID_ARGUMENT
      *                      Invalid argument value.
      * @return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
-     *                      Device has not enabled CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED.
+     *                      CommandSender has not been provided callbacks expected for supporting batck commands.
      */
     CHIP_ERROR SetCommandSenderConfig(ConfigParameters & aConfigParams);
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1286,10 +1286,10 @@ void TestCommandInteraction::TestCommandSenderLegacyCallbackBuildingBatchCommand
     app::CommandSender::AdditionalCommandParameters commandParameters;
     commandParameters.SetStartOrEndDataStruct(true);
 
-    // TODO(#30453): Once CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED is removed we will need
-    // to call SetCommandSenderConfig with remoteMaxPathsPerInvoke set to 2.
-    commandSender.mBatchCommandsEnabled    = true;
-    commandSender.mRemoteMaxPathsPerInvoke = 2;
+    CommandSender::ConfigParameters config;
+    config.SetRemoteMaxPathsPerInvoke(2);
+    err = commandSender.SetCommandSenderConfig(config);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
     auto commandPathParams = MakeTestCommandPath();
     err                    = commandSender.PrepareCommand(commandPathParams, commandParameters);
@@ -1317,10 +1317,10 @@ void TestCommandInteraction::TestCommandSenderExtendableCallbackBuildingBatchCom
     app::CommandSender::AdditionalCommandParameters commandParameters;
     commandParameters.SetStartOrEndDataStruct(true);
 
-    // TODO(#30453): Once CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED is removed we will need
-    // to call SetCommandSenderConfig with remoteMaxPathsPerInvoke set to 2.
-    commandSender.mBatchCommandsEnabled    = true;
-    commandSender.mRemoteMaxPathsPerInvoke = 2;
+    CommandSender::ConfigParameters config;
+    config.SetRemoteMaxPathsPerInvoke(2);
+    err = commandSender.SetCommandSenderConfig(config);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     auto commandPathParams = MakeTestCommandPath();
     err                    = commandSender.PrepareCommand(commandPathParams, commandParameters);

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -68,7 +68,6 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_CONFIG_BIG_ENDIAN_TARGET=${chip_target_is_big_endian}",
     "CHIP_CONFIG_TLV_VALIDATE_CHAR_STRING_ON_WRITE=${chip_tlv_validate_char_string_on_write}",
     "CHIP_CONFIG_TLV_VALIDATE_CHAR_STRING_ON_READ=${chip_tlv_validate_char_string_on_read}",
-    "CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED=${chip_enable_sending_batch_commands}",
   ]
 
   visibility = [ ":chip_config_header" ]

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1690,15 +1690,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
- * @def CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
- *
- * @brief Device supports sending multiple batch commands in a single Invoke Request Message.
- */
-#ifndef CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED
-#define CHIP_CONFIG_SENDING_BATCH_COMMANDS_ENABLED 0
-#endif
-
-/**
  * @def CHIP_CONFIG_MAX_PATHS_PER_INVOKE
  *
  * @brief The maximum number of elements in the InvokeRequests list that the Node is able to process.

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -98,9 +98,6 @@ declare_args() {
   #   - SHALL be valid UTF8
   chip_tlv_validate_char_string_on_write = true
   chip_tlv_validate_char_string_on_read = false
-
-  chip_enable_sending_batch_commands =
-      current_os == "linux" || current_os == "mac" || current_os == "ios"
 }
 
 if (chip_target_style == "") {


### PR DESCRIPTION
Now that we have `CommandSender::ExtendableCallback`, we can rely on that to make sure anything using `CommandSender` is capable of sending batch commands

