### PR TITLE
Make UpTime attribute mandatory in ZAP RootNode

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -86,7 +86,8 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="2"/>
     <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="array" entryType="NetworkInterface" length="8" writable="false" optional="false">NetworkInterfaces</attribute>
     <attribute side="server" code="0x01" define="REBOOT_COUNT" type="int16u" writable="false" default="0x0000" optional="false">RebootCount</attribute>
-    <!-- TODO(#30023): Make Uptime conditionally mandatory at rev >= 2 -->
+    <!-- ***NOTE***: UpTime attribute is mandatory starting at Rev >= 2, but because of backwards compatibility, has to be optional here.
+         The device type config and cert tests (TC-DGGEN-1.1/2.1) ensure that it is present. -->
     <attribute side="server" code="0x02" define="UP_TIME" type="int64u" writable="false" default="0x0000000000000000" optional="true">UpTime</attribute>
     <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="int32u" writable="false" default="0x00000000" optional="true">TotalOperationalHours</attribute>
     <attribute side="server" code="0x04" define="BOOT_REASONS" type="BootReasonEnum" writable="false" optional="true">BootReason</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -78,7 +78,9 @@ limitations under the License.
                 <requireAttribute>HOUR_FORMAT</requireAttribute>
             </include>
             <include cluster="Unit Localization" client="false" server="true" clientLocked="true" serverLocked="false"></include>
-            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="General Diagnostics" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>UP_TIME</requireAttribute>
+            </include>
             <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Software Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
@@ -1871,7 +1873,7 @@ limitations under the License.
             <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>            
+            <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>


### PR DESCRIPTION
- ZAP tool RootNode device type now has UpTime mandatory. It is only mandatory for rev >= 2 (e.g. current rev) but could not be made mandatory in SDK "directly" since it was optional before. Now the test cases check for UpTime presence to be mandatory (TC-DGGEN-1.1), but this change makes it so ZAP will warn if somehow the attribute is not present.

Fixes #30023

Testing done:
  - Ran ZAP tool and saw the warning on removing UpTime attribute in Endpoint 0.
