### PR TITLE
Add TestOnlySendBatchCommands to chip-repl

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -951,7 +951,7 @@ class ChipDeviceControllerBase():
                       - A value of `None` indicates success.
                       - If only a single command fails, for example with `UNSUPPORTED_COMMAND`, the corresponding index associated with the command will,
                         contain `interaction_model.Status.UnsupportedCommand`.
-                      - If a command is not responded to by server, command will contain `interaction_model.Status.Failure`
+                      - If a command is not responded to by server, command will contain `interaction_model.Status.NoCommandResponse`
         Raises:
             - InteractionModelError if error with sending of InvokeRequestMessage fails as a whole.
         '''

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -848,6 +848,34 @@ class ChipDeviceControllerBase():
 
         return res
 
+    async def TestOnlySendBatchCommands(self, nodeid: int, commands: typing.List[ClusterCommand.InvokeRequestInfo],
+                                        timedRequestTimeoutMs: typing.Optional[int] = None,
+                                        interactionTimeoutMs: typing.Optional[int] = None, busyWaitMs: typing.Optional[int] = None,
+                                        suppressResponse: typing.Optional[bool] = None, remoteMaxPathsPerInvoke: typing.Optional[int] = None,
+                                        suppressTimedRequestMessage: bool = False, commandRefsOverride: typing.Optional[list[int]] = None):
+        '''
+
+        Please see SendBatchCommands for description.
+        TestOnly overridable arguments:
+            remoteMaxPathsPerInvoke: Overrides the number of batch commands we think can be sent to remote node.
+            suppressTimedRequestMessage: When set to true, we suppress sending Timed Request Message.
+            commandRefsOverride: List of commandRefs to use for each command with the same index in `commands`.
+        '''
+        self.CheckIsActive()
+
+        eventLoop = asyncio.get_running_loop()
+        future = eventLoop.create_future()
+
+        device = self.GetConnectedDeviceSync(nodeid, timeoutMs=interactionTimeoutMs)
+
+        ClusterCommand.TestOnlySendBatchCommands(
+            future, eventLoop, device.deviceProxy, commands,
+            timedRequestTimeoutMs=timedRequestTimeoutMs,
+            interactionTimeoutMs=interactionTimeoutMs, busyWaitMs=busyWaitMs, suppressResponse=suppressResponse,
+            remoteMaxPathsPerInvoke=remoteMaxPathsPerInvoke, suppressTimedRequestMessage=suppressTimedRequestMessage,
+            commandRefsOverride=commandRefsOverride).raise_on_error()
+        return await future
+
     async def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(self, nodeid: int, endpoint: int,
                                                                    payload: ClusterObjects.ClusterCommand, responseType=None):
         '''

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -852,7 +852,7 @@ class ChipDeviceControllerBase():
                                         timedRequestTimeoutMs: typing.Optional[int] = None,
                                         interactionTimeoutMs: typing.Optional[int] = None, busyWaitMs: typing.Optional[int] = None,
                                         suppressResponse: typing.Optional[bool] = None, remoteMaxPathsPerInvoke: typing.Optional[int] = None,
