### PR TITLE
[Linux] Device scanning status using state machine and fix error status

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -776,10 +776,13 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 & device, const chip::Ble::Chi
     mBLEScanConfig.mBleScanState = BleScanState::kConnecting;
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // We StartScan in the ChipStack thread.
+    // StopScan should also be performed in the ChipStack thread.
+    // At the same time, the scan timer also needs to be canceled in the ChipStack thread.
+    mDeviceScanner.StopScan();
+    // Stop scanning and then start connecting timer
     DeviceLayer::SystemLayer().StartTimer(kConnectTimeout, HandleConnectTimeout, &mEndpoint);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-
-    mDeviceScanner.StopScan();
 
     mEndpoint.ConnectDevice(device);
 }

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -20,6 +20,7 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #include <glib.h>
+#include <mutex>
 
 #include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
@@ -103,6 +104,7 @@ private:
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;
     ChipDeviceScannerState mCurrentState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
+    std::mutex mScannerLock;
     /// Used to track if timer has already expired and doesn't need to be canceled.
     bool mTimerExpired = false;
 };

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -20,7 +20,6 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #include <glib.h>
-#include <mutex>
 
 #include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
@@ -54,7 +53,7 @@ class ChipDeviceScanner
 {
 public:
     ChipDeviceScanner()                                      = default;
-    ChipDeviceScanner(ChipDeviceScanner &&)                  = delete;
+    ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
     ChipDeviceScanner(const ChipDeviceScanner &)             = delete;
     ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
 
@@ -82,6 +81,14 @@ private:
         SCANNER_INITIALIZED,
         SCANNER_SCANNING
     };
+
+    enum ScannerTimerState
+    {
+        TIMER_CANCELED,
+        TIMER_STARTED,
+        TIMER_EXPIRED
+    };
+
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
     static CHIP_ERROR MainLoopStartScan(ChipDeviceScanner * self);
     static CHIP_ERROR MainLoopStopScan(ChipDeviceScanner * self);
@@ -103,10 +110,9 @@ private:
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;
-    ChipDeviceScannerState mCurrentState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
-    std::mutex mScannerStoppingLock;
+    ChipDeviceScannerState mScannerState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
     /// Used to track if timer has already expired and doesn't need to be canceled.
-    bool mTimerExpired = false;
+    ScannerTimerState mTimerState = ScannerTimerState::TIMER_CANCELED;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -52,9 +52,9 @@ public:
 class ChipDeviceScanner
 {
 public:
-    ChipDeviceScanner()                                      = default;
-    ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
-    ChipDeviceScanner(const ChipDeviceScanner &)             = delete;
+    ChipDeviceScanner()                          = default;
+    ChipDeviceScanner(ChipDeviceScanner &&)      = default;
+    ChipDeviceScanner(const ChipDeviceScanner &) = delete;
     ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
 
     ~ChipDeviceScanner() { Shutdown(); }
@@ -75,6 +75,12 @@ public:
     CHIP_ERROR StopScan();
 
 private:
+    enum ChipDeviceScannerState
+    {
+        SCANNER_UNINITIALIZED,
+        SCANNER_INITIALIZED,
+        SCANNER_SCANNING
+    };
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
     static CHIP_ERROR MainLoopStartScan(ChipDeviceScanner * self);
     static CHIP_ERROR MainLoopStopScan(ChipDeviceScanner * self);
@@ -96,9 +102,7 @@ private:
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;
-    bool mIsInitialized                   = false;
-    bool mIsScanning                      = false;
-    bool mIsStopping                      = false;
+    ChipDeviceScannerState mCurrentState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
     /// Used to track if timer has already expired and doesn't need to be canceled.
     bool mTimerExpired = false;
 };

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -104,7 +104,7 @@ private:
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;
     ChipDeviceScannerState mCurrentState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
-    std::mutex mScannerLock;
+    std::mutex mScannerStoppingLock;
     /// Used to track if timer has already expired and doesn't need to be canceled.
     bool mTimerExpired = false;
 };

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -52,9 +52,9 @@ public:
 class ChipDeviceScanner
 {
 public:
-    ChipDeviceScanner()                          = default;
-    ChipDeviceScanner(ChipDeviceScanner &&)      = default;
-    ChipDeviceScanner(const ChipDeviceScanner &) = delete;
+    ChipDeviceScanner()                                      = default;
+    ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
+    ChipDeviceScanner(const ChipDeviceScanner &)             = delete;
     ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
 
     ~ChipDeviceScanner() { Shutdown(); }

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -54,7 +54,7 @@ class ChipDeviceScanner
 {
 public:
     ChipDeviceScanner()                                      = default;
-    ChipDeviceScanner(ChipDeviceScanner &&)                  = default;
+    ChipDeviceScanner(ChipDeviceScanner &&)                  = delete;
     ChipDeviceScanner(const ChipDeviceScanner &)             = delete;
     ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
 


### PR DESCRIPTION
Reopen PR #31262
Under Linux, `mIsStopping` scan status is not modified after `StopScan`, and `StopScan` cannot take effect from the second time on. Use a state machine to represent scan status and fix this problem
