### PR TITLE
pw_unit_tests disable some warning threated as errors

### DIFF
--- a/.gn
+++ b/.gn
@@ -36,6 +36,7 @@ default_args = {
   pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"
   pw_assert_BACKEND = "$dir_pw_assert_log"
   pw_log_BACKEND = "$dir_pw_log_basic"
+  pw_build_DEFAULT_MODULE_CONFIG = "//:pigweed_wno_errors"
 
   # TODO: Make sure only unit tests link against this
   pw_build_LINK_DEPS = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -41,6 +41,18 @@ if (chip_with_lwip) {
   import("//build_overrides/lwip.gni")
 }
 
+config("pigweed_wno_errors_config") {
+  cflags = [
+    "-Wno-error=undef",
+    "-Wno-error=sign-compare",
+    "-Wno-error=sign-conversion",
+  ]
+}
+
+group("pigweed_wno_errors") {
+  public_configs = [ ":pigweed_wno_errors_config" ]
+}
+
 if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   declare_args() {
     chip_enable_python_modules =


### PR DESCRIPTION
PR related to #29682

## Problem
During the build of unit tests based on pigweed in related PR. There is a problem with the warning that is treated as an error in the Pigweed library, a third-party project. The problem was noticed only on the Darwin platform for build:

``` sh
gn gen out/default '--args=target_os="all" is_asan=true enable_host_clang_build=false'
ninja -C out/default
```

## Solution
Set configuration which adds the following compilation flags for pigweed build:
* -Wno-error=undef
* -Wno-error=sign-compare
* -Wno-error=sign-conversion