-                                        suppressTimedRequestMessage: bool = False, commandRefsOverride: typing.Optional[list[int]] = None):
+                                        suppressTimedRequestMessage: bool = False, commandRefsOverride: typing.Optional[typing.List[int]] = None):
         '''
 
         Please see SendBatchCommands for description.

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -320,7 +320,7 @@ def _BuildPyInvokeRequestData(commands: List[InvokeRequestInfo], timedRequestTim
         pyBatchCommandsData[idx].tlvLength = c_size_t(len(payloadTLV))
 
         responseTypes.append(responseType)
-    
+
     return pyBatchCommandsData
 
 
@@ -377,7 +377,8 @@ def TestOnlySendBatchCommands(future: Future, eventLoop, device, commands: List[
     handle = chip.native.GetLibraryHandle()
 
     responseTypes = []
-    pyBatchCommandsData = _BuildPyInvokeRequestData(commands, timedRequestTimeoutMs, responseTypes, suppressTimedRequestMessage=suppressTimedRequestMessage)
+    pyBatchCommandsData = _BuildPyInvokeRequestData(commands, timedRequestTimeoutMs,
+                                                    responseTypes, suppressTimedRequestMessage=suppressTimedRequestMessage)
 
     transaction = AsyncBatchCommandsTransaction(future, eventLoop, responseTypes)
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -361,7 +361,7 @@ def SendBatchCommands(future: Future, eventLoop, device, commands: List[InvokeRe
 def TestOnlySendBatchCommands(future: Future, eventLoop, device, commands: List[InvokeRequestInfo],
                               timedRequestTimeoutMs: Optional[int] = None, interactionTimeoutMs: Optional[int] = None, busyWaitMs: Optional[int] = None,
                               suppressResponse: Optional[bool] = None, remoteMaxPathsPerInvoke: Optional[int] = None,
-                              suppressTimedRequestMessage: bool = False, commandRefsOverride: Optional[list[int]] = None) -> PyChipError:
+                              suppressTimedRequestMessage: bool = False, commandRefsOverride: Optional[List[int]] = None) -> PyChipError:
     ''' ONLY TO BE USED FOR TEST: Send batch commands using various overrides.
     '''
     if suppressTimedRequestMessage and timedRequestTimeoutMs is not None:

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -181,6 +181,129 @@ private:
     bool mIsBatchedCommands;
 };
 
+PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
+                                      uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                      python::TestOnlyPyBatchCommandsOverrides * testOnlyOverrides,
+                                      python::PyInvokeRequestData * batchCommandData, size_t length)
+{
+    CommandSender::ConfigParameters config;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    bool testOnlySuppressTimedRequestMessage = false;
+    uint16_t * testOnlyCommandRefsOverride = nullptr;
+
+    VerifyOrReturnError(device->GetSecureSession().HasValue(), ToPyChipError(CHIP_ERROR_MISSING_SECURE_SESSION));
+
+    // Test only override validation checks and setup
+    if (testOnlyOverrides != nullptr)
+    {
+        if (testOnlyOverrides->suppressTimedRequestMessage)
+        {
+            VerifyOrReturnError(timedRequestTimeoutMs == 0, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+            testOnlySuppressTimedRequestMessage = true;
+        }
+        if (testOnlyOverrides->overrideCommandRefsList != nullptr)
+        {
+            VerifyOrReturnError(length == testOnlyOverrides->overrideCommandRefsListLength, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+            testOnlyCommandRefsOverride = testOnlyOverrides->overrideCommandRefsList;
+        }
+    }
+
+    if (testOnlyOverrides != nullptr && testOnlyOverrides->overrideRemoteMaxPathsPerInvoke)
+    {
+        config.SetRemoteMaxPathsPerInvoke(testOnlyOverrides->overrideRemoteMaxPathsPerInvoke);
+    }
+    else
+    {
+        auto remoteSessionParameters = device->GetSecureSession().Value()->GetRemoteSessionParameters();
+        config.SetRemoteMaxPathsPerInvoke(remoteSessionParameters.GetMaxPathsPerInvoke());
+    }
+
+    std::unique_ptr<CommandSenderCallback> callback =
+        std::make_unique<CommandSenderCallback>(appContext, /* isBatchedCommands =*/true);
+
+    bool isTimedRequest = timedRequestTimeoutMs != 0 || testOnlySuppressTimedRequestMessage;
+    std::unique_ptr<CommandSender> sender =
+        std::make_unique<CommandSender>(callback.get(), device->GetExchangeManager(),
+                                        isTimedRequest, suppressResponse);
+
+    SuccessOrExit(err = sender->SetCommandSenderConfig(config));
+
+    for (size_t i = 0; i < length; i++)
+    {
+        chip::EndpointId endpointId = batchCommandData[i].commandPath.endpointId;
+        chip::ClusterId clusterId   = batchCommandData[i].commandPath.clusterId;
+        chip::CommandId commandId   = batchCommandData[i].commandPath.commandId;
+        void * tlv                  = batchCommandData[i].tlvData;
+        size_t tlvLength            = batchCommandData[i].tlvLength;
+
+        const uint8_t * tlvBuffer = reinterpret_cast<const uint8_t *>(tlv);
+
+        app::CommandPathParams cmdParams = { endpointId, /* group id */ 0, clusterId, commandId,
+                                             (app::CommandPathFlags::kEndpointIdValid) };
+
+        CommandSender::AdditionalCommandParameters additionalParams;
+
+        SuccessOrExit(err = sender->PrepareCommand(cmdParams, additionalParams));
+        if (testOnlyCommandRefsOverride != nullptr)
+        {
+            additionalParams.commandRef.SetValue(testOnlyCommandRefsOverride[i]);
+        }
+        {
+            auto writer = sender->GetCommandDataIBTLVWriter();
+            VerifyOrExit(writer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+            TLV::TLVReader reader;
+            reader.Init(tlvBuffer, static_cast<uint32_t>(tlvLength));
+            reader.Next();
+            SuccessOrExit(err = writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
+        }
+
+        SuccessOrExit(err = sender->FinishCommand(timedRequestTimeoutMs != 0 ? Optional<uint16_t>(timedRequestTimeoutMs)
+                                                                             : Optional<uint16_t>::Missing(),
+                                                  additionalParams));
+
+        // CommandSender provides us with the CommandReference for this associated command. In order to match responses
+        // we have to add CommandRef to index lookup.
+        VerifyOrExit(additionalParams.commandRef.HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
+        if (testOnlyCommandRefsOverride != nullptr)
+        {
+            // Making sure the value we used to override CommandRef was actually used.
+            VerifyOrDie(additionalParams.commandRef.Value() == testOnlyCommandRefsOverride[i]);
+            // Ignoring the result of adding to index as the test might be trying to set duplicate CommandRefs.
+            callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i);
+        } else {
+            SuccessOrExit(err = callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i));
+        }
+    }
+
+    {
+        Optional<System::Clock::Timeout> interactionTimeout = interactionTimeoutMs != 0 ? MakeOptional(System::Clock::Milliseconds32(interactionTimeoutMs)) : Optional<System::Clock::Timeout>::Missing();
+        if (testOnlySuppressTimedRequestMessage)
+        {
+            SuccessOrExit(err = sender->TestOnlyCommandSenderTimedRequestFlagWithNoTimedInvoke(
+                              device->GetSecureSession().Value(), interactionTimeout));
+        }
+        else
+        {
+            SuccessOrExit(err = sender->SendCommandRequest(device->GetSecureSession().Value(),
+                                                           interactionTimeout));
+        }
+    }
+
+    sender.release();
+    callback.release();
+
+    // TODO(#30985): Reconsider the purpose of busyWait and if it can be broken out into it's
+    // own method/primitive.
+    if (busyWaitMs)
+    {
+        usleep(busyWaitMs * 1000);
+    }
+
+exit:
+    return ToPyChipError(err);
+}
+
 } // namespace python
 } // namespace chip
 
@@ -251,82 +374,24 @@ PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProx
                                                    uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
                                                    python::PyInvokeRequestData * batchCommandData, size_t length)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrReturnError(device->GetSecureSession().HasValue(), ToPyChipError(CHIP_ERROR_MISSING_SECURE_SESSION));
-    auto remoteSessionParameters = device->GetSecureSession().Value()->GetRemoteSessionParameters();
-    CommandSender::ConfigParameters config;
-
-    // TODO(#30986): Need to create a separate pychip_CommandSender_TestOnlySendBatchCommands so that we perform
-    // operations that is very clear at callsite that violating certain aspects like setting this MaxPathsPerInvoke
-    // to a number other than what is reported by the remote node is allowed. Right now the only user of this
-    // function is cert test script. To implement pychip_CommandSender_TestOnlySendBatchCommands in a clean way
-    // we need to move away from the variadic arguments.
-    // config.SetRemoteMaxPathsPerInvoke(remoteSessionParameters.GetMaxPathsPerInvoke());
-    (void) remoteSessionParameters; // Still want to get remoteSessionParameters, just wont use it right now.
-    config.SetRemoteMaxPathsPerInvoke(std::numeric_limits<uint16_t>::max());
-
-    std::unique_ptr<CommandSenderCallback> callback =
-        std::make_unique<CommandSenderCallback>(appContext, /* isBatchedCommands =*/true);
-    std::unique_ptr<CommandSender> sender =
-        std::make_unique<CommandSender>(callback.get(), device->GetExchangeManager(),
-                                        /* is timed request */ timedRequestTimeoutMs != 0, suppressResponse);
-
-    SuccessOrExit(err = sender->SetCommandSenderConfig(config));
-
-    for (size_t i = 0; i < length; i++)
-    {
-        chip::EndpointId endpointId = batchCommandData[i].commandPath.endpointId;
-        chip::ClusterId clusterId   = batchCommandData[i].commandPath.clusterId;
-        chip::CommandId commandId   = batchCommandData[i].commandPath.commandId;
-        void * tlv                  = batchCommandData[i].tlvData;
-        size_t tlvLength            = batchCommandData[i].tlvLength;
-
-        const uint8_t * tlvBuffer = reinterpret_cast<const uint8_t *>(tlv);
-
-        app::CommandPathParams cmdParams = { endpointId, /* group id */ 0, clusterId, commandId,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
-
-        CommandSender::AdditionalCommandParameters additionalParams;
-
-        SuccessOrExit(err = sender->PrepareCommand(cmdParams, additionalParams));
-        {
-            auto writer = sender->GetCommandDataIBTLVWriter();
-            VerifyOrExit(writer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-            TLV::TLVReader reader;
-            reader.Init(tlvBuffer, static_cast<uint32_t>(tlvLength));
-            reader.Next();
-            SuccessOrExit(err = writer->CopyContainer(TLV::ContextTag(CommandDataIB::Tag::kFields), reader));
-        }
-
-        SuccessOrExit(err = sender->FinishCommand(timedRequestTimeoutMs != 0 ? Optional<uint16_t>(timedRequestTimeoutMs)
-                                                                             : Optional<uint16_t>::Missing(),
-                                                  additionalParams));
-
-        // CommandSender provides us with the CommandReference for this associated command. In order to match responses
-        // we have to add CommandRef to index lookup.
-        VerifyOrExit(additionalParams.commandRef.HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
-        SuccessOrExit(err = callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i));
-    }
-
-    SuccessOrExit(err = sender->SendCommandRequest(device->GetSecureSession().Value(),
-                                                   interactionTimeoutMs != 0
-                                                       ? MakeOptional(System::Clock::Milliseconds32(interactionTimeoutMs))
-                                                       : Optional<System::Clock::Timeout>::Missing()));
-
-    sender.release();
-    callback.release();
-
-    // TODO(#30985): Reconsider the purpose of busyWait and if it can be broken out into it's
-    // own method/primitive.
-    if (busyWaitMs)
-    {
-        usleep(busyWaitMs * 1000);
-    }
-
-exit:
-    return ToPyChipError(err);
+    python::TestOnlyPyBatchCommandsOverrides * testOnlyOverrides = nullptr;
+    return SendBatchCommandsInternal(appContext, device, timedRequestTimeoutMs, interactionTimeoutMs, busyWaitMs, suppressResponse,
+                                     testOnlyOverrides, batchCommandData, length);
 }
+
+PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
+                                                           uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                                           python::TestOnlyPyBatchCommandsOverrides testOnlyOverrides,
+                                                           python::PyInvokeRequestData * batchCommandData, size_t length)
+{
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    return SendBatchCommandsInternal(appContext, device, timedRequestTimeoutMs, interactionTimeoutMs, busyWaitMs, suppressResponse,
+                                     &testOnlyOverrides, batchCommandData, length);
+#else
+    return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
+#endif
+}
+
 
 PyChipError pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke(
     void * appContext, DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -190,7 +190,7 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     bool testOnlySuppressTimedRequestMessage = false;
-    uint16_t * testOnlyCommandRefsOverride = nullptr;
+    uint16_t * testOnlyCommandRefsOverride   = nullptr;
 
     VerifyOrReturnError(device->GetSecureSession().HasValue(), ToPyChipError(CHIP_ERROR_MISSING_SECURE_SESSION));
 
@@ -204,7 +204,8 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
         }
         if (testOnlyOverrides->overrideCommandRefsList != nullptr)
         {
-            VerifyOrReturnError(length == testOnlyOverrides->overrideCommandRefsListLength, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+            VerifyOrReturnError(length == testOnlyOverrides->overrideCommandRefsListLength,
+                                ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
             testOnlyCommandRefsOverride = testOnlyOverrides->overrideCommandRefsList;
         }
     }
@@ -224,8 +225,7 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
 
     bool isTimedRequest = timedRequestTimeoutMs != 0 || testOnlySuppressTimedRequestMessage;
     std::unique_ptr<CommandSender> sender =
-        std::make_unique<CommandSender>(callback.get(), device->GetExchangeManager(),
-                                        isTimedRequest, suppressResponse);
+        std::make_unique<CommandSender>(callback.get(), device->GetExchangeManager(), isTimedRequest, suppressResponse);
 
     SuccessOrExit(err = sender->SetCommandSenderConfig(config));
 
@@ -271,22 +271,25 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
             VerifyOrDie(additionalParams.commandRef.Value() == testOnlyCommandRefsOverride[i]);
             // Ignoring the result of adding to index as the test might be trying to set duplicate CommandRefs.
             callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i);
-        } else {
+        }
+        else
+        {
             SuccessOrExit(err = callback->AddCommandRefToIndexLookup(additionalParams.commandRef.Value(), i));
         }
     }
 
     {
-        Optional<System::Clock::Timeout> interactionTimeout = interactionTimeoutMs != 0 ? MakeOptional(System::Clock::Milliseconds32(interactionTimeoutMs)) : Optional<System::Clock::Timeout>::Missing();
+        Optional<System::Clock::Timeout> interactionTimeout = interactionTimeoutMs != 0
+            ? MakeOptional(System::Clock::Milliseconds32(interactionTimeoutMs))
+            : Optional<System::Clock::Timeout>::Missing();
         if (testOnlySuppressTimedRequestMessage)
         {
-            SuccessOrExit(err = sender->TestOnlyCommandSenderTimedRequestFlagWithNoTimedInvoke(
-                              device->GetSecureSession().Value(), interactionTimeout));
+            SuccessOrExit(err = sender->TestOnlyCommandSenderTimedRequestFlagWithNoTimedInvoke(device->GetSecureSession().Value(),
+                                                                                               interactionTimeout));
         }
         else
         {
-            SuccessOrExit(err = sender->SendCommandRequest(device->GetSecureSession().Value(),
-                                                           interactionTimeout));
+            SuccessOrExit(err = sender->SendCommandRequest(device->GetSecureSession().Value(), interactionTimeout));
         }
     }
 
@@ -380,7 +383,8 @@ PyChipError pychip_CommandSender_SendBatchCommands(void * appContext, DeviceProx
 }
 
 PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, DeviceProxy * device, uint16_t timedRequestTimeoutMs,
-                                                           uint16_t interactionTimeoutMs, uint16_t busyWaitMs, bool suppressResponse,
+                                                           uint16_t interactionTimeoutMs, uint16_t busyWaitMs,
+                                                           bool suppressResponse,
                                                            python::TestOnlyPyBatchCommandsOverrides testOnlyOverrides,
                                                            python::PyInvokeRequestData * batchCommandData, size_t length)
 {
@@ -391,7 +395,6 @@ PyChipError pychip_CommandSender_TestOnlySendBatchCommands(void * appContext, De
     return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
 #endif
 }
-
 
 PyChipError pychip_CommandSender_TestOnlySendCommandTimedRequestNoTimedInvoke(
     void * appContext, DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -60,6 +60,17 @@ struct PyWriteAttributeData
     size_t tlvLength;
 };
 
+struct TestOnlyPyBatchCommandsOverrides
+{
+    // When max paths per invoke override value is set to 0, we will not use
+    // it as an override. Otherwise, this value will be provided to the
+    // CommandSender as the remote node's maximum paths.
+    uint16_t overrideRemoteMaxPathsPerInvoke;
+    bool suppressTimedRequestMessage;
+    uint16_t * overrideCommandRefsList;
+    size_t overrideCommandRefsListLength;
+};
+
 } // namespace python
 
 namespace Controller {

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -27,11 +27,11 @@ import enum
 from chip.exceptions import ChipStackException
 
 from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct, EventPath, EventPathIBstruct,
-                       PyInvokeRequestData, PyWriteAttributeData, SessionParameters, SessionParametersStruct)
+                       PyInvokeRequestData, PyWriteAttributeData, SessionParameters, SessionParametersStruct, TestOnlyPyBatchCommandsOverrides)
 
 __all__ = ["AttributePath", "AttributePathIBstruct", "DataVersionFilterIBstruct",
            "EventPath", "EventPathIBstruct", "InteractionModelError", "PyInvokeRequestData",
-           "PyWriteAttributeData", "SessionParameters", "SessionParametersStruct", "Status"]
+           "PyWriteAttributeData", "SessionParameters", "SessionParametersStruct", "Status", "TestOnlyPyBatchCommandsOverrides"]
 
 
 # defined src/controller/python/chip/interaction_model/Delegate.h

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -27,7 +27,8 @@ import enum
 from chip.exceptions import ChipStackException
 
 from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct, EventPath, EventPathIBstruct,
-                       PyInvokeRequestData, PyWriteAttributeData, SessionParameters, SessionParametersStruct, TestOnlyPyBatchCommandsOverrides)
+                       PyInvokeRequestData, PyWriteAttributeData, SessionParameters, SessionParametersStruct,
+                       TestOnlyPyBatchCommandsOverrides)
 
 __all__ = ["AttributePath", "AttributePathIBstruct", "DataVersionFilterIBstruct",
            "EventPath", "EventPathIBstruct", "InteractionModelError", "PyInvokeRequestData",

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -199,7 +199,6 @@ class PyWriteAttributeData(ctypes.Structure):
     _fields_ = [('attributePath', PyAttributePath), ('tlvData', ctypes.c_void_p), ('tlvLength', ctypes.c_size_t)]
 
 
-
 class TestOnlyPyBatchCommandsOverrides(ctypes.Structure):
     ''' TestOnly struct for overriding aspects of batch command to send invalid commands.
 
