### PR TITLE
[ICD] Fix ordering issue when triggering a report on Active mode

### DIFF
--- a/examples/lit-icd-app/linux/args.gni
+++ b/examples/lit-icd-app/linux/args.gni
@@ -29,3 +29,4 @@ matter_enable_tracing_support = true
 # ICD configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false
+chip_icd_report_on_active_mode = true

--- a/examples/lit-icd-app/silabs/openthread.gni
+++ b/examples/lit-icd-app/silabs/openthread.gni
@@ -31,6 +31,7 @@ chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false
 sl_use_subscription_synching = true
 icd_enforce_sit_slow_poll_limit = true
+chip_icd_report_on_active_mode = true
 
 # Openthread Configuration flags
 sl_ot_idle_interval_ms = 3600000  # 60mins Idle Polling Interval

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -485,7 +485,7 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
                 // Temporarily claim network activity, until we implement a "user trigger" reason for ICD wakeups.
                 PlatformMgr().LockChipStack();
-                ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+                ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
                 PlatformMgr().UnlockChipStack();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
             }

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -176,7 +176,7 @@ public:
         uint16_t supported_clients = mICDConfigurationData->GetClientsSupportedPerFabric();
         ICDMonitoringTable table(*mStorage, fabricIndex, supported_clients, mSymmetricKeystore);
         table.RemoveAll();
-        ICDNotifier::GetInstance().BroadcastICDManagementEvent(ICDListener::ICDManagementEvents::kTableUpdated);
+        ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDListener::ICDManagementEvents::kTableUpdated);
     }
 
 private:
@@ -337,13 +337,13 @@ Status ICDManagementServer::StayActiveRequest(FabricIndex fabricIndex)
 {
     // TODO: Implementent stay awake logic for end device
     // https://github.com/project-chip/connectedhomeip/issues/24259
-    ICDNotifier::GetInstance().BroadcastICDManagementEvent(ICDListener::ICDManagementEvents::kStayActiveRequestReceived);
+    ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDListener::ICDManagementEvents::kStayActiveRequestReceived);
     return InteractionModel::Status::UnsupportedCommand;
 }
 
 void ICDManagementServer::TriggerICDMTableUpdatedEvent()
 {
-    ICDNotifier::GetInstance().BroadcastICDManagementEvent(ICDListener::ICDManagementEvents::kTableUpdated);
+    ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDListener::ICDManagementEvents::kTableUpdated);
 }
 
 void ICDManagementServer::Init(PersistentStorageDelegate & storage, Crypto::SymmetricKeystore * symmetricKeystore,

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -24,7 +24,7 @@ buildconfig_header("icd_buildconfig") {
 
   defines = [
     "CHIP_CONFIG_ENABLE_ICD_SERVER=${chip_enable_icd_server}",
-    "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_report_on_active_mode}",
+    "ICD_REPORT_ON_ENTER_ACTIVE_MODE=${chip_icd_report_on_active_mode}",
     "ICD_MAX_NOTIFICATION_SUBSCRIBERS=${icd_max_notification_subscribers}",
     "ICD_ENFORCE_SIT_SLOW_POLL_LIMIT=${icd_enforce_sit_slow_poll_limit}",
   ]

--- a/src/app/icd/ICDCheckInSender.cpp
+++ b/src/app/icd/ICDCheckInSender.cpp
@@ -41,12 +41,12 @@ void ICDCheckInSender::OnNodeAddressResolved(const PeerId & peerId, const Addres
         ChipLogError(AppServer, "Failed to send the ICD Check-In message");
     }
 
-    ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCheckInInProgress);
+    ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCheckInInProgress);
 }
 
 void ICDCheckInSender::OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason)
 {
-    ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCheckInInProgress);
+    ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlag::kCheckInInProgress);
     ChipLogProgress(AppServer, "Node Address resolution failed for ICD Check-In with Node ID " ChipLogFormatX64,
                     ChipLogValueX64(peerId.GetNodeId()));
 }
