### PR TITLE
[Silabs] Bugfixes for the WiFi 91x NCP and SoC combos

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -292,7 +292,7 @@ else
     if [ "$SILABS_BOARD" == "BRD4338A" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
-        optArgs+="chip_device_platform =\"SiWx917\" "
+        optArgs+="chip_device_platform =\"SiWx917\" is_debug=false "
     fi
 
     if [ "$USE_GIT_SHA_FOR_VERSION" == true ]; then

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -34,7 +34,6 @@ declare_args() {
   use_wf200 = false
   use_rs9116 = false
   use_SiWx917 = false
-  chip_enable_ble_rs911x = false
 
   wifi_soc = false
 

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -56,7 +56,7 @@ declare_args() {
   show_qr_code = !disable_lcd
 
   # Enabling BLE on 9116/917 NCP by default
-  chip_enable_ble_rs911x = (use_rs9116 || use_SiWx917)
+  chip_enable_ble_rs911x = use_rs9116 || use_SiWx917
 }
 
 if (silabs_board == "") {

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -54,10 +54,19 @@ declare_args() {
 declare_args() {
   # Enables LCD Qr Code on supported devices
   show_qr_code = !disable_lcd
+
+  # Enabling BLE on 9116/917 NCP by default
+  chip_enable_ble_rs911x = (use_rs9116 || use_SiWx917)
 }
 
 if (silabs_board == "") {
   silabs_board = getenv("SILABS_BOARD")
+}
+
+# TODO - Enable LCD once multiplexing changes added MATTER-2763
+if (use_SiWx917) {
+  disable_lcd = true
+  show_qr_code = false
 }
 
 assert(silabs_board != "", "silabs_board must be specified")


### PR DESCRIPTION
This PR have below fixes

1. Enabling BLE on the NCP i.e., RS9116 and SiWx917 combos by default
2. Disabling LCD on SiWx917 NCP due to issues with multiplexing