### PR TITLE
python testing: Add top-level PICS markers to all tests

### DIFF
--- a/src/python_testing/TC_DRLK_2_12.py
+++ b/src/python_testing/TC_DRLK_2_12.py
@@ -38,6 +38,9 @@ class TC_DRLK_2_12(MatterBaseTest, DRLK_COMMON):
         await self.teardown()
         return super().teardown_test()
 
+    def pics_TC_DRLK_2_12(self) -> list[str]:
+        return ["DRLK.S.F0c"]
+
     @async_test_body
     async def test_TC_DRLK_2_12(self):
         await self.run_drlk_test_2_12()

--- a/src/python_testing/TC_DRLK_2_2.py
+++ b/src/python_testing/TC_DRLK_2_2.py
@@ -38,6 +38,9 @@ class TC_DRLK_2_2(MatterBaseTest, DRLK_COMMON):
         await self.teardown()
         return super().teardown_test()
 
+    def pics_TC_DRLK_2_2(self) -> list[str]:
+        return ["DRLK.S"]
+
     @async_test_body
     async def test_TC_DRLK_2_2(self):
         await self.run_drlk_test_2_2()

--- a/src/python_testing/TC_DRLK_2_3.py
+++ b/src/python_testing/TC_DRLK_2_3.py
@@ -38,6 +38,9 @@ class TC_DRLK_2_3(MatterBaseTest, DRLK_COMMON):
         await self.teardown()
         return super().teardown_test()
 
+    def pics_TC_DRLK_2_3(self) -> list[str]:
+        return ["DRLK.S"]
+
     @async_test_body
     async def test_TC_DRLK_2_3(self):
         await self.run_drlk_test_2_3()

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -37,7 +37,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
     def pics_TC_EEVSE_2_2(self):
         """ This function returns a list of PICS for this test case that must be True for the test to be run"""
         # In this case - there is no feature flags needed to run this test case