@@ -110,7 +110,7 @@ CHIP_ERROR ICDCheckInSender::RequestResolve(ICDMonitoringEntry & entry, FabricTa
 
     if (err == CHIP_NO_ERROR)
     {
-        ICDNotifier::GetInstance().BroadcastActiveRequestNotification(ICDListener::KeepActiveFlag::kCheckInInProgress);
+        ICDNotifier::GetInstance().NotifyActiveRequestNotification(ICDListener::KeepActiveFlag::kCheckInInProgress);
     }
 
     return err;

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -468,14 +468,11 @@ void ICDManager::OnActiveRequestWithdrawal(KeepActiveFlags request)
 
 void ICDManager::OnNetworkActivity()
 {
-    assertChipStackLockedByCurrentThread();
     this->UpdateOperationState(OperationalState::ActiveMode);
 }
 
 void ICDManager::OnICDManagementServerEvent(ICDManagementEvents event)
 {
-    assertChipStackLockedByCurrentThread();
-
     switch (event)
     {
     case ICDManagementEvents::kTableUpdated:
@@ -493,8 +490,6 @@ void ICDManager::OnICDManagementServerEvent(ICDManagementEvents event)
 
 void ICDManager::OnSubscriptionReport()
 {
-    assertChipStackLockedByCurrentThread();
-
     // If the device is already in ActiveMode, that means that all active subscriptions have already been marked dirty.
     // Since we only mark them dirty when we enter ActiveMode, it is not necessary to update the operational state a second time.
     // Doing so will only add an ActiveModeThreshold to the active time which we don't want to do here.

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -105,6 +105,7 @@ public:
     void OnKeepActiveRequest(KeepActiveFlags request) override;
     void OnActiveRequestWithdrawal(KeepActiveFlags request) override;
     void OnICDManagementServerEvent(ICDManagementEvents event) override;
+    void OnSubscriptionReport() override;
 
 protected:
     friend class TestICDManager;

--- a/src/app/icd/ICDNotifier.cpp
+++ b/src/app/icd/ICDNotifier.cpp
@@ -56,7 +56,7 @@ void ICDNotifier::Unsubscribe(ICDListener * subscriber)
     }
 }
 
-void ICDNotifier::BroadcastNetworkActivityNotification()
+void ICDNotifier::NotifyNetworkActivityNotification()
 {
     for (auto subscriber : mSubscribers)
     {
@@ -67,7 +67,7 @@ void ICDNotifier::BroadcastNetworkActivityNotification()
     }
 }
 
-void ICDNotifier::BroadcastActiveRequestNotification(ICDListener::KeepActiveFlags request)
+void ICDNotifier::NotifyActiveRequestNotification(ICDListener::KeepActiveFlags request)
 {
     for (auto subscriber : mSubscribers)
     {
@@ -78,7 +78,7 @@ void ICDNotifier::BroadcastActiveRequestNotification(ICDListener::KeepActiveFlag
     }
 }
 
-void ICDNotifier::BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlags request)
+void ICDNotifier::NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlags request)
 {
     for (auto subscriber : mSubscribers)
     {
@@ -89,7 +89,7 @@ void ICDNotifier::BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlags 
     }
 }
 
-void ICDNotifier::BroadcastICDManagementEvent(ICDListener::ICDManagementEvents event)
+void ICDNotifier::NotifyICDManagementEvent(ICDListener::ICDManagementEvents event)
 {
     for (auto subscriber : mSubscribers)
     {
@@ -100,7 +100,7 @@ void ICDNotifier::BroadcastICDManagementEvent(ICDListener::ICDManagementEvents e
     }
 }
 
-void ICDNotifier::BroadcastSubscriptionReport()
+void ICDNotifier::NotifySubscriptionReport()
 {
     for (auto subscriber : mSubscribers)
     {

--- a/src/app/icd/ICDNotifier.cpp
+++ b/src/app/icd/ICDNotifier.cpp
@@ -100,5 +100,16 @@ void ICDNotifier::BroadcastICDManagementEvent(ICDListener::ICDManagementEvents e
     }
 }
 
+void ICDNotifier::BroadcastSubscriptionReport()
+{
+    for (auto subscriber : mSubscribers)
+    {
+        if (subscriber != nullptr)
+        {
+            subscriber->OnSubscriptionReport();
+        }
+    }
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/icd/ICDNotifier.h
+++ b/src/app/icd/ICDNotifier.h
@@ -58,13 +58,13 @@ public:
     virtual ~ICDListener() {}
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastNetworkActivityNotification
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastNetworkActivityNotification.
      * It notifies the subscriber that a NetworkActivity occurred. For example, a message sent or received.
      */
     virtual void OnNetworkActivity() = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestNotification
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestNotification.
      * It informs the subscriber that there is a need to place and keep the ICD in its Active Mode.
      *
      * @param request : Identity the request source
@@ -72,7 +72,7 @@ public:
     virtual void OnKeepActiveRequest(KeepActiveFlags request) = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestWithdrawal
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestWithdrawal.
      * It informs the subscriber that a previous request no longer needs ICD to maintain its Active Mode.
      *
      * @param request : The request source
@@ -80,12 +80,18 @@ public:
     virtual void OnActiveRequestWithdrawal(KeepActiveFlags request) = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastICDManagementEvent
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastICDManagementEvent.
      * It informs the subscriber that an ICD Management action has happened and needs to be processed
      *
      * @param event : The event type
      */
-    virtual void OnICDManagementServerEvent(ICDManagementEvents event){};
+    virtual void OnICDManagementServerEvent(ICDManagementEvents event) = 0;
+
+    /**
+     * @brief This function is called for all subscribers of the ICDNoitifier when it calls BroadcastSubscriptionReport.
+     * It informs the subscriber that a subscription report data is being sent.
+     */
+    virtual void OnSubscriptionReport() = 0;
 };
 
 class ICDNotifier
@@ -104,6 +110,7 @@ public:
     void BroadcastActiveRequestNotification(ICDListener::KeepActiveFlags request);
     void BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlags request);
     void BroadcastICDManagementEvent(ICDListener::ICDManagementEvents event);
+    void BroadcastSubscriptionReport();
 
     inline void BroadcastActiveRequest(ICDListener::KeepActiveFlags request, bool notify)
     {

--- a/src/app/icd/ICDNotifier.h
+++ b/src/app/icd/ICDNotifier.h
@@ -58,13 +58,13 @@ public:
     virtual ~ICDListener() {}
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastNetworkActivityNotification.
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls NotifyNetworkActivityNotification.
      * It notifies the subscriber that a NetworkActivity occurred. For example, a message sent or received.
      */
     virtual void OnNetworkActivity() = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestNotification.
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls NotifyActiveRequestNotification.
      * It informs the subscriber that there is a need to place and keep the ICD in its Active Mode.
      *
      * @param request : Identity the request source
@@ -72,7 +72,7 @@ public:
     virtual void OnKeepActiveRequest(KeepActiveFlags request) = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastActiveRequestWithdrawal.
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls NotifyActiveRequestWithdrawal.
      * It informs the subscriber that a previous request no longer needs ICD to maintain its Active Mode.
      *
      * @param request : The request source
@@ -80,7 +80,7 @@ public:
     virtual void OnActiveRequestWithdrawal(KeepActiveFlags request) = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNotifier when it calls BroadcastICDManagementEvent.
+     * @brief This function is called for all subscribers of the ICDNotifier when it calls NotifyICDManagementEvent.
      * It informs the subscriber that an ICD Management action has happened and needs to be processed
      *
      * @param event : The event type
@@ -88,7 +88,7 @@ public:
     virtual void OnICDManagementServerEvent(ICDManagementEvents event) = 0;
 
     /**
-     * @brief This function is called for all subscribers of the ICDNoitifier when it calls BroadcastSubscriptionReport.
+     * @brief This function is called for all subscribers of the ICDNoitifier when it calls NotifySubscriptionReport.
      * It informs the subscriber that a subscription report data is being sent.
      */
     virtual void OnSubscriptionReport() = 0;
@@ -106,15 +106,15 @@ public:
      * For thread-safety reason (mostly of the ICDManager, which is a full time subscriber),
      * Those functions require to be called from the Chip Task Context, or by holding the chip stack lock.
      */
-    void BroadcastNetworkActivityNotification();
-    void BroadcastActiveRequestNotification(ICDListener::KeepActiveFlags request);
-    void BroadcastActiveRequestWithdrawal(ICDListener::KeepActiveFlags request);
-    void BroadcastICDManagementEvent(ICDListener::ICDManagementEvents event);
-    void BroadcastSubscriptionReport();
+    void NotifyNetworkActivityNotification();
+    void NotifyActiveRequestNotification(ICDListener::KeepActiveFlags request);
+    void NotifyActiveRequestWithdrawal(ICDListener::KeepActiveFlags request);
+    void NotifyICDManagementEvent(ICDListener::ICDManagementEvents event);
+    void NotifySubscriptionReport();
 
     inline void BroadcastActiveRequest(ICDListener::KeepActiveFlags request, bool notify)
     {
-        (notify) ? BroadcastActiveRequestNotification(request) : BroadcastActiveRequestWithdrawal(request);
+        (notify) ? NotifyActiveRequestNotification(request) : NotifyActiveRequestWithdrawal(request);
     }
 
     static ICDNotifier & GetInstance() { return sICDNotifier; }

--- a/src/app/icd/icd.gni
+++ b/src/app/icd/icd.gni
@@ -22,7 +22,7 @@ declare_args() {
   chip_enable_icd_client = false
 
   # Matter SDK Configuration flag to make the ICD manager emit a report on entering active mode
-  chip_report_on_active_mode = false
+  chip_icd_report_on_active_mode = false
 
   icd_max_notification_subscribers = 1
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -647,6 +647,8 @@ void Engine::Run()
         if (readHandler->ShouldReportUnscheduled() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
+            // Notify the ICDManager that we are about to send a subscription report before we prepare the Report payload.
+            // This allows the ICDManager to trigger any necessary updates and have the information in the report about to be sent.
             app::ICDNotifier::GetInstance().BroadcastSubscriptionReport();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -23,6 +23,10 @@
  *
  */
 
+#include <app/icd/ICDConfig.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <app/icd/ICDNotifier.h> // nogncheck
+#endif
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/RequiredPrivilege.h>
@@ -642,6 +646,10 @@ void Engine::Run()
 
         if (readHandler->ShouldReportUnscheduled() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+            app::ICDNotifier::GetInstance().BroadcastSubscriptionReport();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);
             mRunningReadHandler = nullptr;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -513,6 +513,12 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
 
     if (apReadHandler->IsType(ReadHandler::InteractionType::Subscribe))
     {
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        // Notify the ICDManager that we are about to send a subscription report before we prepare the Report payload.
+        // This allows the ICDManager to trigger any necessary updates and have the information in the report about to be sent.
+        app::ICDNotifier::GetInstance().BroadcastSubscriptionReport();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
         SubscriptionId subscriptionId = 0;
         apReadHandler->GetSubscriptionId(subscriptionId);
         reportDataBuilder.SubscriptionId(subscriptionId);
@@ -646,11 +652,6 @@ void Engine::Run()
 
         if (readHandler->ShouldReportUnscheduled() || imEngine->GetReportScheduler()->IsReportableNow(readHandler))
         {
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-            // Notify the ICDManager that we are about to send a subscription report before we prepare the Report payload.
-            // This allows the ICDManager to trigger any necessary updates and have the information in the report about to be sent.
-            app::ICDNotifier::GetInstance().BroadcastSubscriptionReport();
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
             mRunningReadHandler = readHandler;
             CHIP_ERROR err      = BuildAndSendSingleReportData(readHandler);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -516,7 +516,7 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         // Notify the ICDManager that we are about to send a subscription report before we prepare the Report payload.
         // This allows the ICDManager to trigger any necessary updates and have the information in the report about to be sent.
-        app::ICDNotifier::GetInstance().BroadcastSubscriptionReport();
+        app::ICDNotifier::GetInstance().NotifySubscriptionReport();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
         SubscriptionId subscriptionId = 0;

--- a/src/app/reporting/ReportSchedulerImpl.cpp
+++ b/src/app/reporting/ReportSchedulerImpl.cpp
@@ -44,7 +44,7 @@ void ReportSchedulerImpl::OnEnterActiveMode()
 {
 #if ICD_REPORT_ON_ENTER_ACTIVE_MODE
     Timestamp now = mTimerDelegate->GetCurrentMonotonicTimestamp();
-    mNodesPool.ForEachActiveObject([now](ReadHandlerNode * node) {
+    mNodesPool.ForEachActiveObject([this, now](ReadHandlerNode * node) {
         if (now >= node->GetMinTimestamp())
         {
             this->HandlerForceDirtyState(node->GetReadHandler());

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -558,11 +558,11 @@ void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnu
         app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
         if (mWindowStatus != CommissioningWindowStatusEnum::kWindowNotOpen)
         {
-            app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(request);
+            app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(request);
         }
         else
         {
-            app::ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(request);
+            app::ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(request);
         }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
     }

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -154,7 +154,7 @@ public:
         // Events updating the Operation to Active mode can extend the current active mode time by 1 Active mode threshold.
         // Kick an active Threshold just before the end of the Active interval and validate that the active mode is extended.
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() - 1);
-        ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+        ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() / 2);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs());
@@ -168,7 +168,7 @@ public:
         ICDNotifier notifier = ICDNotifier::GetInstance();
 
         // Setting a requirement will transition the ICD to active mode.
-        notifier.BroadcastActiveRequestNotification(ActiveFlag::kCommissioningWindowOpen);
+        notifier.NotifyActiveRequestNotification(ActiveFlag::kCommissioningWindowOpen);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         // Advance time so active mode interval expires.
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() + 1);
@@ -176,17 +176,17 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Remove requirement. we should directly transition to idle mode.
-        notifier.BroadcastActiveRequestWithdrawal(ActiveFlag::kCommissioningWindowOpen);
+        notifier.NotifyActiveRequestWithdrawal(ActiveFlag::kCommissioningWindowOpen);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
-        notifier.BroadcastActiveRequestNotification(ActiveFlag::kFailSafeArmed);
+        notifier.NotifyActiveRequestNotification(ActiveFlag::kFailSafeArmed);
         // Requirement will transition us to active mode.
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Advance time, but by less than the active mode interval and remove the requirement.
         // We should stay in active mode.
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() / 2);
-        notifier.BroadcastActiveRequestWithdrawal(ActiveFlag::kFailSafeArmed);
+        notifier.NotifyActiveRequestWithdrawal(ActiveFlag::kFailSafeArmed);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Advance time again, The activemode interval is completed.
@@ -194,8 +194,8 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Set two requirements
-        notifier.BroadcastActiveRequestNotification(ActiveFlag::kFailSafeArmed);
-        notifier.BroadcastActiveRequestNotification(ActiveFlag::kExchangeContextOpen);
+        notifier.NotifyActiveRequestNotification(ActiveFlag::kFailSafeArmed);
+        notifier.NotifyActiveRequestNotification(ActiveFlag::kExchangeContextOpen);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         // advance time so the active mode interval expires.
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() + 1);
@@ -203,10 +203,10 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // remove 1 requirement. Active mode is maintained
-        notifier.BroadcastActiveRequestWithdrawal(ActiveFlag::kFailSafeArmed);
+        notifier.NotifyActiveRequestWithdrawal(ActiveFlag::kFailSafeArmed);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
         // remove the last requirement
-        notifier.BroadcastActiveRequestWithdrawal(ActiveFlag::kExchangeContextOpen);
+        notifier.NotifyActiveRequestWithdrawal(ActiveFlag::kExchangeContextOpen);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
     }
 
@@ -228,7 +228,7 @@ public:
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
 
         // Trigger a "fake" register, ICDManager shoudl remain in SIT mode
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager stayed in SIT mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
@@ -245,7 +245,7 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table1.Set(0, entry1));
 
         // Trigger register event after first entry was added
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
@@ -258,7 +258,7 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table1.Set(1, entry2));
 
         // Trigger register event after first entry was added
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
@@ -271,7 +271,7 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table2.Set(0, entry3));
 
         // Trigger register event after first entry was added
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
@@ -287,7 +287,7 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table2.RemoveAll());
 
         // Trigger register event after fabric was cleared
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is still in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
@@ -296,7 +296,7 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table1.Remove(1));
 
         // Trigger register event after fabric was cleared
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is still in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
@@ -307,7 +307,7 @@ public:
         NL_TEST_ASSERT(aSuite, table2.IsEmpty());
 
         // Trigger register event after fabric was cleared
