### PR TITLE
[ESP32] Fix lock app factory reseting in a loop on ESP32C3

### DIFF
--- a/examples/lock-app/esp32/main/Button.cpp
+++ b/examples/lock-app/esp32/main/Button.cpp
@@ -27,6 +27,14 @@ esp_err_t Button::Init(gpio_num_t gpioNum, uint16_t debouncePeriod)
     mState           = false;
     mLastPolledState = false;
 
+    gpio_config_t io_conf = {};
+    io_conf.intr_type     = GPIO_INTR_NEGEDGE;
+    io_conf.pin_bit_mask  = 1ULL << gpioNum;
+    io_conf.mode          = GPIO_MODE_INPUT;
+    io_conf.pull_down_en  = GPIO_PULLDOWN_ENABLE;
+
+    gpio_config(&io_conf);
+
     return gpio_set_direction(gpioNum, GPIO_MODE_INPUT);
 }
 


### PR DESCRIPTION
- Problem
>  - On esp32c3 lock app was factory reseting in a loop after flash.
>  - Fixes https://github.com/espressif/esp-matter/issues/800

- Changes
> Enabled Pull down on the GPIO of the Button so that we'll get well-defined logical level at a pin under all conditions

- Test
> Tested lock app on ESP32 and ESP32C3
