### PR TITLE
Add missing include to functional for chef

### DIFF
--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -26,6 +26,8 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <functional>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;


### PR DESCRIPTION
See error in https://github.com/project-chip/connectedhomeip/actions/runs/7513388720/job/20455084516:

```
/__w/connectedhomeip/connectedhomeip/examples/chef/common/chef-fan-control-manager.cpp:103:32: error: 'invoke' is not a member of 'std'
  103 |         newSpeedSetting = std::invoke([&]() -> uint8_t {
```