-        notifier.BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        notifier.NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is still in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
@@ -331,11 +331,11 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Trigger a subscription report
-        notifier.BroadcastSubscriptionReport();
+        notifier.NotifySubscriptionReport();
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Trigger another subscription report - active time should not be increased
-        notifier.BroadcastSubscriptionReport();
+        notifier.NotifySubscriptionReport();
 
         // Advance time so active mode interval expires.
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() + 1);

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -321,6 +321,28 @@ public:
         uint32_t counter2 = ICDConfigurationData::GetInstance().GetICDCounter();
         NL_TEST_ASSERT(aSuite, (counter + 1) == counter2);
     }
+
+    static void TestOnSubscriptionReport(nlTestSuite * aSuite, void * aContext)
+    {
+        TestContext * ctx    = static_cast<TestContext *>(aContext);
+        ICDNotifier notifier = ICDNotifier::GetInstance();
+
+        // After the init we should be in Idle mode
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Trigger a subscription report
+        notifier.BroadcastSubscriptionReport();
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Trigger another subscription report - active time should not be increased
+        notifier.BroadcastSubscriptionReport();
+
+        // Advance time so active mode interval expires.
+        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeDurationMs() + 1);
+
+        // After the init we should be in Idle mode
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+    }
 };
 
 } // namespace app