-        return None
+        return ["EEVSE.S"]
 
     def steps_TC_EEVSE_2_2(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -35,7 +35,7 @@ class TC_EEVSE_2_4(MatterBaseTest, EEVSEBaseTestHelper):
     def pics_TC_EEVSE_2_4(self):
         """ This function returns a list of PICS for this test case that must be True for the test to be run"""
         # In this case - there is no feature flags needed to run this test case
-        return None
+        return ["EEVSE.S"]
 
     def steps_TC_EEVSE_2_4(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -35,7 +35,7 @@ class TC_EEVSE_2_5(MatterBaseTest, EEVSEBaseTestHelper):
     def pics_TC_EEVSE_2_5(self):
         """ This function returns a list of PICS for this test case that must be True for the test to be run"""
         # In this case - there is no feature flags needed to run this test case
-        return None
+        return ["EEVSE.S"]
 
     def steps_TC_EEVSE_2_5(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_FAN_3_3.py
+++ b/src/python_testing/TC_FAN_3_3.py
@@ -42,6 +42,9 @@ class TC_FAN_3_3(MatterBaseTest):
         result = await self.default_controller.WriteAttribute(self.dut_node_id, [(endpoint, Clusters.FanControl.Attributes.RockSetting(rock_setting))])
         asserts.assert_equal(result[0].Status, Status.Success, "RockSetting write failed")
 
+    def pics_TC_FAN_3_3(self) -> list[str]:
+        return ["FAN.S"]
+
     @async_test_body
     async def test_TC_FAN_3_3(self):
         if not self.check_pics("FAN.S.F02"):

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -42,6 +42,9 @@ class TC_FAN_3_4(MatterBaseTest):
         result = await self.default_controller.WriteAttribute(self.dut_node_id, [(endpoint, Clusters.FanControl.Attributes.WindSetting(wind_setting))])
         asserts.assert_equal(result[0].Status, Status.Success, "WindSetting write failed")
 
+    def pics_TC_FAN_3_4(self) -> list[str]:
+        return ["FAN.S"]
+
     @async_test_body
     async def test_TC_FAN_3_4(self):
         if not self.check_pics("FAN.S.F03"):

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -58,6 +58,9 @@ class TC_FAN_3_5(MatterBaseTest):
             asserts.assert_equal(e.status, expected_status, "Unexpected error returned")
             pass
 
+    def pics_TC_FAN_3_5(self) -> list[str]:
+        return ["FAN.S"]
+
     @async_test_body
     async def test_TC_FAN_3_5(self):
         if not self.check_pics("FAN.S.F04"):

--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -29,6 +29,9 @@ class TC_ICDM_2_1(MatterBaseTest):
         cluster = Clusters.Objects.IcdManagement
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
+    def pics_TC_ICDM_2_1(self) -> list[str]:
+        return ["ICDM.S"]
+
     @async_test_body
     async def test_TC_ICDM_2_1(self):
 

--- a/src/python_testing/TC_OPSTATE_2_1.py
+++ b/src/python_testing/TC_OPSTATE_2_1.py
@@ -49,6 +49,9 @@ class TC_OPSTATE_2_1(MatterBaseTest):
         asserts.assert_equal(operational_error.errorStateID, expected_error,
                              "errorStateID(%s) should equal %s" % (operational_error.errorStateID, expected_error))
 
+    def pics_TC_OPSTATE_2_1(self) -> list[str]:
+        return ["OPSTATE.S"]
+
     @async_test_body
     async def test_TC_OPSTATE_2_1(self):
 

--- a/src/python_testing/TC_OPSTATE_2_3.py
+++ b/src/python_testing/TC_OPSTATE_2_3.py
@@ -46,6 +46,9 @@ class TC_OPSTATE_2_3(MatterBaseTest):
                             "Unexpected return type for Resume")
         return ret
 
+    def pics_TC_OPSTATE_2_3(self) -> list[str]:
+        return ["OPSTATE.S"]
+
     @async_test_body
     async def test_TC_OPSTATE_2_3(self):
 

--- a/src/python_testing/TC_RVCCLEANM_1_2.py
+++ b/src/python_testing/TC_RVCCLEANM_1_2.py
@@ -33,6 +33,9 @@ class TC_RVCCLEANM_1_2(MatterBaseTest):
         cluster = Clusters.Objects.RvcCleanMode
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
+    def pics_TC_RVCCLEANM_1_2(self) -> list[str]:
+        return ["RVCCLEANM.S"]
+
     @async_test_body
     async def test_TC_RVCCLEANM_1_2(self):
 

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -38,6 +38,9 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
                             "Unexpected return type for ChangeToMode")
         return ret
 
+    def pics_TC_RVCCLEANM_2_1(self) -> list[str]:
+        return ["RVCCLEANM.S"]
+
     @async_test_body
     async def test_TC_RVCCLEANM_2_1(self):
 

--- a/src/python_testing/TC_RVCCLEANM_3_2.py
+++ b/src/python_testing/TC_RVCCLEANM_3_2.py
@@ -69,6 +69,9 @@ class TC_RVCCLEANM_3_2(MatterBaseTest):
 
         return False
 
+    def pics_TC_RVCCLEANM_3_2(self) -> list[str]:
+        return ["RVCCLEANM.S.A0002"]
+
     @async_test_body
     async def test_TC_RVCCLEANM_3_2(self):
 

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -49,6 +49,9 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
         asserts.assert_equal(operational_error.errorStateID, expected_error,
                              "errorStateID(%s) should equal %s" % (operational_error.errorStateID, expected_error))
 
+    def TC_RVCOPSTATE_2_1(self) -> list[str]:
+        return ["RVCOPSTATE.S"]
+
     @async_test_body
     async def test_TC_RVCOPSTATE_2_1(self):
 

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -46,6 +46,9 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                             "Unexpected return type for Resume")
         return ret
 
+    def TC_RVCOPSTATE_2_3(self) -> list[str]:
+        return ["RVCOPSTATE.S"]
+
     @async_test_body
     async def test_TC_RVCOPSTATE_2_3(self):
 

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -33,6 +33,9 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
         cluster = Clusters.Objects.RvcRunMode
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
+    def pics_TC_RVCRUNM_1_2(self) -> list[str]:
+        return ["RVCRUNM.S"]
+
     @async_test_body
     async def test_TC_RVCRUNM_1_2(self):
 

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -38,6 +38,9 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
                             "Unexpected return type for ChangeToMode")
         return ret
 