@@ -215,7 +214,8 @@ class TestOnlyPyBatchCommandsOverrides(ctypes.Structure):
     };
     ```
     '''
-    _fields_ = [('overrideRemoteMaxPathsPerInvoke', ctypes.c_uint16), ('suppressTimedRequestMessage', ctypes.c_bool), ('overrideCommandRefsList', POINTER(ctypes.c_uint16)), ('overrideCommandRefsListLength', ctypes.c_size_t)]
+    _fields_ = [('overrideRemoteMaxPathsPerInvoke', ctypes.c_uint16), ('suppressTimedRequestMessage', ctypes.c_bool),
+                ('overrideCommandRefsList', POINTER(ctypes.c_uint16)), ('overrideCommandRefsListLength', ctypes.c_size_t)]
 
 
 # typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -17,7 +17,7 @@
 import ctypes
 import threading
 import typing
-from ctypes import CFUNCTYPE, c_uint8, c_uint32, c_uint64, c_void_p
+from ctypes import CFUNCTYPE, POINTER, c_uint8, c_uint32, c_uint64, c_void_p
 from dataclasses import dataclass
 
 import chip.exceptions
@@ -197,6 +197,25 @@ class PyWriteAttributeData(ctypes.Structure):
     ```
     '''
     _fields_ = [('attributePath', PyAttributePath), ('tlvData', ctypes.c_void_p), ('tlvLength', ctypes.c_size_t)]
+
+
+
+class TestOnlyPyBatchCommandsOverrides(ctypes.Structure):
+    ''' TestOnly struct for overriding aspects of batch command to send invalid commands.
+
+    We are using the following struct for passing the information of TestOnlyPyBatchCommandsOverrides between Python and C++:
+
+    ```c
+    struct TestOnlyPyBatchCommandsOverrides
+    {
+        uint16_t overrideRemoteMaxPathsPerInvoke;
+        bool suppressTimedRequestMessage;
+        uint16_t * overrideCommandRefsList;
+        size_t overrideCommandRefsListLength;
+    };
+    ```
+    '''
+    _fields_ = [('overrideRemoteMaxPathsPerInvoke', ctypes.c_uint16), ('suppressTimedRequestMessage', ctypes.c_bool), ('overrideCommandRefsList', POINTER(ctypes.c_uint16)), ('overrideCommandRefsListLength', ctypes.c_size_t)]
 
 
 # typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,


### PR DESCRIPTION
This allows chip-repl to send spec violating InvokeRequest for testing purposes. This is needed for CSG test automation for IDM_1_4


Test:
* With https://github.com/project-chip/connectedhomeip/pull/31458, confirmed that TestOnlySendBatchCommands work as expected