@@ -329,6 +351,7 @@ public:
 namespace {
 static const nlTest sTests[] = {
     NL_TEST_DEF("TestICDModeDurations", TestICDManager::TestICDModeDurations),
+    NL_TEST_DEF("TestOnSubscriptionReport", TestICDManager::TestOnSubscriptionReport),
     NL_TEST_DEF("TestKeepActivemodeRequests", TestICDManager::TestKeepActivemodeRequests),
     NL_TEST_DEF("TestICDMRegisterUnregisterEvents", TestICDManager::TestICDMRegisterUnregisterEvents),
     NL_TEST_DEF("TestICDCounter", TestICDManager::TestICDCounter),

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -203,7 +203,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
         else
         {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-            app::ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+            app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
             // Standalone acks are not application-level message sends.
@@ -329,7 +329,7 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, cons
     SetAutoRequestAck(session->AllowsMRP());
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    app::ICDNotifier::GetInstance().BroadcastActiveRequestNotification(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
+    app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
 #endif
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
@@ -348,7 +348,7 @@ ExchangeContext::~ExchangeContext()
     VerifyOrDie(mFlags.Has(Flags::kFlagClosed));
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    app::ICDNotifier::GetInstance().BroadcastActiveRequestWithdrawal(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
+    app::ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(app::ICDListener::KeepActiveFlag::kExchangeContextOpen);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // Ideally, in this scenario, the retransmit table should
@@ -595,7 +595,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // message received
-    app::ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+    app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // Set kFlagReceivedAtLeastOneMessage to true since we have received at least one new application level message

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -316,7 +316,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
     if (err == CHIP_NO_ERROR)
     {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-        app::ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+        app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #if CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
         const ExchangeManager * exchangeMgr = entry->ec->GetExchangeMgr();


### PR DESCRIPTION
#### Description
When a subscription report was being sent out due to a max interval, the ICDManager was only entering active mode because of an ExchangeContext being created.

Since the ExchangeContext was created after the payload generation, no new data could be added to the subscription being sent out.

Adding a `OnSubscriptionReport` callback to transition the ICD to active mode before the payload is generated to allow the ICDManager to add any data it generates during the transition.
