### PR TITLE
Add min value, max value for attributes of MicrowaveOvenControl cluster

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
@@ -32,27 +32,27 @@ limitations under the License.
     <define>MICROWAVE_OVEN_CONTROL_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <attribute side="server" code="0x0000" define="COOK_TIME"           type="elapsed_s" default="30"  writable="false" optional="false">CookTime</attribute>
+    <attribute side="server" code="0x0000" define="COOK_TIME"           type="elapsed_s" default="30"  writable="false" optional="false" min="1" max="86400">CookTime</attribute>
     <attribute side="server" code="0x0001" define="MAX_COOK_TIME"       type="elapsed_s"               writable="false" optional="false" min="1" max="86400">MaxCookTime</attribute>
-    <attribute side="server" code="0x0002" define="POWER_SETTING"       type="int8u"     default="100" writable="false" optional="true">PowerSetting</attribute>
-    <attribute side="server" code="0x0003" define="MIN_POWER"           type="int8u"     default="10"  writable="false" optional="true">MinPower</attribute>
-    <attribute side="server" code="0x0004" define="MAX_POWER"           type="int8u"     default="100" writable="false" optional="true">MaxPower</attribute>
-    <attribute side="server" code="0x0005" define="POWER_STEP"          type="int8u"     default="10"  writable="false" optional="true">PowerStep</attribute>
-    <attribute side="server" code="0x0006" define="SUPPORTED_WATTS"     type="array" entryType="int16u" writable="false" optional="true">SupportedWatts</attribute>
-    <attribute side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u"                   writable="false" optional="true">SelectedWattIndex</attribute>
+    <attribute side="server" code="0x0002" define="POWER_SETTING"       type="int8u"     default="100" writable="false" optional="true"  min="1" max="100">PowerSetting</attribute>
+    <attribute side="server" code="0x0003" define="MIN_POWER"           type="int8u"     default="10"  writable="false" optional="true"  min="1" max="100">MinPower</attribute>
+    <attribute side="server" code="0x0004" define="MAX_POWER"           type="int8u"     default="100" writable="false" optional="true"  min="1" max="100">MaxPower</attribute>
+    <attribute side="server" code="0x0005" define="POWER_STEP"          type="int8u"     default="10"  writable="false" optional="true"  min="1" max="100">PowerStep</attribute>
+    <attribute side="server" code="0x0006" define="SUPPORTED_WATTS"     type="array" entryType="int16u" writable="false" optional="true" min="1" max="10">SupportedWatts</attribute>
+    <attribute side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u"                   writable="false" optional="true"  min="1" max="10">SelectedWattIndex</attribute>
     <attribute side="server" code="0x0008" define="WATT_RATING"         type="int16u"                  writable="false" optional="true">WattRating</attribute>
 
     <command source="client" code="0x00" name="SetCookingParameters" optional="false">
         <description>Set Cooking Parameters</description>
         <arg name="CookMode"          type="int8u"     optional="true"/>
-        <arg name="CookTime"          type="elapsed_s" optional="true"/>
-        <arg name="PowerSetting"      type="int8u" min="MIN_POWER" max="MAX_POWER" optional="true"/>
-        <arg name="WattSettingIndex"  type="int8u"     optional="true"/>
+        <arg name="CookTime"          type="elapsed_s" min="1" max="MAX_COOK_TIME"     optional="true"/>
+        <arg name="PowerSetting"      type="int8u"     min="MIN_POWER" max="MAX_POWER" optional="true"/>
+        <arg name="WattSettingIndex"  type="int8u"     min="1" max="10"                optional="true"/>
         <arg name="StartAfterSetting" type="boolean"   optional="true"/>
     </command>
     <command source="client" code="0x01" name="AddMoreTime" optional="true">
         <description>Add More Cooking Time</description>
-        <arg name="TimeToAdd" type="elapsed_s" optional="false"/>
+        <arg name="TimeToAdd" type="elapsed_s" min="1" max="MAX_COOK_TIME" optional="false"/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
@@ -39,7 +39,7 @@ limitations under the License.
     <attribute side="server" code="0x0004" define="MAX_POWER"           type="int8u"     default="100" writable="false" optional="true"  min="1" max="100">MaxPower</attribute>
     <attribute side="server" code="0x0005" define="POWER_STEP"          type="int8u"     default="10"  writable="false" optional="true"  min="1" max="100">PowerStep</attribute>
     <attribute side="server" code="0x0006" define="SUPPORTED_WATTS"     type="array" entryType="int16u" writable="false" optional="true" min="1" max="10">SupportedWatts</attribute>
-    <attribute side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u"                   writable="false" optional="true"  min="1" max="10">SelectedWattIndex</attribute>
+    <attribute side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u"                   writable="false" optional="true"  min="0" max="9">SelectedWattIndex</attribute>
     <attribute side="server" code="0x0008" define="WATT_RATING"         type="int16u"                  writable="false" optional="true">WattRating</attribute>
 
     <command source="client" code="0x00" name="SetCookingParameters" optional="false">
@@ -47,7 +47,7 @@ limitations under the License.
         <arg name="CookMode"          type="int8u"     optional="true"/>
         <arg name="CookTime"          type="elapsed_s" min="1" max="MAX_COOK_TIME"     optional="true"/>
         <arg name="PowerSetting"      type="int8u"     min="MIN_POWER" max="MAX_POWER" optional="true"/>
-        <arg name="WattSettingIndex"  type="int8u"     min="1" max="10"                optional="true"/>
+        <arg name="WattSettingIndex"  type="int8u"     min="0" max="9"                optional="true"/>
         <arg name="StartAfterSetting" type="boolean"   optional="true"/>
     </command>
     <command source="client" code="0x01" name="AddMoreTime" optional="true">


### PR DESCRIPTION
Add min value, max value for attributes of MicrowaveOvenControl cluster.

fix issue #30818

Updated file:
microwave-oven-control-cluster.xml 