+    def pics_TC_RVCRUNM_2_1(self) -> list[str]:
+        return ["RVCRUNM.S"]
+
     @async_test_body
     async def test_TC_RVCRUNM_2_1(self):
 

--- a/src/python_testing/TC_RVCRUNM_3_2.py
+++ b/src/python_testing/TC_RVCRUNM_3_2.py
@@ -69,6 +69,9 @@ class TC_RVCRUNM_3_2(MatterBaseTest):
 
         return False
 
+    def pics_TC_RVCRUNM_3_2(self) -> list[str]:
+        return ["RVCRUNM.S"]
+
     @async_test_body
     async def test_TC_RVCRUNM_3_2(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -29,6 +29,9 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
         cluster = Clusters.Objects.TimeSynchronization
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
+    def pics_TC_TIMESYNC_2_1(self) -> list[str]:
+        return ["TIMESYNC.S"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_1(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -45,6 +45,9 @@ class TC_TIMESYNC_2_10(MatterBaseTest):
     async def send_set_utc_cmd(self, utc: uint) -> None:
         await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity))
 
+    def pics_TC_TIMESYNC_2_10(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_10(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -51,6 +51,9 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
             asserts.fail("Did not receive DSTStatus event")
             pass
 
+    def pics_TC_TIMESYNC_2_11(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_11(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -51,6 +51,9 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
         except queue.Empty:
             asserts.fail("Did not receive TZStatus event")
 
+    def pics_TC_TIMESYNC_2_12(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_12(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -34,6 +34,9 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
         except queue.Empty:
             asserts.fail("Did not receive MissingTrustedTimeSouce event")
 
+    def pics_TC_TIMESYNC_2_13(self) -> list[str]:
+        return ["TIMESYNC.S.F01"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_13(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -29,6 +29,9 @@ class TC_TIMESYNC_2_2(MatterBaseTest):
         cluster = Clusters.Objects.TimeSynchronization
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
+    def pics_TC_TIMESYNC_2_2(self) -> list[str]:
+        return ["TIMESYNC.S"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_2(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -43,6 +43,9 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
             asserts.assert_equal(e.status, error, "Unexpected error returned")
             pass
 
+    def pics_TC_TIMESYNC_2_4(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_4(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_5.py
+++ b/src/python_testing/TC_TIMESYNC_2_5.py
@@ -40,6 +40,9 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
             asserts.assert_equal(e.status, error, "Unexpected error returned")
             pass
 
+    def pics_TC_TIMESYNC_2_5(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_5(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_6.py
+++ b/src/python_testing/TC_TIMESYNC_2_6.py
@@ -40,6 +40,9 @@ class TC_TIMESYNC_2_6(MatterBaseTest):
             asserts.assert_equal(e.status, error, "Unexpected error returned")
             pass
 
+    def pics_TC_TIMESYNC_2_6(self) -> list[str]:
+        return ["TIMESYNC.S.F01"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_6(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -46,6 +46,9 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
     async def send_set_utc_cmd(self, utc: uint) -> None:
         await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity))
 
+    def pics_TC_TIMESYNC_2_7(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_7(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -50,6 +50,9 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
     async def send_set_utc_cmd(self, utc: uint) -> None:
         await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity))
 
+    def pics_TC_TIMESYNC_2_8(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_8(self):
 

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -45,6 +45,9 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
     async def send_set_utc_cmd(self, utc: uint) -> None:
         await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity))
 
+    def pics_TC_TIMESYNC_2_9(self) -> list[str]:
+        return ["TIMESYNC.S.F00"]
+
     @async_test_body
     async def test_TC_TIMESYNC_2_9(self):
 

--- a/src/python_testing/TC_TIMESYNC_3_1.py
+++ b/src/python_testing/TC_TIMESYNC_3_1.py
@@ -22,6 +22,9 @@ from mobly import asserts
 
 class TC_TIMESYNC_3_1(MatterBaseTest):
 
+    def pics_TC_TIMESYNC_3_1(self) -> list[str]:
+        return ["TIMESYNC.S"]
+
     @async_test_body
     async def test_TC_TIMESYNC_3_1(self):
         self.print_step(1, "Wildcard read of time sync cluster")


### PR DESCRIPTION
Without these, all the python tests will be run on every device on the TH.

