### PR TITLE
Add testing_pw library

### DIFF
--- a/build/chip/chip_test_group.gni
+++ b/build/chip/chip_test_group.gni
@@ -39,10 +39,14 @@ template("chip_test_group") {
                            [
                              "build_monolithic_library",
                              "deps",
+                             "tests",
                            ])
 
     deps = []
-    foreach(_test, invoker.deps) {
+    if (defined(invoker.deps)) {
+      deps = invoker.deps
+    }
+    foreach(_test, invoker.tests) {
       deps += [ get_label_info(_test, "label_no_toolchain") + ".lib" ]
     }
 
@@ -53,7 +57,7 @@ template("chip_test_group") {
 
   group("${_test_group_name}") {
     deps = []
-    data_deps = invoker.deps
+    data_deps = invoker.tests
 
     if (_build_monolithic_library) {
       deps += [ ":${_lib_target_name}" ]
@@ -64,7 +68,10 @@ template("chip_test_group") {
     group("${_test_group_name}_run") {
       if (chip_link_tests) {
         deps = []
-        foreach(_test, invoker.deps) {
+        if (defined(invoker.deps)) {
+          deps = invoker.deps
+        }
+        foreach(_test, invoker.tests) {
           deps += [ get_label_info(_test, "label_no_toolchain") + "_run" ]
         }
       }

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -116,6 +116,7 @@ class TizenBuilder(GnBuilder):
 
         if app == TizenApp.TESTS:
             self.extra_gn_options.append('chip_build_tests=true')
+            self.build_command = 'check'
 
         if not enable_ble:
             self.extra_gn_options.append('chip_config_network_layer_ble=false')

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -144,7 +144,11 @@ if (chip_build_tests) {
     }
 
     if (chip_monolithic_tests) {
-      deps += [ "${chip_root}/src/lib/support:testing_pw" ]
+      # TODO [PW_MIGRATION] Remove this if after migartion to PW_TEST is completed for all platforms
+      # TODO [PW_MIGRATION] There will be a list of already migrated platforms
+      if (false) {
+        deps += [ "${chip_root}/src/lib/support:testing_pw" ]
+      }
       build_monolithic_library = true
       output_name = "libCHIP_tests"
       output_dir = "${root_out_dir}/lib"

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -56,7 +56,8 @@ if (chip_build_tests) {
   import("${chip_root}/build/chip/chip_test_group.gni")
 
   chip_test_group("tests") {
-    deps = [
+    deps = []
+    tests = [
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
@@ -72,7 +73,7 @@ if (chip_build_tests) {
 
     # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {
-      deps += [
+      tests += [
         "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
         "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
         "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
@@ -81,19 +82,19 @@ if (chip_build_tests) {
     }
 
     if (current_os != "zephyr" && current_os != "mbed") {
-      deps += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
+      tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
     }
 
     if (current_os != "zephyr" && current_os != "mbed" &&
         chip_device_platform != "efr32") {
-      deps += [
+      tests += [
         "${chip_root}/src/setup_payload/tests",
         "${chip_root}/src/transport/raw/tests",
       ]
     }
 
     if (chip_device_platform != "efr32") {
-      deps += [
+      tests += [
         # TODO(#10447): App test has HF on EFR32.
         "${chip_root}/src/app/tests",
         "${chip_root}/src/credentials/tests",
@@ -106,21 +107,21 @@ if (chip_build_tests) {
 
       if (matter_enable_tracing_support &&
           matter_trace_config == "multiplexed") {
-        deps += [ "${chip_root}/src/tracing/tests" ]
+        tests += [ "${chip_root}/src/tracing/tests" ]
       }
     }
 
     if (chip_device_platform != "none") {
-      deps += [ "${chip_root}/src/lib/dnssd/minimal_mdns/tests" ]
+      tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/tests" ]
     }
 
     if (chip_device_platform != "esp32" && chip_device_platform != "efr32" &&
         chip_device_platform != "ameba") {
-      deps += [ "${chip_root}/src/platform/tests" ]
+      tests += [ "${chip_root}/src/platform/tests" ]
     }
 
     if (chip_config_network_layer_ble) {
-      deps += [ "${chip_root}/src/ble/tests" ]
+      tests += [ "${chip_root}/src/ble/tests" ]
     }
 
     # On nrfconnect, the controller tests run into
@@ -128,21 +129,22 @@ if (chip_build_tests) {
     if (chip_device_platform != "nrfconnect" &&
         chip_device_platform != "efr32") {
       # TODO(#10447): Controller test has HF on EFR32.
-      deps += [ "${chip_root}/src/controller/tests/data_model" ]
+      tests += [ "${chip_root}/src/controller/tests/data_model" ]
 
       # Skip controller test for Open IoT SDK
       # https://github.com/project-chip/connectedhomeip/issues/23747
       if (chip_device_platform != "openiotsdk") {
-        deps += [ "${chip_root}/src/controller/tests" ]
+        tests += [ "${chip_root}/src/controller/tests" ]
       }
     }
 
     if (current_os != "zephyr" && current_os != "mbed" &&
         chip_device_platform != "esp32" && chip_device_platform != "ameba") {
-      deps += [ "${chip_root}/src/lib/shell/tests" ]
+      tests += [ "${chip_root}/src/lib/shell/tests" ]
     }
 
     if (chip_monolithic_tests) {
+      deps += [ "${chip_root}/src/lib/support:testing_pw" ]
       build_monolithic_library = true
       output_name = "libCHIP_tests"
       output_dir = "${root_out_dir}/lib"
@@ -150,12 +152,12 @@ if (chip_build_tests) {
   }
 
   chip_test_group("fake_platform_tests") {
-    deps = [ "${chip_root}/src/lib/dnssd/platform/tests" ]
+    tests = [ "${chip_root}/src/lib/dnssd/platform/tests" ]
   }
 
   # Tests to run with each Crypto PAL
   chip_test_group("crypto_tests") {
-    deps = [
+    tests = [
       "${chip_root}/src/credentials/tests",
       "${chip_root}/src/crypto/tests",
     ]

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -147,7 +147,7 @@ if (chip_build_tests) {
       # TODO [PW_MIGRATION] Remove this if after migartion to PW_TEST is completed for all platforms
       # TODO [PW_MIGRATION] There will be a list of already migrated platforms
       if (false) {
-        deps += [ "${chip_root}/src/lib/support:testing_pw" ]
+        deps += [ "${chip_root}/src/lib/support:pw_tests_wrapper" ]
       }
       build_monolithic_library = true
       output_name = "libCHIP_tests"

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -18,7 +18,9 @@ import("//build_overrides/nlassert.gni")
 import("//build_overrides/nlfaultinjection.gni")
 import("//build_overrides/nlio.gni")
 import("//build_overrides/nlunit_test.gni")
+import("//build_overrides/pigweed.gni")
 
+import("$dir_pw_build/target_types.gni")
 import("${chip_root}/build/chip/chip_version.gni")
 import("${chip_root}/build/chip/java/config.gni")
 import("${chip_root}/build/chip/tests.gni")
@@ -306,6 +308,22 @@ static_library("test_utils") {
   sources = [
     "UnitTestUtils.cpp",
     "UnitTestUtils.h",
+  ]
+}
+
+pw_static_library("testing_pw") {
+  if (chip_device_platform == "esp32") {
+    complete_static_lib = true
+  }
+  output_name = "libTestPW"
+  output_dir = "${root_out_dir}/lib"
+  public_deps = [
+    "$dir_pw_log:impl",
+    "$dir_pw_unit_test",
+  ]
+  sources = [
+    "UnitTest.cpp",
+    "UnitTest.h",
   ]
 }
 

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -311,11 +311,11 @@ static_library("test_utils") {
   ]
 }
 
-pw_static_library("testing_pw") {
+pw_static_library("pw_tests_wrapper") {
   if (chip_device_platform == "esp32") {
     complete_static_lib = true
   }
-  output_name = "libTestPW"
+  output_name = "libPWTestsWrapper"
   output_dir = "${root_out_dir}/lib"
   public_deps = [
     "$dir_pw_log:impl",

--- a/src/lib/support/UnitTest.cpp
+++ b/src/lib/support/UnitTest.cpp
@@ -1,0 +1,14 @@
+#include "UnitTest.h"
+
+#include "pw_unit_test/framework.h"
+
+namespace chip {
+namespace test {
+
+int RunAllTests()
+{
+    return RUN_ALL_TESTS();
+}
+
+} // namespace test
+} // namespace chip

--- a/src/lib/support/UnitTest.h
+++ b/src/lib/support/UnitTest.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace chip {
+namespace test {
+
+int RunAllTests();
+
+} // namespace test
+} // namespace chip

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -98,6 +98,6 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
 } else {
   import("${chip_root}/build/chip/chip_test_group.gni")
   chip_test_group("tests") {
-    deps = []
+    tests = []
   }
 }


### PR DESCRIPTION
PR related to #29682

## Problem

1. I'm adding `pw_unit_test` support project. If I want to link the `pw_unit_test` library to embedded platforms, I need to duplicate the pigweed backend configuration in gn related files and later in CMakeFiles for those platforms. 
2. The configuration of Tizen unit tests builds every target, not only one related to the check.  

## Solution

1. To solve this problem, I would like to link everything related to `pw_unit_test` into `libCHIP_tests` and create a proxy function which will call `RUN_ALL_TESTS`. This allows me not to duplicate the Pigweed backend settings. Unit tests for the ESP32 platform don't use `libCHIP_tests`, so I want to create a separate `libPWTestsWrapper` for them. 
2. Add check build_command to tizen building script
