### PR TITLE
Remove DeviceLayer include in attribute-storage

### DIFF
--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -24,7 +24,6 @@
 #include <app/util/config.h>
 #include <app/util/endpoint-config-api.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/CHIPDeviceLayer.h>
 
 #if !defined(EMBER_SCRIPTED_TEST)
 #include <app/att-storage.h>


### PR DESCRIPTION
This dependency does not seem needed, especially at the attribute-storage header level. CI should validate that compilation still passes (I compiled some linux examples and it seemed fine)