### PR TITLE
[Ameba] update LwIP and wifi API

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -83,10 +83,11 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     chip_connmgr_set_callback_func((chip_connmgr_callback) (conn_callback_dispatcher), this);
 
     // Register WiFi event handlers
-    wifi_reg_event_handler(MATTER_WIFI_EVENT_CONNECT, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
-    wifi_reg_event_handler(MATTER_WIFI_EVENT_FOURWAY_HANDSHAKE_DONE, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
-    wifi_reg_event_handler(MATTER_WIFI_EVENT_DISCONNECT, ConnectivityManagerImpl::RtkWiFiStationDisconnectedHandler, NULL);
-    wifi_reg_event_handler(MATTER_WIFI_EVENT_DHCP6_DONE, ConnectivityManagerImpl::RtkWiFiDHCPCompletedHandler, NULL);
+    matter_wifi_reg_event_handler(MATTER_WIFI_EVENT_CONNECT, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
+    matter_wifi_reg_event_handler(MATTER_WIFI_EVENT_FOURWAY_HANDSHAKE_DONE, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler,
+                                  NULL);
+    matter_wifi_reg_event_handler(MATTER_WIFI_EVENT_DISCONNECT, ConnectivityManagerImpl::RtkWiFiStationDisconnectedHandler, NULL);
+    matter_wifi_reg_event_handler(MATTER_WIFI_EVENT_DHCP6_DONE, ConnectivityManagerImpl::RtkWiFiDHCPCompletedHandler, NULL);
 
     err = Internal::AmebaUtils::StartWiFi();
     SuccessOrExit(err);

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -83,10 +83,10 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     chip_connmgr_set_callback_func((chip_connmgr_callback) (conn_callback_dispatcher), this);
 
     // Register WiFi event handlers
-    wifi_reg_event_handler(WIFI_EVENT_CONNECT, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
-    wifi_reg_event_handler(WIFI_EVENT_FOURWAY_HANDSHAKE_DONE, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
-    wifi_reg_event_handler(WIFI_EVENT_DISCONNECT, ConnectivityManagerImpl::RtkWiFiStationDisconnectedHandler, NULL);
-    wifi_reg_event_handler(WIFI_EVENT_DHCP6_DONE, ConnectivityManagerImpl::RtkWiFiDHCPCompletedHandler, NULL);
+    wifi_reg_event_handler(MATTER_WIFI_EVENT_CONNECT, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
+    wifi_reg_event_handler(MATTER_WIFI_EVENT_FOURWAY_HANDSHAKE_DONE, ConnectivityManagerImpl::RtkWiFiStationConnectedHandler, NULL);
+    wifi_reg_event_handler(MATTER_WIFI_EVENT_DISCONNECT, ConnectivityManagerImpl::RtkWiFiStationDisconnectedHandler, NULL);
+    wifi_reg_event_handler(MATTER_WIFI_EVENT_DHCP6_DONE, ConnectivityManagerImpl::RtkWiFiDHCPCompletedHandler, NULL);
 
     err = Internal::AmebaUtils::StartWiFi();
     SuccessOrExit(err);
@@ -702,7 +702,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                 {
                     haveIPv4Conn = true;
                     char addrStr[INET_ADDRSTRLEN];
-                    ip4addr_ntoa_r((const ip4_addr_t *) LwIP_GetIP(&xnetif[0]), addrStr, sizeof(addrStr));
+                    ip4addr_ntoa_r((const ip4_addr_t *) matter_LwIP_GetIP(0), addrStr, sizeof(addrStr));
                     IPAddress::FromString(addrStr, addr);
                 }
 
@@ -749,13 +749,13 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
 
 void ConnectivityManagerImpl::OnStationIPv4v6AddressAvailable(void)
 {
-    uint8_t * ip  = LwIP_GetIP(&xnetif[0]);
-    uint8_t * gw  = LwIP_GetGW(&xnetif[0]);
-    uint8_t * msk = LwIP_GetMASK(&xnetif[0]);
+    uint8_t * ip  = matter_LwIP_GetIP(0);
+    uint8_t * gw  = matter_LwIP_GetGW(0);
+    uint8_t * msk = matter_LwIP_GetMASK(0);
 #if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if LWIP_IPV6
-    uint8_t * ipv6_0 = LwIP_GetIPv6_linklocal(&xnetif[0]);
-    uint8_t * ipv6_1 = LwIP_GetIPv6_global(&xnetif[0]);
+    uint8_t * ipv6_0 = matter_LwIP_GetIPv6_linklocal(0);
+    uint8_t * ipv6_1 = matter_LwIP_GetIPv6_global(0);
 #endif
 #endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 


### PR DESCRIPTION
- Updated the API call for LwIP functions of Ameba ConnectivityManagerImpl.cpp:
  - LwIP_GetIP --> matter_LwIP_GetIP
  - LwIP_GetGW --> matter_LwIP_GetGW
  - LwIP_GetMASK --> matter_LwIP_GetMASK
  - LwIP_GetIPv6_linklocal --> matter_LwIP_GetIPv6_linklocal
  - LwIP_GetIPv6_global --> matter_LwIP_GetIPv6_global
- Updated the API call for wifi functions of NetworkCommissioningWiFiDriver.cpp:
  - wifi_reg_event_handler --> matter_wifi_reg_event_handler

