### PR TITLE
[nxp] Fix recvmsg duplicate definition on latest Zephyr tree

### DIFF
--- a/src/inet/ZephyrSocket.h
+++ b/src/inet/ZephyrSocket.h
@@ -31,6 +31,7 @@
 #include <zephyr/net/socket.h>
 #endif
 
+#ifndef CONFIG_NET_CONTEXT_RECV_PKTINFO
 static inline ssize_t recvmsg(int sock, struct msghdr * msg, int flags)
 {
     // Zephyr doesn't implement recvmsg at all, but if the message vector size is > 0 we can simply
@@ -51,3 +52,4 @@ static inline ssize_t recvmsg(int sock, struct msghdr * msg, int flags)
 
     return ret;
 }
+#endif


### PR DESCRIPTION
Fixes #31488

recvmsg was implemented recently in Zephyr:
https://github.com/zephyrproject-rtos/zephyr/pull/65694

This commit aims to mitigate this issue and keep backward compatibility by using NET_CONTEXT_RECV_PKTINFO Kconfig to differentiate Zephyr versions.