### PR TITLE
Add support for not complaining about abi changes in `provisional` clusters

### DIFF
--- a/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
@@ -17,7 +17,7 @@ import enum
 import logging
 from typing import Callable, Dict, List, Optional, Protocol, TypeVar
 
-from matter_idl.matter_idl_types import Attribute, Bitmap, Cluster, Command, Enum, Event, Field, Idl, Struct
+from matter_idl.matter_idl_types import Attribute, ApiMaturity, Bitmap, Cluster, Command, Enum, Event, Field, Idl, Struct
 
 
 class Compatibility(enum.Enum):
@@ -50,6 +50,13 @@ def group_list_by_name(items: List[NAMED]) -> Dict[str, NAMED]:
 def attribute_name(attribute: Attribute) -> str:
     """Get the name of an attribute."""
     return attribute.definition.name
+
+
+def not_stable(maturity: ApiMaturity):
+    """Determine if the given api maturity allows binary/api changes or not."""
+    # TODO: internal and deprecated not currently widely used,
+    #       so we enforce stability on them for now.
+    return maturity == ApiMaturity.PROVISIONAL
 
 
 class CompatibilityChecker:
@@ -271,6 +278,11 @@ class CompatibilityChecker:
 
         for original_cluster in original:
             updated_cluster = updated_clusters.get(original_cluster.name)
+
+            if not_stable(updated_cluster.api_maturity) or not_stable(original_cluster.api_maturity):
+                # no point in checking
+                continue
+
             self._check_cluster_compatible(original_cluster, updated_cluster)
 
     def _check_cluster_compatible(self, original_cluster: Cluster, updated_cluster: Optional[Cluster]):

--- a/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
@@ -17,7 +17,7 @@ import enum
 import logging
 from typing import Callable, Dict, List, Optional, Protocol, TypeVar
 
-from matter_idl.matter_idl_types import Attribute, ApiMaturity, Bitmap, Cluster, Command, Enum, Event, Field, Idl, Struct
+from matter_idl.matter_idl_types import ApiMaturity, Attribute, Bitmap, Cluster, Command, Enum, Event, Field, Idl, Struct
 
 
 class Compatibility(enum.Enum):

--- a/scripts/py_matter_idl/matter_idl/test_backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/test_backwards_compatibility.py
@@ -104,6 +104,13 @@ class TestCompatibilityChecks(unittest.TestCase):
             "server cluster A = 16 { enum X : ENUM8 { A = 1; }}",
             Compatibility.FORWARD_FAIL)
 
+    def test_provisional_cluster(self):
+        self.ValidateUpdate(
+            "Provisional cluster changes are ok.",
+            "provisional server cluster A = 16 { enum X : ENUM8 { A = 1; B = 2; } info event A = 1 { int8u x = 1;} }",
+            "provisional server cluster A = 16 { enum X : ENUM8 { A = 1; B = 3; } info event A = 2 { int16u x = 1;} }",
+            Compatibility.ALL_OK)
+
     def test_clusters_enum_code(self):
         self.ValidateUpdate(
             "Adding an enum is ok. Also validates code formatting",


### PR DESCRIPTION
Only handles cluster level, however this should already help us quite a bit in not ignoring backwards compatibility checker errors.